### PR TITLE
Cache-bust homepage og:image so X re-fetches new design

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,13 +11,18 @@
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://hermesatlas.com/">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=Hermes+Agent&amp;subtitle=The+Community+Ecosystem+Map+-+100%2B+tools%2C+skills%2C+plugins">
+<!-- The &v=YYYYMMDD on og:image / twitter:image is a cache-buster for X /
+     Facebook / LinkedIn, which key their preview-image cache on the URL
+     string. /api/og ignores unknown query params, so the renderer is
+     unaffected. Bump this value any time the OG template design changes
+     so social platforms re-fetch instead of serving the old cached image. -->
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=Hermes+Agent&amp;subtitle=The+Community+Ecosystem+Map+-+100%2B+tools%2C+skills%2C+plugins&amp;v=20260425">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Hermes Agent — The Community Ecosystem Map">
 <meta name="twitter:description" content="The community-curated map for Hermes Agent by Nous Research. 100+ tools, skills, plugins &amp; integrations — quality-filtered, live GitHub data.">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Hermes+Agent&amp;subtitle=The+Community+Ecosystem+Map+-+100%2B+tools%2C+skills%2C+plugins">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Hermes+Agent&amp;subtitle=The+Community+Ecosystem+Map+-+100%2B+tools%2C+skills%2C+plugins&amp;v=20260425">
 <meta name="twitter:url" content="https://hermesatlas.com/">
 <link rel="alternate" type="application/rss+xml" title="Hermes Atlas — new projects" href="/rss.xml">
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' fill='%23d49a4f'/><text x='16' y='23' font-family='Space Grotesk,sans-serif' font-size='22' font-weight='700' fill='%230e0d0b' text-anchor='middle'>H</text></svg>">


### PR DESCRIPTION
## Summary

X (and other social platforms) keys their preview-image cache on the `og:image` URL string. Our homepage `og:image` is `/api/og?title=...&subtitle=...` — the URL was unchanged when the OG template was redesigned, so X kept serving the old cached PNG.

Adding `&v=20260425` to `og:image` and `twitter:image`. `/api/og` only reads `title` and `subtitle` from the query string and ignores unknown params, so the rendered image is unaffected. X sees a "new" URL and fetches fresh.

Comment added in the source explaining when to bump the value.

## Aside

Grok's diagnosis was wrong on the main claim — the meta tags are present in the raw HTML and visible to crawlers. Verified with `curl -A "Twitterbot/1.0" https://hermesatlas.com/`. Only Grok's cache-bust suggestion was correct.

## Test plan

- [ ] Vercel preview deploy clean
- [ ] After merge, paste `https://hermesatlas.com/` into a new X post composer (don't post). Wait 5–10s. Preview card should show the new design.
- [ ] If X still shows old cached version: composer-paste trick sometimes needs a couple tries; failing that, X usually re-fetches within ~24h once the URL changes

## What's NOT in this PR

Project pages (`projects/*/*.html`, regenerated by `build-pages.js`) and guide pages (`guide/*/index.html`, hand-written) still point at the un-versioned `/api/og?...`. They're less commonly shared, so leaving alone for now. If their previews ever go stale visibly, easy follow-up: add the `v=` param to the build-pages template + edit the 3 guide pages by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)