### PR TITLE
Ship Phase 9: star CTA + newsletter capture + /privacy

### DIFF
--- a/404.html
+++ b/404.html
@@ -27,11 +27,13 @@
     <span>apr·2026</span>
     <span>93·repos</span>
     <span>hermes·v0.10.0</span>
+    <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/#curated-lists">lists</a>
     <a href="/reports/state-of-hermes-april-2026">reports</a>
+    <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
@@ -74,6 +76,14 @@
       try { localStorage.setItem('theme', n); } catch (e) {}
       render();
     });
+  })();
+</script>
+<script>
+  (function(){
+    fetch('/api/stars').then(function(r){ return r.ok && r.json(); }).then(function(d){
+      var el = document.getElementById('meta-atlas');
+      if (el && d && d.atlas && d.atlas.stars) el.textContent = '★ ' + d.atlas.stars + ' · star this repo';
+    }).catch(function(){});
   })();
 </script>
 <!-- Cloudflare Web Analytics -->

--- a/api/stars.js
+++ b/api/stars.js
@@ -62,7 +62,12 @@ export default async function handler(req, res) {
       }`;
     }).join("\n");
 
-    const query = `query { ${repoQueries} }`;
+    // Also fetch the Hermes Atlas repo's own star count for the masthead CTA
+    const query = `query { ${repoQueries}
+      atlas: repository(owner: "ksimback", name: "hermes-ecosystem") {
+        stargazerCount
+      }
+    }`;
 
     const ghRes = await fetch("https://api.github.com/graphql", {
       method: "POST",
@@ -108,7 +113,8 @@ export default async function handler(req, res) {
       };
     });
 
-    const response = buildResponse(starData, hermesRelease);
+    const atlasStars = ghData.data?.atlas?.stargazerCount ?? null;
+    const response = buildResponse(starData, hermesRelease, atlasStars);
 
     // Cache the result
     await kvSet(CACHE_KEY, response, { ex: CACHE_TTL });
@@ -136,7 +142,7 @@ export default async function handler(req, res) {
   }
 }
 
-function buildResponse(starData, hermesRelease = null) {
+function buildResponse(starData, hermesRelease = null, atlasStars = null) {
   const totalStars = starData.reduce((sum, r) => sum + r.stars, 0);
 
   // Build a lookup map
@@ -155,6 +161,7 @@ function buildResponse(starData, hermesRelease = null) {
       count: starData.length,
       updated: new Date().toISOString()
     },
-    hermes: hermesRelease
+    hermes: hermesRelease,
+    atlas: { stars: atlasStars }
   };
 }

--- a/api/subscribe.js
+++ b/api/subscribe.js
@@ -1,0 +1,72 @@
+const PUBLICATION_ID = "pub_cd668a5c-262b-4dd2-882b-6fb542d1a85a";
+const BEEHIIV_URL = `https://api.beehiiv.com/v2/publications/${PUBLICATION_ID}/subscriptions`;
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function json(res, status, body) {
+  res.status(status).setHeader("Content-Type", "application/json");
+  res.send(JSON.stringify(body));
+}
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    return json(res, 405, { ok: false, error: "Method not allowed" });
+  }
+
+  const apiKey = process.env.BEEHIIV_API_KEY;
+  if (!apiKey) {
+    console.error("[subscribe] BEEHIIV_API_KEY not set");
+    return json(res, 500, { ok: false, error: "Newsletter is temporarily unavailable." });
+  }
+
+  const body = typeof req.body === "string" ? safeParse(req.body) : (req.body || {});
+  const email = String(body.email || "").trim().toLowerCase();
+  const page = String(body.page || "").slice(0, 200);
+  const referrer = String(body.referrer || "").slice(0, 400);
+
+  if (!email || !EMAIL_RE.test(email) || email.length > 254) {
+    return json(res, 400, { ok: false, error: "Enter a valid email." });
+  }
+
+  try {
+    const upstream = await fetch(BEEHIIV_URL, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+        "Accept": "application/json"
+      },
+      body: JSON.stringify({
+        email,
+        reactivate_existing: true,
+        send_welcome_email: true,
+        utm_source: "hermesatlas.com",
+        utm_medium: "organic",
+        utm_campaign: page || "site",
+        referring_site: referrer || "https://hermesatlas.com"
+      })
+    });
+
+    if (upstream.ok) {
+      return json(res, 200, { ok: true });
+    }
+
+    const text = await upstream.text();
+    console.error(`[subscribe] Beehiiv ${upstream.status}: ${text.slice(0, 500)}`);
+
+    if (upstream.status === 400) {
+      return json(res, 400, { ok: false, error: "Enter a valid email." });
+    }
+    if (upstream.status === 429) {
+      return json(res, 429, { ok: false, error: "Too many signups — try again in a minute." });
+    }
+    return json(res, 502, { ok: false, error: "Signup is temporarily unavailable. Try again?" });
+  } catch (err) {
+    console.error("[subscribe] fetch error:", err?.message || err);
+    return json(res, 502, { ok: false, error: "Network error. Try again?" });
+  }
+}
+
+function safeParse(s) {
+  try { return JSON.parse(s); } catch { return {}; }
+}

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -113,3 +113,166 @@ body::after {
     scroll-behavior: auto !important;
   }
 }
