### PR TITLE
Close stale-content windows: audit→regen chain + chat quota signal

### DIFF
--- a/.github/workflows/audit-summaries.yml
+++ b/.github/workflows/audit-summaries.yml
@@ -28,10 +28,21 @@ jobs:
         run: npm install
 
       - name: Run summary audit
+        id: audit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-        run: node scripts/audit-summaries.js
+        run: |
+          node scripts/audit-summaries.js
+          # Capture whether anything was flagged so the next step can decide
+          # whether to trigger immediate regeneration. The audit clears
+          # readmeHash on flagged entries, so a non-empty diff in
+          # data/summaries.json means something was flagged.
+          if git diff --quiet data/summaries.json; then
+            echo "flagged=false" >> $GITHUB_OUTPUT
+          else
+            echo "flagged=true" >> $GITHUB_OUTPUT
+          fi
 
       - name: Commit if flagged
         run: |
@@ -51,10 +62,25 @@ jobs:
           for attempt in 1 2 3; do
             if git push; then
               echo "Pushed on attempt $attempt"
-              exit 0
+              break
             fi
             echo "Push rejected (attempt $attempt) — pulling --rebase and retrying"
             git pull --rebase origin main || { echo "Rebase failed — aborting"; exit 1; }
+            if [ "$attempt" = "3" ]; then
+              echo "Push failed after 3 attempts"
+              exit 1
+            fi
           done
-          echo "Push failed after 3 attempts"
-          exit 1
+
+      - name: Trigger build-pages to regenerate flagged summaries
+        if: steps.audit.outputs.flagged == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Without this dispatch, flagged-as-hallucinated summaries stay
+          # live until the next daily build-pages cron — up to ~22 hours
+          # of stale content for what the audit just identified as wrong.
+          # Triggering build-pages immediately closes that window to the
+          # length of one build run (~3 minutes).
+          gh workflow run build-pages.yml
+          echo "Dispatched build-pages.yml to regenerate flagged summaries"

--- a/index.html
+++ b/index.html
@@ -1471,7 +1471,15 @@
     try {
       const trimmed = chatHistory.slice(-CHAT_MAX_SAVED);
       localStorage.setItem(CHAT_STORAGE_KEY, JSON.stringify(trimmed));
-    } catch {}
+    } catch (e) {
+      // Previously `catch {}` swallowed everything — including
+      // QuotaExceededError on full-storage devices, where the user's
+      // chat history would silently vanish on reload. Logging gives at
+      // least a console signal so this isn't invisible if it ever fires.
+      if (e?.name === 'QuotaExceededError') {
+        console.warn('[chat] localStorage quota exceeded — chat history will not persist this session');
+      }
+    }
   }
 
   function clearChatHistory() {


### PR DESCRIPTION
## Summary

Last two real items from the 🟢 Medium tier (others are bigger refactors better done as roadmap-time work). Bundled because both are small and unrelated.

1. **`audit-summaries.yml` — chain to `build-pages` on flag.** The weekly audit flagged hallucinated summaries by clearing `readmeHash`, but regeneration only happened on the next daily build-pages cron — leaving flagged content live for up to ~22h. Now the audit dispatches `build-pages.yml` immediately when anything is flagged. Stale window drops to ~3 min (one build run).

2. **`index.html` — surface localStorage `QuotaExceededError`.** The chat widget's `saveChatHistory()` had a bare `catch {}` that swallowed quota errors. Users on full-storage devices saw chat work in-session, then lose all history on reload with no signal. Now a console warn fires on `QuotaExceededError` only; other exceptions still pass silently (they'd be unactionable).

## Test plan

- [ ] Vercel preview deploy clean
- [ ] Next time `audit-summaries` runs (Mondays 08:00 UTC), confirm it dispatches `build-pages` if anything is flagged. The audit log already prints flag reasons; new "Dispatched build-pages.yml..." line confirms the chain.
- [ ] Chat widget on production still saves history normally (most users have plenty of localStorage)

## What's NOT in this PR (intentionally deferred)

The remaining medium-tier items are real but disproportionate-effort:
- **Centralize hardcoded version/month constants** — review said 8 files; grep finds 20+ touchpoints, most of which are editorial body text in handbook pages that wouldn't auto-update from a constants file anyway. Real refactor across many files.
- **Extract chat widget out of `index.html` (94KB)** — large refactor with subtle breakage risk; better when actively touching the homepage.
- **Split `build-pages.js` (1,035 lines, 6 jobs)** — same; do when touching it for a feature.
- **`chunks.json` cold-start memory (14MB)** — only affects Vercel cold-start time; not user-visible. Defer until it actually causes problems.
- **`llms-full.txt` size cap planning (198KB / 1MB cap)** — premature; lots of headroom.

## Status after this merges

- 🔴 Critical (7) — all shipped
- 🟡 High (7) — all shipped or invalidated
- 🟢 Medium (~7) — 2 shipped, 5 deferred to roadmap-time

Cleanup arc complete. Ready to return to roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)