### PR TITLE
Polish Ask Atlas chat widget UI

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -569,7 +569,7 @@
   width: min(420px, calc(100vw - 48px));
   max-height: min(640px, calc(100vh - 120px));
   background: var(--bg);
-  border: 1px solid var(--rule-strong);
+  border: 2px solid var(--ink);
   z-index: 900;
   display: none;
   flex-direction: column;
@@ -604,7 +604,7 @@
 .chat-header-actions button {
   font-family: var(--font-mono);
   font-size: 13px;
-  color: var(--ink-mute);
+  color: var(--ink-dim);
   padding: 4px 8px;
 }
 .chat-header-actions button:hover { color: var(--ink); }
@@ -668,6 +668,7 @@
 .chat-input-wrap {
   display: flex;
   gap: 0;
+  padding: 0 20px;
   border-top: 1px solid var(--rule-strong);
 }
 #chat-input {


### PR DESCRIPTION
## Summary
Three CSS-only fixes to `assets/css/index.css` addressing visible issues in the Ask Atlas chat widget on both dark and light themes:

- **Panel border blends into bg** → `1px solid var(--rule-strong)` → `2px solid var(--ink)`. Hard brutalist edge that separates the widget from the page on both `#0e0d0b` dark paper and `#f4f0e4` light paper.
- **Clear/close buttons hard to read** → `.chat-header-actions button` color `--ink-mute` → `--ink-dim`. Contrast jumps from ~3:1 to ~11:1 on both themes; hover state unchanged (still `--ink`).
- **Input row wider than results column** → `.chat-input-wrap` gains `padding: 0 20px`, matching `#chat-messages`'s 20px horizontal gutter so the input/send bar stops extending past the message column.

Net diff: 3 lines changed in one file. No JS, no markup, no rebuild needed.

## Test plan
- [ ] Dark mode: open widget on `/`, confirm panel border is crisp against paper bg
- [ ] Light mode: toggle theme, confirm same
- [ ] Dark mode: clear/close buttons are clearly readable at rest (not just on hover)
- [ ] Input bar left/right edges align with message column padding
- [ ] Mobile (<900px): panel still fits viewport and input alignment holds

🤖 Generated with [Claude Code](https://claude.com/claude-code)