+
+/* Star-the-repo CTA — shared across all page types */
+.mast-star {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  color: var(--ink-mute);
+  text-decoration: none;
+  transition: color 0.15s;
+}
+.mast-star:hover { color: var(--accent); }
+@media (max-width: 900px) {
+  .mast-star { font-size: 10px; }
+}
+
+.star-cta {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--ink-dim, var(--ink-mute));
+  margin: 24px 0 16px;
+  line-height: 1.6;
+}
+.star-cta a {
+  color: var(--ink);
+  text-decoration: underline;
+  text-decoration-color: var(--accent);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+  transition: color 0.15s;
+}
+.star-cta a:hover { color: var(--accent); }
+
+/* Email capture CTA — brutalist wrapper around Beehiiv iframe.
+   Used on homepage, handbook hub, vs-claude-code satellite, April report. */
+.email-cta {
+  margin: var(--s-10) 0 var(--s-6);
+  padding: var(--s-6);
+  border: 1px solid var(--rule);
+  background: var(--bg-elev);
+  max-width: 640px;
+}
+.email-cta-kicker {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0 0 var(--s-3);
+}
+.email-cta-title {
+  font-family: var(--font-display);
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+  margin: 0 0 var(--s-2);
+}
+.email-cta-lede {
+  font-family: var(--font-display);
+  font-size: 15px;
+  line-height: 1.5;
+  color: var(--ink-dim);
+  margin: 0 0 var(--s-4);
+}
+.email-cta-form {
+  display: flex;
+  gap: 0;
+  margin: 0;
+}
+.email-cta-input {
+  flex: 1;
+  min-width: 0;
+  height: 44px;
+  padding: 10px var(--s-4);
+  border: 1px solid var(--rule-strong);
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--font-mono);
+  font-size: 14px;
+  line-height: 1.4;
+  transition: border-color 0.15s;
+}
+.email-cta-input::placeholder { color: var(--ink-mute); }
+.email-cta-input:hover { border-color: var(--ink-soft); }
+.email-cta-input:focus-visible {
+  outline: 0;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent);
+}
+.email-cta-button {
+  height: 44px;
+  margin-left: -1px;
+  padding: 0 var(--s-5);
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  color: var(--bg);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s, color 0.15s;
+}
+.email-cta-button:hover {
+  background: transparent;
+  color: var(--accent);
+}
+.email-cta-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+.email-cta-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.email-cta-status {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--ink-dim);
+  min-height: 18px;
+  margin: var(--s-3) 0 0;
+  letter-spacing: 0.02em;
+}
+.email-cta-status[data-status="success"] { color: var(--positive); }
+.email-cta-status[data-status="error"] { color: var(--negative); }
+@media (max-width: 480px) {
+  .email-cta-form { flex-direction: column; }
+  .email-cta-button { margin-left: 0; margin-top: -1px; }
+}
+.email-cta-foot {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  margin: var(--s-3) 0 0;
+}
+.email-cta-foot a {
+  color: var(--ink-mute);
+  border-bottom: 1px solid var(--rule-strong);
+  padding-bottom: 1px;
+  transition: color 0.15s, border-color 0.15s;
+}
+.email-cta-foot a:hover {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+@media (max-width: 600px) {
+  .email-cta { padding: var(--s-5); }
+  .email-cta-title { font-size: 19px; }
+}
+
+/* Compact variant — inline newsletter capture above-the-fold.
+   Just kicker + form + status; no big title/lede. */
+.email-cta--compact {
+  padding: var(--s-4) var(--s-5);
+  margin: var(--s-8) 0;
+  max-width: 560px;
+}
+.email-cta--compact .email-cta-kicker { margin-bottom: var(--s-3); }

--- a/assets/js/email-capture.js
+++ b/assets/js/email-capture.js
@@ -1,0 +1,52 @@
+(function () {
+  var forms = document.querySelectorAll("[data-email-form]");
+  forms.forEach(function (form) {
+    form.addEventListener("submit", function (e) {
+      e.preventDefault();
+      submit(form);
+    });
+  });
+
+  function submit(form) {
+    var input = form.querySelector('input[name="email"]');
+    var button = form.querySelector("button");
+    var status = form.parentElement.querySelector(".email-cta-status");
+    var email = (input.value || "").trim();
+    if (!email) return;
+
+    button.disabled = true;
+    button.dataset.label = button.dataset.label || button.textContent;
+    button.textContent = "sending…";
+    status.removeAttribute("data-status");
+    status.textContent = "";
+
+    fetch("/api/subscribe", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: email,
+        referrer: document.referrer || "",
+        page: window.location.pathname
+      })
+    })
+      .then(function (r) { return r.json().then(function (d) { return { ok: r.ok, data: d }; }); })
+      .then(function (r) {
+        if (r.ok && r.data && r.data.ok) {
+          status.setAttribute("data-status", "success");
+          status.textContent = "check your inbox to confirm.";
+          input.value = "";
+        } else {
+          status.setAttribute("data-status", "error");
+          status.textContent = (r.data && r.data.error) || "something went wrong. try again?";
+        }
+      })
+      .catch(function () {
+        status.setAttribute("data-status", "error");
+        status.textContent = "network error. try again?";
+      })
+      .then(function () {
+        button.disabled = false;
+        button.textContent = button.dataset.label;
+      });
+  }
+})();

