### PR TITLE
Build pipeline: fail loudly + retry transient OpenRouter errors

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -78,12 +78,18 @@ export async function fetchAllMetadata(repos, headers) {
     body: JSON.stringify({ query }),
   });
 
+  // Throw on failure so the caller (build-pages.js) fails loudly. Returning {}
+  // here would silently regenerate every page with no stars/descriptions and
+  // commit the broken output. Production stays on the last good build instead.
   if (!res.ok) {
-    console.error(`GraphQL error: ${res.status}`);
-    return {};
+    const body = await res.text().catch(() => "");
+    throw new Error(`GitHub GraphQL ${res.status}: ${body.slice(0, 200)}`);
   }
 
   const data = await res.json();
+  if (data.errors) {
+    throw new Error(`GitHub GraphQL errors: ${JSON.stringify(data.errors).slice(0, 300)}`);
+  }
   const metadata = {};
 
   repos.forEach((r, i) => {

--- a/lib/openrouter.js
+++ b/lib/openrouter.js
@@ -8,28 +8,12 @@ const FALLBACK_MODELS = [
   "google/gemini-3-flash-preview",
 ];
 
-/**
- * Call OpenRouter with automatic model fallback.
- *
- * @param {Object} options
- * @param {string} options.system - System prompt
- * @param {string} options.user - User prompt
- * @param {string} options.apiKey - OpenRouter API key
- * @param {string[]} [options.models] - Model fallback chain (max 3)
- * @param {number} [options.maxTokens=800] - Max output tokens
- * @returns {Promise<string>} Raw response text
- */
-export async function callOpenRouter({
-  system,
-  user,
-  apiKey,
-  models,
-  maxTokens = 800,
-}) {
-  if (!apiKey) throw new Error("OpenRouter API key required");
+// Exponential backoff for transient failures: 1s, 2s, 4s between retries.
+// Total max wait is ~7s — small enough not to balloon CI runtime, large
+// enough to ride out a typical 429 burst or brief upstream blip.
+const RETRY_DELAYS_MS = [1000, 2000, 4000];
 
-  const modelChain = models || [PRIMARY_MODEL, ...FALLBACK_MODELS];
-
+async function callOpenRouterOnce({ system, user, apiKey, modelChain, maxTokens }) {
   const res = await fetch("https://openrouter.ai/api/v1/chat/completions", {
     method: "POST",
     headers: {
@@ -52,7 +36,9 @@ export async function callOpenRouter({
 
   if (!res.ok) {
     const body = await res.text().catch(() => "");
-    throw new Error(`OpenRouter ${res.status}: ${body.slice(0, 200)}`);
+    const err = new Error(`OpenRouter ${res.status}: ${body.slice(0, 200)}`);
+    err.status = res.status;
+    throw err;
   }
 
   const data = await res.json();
@@ -60,6 +46,56 @@ export async function callOpenRouter({
   if (!content) throw new Error("Empty response from OpenRouter");
 
   return content;
+}
+
+/**
+ * Call OpenRouter with automatic model fallback and retry on transient errors.
+ *
+ * Retries on 429 (rate limit), 5xx (server error), and network failures.
+ * Does NOT retry on 4xx (bad request, missing key, etc.) — those are caller bugs.
+ *
+ * @param {Object} options
+ * @param {string} options.system - System prompt
+ * @param {string} options.user - User prompt
+ * @param {string} options.apiKey - OpenRouter API key
+ * @param {string[]} [options.models] - Model fallback chain (max 3)
+ * @param {number} [options.maxTokens=800] - Max output tokens
+ * @returns {Promise<string>} Raw response text
+ */
+export async function callOpenRouter({
+  system,
+  user,
+  apiKey,
+  models,
+  maxTokens = 800,
+}) {
+  if (!apiKey) throw new Error("OpenRouter API key required");
+
+  const modelChain = models || [PRIMARY_MODEL, ...FALLBACK_MODELS];
+  const args = { system, user, apiKey, modelChain, maxTokens };
+
+  let lastError;
+  for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt++) {
+    try {
+      return await callOpenRouterOnce(args);
+    } catch (err) {
+      lastError = err;
+
+      // Retryable: HTTP 429, any 5xx, or no status (network/DNS/timeout).
+      // Non-retryable: 4xx other than 429 (auth, malformed prompt, etc.).
+      const isRetryable = !err.status || err.status === 429 || err.status >= 500;
+      const isLastAttempt = attempt === RETRY_DELAYS_MS.length;
+
+      if (!isRetryable || isLastAttempt) throw err;
+
+      const delay = RETRY_DELAYS_MS[attempt];
+      console.warn(
+        `OpenRouter ${err.status || "network error"} — retrying in ${delay}ms (attempt ${attempt + 1}/${RETRY_DELAYS_MS.length})`
+      );
+      await new Promise((r) => setTimeout(r, delay));
+    }
+  }
+  throw lastError; // unreachable, but keeps TS/lints happy
 }
 
 /**


### PR DESCRIPTION
## Summary

Two 🟡 High-tier items from yesterday's review, both about CI reliability when external APIs misbehave:

1. **`lib/github.js` — throw instead of returning `{}` on GraphQL failure.** Previously, a 401/403/5xx from GitHub silently produced an empty metadata map; build-pages then regenerated all 100+ project pages with missing stars/descriptions and committed the broken output. Now throws, the script exits 1, the workflow fails, production stays on the previous good build.

2. **`lib/openrouter.js` — exponential-backoff retry on 429/5xx/network.** A single transient OpenRouter blip during `generate-summaries.js` previously meant one missing summary that stayed missing ≥24h. Now retries up to 3 times (1s/2s/4s backoff). Doesn't retry 4xx-other-than-429 (those are caller bugs, no point waiting).

Note: `api/chat.js` makes its own fetch directly to OpenRouter and is unaffected. We don't want to add retry latency on top of streaming user-facing LLM calls.

## Test plan

- [ ] Verify Vercel preview build is clean
- [ ] After merge, monitor next `build-pages` run for the GraphQL error path — should fail loudly if GitHub has issues
- [ ] After merge, monitor `generate-summaries.js` logs for `OpenRouter 429 — retrying in 1000ms` lines if rate limits hit; expect fewer `FAILED ${repo}` lines over time
- [ ] Sanity check: chat API still works on production (it's not using the retry helper, so should be unchanged)

## What's NOT in this PR

I checked all six remaining 🟡 High items from the review and found two are not actually bugs:
- **build-pages partial writes** — the CI workflow is the transaction layer; if the script fails mid-run, no commit happens.
- **Chunk ID instability** — `build-chunks.js` has no embedding cache, so unstable IDs don't cause spurious re-embedding. Full rebuild costs ~$0.005 anyway.

Going to PR 4 next: email regex tightening + 7-day star delta off-by-one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)