### PR TITLE
Use semantic <main> element as skip-to-content target

### DIFF
--- a/404.html
+++ b/404.html
@@ -42,7 +42,7 @@
   </button>
 </header>
 
-<section class="notfound" id="main">
+<main class="notfound" id="main">
   <div>
     <div class="label">error · 404</div>
     <h1>this page <em>doesn't exist</em>.</h1>
@@ -53,7 +53,7 @@
     </p>
     <a href="/" class="back">← back to the map</a>
   </div>
-</section>
+</main>
 
 <footer class="page-footer">
   <div class="fn-left">hermes atlas · curated by <a href="https://github.com/ksimback">ksimback</a> · <a href="https://github.com/ksimback/hermes-ecosystem/issues">suggest a repo</a></div>

--- a/guide/index.html
+++ b/guide/index.html
@@ -234,7 +234,7 @@
   <a href="/">map</a><span class="sep">/</span>handbook
 </div>
 
-<article class="article" id="main">
+<main class="article" id="main">
 
 <header class="article-header">
   <div class="article-badge">beginner's guide · the hermes handbook</div>
@@ -663,7 +663,7 @@ hermes skills info &lt;name&gt;      # inspect before installing</code></pre>
   <a class="cta" href="/">explore the ecosystem map →</a>
 </div>
 
-</article>
+</main>
 
 <!-- Email capture -->
 <aside class="email-cta" id="newsletter" aria-label="Newsletter signup">

--- a/guide/install/index.html
+++ b/guide/install/index.html
@@ -217,7 +217,7 @@
   <a href="/">map</a><span class="sep">/</span><a href="/guide/">handbook</a><span class="sep">/</span>install
 </div>
 
-<article class="article" id="main">
+<main class="article" id="main">
 
 <header class="article-header">
   <div class="article-badge">handbook · satellite · install</div>
@@ -642,7 +642,7 @@ curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scri
   <a class="cta" href="/guide/">back to The Hermes Handbook →</a>
 </div>
 
-</article>
+</main>
 
 <!-- Email capture -->
 <aside class="email-cta email-cta--compact" id="newsletter" aria-label="Newsletter signup">

--- a/guide/vs-claude-code/index.html
+++ b/guide/vs-claude-code/index.html
@@ -149,7 +149,7 @@
   <a href="/">map</a><span class="sep">/</span><a href="/guide/">handbook</a><span class="sep">/</span>hermes vs claude code
 </div>
 
-<article class="article" id="main">
+<main class="article" id="main">
 
 <header class="article-header">
   <div class="article-badge">handbook · satellite · comparison</div>
@@ -306,7 +306,7 @@
   <a class="cta" href="/guide/">back to The Hermes Handbook →</a>
 </div>
 
-</article>
+</main>
 
 <!-- Email capture -->
 <aside class="email-cta" aria-label="Newsletter signup">

--- a/index.html
+++ b/index.html
@@ -129,12 +129,12 @@
 </div>
 
 <!-- Hero strip -->
-<section class="hero-strip" id="main">
+<main class="hero-strip" id="main">
   <h1 class="hero-title">the community map of <em>hermes agent</em>.</h1>
   <p class="hero-sub">
     Hermes Atlas tracks <strong><span id="hero-sub-count">100</span>+ open-source projects</strong> across 12 categories built on Nous Research's Hermes Agent — tools, skills, plugins, workspaces, and integrations. Live GitHub data, quality-filtered, security reviewed, curated weekly. As of April 2026.
   </p>
-</section>
+</main>
 
 <!-- Stats row -->
 <section class="stats-row" aria-label="Ecosystem stats">

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -69,7 +69,7 @@
   <a href="/">map</a><span class="sep">/</span>privacy
 </div>
 
-<article class="article" id="main">
+<main class="article" id="main">
 
 <header class="article-header">
   <div class="article-badge">site · policy</div>
@@ -107,7 +107,7 @@
 
 <p>Questions or corrections: open an <a href="https://github.com/ksimback/hermes-ecosystem/issues/new" target="_blank" rel="noopener">issue on GitHub</a>.</p>
 