--- a/guide/index.html
+++ b/guide/index.html
@@ -214,12 +214,14 @@
     <span>apr·2026</span>
     <span>93·repos</span>
     <span>hermes·v0.10.0</span>
+    <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/#curated-lists">lists</a>
     <a href="/guide/" class="active">handbook</a>
     <a href="/reports/state-of-hermes-april-2026">reports</a>
+    <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
@@ -241,6 +243,15 @@
 </header>
 
 <blockquote>Based on 93 ecosystem projects reviewed, 33 research sources, and the live GitHub repo. Updated monthly.</blockquote>
+
+<aside class="email-cta email-cta--compact" id="newsletter" aria-label="Newsletter signup">
+  <div class="email-cta-kicker">newsletter · free · 1–2× / month</div>
+  <form class="email-cta-form" data-email-form novalidate>
+    <input type="email" name="email" class="email-cta-input" placeholder="you@domain.com" required autocomplete="email" aria-label="Email address">
+    <button type="submit" class="email-cta-button">subscribe</button>
+  </form>
+  <p class="email-cta-status" role="status" aria-live="polite"></p>
+</aside>
 
 <h2>Table of contents</h2>
 
@@ -658,13 +669,28 @@ hermes skills info &lt;name&gt;      # inspect before installing</code></pre>
     <li>643 skills in the community Hub (as of 2026-04-19)</li>
   </ul>
   <p><strong>Corrections and feedback:</strong> <a href="https://github.com/ksimback/hermes-ecosystem/issues/new">open an issue</a> or message <a href="https://x.com/ksimback">@ksimback</a> on X.</p>
+  <p class="star-cta">if this was useful, drop a ★ on the <a href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener">atlas repo</a> →</p>
   <a class="cta" href="/">explore the ecosystem map →</a>
 </div>
 
 </article>
 
+<!-- Email capture -->
+<aside class="email-cta" aria-label="Newsletter signup">
+  <div class="email-cta-kicker">newsletter · free</div>
+  <h2 class="email-cta-title">stay in the loop</h2>
+  <p class="email-cta-lede">new research, reports, and project drops from across the Hermes ecosystem — 1–2× per month. no spam.</p>
+  <form class="email-cta-form" data-email-form novalidate>
+    <input type="email" name="email" class="email-cta-input" placeholder="you@domain.com" required autocomplete="email" aria-label="Email address">
+    <button type="submit" class="email-cta-button">subscribe</button>
+  </form>
+  <p class="email-cta-status" role="status" aria-live="polite"></p>
+  <p class="email-cta-foot">handled by beehiiv · <a href="/privacy">privacy</a></p>
+</aside>
+<script src="/assets/js/email-capture.js" defer></script>
+
 <footer class="page-footer">
-  <div class="fn-left">hermes atlas · curated by <a href="https://github.com/ksimback">ksimback</a> · <a href="https://github.com/ksimback/hermes-ecosystem/issues">suggest a repo</a></div>
+  <div class="fn-left">hermes atlas · curated by <a href="https://github.com/ksimback">ksimback</a> · <a href="https://github.com/ksimback/hermes-ecosystem/issues">suggest a repo</a> · <a href="/privacy">privacy</a></div>
   <div>v2 · 2026.04</div>
 </footer>
 
@@ -685,6 +711,15 @@ hermes skills info &lt;name&gt;      # inspect before installing</code></pre>
       try { localStorage.setItem('theme', n); } catch (e) {}
       render();
     });
+  })();
+</script>
+
+<script>
+  (function(){
+    fetch('/api/stars').then(function(r){ return r.ok && r.json(); }).then(function(d){
+      var el = document.getElementById('meta-atlas');
+      if (el && d && d.atlas && d.atlas.stars) el.textContent = '★ ' + d.atlas.stars + ' · star this repo';
+    }).catch(function(){});
   })();
 </script>
 

