### PR TITLE
Polish: tighter email regex + honest weekly star delta

### DIFF
--- a/api/subscribe.js
+++ b/api/subscribe.js
@@ -1,7 +1,11 @@
 const PUBLICATION_ID = "pub_cd668a5c-262b-4dd2-882b-6fb542d1a85a";
 const BEEHIIV_URL = `https://api.beehiiv.com/v2/publications/${PUBLICATION_ID}/subscriptions`;
 
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+// Local part: letters/digits and the safe-printable subset of RFC 5322;
+// domain labels: letters/digits/hyphens; TLD: ≥2 letters (excludes numeric
+// or single-char TLDs like .x or .123). Beehiiv does its own validation
+// downstream — this just blocks obvious garbage and avoids a wasted API call.
+const EMAIL_RE = /^[a-zA-Z0-9._+-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.[a-zA-Z]{2,}$/;
 
 function json(res, status, body) {
   res.status(status).setHeader("Content-Type", "application/json");

--- a/api/subscribe.js
+++ b/api/subscribe.js
@@ -1,11 +1,13 @@
 const PUBLICATION_ID = "pub_cd668a5c-262b-4dd2-882b-6fb542d1a85a";
 const BEEHIIV_URL = `https://api.beehiiv.com/v2/publications/${PUBLICATION_ID}/subscriptions`;
 
-// Local part: letters/digits and the safe-printable subset of RFC 5322;
-// domain labels: letters/digits/hyphens; TLD: ≥2 letters (excludes numeric
-// or single-char TLDs like .x or .123). Beehiiv does its own validation
-// downstream — this just blocks obvious garbage and avoids a wasted API call.
-const EMAIL_RE = /^[a-zA-Z0-9._+-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.[a-zA-Z]{2,}$/;
+// Local part: letters/digits + the punctuation that actually appears in
+// real-world addresses (`. _ - + '`). RFC 5322 technically allows more
+// (`!#$%&*/=?^`{|}~`) but those are vanishingly rare and skipping them
+// blocks obvious garbage. Domain labels: letters/digits/hyphens; TLD:
+// ≥2 letters (rejects `.x` and `.123`). Beehiiv does its own validation
+// downstream — this just avoids wasted API calls on clearly bad input.
+const EMAIL_RE = /^[a-zA-Z0-9._'+\-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.[a-zA-Z]{2,}$/;
 
 function json(res, status, body) {
   res.status(status).setHeader("Content-Type", "application/json");

--- a/index.html
+++ b/index.html
@@ -1263,9 +1263,14 @@
       const deltas = {};
       const growthPct = {};
       for (const [key, series] of Object.entries(timeSeries)) {
-        if (series.length < 2) continue;
+        // Require 8 snapshots (= 7 full days, since cron runs daily) before
+        // showing weekly growth. Previously fell back to series[0] when
+        // history was sparse, which mislabeled "since first snapshot" as
+        // "weekly" — inflating trending badges during the first week of
+        // tracking or after data gaps.
+        if (series.length < 8) continue;
         const current = series[series.length - 1];
-        const weekAgo = series[Math.max(0, series.length - 8)] || series[0];
+        const weekAgo = series[series.length - 8];
         const delta = current - weekAgo;
         deltas[key] = delta;
         if (weekAgo > 0) growthPct[key] = (delta / weekAgo) * 100;


### PR DESCRIPTION
## Summary

Last two 🟡 High items from yesterday's review, both small and isolated:

1. **`api/subscribe.js` — tightened the email regex.** The previous `/^[^\s@]+@[^\s@]+\.[^\s@]+$/` accepted `a@b.x` and `a@b.123`. Replaced with an ASCII-restricted pattern requiring a ≥2-letter TLD. Beehiiv does its own validation downstream — this just blocks obvious garbage before the upstream POST. Not a security fix — the review's "phishing via IDN" framing didn't apply to a newsletter signup endpoint.

2. **`index.html` — fixed the dishonest "weekly" star delta.** With <8 snapshots, the homepage previously fell back to `series[0]` and labeled the result as weekly growth — which it wasn't. Trending badges showed inflated values during the first week of tracking and after any data gap. Now the calculation is skipped entirely until we have 7 full days of data.

## Test plan

- [ ] Vercel preview deploy clean
- [ ] Visit preview homepage; trending badges should still appear normally for repos with full history
- [ ] After merge, check `https://hermesatlas.com` — trending section should look identical (we have ≥7 days of history for everything)
- [ ] Email subscribe form on production — submit a real email, confirm normal flow still works

## Closes the 🟡 High tier

With this PR merged, all 🟡 High-tier review items are resolved (or, in the case of build-pages atomicity and chunk ID instability, validated as not-actually-bugs). 🟢 Medium tier deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)