### PR TITLE
Auto-categorize: prioritize Guides & Docs + match plural skills

### DIFF
--- a/.github/workflows/validate-repo-suggestion.yml
+++ b/.github/workflows/validate-repo-suggestion.yml
@@ -81,16 +81,24 @@ jobs:
 
               let category = 'Developer Tools'; // fallback
 
+              // Order matters: most-specific signal wins. "Guides & Docs"
+              // moved up because tutorials commonly mention every topic
+              // (memory, skills, MCP, plugins...) in their description, and
+              // the fact that something IS a tutorial outranks what it
+              // describes. The plural-aware skills regex (`skills?`) catches
+              // "Skills that teach..." which `\bskill\b` missed.
               if (data.owner?.login === 'NousResearch') {
                 category = 'Core & Official';
               } else if (data.fork) {
                 category = 'Forks & Derivatives';
+              } else if (/\b(guide|tutorial|book|wiki|awesome|learning|course|handbook|chapters?)\b/.test(text)) {
+                category = 'Guides & Docs';
+              } else if (/\b(skills?|agentskills?|skill.?registry|skill.?factory)\b/.test(text)) {
+                category = 'Skills & Skill Registries';
               } else if (/\b(memory|context|recall|remember|semantic search|knowledge graph|rag|retrieval|embedding|vector|long.?term)\b/.test(text)) {
                 category = 'Memory & Context';
               } else if (/\b(gui|ui|dashboard|desktop|workspace|webui|web.?ui|frontend|interface|chat.?app|companion.?app|panel)\b/.test(text)) {
                 category = 'Workspaces & GUIs';
-              } else if (/\b(skill|agentskills|skill.?registry|skill.?factory)\b/.test(text)) {
-                category = 'Skills & Skill Registries';
               } else if (/\b(plugin|extension|bridge|adapter|connector|integration|webhook|mcp)\b/.test(text)) {
                 category = 'Plugins & Extensions';
               } else if (/\b(multi.?agent|swarm|orchestrat|fleet|delegation|coordinator)\b/.test(text)) {
@@ -99,8 +107,6 @@ jobs:
                 category = 'Deployment & Infra';
               } else if (/\b(telegram|discord|slack|android|ios|mobile|whatsapp|cloudflare|browser)\b/.test(text)) {
                 category = 'Integrations & Bridges';
-              } else if (/\b(guide|tutorial|doc|book|wiki|awesome|learning|course|handbook)\b/.test(text)) {
-                category = 'Guides & Docs';
               } else if (/\b(cybersecurity|finance|trading|medical|legal|blockchain|oracle|game|novel|creative|domain)\b/.test(text)) {
                 category = 'Domain Applications';
               } else if (/\b(cli|linter|migration|token.?track|devtool|debug|test|benchmark|lint)\b/.test(text)) {


### PR DESCRIPTION
## Summary
Two related fixes to the auto-categorize chain in `validate-repo-suggestion.yml`:

1. **Plural-aware skill regex**: `\bskill\b` didn't match "Skills" (plural) because of the trailing word boundary. Caught during today's triage — `Cranot/super-hermes` ("Skills that teach Hermes Agent...") got routed to Developer Tools instead of Skills & Skill Registries. Fix: `\bskills?\b` and `agentskills?`.

2. **Reorder so guides/tutorials beat memory**: tutorials commonly describe many topics in their blurb ("memory, skills, MCP, …"). `longyunfeigu/learn-hermes-agent` ("27-chapter hands-on tutorial…") got routed to Memory & Context because the Memory regex hit first. Fix: move Guides & Docs above Memory + Skills in the chain so the fact that something **IS** a guide outranks what it **describes**. Also added `chapters?` as a tutorial signal, removed overly broad `doc`.

## Why this matters
Auto-categorize runs on every new submission via `validate-repo-suggestion`. A miscategorization survives until a maintainer notices and edits the auto-PR by hand. Today both miscategorizations had to be flagged manually for #138 + #142.

## Test plan
- [ ] Merge
- [ ] Open a fresh test issue using `[Repo]` template against a known tutorial repo
- [ ] Confirm auto-PR's category is `Guides & Docs`
- [ ] Repeat against a known skill-pack repo → `Skills & Skill Registries`

🤖 Generated with [Claude Code](https://claude.com/claude-code)