### PR TITLE
Auto-merge release-notes PRs from release-monitor

### DIFF
--- a/.github/workflows/release-monitor.yml
+++ b/.github/workflows/release-monitor.yml
@@ -225,6 +225,30 @@ jobs:
 
             console.log(`PR #${pr.number} created for ${tag}`);
 
+            // Enable native auto-merge so the PR lands without a manual click.
+            // Content is copied verbatim from upstream RELEASE_v*.md (or the
+            // GitHub release body) — not LLM-generated — so the human review
+            // checkpoint here was guarding against zero hallucination risk.
+            // With no required checks today this merges immediately; if a CI
+            // gate is ever added, auto-merge waits for it. Falls back to a
+            // manual-merge PR if the mutation fails for any reason.
+            try {
+              await github.graphql(
+                `mutation($pullRequestId: ID!) {
+                  enablePullRequestAutoMerge(input: {
+                    pullRequestId: $pullRequestId,
+                    mergeMethod: MERGE
+                  }) {
+                    pullRequest { autoMergeRequest { enabledAt } }
+                  }
+                }`,
+                { pullRequestId: pr.node_id }
+              );
+              console.log(`Auto-merge enabled on PR #${pr.number}`);
+            } catch (e) {
+              core.warning(`Could not enable auto-merge on PR #${pr.number}: ${e.message}. PR remains open for manual merge.`);
+            }
+
       - name: Bust stars API cache so site shows new version immediately
         if: steps.check.outputs.new_release == 'true'
         env:


### PR DESCRIPTION
## Summary
- After `release-monitor.yml` opens a release-notes PR, immediately enable native GitHub auto-merge (`enablePullRequestAutoMerge`, method `MERGE`).
- Wrapped in try/catch so any GraphQL hiccup falls back to today's manual-merge behavior (warning surfaced via `core.warning`).
- Repo-level `allow_auto_merge` was just enabled to make the mutation valid.

## Why
- Release-notes file content is the upstream `RELEASE_v*.md` copied verbatim (or the GitHub release body) — **not LLM-generated** — so the human checkpoint here was guarding zero hallucination risk.
- Today the masthead version stat updates live (cache-bust step), but the chatbot KB stays on the previous release until someone merges the PR. Reproduced just now with PR #131 (v0.12.0): masthead live, Ask Atlas couldn't cite it.
- After merge, `rebuild-chunks.yml` already auto-fires on `research/**` push and bot-commits new chunks. So this closes the loop.

## Future-proofing
- If a CI gate is added on PRs later (e.g. a smoke test for `build-chunks.js` against the new file), native auto-merge respects required checks. With none today it merges immediately.

## Test plan
- [ ] Merge this PR
- [ ] Wait for the next Hermes Agent release (or `workflow_dispatch` `release-monitor.yml` manually after a release lands)
- [ ] Confirm the auto-opened release-notes PR shows "Auto-merge enabled"
- [ ] Confirm `rebuild-chunks.yml` fires on the merge commit and `chunks.json` picks up the new release tag
- [ ] Spot-check Ask Atlas can cite the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)