### PR TITLE
Mark vectorize-io/hindsight as official

### DIFF
--- a/data/repos.json
+++ b/data/repos.json
@@ -276,7 +276,7 @@
     "description": "Agent memory that learns — long-term retain/recall/reflect workflows",
     "stars": 8362,
     "url": "https://github.com/vectorize-io/hindsight",
-    "official": false,
+    "official": true,
     "category": "Memory & Context"
   },
   {


### PR DESCRIPTION
Hindsight ships as one of the bundled memory providers in `NousResearch/hermes-agent` (plugin at `plugins/memory/hindsight/`). Proposing `official: true` on that basis.

Disclosure: I work at vectorize.io. Happy to defer to maintainer judgment on whether this fits the `official` criterion vs. a separate tag for bundled integrations.