### PR TITLE
Fix workflow git-push race + restore release-monitor cache bust

### DIFF
--- a/.github/workflows/audit-summaries.yml
+++ b/.github/workflows/audit-summaries.yml
@@ -38,9 +38,23 @@ jobs:
           git add data/summaries.json
           if git diff --cached --quiet; then
             echo "No changes to commit"
-          else
-            git config user.name "Hermes Atlas Bot"
-            git config user.email "bot@hermesatlas.com"
-            git commit -m "Audit: flag stale/hallucinated summaries for regeneration"
-            git push
+            exit 0
           fi
+          git config user.name "Hermes Atlas Bot"
+          git config user.email "bot@hermesatlas.com"
+          git commit -m "Audit: flag stale/hallucinated summaries for regeneration"
+
+          # main can move during the audit (PR merge, another bot workflow
+          # committing) — vanilla `git push` then fails with
+          # `! [rejected] main -> main (fetch first)`. Retry up to 3 times,
+          # rebasing onto the new remote tip between attempts.
+          for attempt in 1 2 3; do
+            if git push; then
+              echo "Pushed on attempt $attempt"
+              exit 0
+            fi
+            echo "Push rejected (attempt $attempt) — pulling --rebase and retrying"
+            git pull --rebase origin main || { echo "Rebase failed — aborting"; exit 1; }
+          done
+          echo "Push failed after 3 attempts"
+          exit 1

--- a/.github/workflows/build-pages.yml
+++ b/.github/workflows/build-pages.yml
@@ -64,7 +64,21 @@ jobs:
           git config user.name "Hermes Atlas Bot"
           git config user.email "bot@hermesatlas.com"
           git commit -m "Rebuild project pages (${{ steps.diff.outputs.pages }} projects, ${{ steps.diff.outputs.lists }} lists)"
-          git push
+
+          # main can move during a multi-minute build (PR merge, another
+          # bot workflow committing) — vanilla `git push` then fails with
+          # `! [rejected] main -> main (fetch first)`. Retry up to 3 times,
+          # rebasing onto the new remote tip between attempts.
+          for attempt in 1 2 3; do
+            if git push; then
+              echo "Pushed on attempt $attempt"
+              exit 0
+            fi
+            echo "Push rejected (attempt $attempt) — pulling --rebase and retrying"
+            git pull --rebase origin main || { echo "Rebase failed — aborting"; exit 1; }
+          done
+          echo "Push failed after 3 attempts"
+          exit 1
 
       - name: Ping IndexNow with changed URLs
         if: steps.diff.outputs.changed == 'true'

--- a/.github/workflows/rebuild-chunks.yml
+++ b/.github/workflows/rebuild-chunks.yml
@@ -57,4 +57,18 @@ jobs:
           git config user.email "bot@hermesatlas.com"
           git add data/chunks.json
           git commit -m "Rebuild knowledge base chunks (${{ steps.diff.outputs.count }} chunks)"
-          git push
+
+          # main can move during a multi-minute build (PR merge, another
+          # bot workflow committing) — vanilla `git push` then fails with
+          # `! [rejected] main -> main (fetch first)`. Retry up to 3 times,
+          # rebasing onto the new remote tip between attempts.
+          for attempt in 1 2 3; do
+            if git push; then
+              echo "Pushed on attempt $attempt"
+              exit 0
+            fi
+            echo "Push rejected (attempt $attempt) — pulling --rebase and retrying"
+            git pull --rebase origin main || { echo "Rebase failed — aborting"; exit 1; }
+          done
+          echo "Push failed after 3 attempts"
+          exit 1

--- a/.github/workflows/release-monitor.yml
+++ b/.github/workflows/release-monitor.yml
@@ -227,12 +227,18 @@ jobs:
 
       - name: Bust stars API cache so site shows new version immediately
         if: steps.check.outputs.new_release == 'true'
+        env:
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
         run: |
           # The /api/stars endpoint caches GitHub results in Redis with a 1hr
           # TTL. Passing ?cron=1 bypasses the cache read and writes a fresh
           # snapshot — so the masthead "Latest" stat picks up the new version
           # on the next site visit rather than waiting up to an hour.
-          code=$(curl -s -o /dev/null -w "%{http_code}" "https://hermesatlas.com/api/stars?cron=1")
+          # Cache-bypass is now auth-gated; we send the same Bearer token
+          # that Vercel Cron sends on its scheduled invocations.
+          code=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "Authorization: Bearer ${CRON_SECRET}" \
+            "https://hermesatlas.com/api/stars?cron=1")
           echo "Cache refresh returned HTTP $code"
           if [ "$code" != "200" ]; then
             echo "::warning::Cache bust returned non-200; site may briefly show stale version"


### PR DESCRIPTION
## Summary

Two fixes flushed out by reading the workflow files after yesterday's review:

1. **Restore release-monitor cache-bust.** Yesterday's PR #105 added Authorization checks on `/api/stars?cron=...`, but missed updating `release-monitor.yml` — its post-release cache-bust step would have started silently failing. Adds the `Authorization: Bearer ${CRON_SECRET}` header to match what Vercel Cron sends on its own scheduled invocations.

2. **Retry git push with rebase.** Bot workflows that push to main have been failing on `! [rejected] main -> main (fetch first)` errors — 14 confirmed failures in the last 11 days (most recent: build-pages run `24892509178` on 2026-04-24). Concurrency groups serialize bot-vs-bot, but main can still move during a multi-minute run via human PR merges or another bot's commit. Each pushing step now retries up to 3 times, rebasing onto the new remote tip between attempts.

The original review claimed concurrency groups don't serialize across workflows — that was wrong (they do). The actual race is workflow-vs-external-push during the run window. Empirically validated against the failure log before fixing.

## ⚠️ Required before merge

- [ ] **Add `CRON_SECRET` as a GitHub Actions repo secret** (Settings → Secrets and variables → Actions → New repository secret). Use the same value you set in Vercel yesterday. Without this, the release-monitor cache-bust will get an empty Bearer token and continue to 401.

## Test plan

- [ ] Verify CI workflows still parse (Vercel preview build will catch YAML errors)
- [ ] After merge, on next bot-driven push to main: watch for the `Pushed on attempt N` log line — confirms the new code path runs
- [ ] After next Hermes release: confirm `Cache refresh returned HTTP 200` in release-monitor logs (was silently 401-able post-#105)
- [ ] Monitor failure rate over the next ~week — expect drop from ~1/day to ~0 for non-fast-forward errors

## What's NOT in this PR

Other 🟡 High-tier review items still queued: build-pages atomicity (no temp-dir rename), chunk ID instability, GraphQL silent fallback, history off-by-one, summary retry/backoff. Tackle in subsequent PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)