### PR TITLE
A11y: nudge contrast tokens to WCAG AA + email focus ring parity

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -201,7 +201,7 @@ body::after {
 .email-cta-input:focus-visible {
   outline: 0;
   border-color: var(--accent);
-  box-shadow: 0 0 0 1px var(--accent);
+  box-shadow: 0 0 0 2px var(--accent);
 }
 .email-cta-button {
   height: 44px;

--- a/assets/css/tokens.css
+++ b/assets/css/tokens.css
@@ -33,7 +33,7 @@
   --ink:         #e8e3d6;
   --ink-dim:     #b8b1a0;
   --ink-soft:    #8a8378;
-  --ink-mute:    #6b6355;
+  --ink-mute:    #807a6e; /* was #6b6355 (3.28:1) — bumped for WCAG AA on body text */
   --accent:      #d49a4f;
   --accent-dim:  #a07a3c;
   --rule:        #2a2620;
@@ -50,8 +50,8 @@
   --ink:         #1a1814;
   --ink-dim:     #3d3830;
   --ink-soft:    #6b6355;
-  --ink-mute:    #8a8378;
-  --accent:      #a36f28;
+  --ink-mute:    #75695b; /* was #8a8378 (3.29:1) — bumped for WCAG AA on body text */
+  --accent:      #946325; /* was #a36f28 (3.79:1) — bumped for WCAG AA on body text */
   --accent-dim:  #8a5e22;
   --rule:        #d9d3c2;
   --rule-strong: #b8b2a0;


### PR DESCRIPTION
## Summary

Three token tweaks + one focus-ring tweak following the static a11y audit that came with PR #113. **None of these are regressions from PR #113** — all are pre-existing failures that surfaced when I computed actual contrast ratios.

## Changes

### Color tokens (`assets/css/tokens.css`)

Smallest-possible-delta nudges to clear WCAG AA (4.5:1 normal text):

| Token | Before | After | Ratio (before → after) |
|---|---|---|---|
| Dark `--ink-mute` | `#6b6355` | `#807a6e` | 3.28:1 → 4.56:1 ✓ |
| Light `--ink-mute` | `#8a8378` | `#75695b` | 3.29:1 → 4.69:1 ✓ |
| Light `--accent` | `#a36f28` | `#946325` | 3.79:1 → 4.53:1 ✓ |

These are luminance-only adjustments — no hue shift, brutalist warm-sepia character preserved. The deltas are deliberately at the AA boundary (just clearing 4.5:1) to minimize visual change.

### Focus ring (`assets/css/base.css`)

Email subscribe input focus ring bumped from 1px to 2px box-shadow. Brings it to parity with the site-wide `:focus-visible` rule (2px outline + 2px offset). Trivial visual change.

## Where these tokens are used

- `--ink-mute` (15+ places in `index.css`): masthead meta line, footnote text, repo-delta `.zero`, listicle attribution, search placeholder
- Light `--accent`: nav hover, masthead version label, "view on github →" link, sort buttons, etc. Most uses are large text or UI elements that already passed 3:1 — this just brings the body-text uses to AA.

## What I want you to verify

This is **the design-judgment PR**. The math is right but the visual impact deserves your eyes:

- [ ] Vercel preview deploy clean
- [ ] Open the preview homepage in **both light and dark mode**. Does the masthead meta line ("apr·2026 · 100·repos · hermes·v0.10.0") still read as muted/secondary? Or is it now too prominent?
- [ ] Same for footnote text at the bottom.
- [ ] Light mode: does the new `--accent` still feel warm-gold? Or has it shifted into "dull olive" territory?
- [ ] Email signup form: focus the input — the focus ring should now be a clear 2px gold border (was a thin 1px line).

If any of the contrast bumps make a label feel TOO prominent (eats hierarchy), I'd push the value back toward the original — we can absorb 4.0–4.4:1 contrast as "AA-large/UI" if it preserves the design feel and the labels are clearly secondary.

## What's NOT in this PR

- `--accent-dim` (light mode `#8a5e22`) is still very close to the new `--accent` (`#946325`). Worth reviewing in a future design pass, but leaving alone here to bound the blast radius.
- Manual keyboard / screen-reader testing — still pending the gstack browse upgrade or a manual session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)