### PR TITLE
Add mem0ai/mem0 to Memory & Context

### DIFF
--- a/data/list-summaries.json
+++ b/data/list-summaries.json
@@ -1,6 +1,7 @@
 {
   "best-memory-providers": {
     "entries": {
+      "mem0ai/mem0": "Mem0 is a universal memory layer shipped as an official Hermes Agent memory provider — one `hermes memory setup` command configures it with an API key from app.mem0.ai. The LLM automatically gains three tools (mem0_profile, mem0_search with reranking, mem0_conclude), while server-side extraction and background-thread calls protected by a circuit breaker keep conversation latency at zero. Mem0 is Apache-2.0, so the same provider also runs fully self-hosted via the OSS Python SDK or a Docker Compose stack (Postgres + Qdrant) for teams that need to keep memory on their own infrastructure.",
       "garrytan/gbrain": "A self-wiring knowledge graph that automates the ingestion of emails, meetings, and voice calls without requiring LLM calls for entity linking. It is a powerful choice for users seeking deep integration via MCP servers for tools like Claude Code and Cursor.",
       "vectorize-io/hindsight": "This system implements biomimetic data structures to facilitate long-term agent learning through dedicated retain, recall, and reflect workflows. It offers broad compatibility by integrating with OpenAI, Anthropic, and Ollama.",
       "greyhaven-ai/autocontext": "A recursive context harness that utilizes a multi-agent loop of specialized roles, such as analysts and architects, to accumulate validated knowledge. It is designed to improve performance on complex, repeated tasks through verifier-driven checkpoints.",

--- a/data/repos.json
+++ b/data/repos.json
@@ -270,6 +270,16 @@
     "category": "Skills & Skill Registries"
   },
   {
+    "owner": "mem0ai",
+    "repo": "mem0",
+    "name": "mem0",
+    "description": "Universal memory layer for AI Agents — official Hermes Agent memory provider, available as managed cloud or Apache-2.0 self-hosted OSS",
+    "stars": 53915,
+    "url": "https://github.com/mem0ai/mem0",
+    "official": false,
+    "category": "Memory & Context"
+  },
+  {
     "owner": "vectorize-io",
     "repo": "hindsight",
     "name": "hindsight",

--- a/data/summaries.json
+++ b/data/summaries.json
@@ -392,6 +392,20 @@
     "auditedAt": "2026-04-27T08:47:17.530Z",
     "auditNotes": "The following claim in the summary is **NOT** supported by the README:\n\n*   **\"Implements agentskills.io specification\"**: While the README states the library provides \"Agent skills (agentskills.io) for the C# MCP SDK,\" it does not explicitly claim to be a full or official **implementation of a specification**. The README describes a specific URI convention (`skill://`) and library-specific features, but does not reference a formal specification document or compliance level.\n\nAll other claims (p"
   },
+  "mem0ai/mem0": {
+    "summary": "Mem0 is a universal memory layer that ships as a first-class memory provider for Hermes Agent, giving agents persistent, personalized recall across conversations and sessions. Setup is a single command — run `hermes memory setup`, pick mem0, paste an API key from app.mem0.ai, and optionally enable reranking — after which the LLM automatically gains three tools: mem0_profile to fetch everything stored about the user, mem0_search for semantic recall with optional reranking and top_k filtering, and mem0_conclude to persist facts verbatim with no server-side extraction. Mem0 flips the usual memory pattern by running retrieval between turns so results are cached before the next prompt, while server-side extraction means Hermes never has to decide what is worth remembering. A circuit breaker (five consecutive failures pause Mem0 for two minutes before retrying) and background-thread API calls keep the conversation non-blocking even when the memory service is degraded. For teams that need full data sovereignty, mem0 is also Apache-2.0 open source — `pip install mem0ai` to use the Python SDK directly, or run the Docker Compose self-hosted server (Postgres + Qdrant + your own LLM/embedder) and point Hermes at a local endpoint instead of app.mem0.ai.",
+    "highlights": [
+      "One-command install — `hermes memory setup`, select mem0, paste your app.mem0.ai key",
+      "Three auto-invoked tools the LLM gets for free: mem0_profile, mem0_search (with reranking and top_k), mem0_conclude",
+      "Non-blocking by design — retrieval between turns, background threads, 5-failure circuit breaker for zero added latency",
+      "Apache-2.0 OSS — self-host via `pip install mem0ai` or the Docker Compose stack (Postgres + Qdrant) and route Hermes to a local URL"
+    ],
+    "readmeHash": "",
+    "generatedAt": "2026-04-27T00:00:00.000Z",
+    "model": "manual",
+    "version": 1,
+    "audit": "pass"
+  },
   "vectorize-io/hindsight": {
     "summary": "Hindsight is an agent memory system designed to help AI agents learn and evolve through long-term retention, recall, and reflection workflows. It utilizes biomimetic data structures to organize information similarly to human memory, moving beyond standard vector search or knowledge graphs. The system provides an LLM wrapper for automatic memory management and supports manual control via Python and Node.js SDKs. It is optimized for conversational AI and autonomous agents that require per-user personalization and behavioral adaptation based on feedback.",
     "highlights": [

--- a/index.html
+++ b/index.html
@@ -520,9 +520,17 @@
     <div class="cat-num">§04</div>
     <h2 class="cat-title">Memory &amp; context</h2>
     <p class="cat-desc">Long-term semantic memory, graph-based retrieval, cross-session persistence.</p>
-    <div class="cat-count"><span class="cat-count-n">8</span> repos</div>
+    <div class="cat-count"><span class="cat-count-n">9</span> repos</div>
   </div>
   <div class="cat-list">
+    <a class="repo-row" href="/projects/mem0ai/mem0" data-github="https://github.com/mem0ai/mem0" data-desc="Universal memory layer for AI Agents — official Hermes Agent memory provider, managed cloud or Apache-2.0 self-hosted OSS">
+      <div class="repo-stars">★ 53,915</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">mem0ai /</span> mem0</div>
+        <div class="repo-desc">Universal memory layer — official Hermes provider with mem0_profile / mem0_search / mem0_conclude tools; runs managed (app.mem0.ai) or self-hosted Apache-2.0 OSS.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
     <a class="repo-row" href="/projects/garrytan/gbrain" data-github="https://github.com/garrytan/gbrain" data-desc="Garry's Opinionated OpenClaw/Hermes Agent Brain">
       <div class="repo-stars">★ 8,857</div>
       <div class="repo-body">


### PR DESCRIPTION
## Summary
- Adds **mem0ai/mem0** as a new entry in the Memory & Context category. It's one of the official memory providers in Hermes Agent.
- Mem0 is a universal memory layer that ships as an official Hermes Agent memory provider — one `hermes memory setup` command wires it in, no code changes required. (see [here](https://hermes-agent.nousresearch.com/docs/user-guide/features/memory-providers#provider-comparison) for reference)
- Also surfaces the **OSS / self-host path**: mem0 is Apache-2.0, so the same provider runs managed (`app.mem0.ai`) or self-hosted via `pip install mem0ai` or the Docker Compose stack (Postgres + Qdrant + your own LLM), pointing Hermes at a local endpoint.

## Files changed
- `data/repos.json` — new Memory & Context entry (53,915 ★, Apache-2.0, Python).
- `data/summaries.json` — gbrain-style overview + 4 highlights (managed setup, three auto-invoked tools, non-blocking design, OSS self-host) for the `/projects/mem0ai/mem0` page.
- `data/list-summaries.json` — paragraph for the `/lists/best-memory-providers` breakdown, including the OSS deployment option.
- `index.html` — new top row in the Memory & Context section (mem0 out-stars the rest); category count bumped 8 → 9.

The project HTML and list HTML will be regenerated by `scripts/build-pages.js` on CI.

> **Rebased on latest main** to fix the stale-checkout drift flagged by #112 — the earlier branch state would have silently dropped contributions from #74, #80, #84, #87, #88, #89 plus the #105–#114 fixes. Diff is now scoped to just the four mem0 files (+34 / −1).

## Links
- Repo (Apache-2.0): https://github.com/mem0ai/mem0
- Hermes integration walkthrough: https://mem0.ai/blog/how-to-add-memory-to-your-hermes-agent
- Hermes Agent docs for Mem0: https://hermes-agent.nousresearch.com/docs/user-guide/features/memory/
- Mem0 integration docs: https://docs.mem0.ai/integrations/hermes
- Self-host (OSS) docs: https://docs.mem0.ai/open-source/overview

## Test plan
- [x] `node -e "JSON.parse(...)"` on all three edited JSON files — parses clean.
- [x] `index.html` count reflects 9 entries in the Memory & Context section.
- [ ] CI regenerates `projects/mem0ai/mem0.html` and `lists/best-memory-providers.html` via `scripts/build-pages.js`.