### PR TITLE
replace honcho-self-hosted with plastic-labs/honcho (official)

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -118,7 +118,7 @@ Extensions to Hermes's built-in memory system — external providers, context en
 | Repository | Description | Stars | Maturity |
 |:-----------|:------------|------:|:---------|
 | [vectorize-io/hindsight](https://github.com/vectorize-io/hindsight) | Long-term memory provider with retain/recall/reflect workflows | 8,362 | Production |
-| [elkimek/honcho-self-hosted](https://github.com/elkimek/honcho-self-hosted) | Self-hosted Honcho memory backend for cross-session persistence | 126 | Beta |
+| [plastic-labs/honcho](https://github.com/plastic-labs/honcho) | Memory library for building stateful agents | 2285 | Production |
 | [yoloshii/ClawMem](https://github.com/yoloshii/ClawMem) | On-device memory and context engine for agents | 86 | Beta |
 | [plur-ai/plur](https://github.com/plur-ai/plur) | Shared memory layer with open engram YAML format for multi-agent systems | 31 | Beta |
 | [amanning3390/flowstate-qmd](https://github.com/amanning3390/flowstate-qmd) | Anticipatory memory with RAG and vector search | — | Experimental |

--- a/data/repos.json
+++ b/data/repos.json
@@ -290,13 +290,13 @@
     "category": "Memory & Context"
   },
   {
-    "owner": "elkimek",
-    "repo": "honcho-self-hosted",
-    "name": "honcho-self-hosted",
-    "description": "Self-hosted Honcho memory backend for cross-session persistence",
-    "stars": 126,
-    "url": "https://github.com/elkimek/honcho-self-hosted",
-    "official": false,
+    "owner": "plastic-labs",
+    "repo": "honcho",
+    "name": "honcho",
+    "description": "Memory library for building stateful agents",
+    "stars": 2285,
+    "url": "https://github.com/plastic-labs/honcho",
+    "official": true,
     "category": "Memory & Context"
   },
   {

--- a/ecosystem-map.html
+++ b/ecosystem-map.html
@@ -858,7 +858,7 @@
     <div class="items">
       <a class="item" href="https://github.com/vectorize-io/hindsight" target="_blank" rel="noopener" data-desc="Agent memory that learns — long-term retain/recall/reflect workflows">hindsight <span class="stars">★ 8,362</span></a>
       <a class="item" href="https://github.com/greyhaven-ai/autocontext" target="_blank" rel="noopener" data-desc="Recursive self-improving context harness — helps agents succeed on complex tasks">autocontext <span class="stars">★ 711</span></a>
-      <a class="item" href="https://github.com/elkimek/honcho-self-hosted" target="_blank" rel="noopener" data-desc="Self-hosted Honcho memory backend for cross-session persistence">honcho-self-hosted <span class="stars">★ 126</span></a>
+      <a class="item" href="https://github.com/plastic-labs/honcho" target="_blank" rel="noopener" data-desc="Memory library for building stateful agents">honcho <span class="stars">★ 2,285</span></a>
       <a class="item" href="https://github.com/yoloshii/ClawMem" target="_blank" rel="noopener" data-desc="On-device memory and context engine for agents — local-first, no cloud dependencies">ClawMem <span class="stars">★ 86</span></a>
       <a class="item" href="https://github.com/plur-ai/plur" target="_blank" rel="noopener" data-desc="Shared memory layer with open engram YAML format for multi-agent systems">plur <span class="stars">★ 31</span></a>
       <a class="item" href="https://github.com/amanning3390/flowstate-qmd" target="_blank" rel="noopener" data-desc="Anticipatory memory with RAG and vector search — Hermes 2026 Hackathon entry">flowstate-qmd <span class="stars">★ 5</span></a>

--- a/index.html
+++ b/index.html
@@ -858,7 +858,7 @@
     <div class="items">
       <a class="item" href="https://github.com/vectorize-io/hindsight" target="_blank" rel="noopener" data-desc="Agent memory that learns — long-term retain/recall/reflect workflows">hindsight <span class="stars">★ 8,362</span></a>
       <a class="item" href="https://github.com/greyhaven-ai/autocontext" target="_blank" rel="noopener" data-desc="Recursive self-improving context harness — helps agents succeed on complex tasks">autocontext <span class="stars">★ 711</span></a>
-      <a class="item" href="https://github.com/elkimek/honcho-self-hosted" target="_blank" rel="noopener" data-desc="Self-hosted Honcho memory backend for cross-session persistence">honcho-self-hosted <span class="stars">★ 126</span></a>
+      <a class="item" href="https://github.com/plastic-labs/honcho" target="_blank" rel="noopener" data-desc="Memory library for building stateful agents">honcho <span class="stars">★ 2,285</span></a>
       <a class="item" href="https://github.com/yoloshii/ClawMem" target="_blank" rel="noopener" data-desc="On-device memory and context engine for agents — local-first, no cloud dependencies">ClawMem <span class="stars">★ 86</span></a>
       <a class="item" href="https://github.com/plur-ai/plur" target="_blank" rel="noopener" data-desc="Shared memory layer with open engram YAML format for multi-agent systems">plur <span class="stars">★ 31</span></a>
       <a class="item" href="https://github.com/amanning3390/flowstate-qmd" target="_blank" rel="noopener" data-desc="Anticipatory memory with RAG and vector search — Hermes 2026 Hackathon entry">flowstate-qmd <span class="stars">★ 5</span></a>


### PR DESCRIPTION
## Summary

- Replaces `elkimek/honcho-self-hosted` (126 stars, community fork) with [`plastic-labs/honcho`](https://github.com/plastic-labs/honcho) (2.2k+ stars, official repo)
- Updated across all 4 relevant files: `data/repos.json`, `ECOSYSTEM.md`, `index.html`, `ecosystem-map.html`
- Set `official: true` in repos.json since this is the source repo, not a fork/community project
- Star count and description updated to match the actual repo