### PR TITLE
Fix validate-repo-suggestion stale-base bug

### DIFF
--- a/.github/workflows/validate-repo-suggestion.yml
+++ b/.github/workflows/validate-repo-suggestion.yml
@@ -252,7 +252,6 @@ jobs:
           INFERRED_CATEGORY: ${{ steps.metadata.outputs.inferred_category }}
         with:
           script: |
-            const fs = require('fs');
             const owner = process.env.REPO_OWNER;
             const repo = process.env.REPO_NAME;
             const stars = parseInt(process.env.REPO_STARS) || 0;
@@ -264,8 +263,24 @@ jobs:
               category = process.env.INFERRED_CATEGORY || 'Developer Tools';
             }
 
-            // Read current repos.json
-            const repos = JSON.parse(fs.readFileSync('data/repos.json', 'utf-8'));
+            // Always source repos.json from the LATEST main via API, not from
+            // the workflow's local checkout. The checkout happens at the start
+            // of the run; if any other PR merges to main during this run
+            // (auto-PRs from concurrent issue submissions, manual merges,
+            // etc.) the local copy is stale. Committing stale content on a
+            // branch based on latest main means the squash-merge later
+            // silently drops everything that landed in the gap. PR #89 hit
+            // exactly this and lost AxDSan/mnemosyne; PR #79 (mem0) is still
+            // DIRTY for the same reason.
+            const { data: file } = await github.rest.repos.getContent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              path: 'data/repos.json',
+              ref: 'main'
+            });
+            const repos = JSON.parse(
+              Buffer.from(file.content, 'base64').toString('utf-8')
+            );
 
             // Add new repo
             const newRepo = {
@@ -310,15 +325,10 @@ jobs:
               sha: ref.object.sha
             });
 
-            // Get current file
-            const { data: file } = await github.rest.repos.getContent({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              path: 'data/repos.json',
-              ref: 'main'
-            });
-
-            // Update file on new branch
+            // Update file on new branch. createOrUpdateFileContents requires
+            // the file's current SHA on `ref: branch` — same as on main since
+            // the branch was just created from main and we haven't committed
+            // anything to it yet.
             await github.rest.repos.createOrUpdateFileContents({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## Summary

Active-priorities #3 from the roadmap. The `validate-repo-suggestion.yml` workflow was reading `data/repos.json` from the workflow's local checkout, then committing that content to a branch based on latest main via the GitHub API. If main moved between checkout and the commit step, the local copy was stale — and the later squash-merge silently dropped everything that had landed in the gap.

PR #89 hit this in the wild: keepnotes-ai/keep was added cleanly, but AxDSan/mnemosyne (added moments earlier in PR #88) was overwritten. Had to be restored manually in PR #94.

## Fix

Fetch `repos.json` content via the GitHub API (`ref: 'main'`) right before mutating it, instead of reading from `fs`. The fetched `file.sha` is reused as the parent SHA for the commit — same optimistic-concurrency check as before, so if another PR squeaks in between the API fetch and the commit, this run fails loudly with a 409 instead of silently dropping content.

## Action item

⚠️ **PR #79 (mem0) is still DIRTY for the same reason** and this fix doesn't retroactively repair it. Two options:
- **Manual rebase** — pull the mem0 branch locally, rebase on main, force-push. Resolves the conflict, preserves the PR.
- **Close and re-trigger** — close PR #79, find the original issue, re-label it `repo-suggestion` to re-fire the workflow. New branch will be based on current main.

Recommend option 2 since it exercises the new code path and confirms the fix in production.

## Test plan

- [ ] Vercel preview deploy clean (workflow YAML only — no runtime impact)
- [ ] After merge, next repo-suggestion issue submitted will exercise the new code path
- [ ] Validate by submitting a test repo suggestion + watching the auto-PR's diff vs latest main: should only show the *one* new entry being added, not changes to other entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)