--- a/guide/vs-claude-code/index.html
+++ b/guide/vs-claude-code/index.html
@@ -129,12 +129,14 @@
     <span>apr·2026</span>
     <span>93·repos</span>
     <span>hermes·v0.10.0</span>
+    <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/#curated-lists">lists</a>
     <a href="/guide/" class="active">handbook</a>
     <a href="/reports/state-of-hermes-april-2026">reports</a>
+    <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
@@ -158,6 +160,15 @@
 <h2>TL;DR</h2>
 
 <p><strong>Claude Code is the best in-repo coding agent you can run today (Codex is good too). Hermes Agent is the best cross-session, multi-channel autonomous agent you can run today. They don't compete — they stack. If you code for a living, you probably want both.</strong> Pick Claude Code if your job is "edit this codebase and commit." Pick Hermes if your job is "run my digital life in the background." Most serious users run them side by side.</p>
+
+<aside class="email-cta email-cta--compact" id="newsletter" aria-label="Newsletter signup">
+  <div class="email-cta-kicker">newsletter · free · 1–2× / month</div>
+  <form class="email-cta-form" data-email-form novalidate>
+    <input type="email" name="email" class="email-cta-input" placeholder="you@domain.com" required autocomplete="email" aria-label="Email address">
+    <button type="submit" class="email-cta-button">subscribe</button>
+  </form>
+  <p class="email-cta-status" role="status" aria-live="polite"></p>
+</aside>
 
 <hr>
 
@@ -292,13 +303,28 @@
     <li>643 skills in the community Hub (research bank snapshot, as of 2026-04-19)</li>
   </ul>
   <p><strong>Corrections and feedback:</strong> <a href="https://github.com/ksimback/hermes-ecosystem/issues/new">open an issue</a> or message <a href="https://x.com/ksimback">@ksimback</a> on X.</p>
+  <p class="star-cta">if this was useful, drop a ★ on the <a href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener">atlas repo</a> →</p>
   <a class="cta" href="/guide/">back to The Hermes Handbook →</a>
 </div>
 
 </article>
 
+<!-- Email capture -->
+<aside class="email-cta" aria-label="Newsletter signup">
+  <div class="email-cta-kicker">newsletter · free</div>
+  <h2 class="email-cta-title">stay in the loop</h2>
+  <p class="email-cta-lede">new research, reports, and project drops from across the Hermes ecosystem — 1–2× per month. no spam.</p>
+  <form class="email-cta-form" data-email-form novalidate>
+    <input type="email" name="email" class="email-cta-input" placeholder="you@domain.com" required autocomplete="email" aria-label="Email address">
+    <button type="submit" class="email-cta-button">subscribe</button>
+  </form>
+  <p class="email-cta-status" role="status" aria-live="polite"></p>
+  <p class="email-cta-foot">handled by beehiiv · <a href="/privacy">privacy</a></p>
+</aside>
+<script src="/assets/js/email-capture.js" defer></script>
+
 <footer class="page-footer">
-  <div class="fn-left">hermes atlas · curated by <a href="https://github.com/ksimback">ksimback</a> · <a href="https://github.com/ksimback/hermes-ecosystem/issues">suggest a repo</a></div>
+  <div class="fn-left">hermes atlas · curated by <a href="https://github.com/ksimback">ksimback</a> · <a href="https://github.com/ksimback/hermes-ecosystem/issues">suggest a repo</a> · <a href="/privacy">privacy</a></div>
   <div>v2 · 2026.04</div>
 </footer>
 
@@ -319,6 +345,15 @@
       try { localStorage.setItem('theme', n); } catch (e) {}
       render();
     });
+  })();
+</script>
+
+<script>
+  (function(){
+    fetch('/api/stars').then(function(r){ return r.ok && r.json(); }).then(function(d){
+      var el = document.getElementById('meta-atlas');
+      if (el && d && d.atlas && d.atlas.stars) el.textContent = '★ ' + d.atlas.stars + ' · star this repo';
+    }).catch(function(){});
   })();
 </script>
 

--- a/index.html
+++ b/index.html
@@ -51,13 +51,14 @@
     <span id="meta-month">apr·2026</span>
     <span id="meta-count">93·repos</span>
     <span id="meta-version">hermes·v0.10.0</span>
-    <span id="meta-sync">last·sync·—</span>
+    <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="#curated-lists">lists</a>
     <a href="/guide/">handbook</a>
     <a href="/reports/state-of-hermes-april-2026">reports</a>
+    <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
@@ -109,6 +110,16 @@
     <div><span class="big">16</span><div class="lbl">platforms</div></div>
   </div>
 </section>
