### PR TITLE
Ask Atlas dark-mode panel: white bg instead of amber

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -590,15 +590,17 @@
   flex-direction: column;
 }
 :root[data-theme="dark"] #chat-panel {
-  --chat-bg: var(--accent);       /* amber panel */
-  --chat-ink: #0e0d0b;             /* dark ink on amber */
-  --chat-ink-dim: #1a1814;
-  --chat-ink-mute: #3d3830;
-  --chat-rule: #0e0d0b;            /* dark rules on amber */
-  --chat-rule-soft: #3d3830;
-  --chat-accent: #0e0d0b;          /* amber bg means accent flips to dark for contrast */
-  --chat-accent-bg: rgba(0, 0, 0, 0.08);
-  --chat-border: #0e0d0b;
+  /* Same white-panel look as light mode (stands out against black page bg).
+     Ink + rules kept dark so text is legible on white, regardless of page theme. */
+  --chat-bg: #ffffff;
+  --chat-ink: #1a1814;
+  --chat-ink-dim: #3d3830;
+  --chat-ink-mute: #8a8378;
+  --chat-rule: #b8b2a0;
+  --chat-rule-soft: #d9d3c2;
+  --chat-accent: #a36f28;           /* amber ink for links/send on white */
+  --chat-accent-bg: #f4f0e4;        /* subtle paper tint for user bubbles + code */
+  --chat-border: #1a1814;
 }
 #chat-panel.open { display: flex; }
 


### PR DESCRIPTION
Post-#102 iteration per Kevin's feedback — amber panel in dark mode was too loud. Reverting dark-mode panel to white (same as light). Keeps the chat widget readable against any page theme while still contrasting against the black page bg in dark mode.

Only change: the 9-property `:root[data-theme="dark"] #chat-panel` override. Light mode is untouched.