### PR TITLE
Add hermes-nextcloud - Hermes Agent skill for Nextcloud

### DIFF
--- a/data/repos.json
+++ b/data/repos.json
@@ -998,5 +998,15 @@
     "url": "https://github.com/AxDSan/mnemosyne",
     "official": false,
     "category": "Memory & Context"
+  },
+  {
+    "owner": "adnw-vinc",
+    "repo": "hermes-nextcloud",
+    "name": "hermes-nextcloud",
+    "description": "Hermes Agent skill for Nextcloud - manage files, notes, calendar, tasks, and contacts via WebDAV and CalDAV",
+    "stars": 1,
+    "url": "https://github.com/adnw-vinc/hermes-nextcloud",
+    "official": false,
+    "category": "Skills & Skill Registries"
   }
 ]


### PR DESCRIPTION
## Add hermes-nextcloud

**Repository:** https://github.com/adnw-vinc/hermes-nextcloud

**Category:** Skills & Skill Registries

**Description:** Hermes Agent skill for Nextcloud - manage files, notes, calendar, tasks, and contacts via WebDAV and CalDAV. Self-hosted Nextcloud integration with guided setup, timezone configuration, and CalDAV/CardDAV support.

**Why it belongs on the map:**
Full-featured Nextcloud integration for Hermes Agent — covers WebDAV files, Notes API, CalDAV calendar/events, CardDAV contacts, and Tasks. Works with any self-hosted Nextcloud instance. Addresses a common use case (self-hosted cloud storage) that wasn't covered by existing skills.

**Maturity:** beta (functional, tested against real Nextcloud instance, comprehensive README with usage examples)