+
+<!-- Newsletter capture (compact, above-the-fold) -->
+<aside class="email-cta email-cta--compact" id="newsletter" aria-label="Newsletter signup">
+  <div class="email-cta-kicker">newsletter · free · 1–2× / month</div>
+  <form class="email-cta-form" data-email-form novalidate>
+    <input type="email" name="email" class="email-cta-input" placeholder="you@domain.com" required autocomplete="email" aria-label="Email address">
+    <button type="submit" class="email-cta-button">subscribe</button>
+  </form>
+  <p class="email-cta-status" role="status" aria-live="polite"></p>
+</aside>
 
 <!-- Controls -->
 <div class="controls" role="search">
@@ -1054,9 +1065,23 @@
   </div>
 </section>
 
+<!-- Email capture -->
+<aside class="email-cta" aria-label="Newsletter signup">
+  <div class="email-cta-kicker">newsletter · free</div>
+  <h2 class="email-cta-title">stay in the loop</h2>
+  <p class="email-cta-lede">new research, reports, and project drops from across the Hermes ecosystem — 1–2× per month. no spam.</p>
+  <form class="email-cta-form" data-email-form novalidate>
+    <input type="email" name="email" class="email-cta-input" placeholder="you@domain.com" required autocomplete="email" aria-label="Email address">
+    <button type="submit" class="email-cta-button">subscribe</button>
+  </form>
+  <p class="email-cta-status" role="status" aria-live="polite"></p>
+  <p class="email-cta-foot">handled by beehiiv · <a href="/privacy">privacy</a></p>
+</aside>
+<script src="/assets/js/email-capture.js" defer></script>
+
 <!-- Footnote -->
 <footer class="footnote">
-  <div class="fn-left">hermes atlas · curated by <a href="https://github.com/ksimback">ksimback</a> · <a href="https://github.com/ksimback/hermes-ecosystem/issues">suggest a repo</a></div>
+  <div class="fn-left">hermes atlas · curated by <a href="https://github.com/ksimback">ksimback</a> · <a href="https://github.com/ksimback/hermes-ecosystem/issues">suggest a repo</a> · <a href="/privacy">privacy</a></div>
   <div>v2 · 2026.04</div>
 </footer>
 
@@ -1258,12 +1283,9 @@
       const metaVersion = document.getElementById('meta-version');
       if (metaVersion && data.hermes?.version) metaVersion.textContent = 'hermes·' + data.hermes.version;
 
