### PR TITLE
Remove dead Web3CZ/Web3Hermes entry — unblocks build-pages

### DIFF
--- a/data/repos.json
+++ b/data/repos.json
@@ -980,16 +980,6 @@
     "category": "Workspaces & GUIs"
   },
   {
-    "owner": "Web3CZ",
-    "repo": "Web3Hermes",
-    "name": "Web3Hermes",
-    "description": "【Hermes WebUI】Hermes-Agent 中文版 WebUI，便于中国用户使用",
-    "stars": 140,
-    "url": "https://github.com/Web3CZ/Web3Hermes",
-    "official": false,
-    "category": "Workspaces & GUIs"
-  },
-  {
     "owner": "keepnotes-ai",
     "repo": "keep",
     "name": "keep",


### PR DESCRIPTION
## Summary
Removes the `Web3CZ/Web3Hermes` entry from `data/repos.json`. The Web3CZ user account is gone from GitHub entirely — both `https://github.com/Web3CZ/Web3Hermes` and `https://github.com/Web3CZ` return HTTP 404.

## Why this is urgent
PR #107's fail-loud GraphQL handling correctly surfaced the issue, but it's been blocking **every** `build-pages` run for at least 2 days:

| Run | Result |
|---|---|
| 2026-04-30 06:30 UTC daily cron | failure |
| 2026-05-01 07:19 UTC daily cron | failure |
| 2026-05-01 15:13 (merge of #79 mem0) | failure |
| 2026-05-01 16:27 (merge of #146 — 9 repos) | failure |
| 2026-05-01 16:33 (merge of #147 — honcho + nextcloud) | failure |

Net effect: **all 12 community repos added during today's triage are sitting in `data/repos.json` but not yet rendered as project pages on hermesatlas.com**. This unblocks them.

## Follow-up
Should add a periodic "dead repo detector" so this doesn't recur silently. Either:
- Extend the existing `audit-summaries.yml` weekly cron to also `HEAD`-check each entry's GitHub URL
- Or have `lib/github.js` log+skip NOT_FOUND repos with a warning instead of throwing (less safe — silent corruption risk)

I'd lean toward the first.

## Test plan
- [ ] Merge
- [ ] Confirm next build-pages run completes successfully
- [ ] Confirm new project pages render at `/projects/{owner}/{repo}` for the 12 today-added repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)