### PR TITLE
Add plastic-labs/honcho + adnw-vinc/hermes-nextcloud

### DIFF
--- a/data/repos.json
+++ b/data/repos.json
@@ -1098,5 +1098,25 @@
     "url": "https://github.com/jpalmae/hermeshq",
     "official": false,
     "category": "Deployment & Infra"
+  },
+  {
+    "owner": "plastic-labs",
+    "repo": "honcho",
+    "name": "honcho",
+    "description": "Memory library for building stateful agents — the upstream library that the elkimek/honcho-self-hosted Hermes wrapper builds on.",
+    "stars": 3143,
+    "url": "https://github.com/plastic-labs/honcho",
+    "official": true,
+    "category": "Memory & Context"
+  },
+  {
+    "owner": "adnw-vinc",
+    "repo": "hermes-nextcloud",
+    "name": "hermes-nextcloud",
+    "description": "Hermes Agent skill for Nextcloud — manage files, notes, calendar, tasks, and contacts via WebDAV and CalDAV.",
+    "stars": 1,
+    "url": "https://github.com/adnw-vinc/hermes-nextcloud",
+    "official": false,
+    "category": "Skills & Skill Registries"
   }
 ]


### PR DESCRIPTION
## Summary
Adds two repos that were stuck in older community PRs:
- **plastic-labs/honcho** — 3,143★, AGPL-3.0 → Memory & Context (official: true). The upstream memory library that elkimek/honcho-self-hosted (already in atlas) wraps for Hermes-specific deployment.
- **adnw-vinc/hermes-nextcloud** — 1★, MIT → Skills & Skill Registries. Manages Nextcloud files / notes / calendar / tasks / contacts via WebDAV+CalDAV.

## Context
- **PR #25** (erosika): wanted to *replace* `elkimek/honcho-self-hosted` with `plastic-labs/honcho`. Review thread agreed both belong (upstream + Hermes wrapper), but the contributor went silent for 12 days after the ask to broaden scope. Closing in favor of this direct add per the closing offer in [the original review comment](https://github.com/ksimback/hermes-ecosystem/pull/25#issuecomment-4275788625) ("If you'd rather not, no worries — feel free to close and I can add `plastic-labs/honcho` directly").
- **PR #111** (adnw-vinc): manually-edited repos.json bypassing the validator. Now conflicts against today's consolidated batch (#146) and had a missing-trailing-newline issue; re-applied cleanly here.

## Closes
#25, #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)