-      const metaSync = document.getElementById('meta-sync');
-      if (metaSync && data.totals?.updated) {
-        const d = new Date(data.totals.updated);
-        const h = String(d.getUTCHours()).padStart(2, '0');
-        const m = String(d.getUTCMinutes()).padStart(2, '0');
-        metaSync.textContent = 'last·sync·' + h + ':' + m + '·utc';
+      const metaAtlas = document.getElementById('meta-atlas');
+      if (metaAtlas && data.atlas?.stars) {
+        metaAtlas.textContent = '★ ' + data.atlas.stars + ' · star this repo';
       }
 
       // Hero sub count

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Privacy | Hermes Atlas</title>
+<meta name="description" content="What data Hermes Atlas collects, how it is processed, and your rights. No cookies, no fingerprinting, minimal retention.">
+<link rel="canonical" href="https://hermesatlas.com/privacy">
+<meta name="robots" content="index,follow">
+<meta property="og:title" content="Privacy — Hermes Atlas">
+<meta property="og:description" content="What data Hermes Atlas collects and how it is processed. No cookies, minimal retention.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://hermesatlas.com/privacy">
+<meta property="og:site_name" content="Hermes Atlas">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="Privacy — Hermes Atlas">
+<meta name="twitter:description" content="What data Hermes Atlas collects and how it is processed.">
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' fill='%23d49a4f'/><text x='16' y='23' font-family='Space Grotesk,sans-serif' font-size='22' font-weight='700' fill='%230e0d0b' text-anchor='middle'>H</text></svg>">
+<script>
+  (function() {
+    try {
+      var stored = localStorage.getItem('theme');
+      var osLight = window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches;
+      var theme = stored || (osLight ? 'light' : 'dark');
+      document.documentElement.setAttribute('data-theme', theme);
+    } catch (e) {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    }
+  })();
+</script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap">
+<link rel="stylesheet" href="/assets/css/tokens.css">
+<link rel="stylesheet" href="/assets/css/base.css">
+<link rel="stylesheet" href="/assets/css/page.css">
+</head>
+<body>
+
+<a class="skip-link" href="#main">Skip to content</a>
+
+<header class="masthead">
+  <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
+  <div class="mast-meta" aria-label="Site metadata">
+    <span>apr·2026</span>
+    <span>93·repos</span>
+    <span>hermes·v0.10.0</span>
+    <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
+  </div>
+  <nav class="mast-nav" aria-label="Primary">
+    <a href="/">map</a>
+    <a href="/#curated-lists">lists</a>
+    <a href="/guide/">handbook</a>
+    <a href="/reports/state-of-hermes-april-2026">reports</a>
+    <a href="/#newsletter">newsletter</a>
+    <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
+  </nav>
+  <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
+    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+  </button>
+</header>
+
+<div class="breadcrumb" aria-label="Breadcrumb">
+  <a href="/">map</a><span class="sep">/</span>privacy
+</div>
+
+<article class="article" id="main">
+
+<header class="article-header">
+  <div class="article-badge">site · policy</div>
+  <h1>Privacy</h1>
+  <p class="subtitle">Minimal data, no cookies, no tracking pixels. Here's exactly what's collected and why.</p>
+  <p class="meta">Last updated apr 22, 2026</p>
+</header>
+
+<h2>What's collected</h2>
+
+<p><strong>Your email address</strong> — only if you subscribe to the Hermes Atlas Newsletter. It's used to send you the newsletter and nothing else. You can unsubscribe from any issue via the one-click link at the bottom of every email.</p>
+
+<p><strong>Anonymous site analytics</strong> — page views, referrer, and approximate country. No cookies, no fingerprinting, no personal identifiers. Collected via Cloudflare Web Analytics and Vercel Web Analytics, both of which are cookieless by design.</p>
+
+<p><strong>Search logs</strong> — queries you type into the "ask the atlas" chat are sent to OpenRouter to generate a response. They are not stored by Hermes Atlas. OpenRouter's retention applies per <a href="https://openrouter.ai/privacy" target="_blank" rel="noopener">their privacy policy</a>.</p>
+
+<h2>Who processes your data</h2>
+
+<ul>
+  <li><strong>Beehiiv</strong> — newsletter delivery. See <a href="https://www.beehiiv.com/privacy" target="_blank" rel="noopener">Beehiiv's privacy policy</a>.</li>
+  <li><strong>Cloudflare</strong> — DNS, CDN, and cookieless web analytics. See <a href="https://www.cloudflare.com/privacypolicy/" target="_blank" rel="noopener">Cloudflare's privacy policy</a>.</li>
+  <li><strong>Vercel</strong> — site hosting and cookieless web analytics. See <a href="https://vercel.com/legal/privacy-policy" target="_blank" rel="noopener">Vercel's privacy policy</a>.</li>
+  <li><strong>OpenRouter</strong> — LLM routing for the on-page chat. See <a href="https://openrouter.ai/privacy" target="_blank" rel="noopener">OpenRouter's privacy policy</a>.</li>
+</ul>
+
+<h2>Retention</h2>
+
+<p>Email addresses are kept until you unsubscribe. Analytics data is retained per Cloudflare and Vercel defaults — generally 6 months or less. Nothing is sold, nothing is shared with third parties outside the processors above.</p>
+
+<h2>Your rights</h2>
+
+<p>To unsubscribe, use the link in any newsletter issue. To request deletion of any data held about you, open an <a href="https://github.com/ksimback/hermes-ecosystem/issues/new" target="_blank" rel="noopener">issue on GitHub</a> — requests are handled within 30 days.</p>
+
+<h2>Contact</h2>
+
+<p>Questions or corrections: open an <a href="https://github.com/ksimback/hermes-ecosystem/issues/new" target="_blank" rel="noopener">issue on GitHub</a>.</p>
+
+</article>
+
+<footer class="page-footer">
+  <div class="fn-left">hermes atlas · curated by <a href="https://github.com/ksimback">ksimback</a> · <a href="https://github.com/ksimback/hermes-ecosystem/issues">suggest a repo</a> · <a href="/privacy">privacy</a></div>
+  <div>v2 · 2026.04</div>
+</footer>
+
+<script>
+  (function(){
+    var t = document.getElementById('theme-toggle');
+    if (!t) return;
+    function render() {
+      var c = document.documentElement.getAttribute('data-theme');
+      t.querySelector('.tt-light').classList.toggle('tt-active', c === 'light');
+      t.querySelector('.tt-dark').classList.toggle('tt-active', c !== 'light');
+    }
+    render();
+    t.addEventListener('click', function() {
+      var c = document.documentElement.getAttribute('data-theme');
+      var n = c === 'light' ? 'dark' : 'light';
+      document.documentElement.setAttribute('data-theme', n);
+      try { localStorage.setItem('theme', n); } catch (e) {}
+      render();
+    });
+  })();
+</script>
+
+<script>
+  (function(){
+    fetch('/api/stars').then(function(r){ return r.ok && r.json(); }).then(function(d){
+      var el = document.getElementById('meta-atlas');
+      if (el && d && d.atlas && d.atlas.stars) el.textContent = '★ ' + d.atlas.stars + ' · star this repo';
+    }).catch(function(){});
+  })();
+</script>
+
+<!-- Cloudflare Web Analytics -->
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js"
+        data-cf-beacon='{"token": "fe0d4d79280b4386b6b0cd99b2d94dbc"}'></script>
+<!-- End Cloudflare Web Analytics -->
+</body>
+</html>

--- a/reports/state-of-hermes-april-2026.html
+++ b/reports/state-of-hermes-april-2026.html
@@ -49,12 +49,14 @@
     <span>apr·2026</span>
     <span>93·repos</span>
     <span>hermes·v0.10.0</span>
+    <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/#curated-lists">lists</a>
     <a href="/guide/">handbook</a>
     <a href="/reports/state-of-hermes-april-2026" class="active">reports</a>
+    <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
@@ -94,6 +96,15 @@
 </ul>
 
 <p>This report unpacks how a model-research lab from upstate New York turned an open-source release into a movement, what Hermes does differently from OpenClaw and Claude Code, and what to watch for in Q2.</p>
+
+<aside class="email-cta email-cta--compact" id="newsletter" aria-label="Newsletter signup">
+  <div class="email-cta-kicker">newsletter · free · 1–2× / month</div>
+  <form class="email-cta-form" data-email-form novalidate>
+    <input type="email" name="email" class="email-cta-input" placeholder="you@domain.com" required autocomplete="email" aria-label="Email address">
+    <button type="submit" class="email-cta-button">subscribe</button>
+  </form>
+  <p class="email-cta-status" role="status" aria-live="polite"></p>
+</aside>
 
 <hr>
 
@@ -277,13 +288,28 @@
   <p><strong>Methodology:</strong> Synthesized from 27 research files including official documentation, GitHub release notes, press coverage, X/Twitter analysis, Reddit discussion, and the awesome-hermes-agent curated list. All 80+ ecosystem repos are independently security-reviewed and live-tracked.</p>
   <p>Not affiliated with Nous Research. Hermes Atlas is an independent community project.</p>
   <p>Corrections welcome: <a href="https://github.com/ksimback/hermes-ecosystem/issues">open an issue</a></p>
+  <p class="star-cta">if this was useful, drop a ★ on the <a href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener">atlas repo</a> →</p>
   <a class="cta" href="https://hermesatlas.com">explore the ecosystem map →</a>
 </div>
 
 </article>
 
+<!-- Email capture -->
+<aside class="email-cta" aria-label="Newsletter signup">
+  <div class="email-cta-kicker">newsletter · free</div>
+  <h2 class="email-cta-title">stay in the loop</h2>
+  <p class="email-cta-lede">new research, reports, and project drops from across the Hermes ecosystem — 1–2× per month. no spam.</p>
+  <form class="email-cta-form" data-email-form novalidate>
+    <input type="email" name="email" class="email-cta-input" placeholder="you@domain.com" required autocomplete="email" aria-label="Email address">
+    <button type="submit" class="email-cta-button">subscribe</button>
+  </form>
+  <p class="email-cta-status" role="status" aria-live="polite"></p>
+  <p class="email-cta-foot">handled by beehiiv · <a href="/privacy">privacy</a></p>
+</aside>
+<script src="/assets/js/email-capture.js" defer></script>
+
 <footer class="page-footer">
-  <div class="fn-left">hermes atlas · curated by <a href="https://github.com/ksimback">ksimback</a> · <a href="https://github.com/ksimback/hermes-ecosystem/issues">suggest a repo</a></div>
+  <div class="fn-left">hermes atlas · curated by <a href="https://github.com/ksimback">ksimback</a> · <a href="https://github.com/ksimback/hermes-ecosystem/issues">suggest a repo</a> · <a href="/privacy">privacy</a></div>
   <div>v2 · 2026.04</div>
 </footer>
 
@@ -304,6 +330,15 @@
       try { localStorage.setItem('theme', n); } catch (e) {}
       render();
     });
