### PR TITLE
fix: remove duplicate newsletter form from /guide/ hub

### DIFF
--- a/guide/index.html
+++ b/guide/index.html
@@ -244,15 +244,6 @@
 
 <blockquote>Based on 93 ecosystem projects reviewed, 33 research sources, and the live GitHub repo. Updated monthly.</blockquote>
 
-<aside class="email-cta email-cta--compact" id="newsletter" aria-label="Newsletter signup">
-  <div class="email-cta-kicker">newsletter · free · 1–2× / month</div>
-  <form class="email-cta-form" data-email-form novalidate>
-    <input type="email" name="email" class="email-cta-input" placeholder="you@domain.com" required autocomplete="email" aria-label="Email address">
-    <button type="submit" class="email-cta-button">subscribe</button>
-  </form>
-  <p class="email-cta-status" role="status" aria-live="polite"></p>
-</aside>
-
 <h2>Table of contents</h2>
 
 <ol>
@@ -674,7 +665,7 @@ hermes skills info &lt;name&gt;      # inspect before installing</code></pre>
 </article>
 
 <!-- Email capture -->
-<aside class="email-cta" aria-label="Newsletter signup">
+<aside class="email-cta" id="newsletter" aria-label="Newsletter signup">
   <div class="email-cta-kicker">newsletter · free</div>
   <h2 class="email-cta-title">stay in the loop</h2>
   <p class="email-cta-lede">new research, reports, and project drops from across the Hermes ecosystem — 1–2× per month. no spam.</p>


### PR DESCRIPTION
## Summary
The compact newsletter block sat between the byline blockquote and the TOC — premature placement and redundant with the full-width newsletter aside at the bottom of the page. Removes the top block and moves its `id="newsletter"` to the bottom aside so `/#newsletter` nav anchor still resolves on the handbook page.

Before: two forms (top compact + bottom full).
After: one form (bottom full), with the anchor id preserved.

## Test plan
- [x] Single newsletter block remains at line 668
- [x] `id="newsletter"` transferred to the bottom aside
- [ ] Post-merge: confirm `/guide/#newsletter` on the live site scrolls to the bottom form

🤖 Generated with [Claude Code](https://claude.com/claude-code)