-</article>
+</main>
 
 <footer class="page-footer">
   <div class="fn-left">hermes atlas · curated by <a href="https://github.com/ksimback">ksimback</a> · <a href="https://github.com/ksimback/hermes-ecosystem/issues">suggest a repo</a> · <a href="/privacy">privacy</a></div>

--- a/reports/state-of-hermes-april-2026.html
+++ b/reports/state-of-hermes-april-2026.html
@@ -143,7 +143,7 @@
   <a href="/">map</a><span class="sep">/</span>reports<span class="sep">/</span>state of hermes — april 2026
 </div>
 
-<article class="article" id="main">
+<main class="article" id="main">
 
 <!-- Header -->
 <header class="article-header">
@@ -367,7 +367,7 @@
   <a class="cta" href="https://hermesatlas.com">explore the ecosystem map →</a>
 </div>
 
-</article>
+</main>
 
 <!-- Email capture -->
 <aside class="email-cta" aria-label="Newsletter signup">

--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -647,7 +647,7 @@ ${renderMasthead("map")}
   <a href="/">map</a><span class="sep">/</span><a href="${listSlug ? `/lists/${listSlug}` : "/"}">${escapeHtml(repo.category.toLowerCase())}</a><span class="sep">/</span>${escapeHtml(repo.repo.toLowerCase())}
 </div>
 
-<article id="main">
+<main id="main">
 
 <section class="project">
   <h1 class="project-name">
@@ -707,7 +707,7 @@ ${summary ? `
   </div>
 </aside>
 
-</article>
+</main>
 
 ${PAGE_FOOTER}
 
@@ -815,7 +815,7 @@ ${renderMasthead("lists")}
   <a href="/">map</a><span class="sep">/</span><a href="/#curated-lists">lists</a><span class="sep">/</span>${escapeHtml(list.slug)}
 </div>
 
-<article id="main">
+<main id="main">
 
 <section class="list-page">
   <h1 class="list-title">${escapeHtml(list.title)}</h1>
@@ -834,7 +834,7 @@ ${listicleHtml}
 
 <div class="back-link"><a href="/">← back to the map</a></div>
 
-</article>
+</main>
 
 ${PAGE_FOOTER}
 


### PR DESCRIPTION
## Summary

Phase 4 a11y polish from the roadmap. Pages were using `<article id="main">` or `<section id="main">` as the skip-link target — functional (screen readers reach the content) but missing the literal HTML5 `<main>` landmark that assistive tech expects.

Tag-name swap only. `id` and `class` preserved on every element, so existing CSS continues to target by class without change. Layout unchanged.

## Files

- `index.html` — `section.hero-strip` → `main`
- `404.html` — `section.notfound` → `main`
- `privacy/index.html`, `guide/index.html`, `guide/install/index.html`, `guide/vs-claude-code/index.html`, `reports/state-of-hermes-april-2026.html` — `article.article` → `main`
- `scripts/build-pages.js` — `article` (project + list page templates) → `main`. **`build-pages` run after merge will regenerate the 100+ project pages and 6 list pages with the new tag.**

## Phase 4 status after this lands

Audit findings from this session — most of Phase 4 was already clean before this PR:

- ✅ `<img>` alt attributes (no missing)
- ✅ `aria-label` on all icon-only buttons + form inputs
- ✅ Single `<h1>` per page
- ✅ Heading hierarchy clean (no skipped levels on guide pages)
- ✅ Semantic landmarks: `<header>`, `<nav>`, `<aside>`, `<footer>` all present + labeled
- ✅ Skip-to-content link works
- ✅ **Semantic `<main>` element (this PR)**

Still requiring browser/AT tooling:
- 🔲 Focus ring verification (visual)
- 🔲 Keyboard nav sweep (manual)
- 🔲 Contrast verification via axe DevTools
- 🔲 Screen reader smoke test

Running `/qa-only` after this merges to cover what's automatable from a headless browser.

## Test plan

- [ ] Vercel preview deploy clean
- [ ] After merge, `build-pages` regenerates project + list pages with `<main>` instead of `<article id="main">`
- [ ] Spot-check on production: `curl -s https://hermesatlas.com/ | grep '<main'` and confirm one `<main class="hero-strip" id="main">`

🤖 Generated with [Claude Code](https://claude.com/claude-code)