+  })();
+</script>
+
+<script>
+  (function(){
+    fetch('/api/stars').then(function(r){ return r.ok && r.json(); }).then(function(d){
+      var el = document.getElementById('meta-atlas');
+      if (el && d && d.atlas && d.atlas.stars) el.textContent = '★ ' + d.atlas.stars + ' · star this repo';
+    }).catch(function(){});
   })();
 </script>
 

--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -169,6 +169,7 @@ function renderMasthead(activeNav) {
     { href: "/#curated-lists", label: "lists", id: "lists" },
     { href: "/guide/", label: "handbook", id: "handbook" },
     { href: "/reports/state-of-hermes-april-2026", label: "reports", id: "reports" },
+    { href: "/#newsletter", label: "newsletter", id: "newsletter" },
     { href: "https://github.com/ksimback/hermes-ecosystem", label: "source", id: "source" },
   ];
   const navHtml = nav
@@ -180,6 +181,7 @@ function renderMasthead(activeNav) {
     <span>apr·2026</span>
     <span>93·repos</span>
     <span>hermes·v0.10.0</span>
+    <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
   <nav class="mast-nav" aria-label="Primary">
     ${navHtml}
@@ -192,7 +194,7 @@ function renderMasthead(activeNav) {
 
 // ── Shared footer ──
 const PAGE_FOOTER = `<footer class="page-footer">
-  <div class="fn-left">hermes atlas · curated by <a href="https://github.com/ksimback">ksimback</a> · <a href="https://github.com/ksimback/hermes-ecosystem/issues">suggest a repo</a></div>
+  <div class="fn-left">hermes atlas · curated by <a href="https://github.com/ksimback">ksimback</a> · <a href="https://github.com/ksimback/hermes-ecosystem/issues">suggest a repo</a> · <a href="/privacy">privacy</a></div>
   <div>v2 · 2026.04</div>
 </footer>`;
 
@@ -328,6 +330,7 @@ ${summary ? `
 ${PAGE_FOOTER}
 
 <script>${THEME_TOGGLE_SCRIPT}</script>
+<script>(function(){fetch('/api/stars').then(function(r){return r.ok&&r.json()}).then(function(d){var el=document.getElementById('meta-atlas');if(el&&d&&d.atlas&&d.atlas.stars)el.textContent='★ '+d.atlas.stars+' · star this repo'}).catch(function(){});})();</script>
 <!-- Cloudflare Web Analytics -->
 <script defer src="https://static.cloudflareinsights.com/beacon.min.js"
         data-cf-beacon='{"token": "fe0d4d79280b4386b6b0cd99b2d94dbc"}'></script>
@@ -437,6 +440,7 @@ ${listicleHtml}
 ${PAGE_FOOTER}
 
 <script>${THEME_TOGGLE_SCRIPT}</script>
+<script>(function(){fetch('/api/stars').then(function(r){return r.ok&&r.json()}).then(function(d){var el=document.getElementById('meta-atlas');if(el&&d&&d.atlas&&d.atlas.stars)el.textContent='★ '+d.atlas.stars+' · star this repo'}).catch(function(){});})();</script>
 <!-- Cloudflare Web Analytics -->
 <script defer src="https://static.cloudflareinsights.com/beacon.min.js"
         data-cf-beacon='{"token": "fe0d4d79280b4386b6b0cd99b2d94dbc"}'></script>
@@ -453,6 +457,7 @@ function generateSitemap(projectPages, listPages) {
   urls += `  <url><loc>${SITE_URL}/guide/</loc><changefreq>monthly</changefreq><priority>0.9</priority><lastmod>${today}</lastmod></url>\n`;
   urls += `  <url><loc>${SITE_URL}/guide/vs-claude-code/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>${today}</lastmod></url>\n`;
   urls += `  <url><loc>${SITE_URL}/reports/state-of-hermes-april-2026</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>\n`;
+  urls += `  <url><loc>${SITE_URL}/privacy</loc><changefreq>yearly</changefreq><priority>0.3</priority></url>\n`;
 
   for (const page of projectPages) {
     urls += `  <url><loc>${SITE_URL}/projects/${page.owner}/${page.repo}</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>${today}</lastmod></url>\n`;


### PR DESCRIPTION
## Summary
- ★ star this repo masthead badge on every page, live star count from /api/stars
- Post-content star CTA on handbook hub + vs-claude-code satellite + April report
- Brutalist newsletter form proxying to Beehiiv v2 via /api/subscribe (BEEHIIV_API_KEY env var already set on Vercel)
- Compact above-the-fold signup on homepage, handbook, vs-claude-code, April report
- 'newsletter' link added to top nav (anchors to /#newsletter)
- /privacy page covering data collection, processors, retention + footer link across every page

Note: removes the 'last sync' element from the homepage masthead; changes masthead star badge text from `★ atlas` to `★ star this repo`.

Bundles the work that was in #65 (star-the-repo CTA) — #65 closed as superseded.

## Test plan
- [x] Smoke test /api/subscribe end-to-end (test sub landed in Beehiiv)
- [x] Visual pass: light + dark themes, mobile + desktop
- [x] Privacy page renders, no personal email exposed
- [x] Preview deployment verified on the 4 hand-written content pages
- [ ] On merge: confirm CI rebuilds the 101 project/list pages with the new masthead + nav (auto-triggered by scripts/build-pages.js change)
- [ ] Post-merge: test-subscribe once on hermesatlas.com to confirm production path works

🤖 Generated with [Claude Code](https://claude.com/claude-code)