### PR TITLE
ci: serialize bot-push workflows via concurrency group

### DIFF
--- a/.github/workflows/audit-summaries.yml
+++ b/.github/workflows/audit-summaries.yml
@@ -1,5 +1,9 @@
 name: Audit Summaries
 
+concurrency:
+  group: main-bot-push
+  cancel-in-progress: false
+
 on:
   schedule:
     - cron: '0 8 * * 1'  # Every Monday at 08:00 UTC

--- a/.github/workflows/build-pages.yml
+++ b/.github/workflows/build-pages.yml
@@ -1,5 +1,9 @@
 name: Build Project & List Pages
 
+concurrency:
+  group: main-bot-push
+  cancel-in-progress: false
+
 on:
   schedule:
     - cron: '30 6 * * *'  # Daily at 06:30 UTC (30 min after release-monitor)

--- a/.github/workflows/rebuild-chunks.yml
+++ b/.github/workflows/rebuild-chunks.yml
@@ -1,5 +1,9 @@
 name: Rebuild Knowledge Base Chunks
 
+concurrency:
+  group: main-bot-push
+  cancel-in-progress: false
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
## Summary

Three workflows push bot commits to `main`: `build-pages`, `rebuild-chunks`, `audit-summaries`. When two fire on the same merge commit (common when a PR touches both `data/repos.json` AND `research/`), they race — whichever pushes second gets rejected with `! [rejected] main -> main (fetch first)` and the workflow reports failure.

The "failure" has zero user impact (the lost commit is always redundant with what already merged), but it generates noisy emails like the "All jobs have failed" notification received after PR #94 merged.

## Fix

Add a shared concurrency group to all three workflows:

```yaml
concurrency:
  group: main-bot-push
  cancel-in-progress: false
```

- `group: main-bot-push` — all three workflows share the same group, so GitHub Actions serializes them.
- `cancel-in-progress: false` — we want both to run, just not simultaneously. Second queues until first finishes.

## Evidence of the problem

Race observed on last 3 PR merges:
- `e5b852a` (PR #94): chunks succeeded, pages failed
- `e36aaff` (PR #89): chunks succeeded, pages failed
- `8283fde` (PR #92): pages succeeded, chunks failed

## Test plan

- [x] YAML syntax valid (three workflow files still parse)
- [ ] Post-merge: next PR that touches both `data/repos.json` and `research/` will trigger both workflows; second should now queue cleanly instead of failing to push. Expected next trigger: next bot-merged repo-suggestion PR (e.g., if we resolve PR #79 conflicts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)