### PR TITLE
Fix duplicate separator + left-aligned newsletter on content pages

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -148,7 +148,7 @@ body::after {
 /* Email capture CTA — brutalist wrapper around Beehiiv iframe.
    Used on homepage, handbook hub, vs-claude-code satellite, April report. */
 .email-cta {
-  margin: var(--s-10) 0 var(--s-6);
+  margin: var(--s-10) auto var(--s-6);
   padding: var(--s-6);
   border: 1px solid var(--rule);
   background: var(--bg-elev);
@@ -272,7 +272,7 @@ body::after {
    Just kicker + form + status; no big title/lede. */
 .email-cta--compact {
   padding: var(--s-4) var(--s-5);
-  margin: var(--s-8) 0;
+  margin: var(--s-8) auto;
   max-width: 560px;
 }
 .email-cta--compact .email-cta-kicker { margin-bottom: var(--s-3); }

--- a/guide/index.html
+++ b/guide/index.html
@@ -657,8 +657,6 @@ hermes skills info &lt;name&gt;      # inspect before installing</code></pre>
 <pre><code>hermes update</code></pre>
 <p>Hermes self-updates. It tells you what changed, backs up your config, and applies the new version. Current release is v0.10.0 (as of 2026-04-20); the team ships roughly every two weeks.</p>
 
-<hr>
-
 <div class="article-footer">
   <p><strong>Written by <a href="https://x.com/ksimback">Kevin Simback</a></strong> · maintainer, Hermes Atlas</p>
   <p><strong>Last updated:</strong> 2026-04-20 · <strong>Next scheduled refresh:</strong> 2026-05-15</p>

--- a/guide/install/index.html
+++ b/guide/install/index.html
@@ -504,8 +504,6 @@ curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scri
 
 <p>Re-running the same curl command is safe — the installer is idempotent. If it fails a second time, fall back to the <a href="#manual-install">manual install</a> above.</p>
 
-<hr>
-
 <div class="article-footer">
   <p><strong>Written by <a href="https://x.com/ksimback">Kevin Simback</a></strong> · maintainer, Hermes Atlas</p>
   <p><strong>Last updated:</strong> 2026-04-23 · <strong>Next scheduled refresh:</strong> 2026-05-20 (or sooner if Nous ships a breaking installer change)</p>

--- a/guide/vs-claude-code/index.html
+++ b/guide/vs-claude-code/index.html
@@ -292,8 +292,6 @@
 <li><strong>Curious about the ecosystem?</strong> Read the <strong><a href="/reports/state-of-hermes-april-2026">State of Hermes — April 2026 report →</a></strong></li>
 </ul>
 
-<hr>
-
 <div class="article-footer">
   <p><strong>Written by <a href="https://x.com/ksimback">Kevin Simback</a></strong> · maintainer, Hermes Atlas</p>
   <p><strong>Last updated:</strong> 2026-04-20 · <strong>Next scheduled refresh:</strong> 2026-05-15</p>


### PR DESCRIPTION
## Summary
- Remove redundant \`<hr>\` immediately before \`<div class="article-footer">\` on /guide/, /guide/install/, /guide/vs-claude-code/ — the footer's own top border already serves that role, so we were rendering a visible double line.
- Change \`.email-cta\` and \`.email-cta--compact\` margin from \`<v> 0\` to \`<v> auto\` so the newsletter block centers instead of left-aligning below the centered article.

## Test plan
- [x] Visual pass on preview (install guide + handbook hub, dark + light)

🤖 Generated with [Claude Code](https://claude.com/claude-code)