### PR TITLE
build-pages: remove orphan project pages

### DIFF
--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -986,6 +986,35 @@ async function main() {
 
   console.log(`\n  Generated ${generated} project pages (${errors} errors)\n`);
 
+  // ── Orphan cleanup ──
+  // Delete any project HTML whose owner/repo no longer appears in repos.json.
+  // Without this, removing a repo (e.g. account deleted, project archived,
+  // intentional curation drop) leaves a stale HTML on the live site rendering
+  // pre-removal data — see PR #148 / Web3CZ/Web3Hermes incident.
+  const canonical = new Set(repos.map((r) => `${r.owner}/${r.repo}.html`));
+  let orphansRemoved = 0;
+  const ownerDirents = fs.readdirSync(projectsDir, { withFileTypes: true })
+    .filter((d) => d.isDirectory());
+  for (const od of ownerDirents) {
+    const ownerPath = path.join(projectsDir, od.name);
+    for (const file of fs.readdirSync(ownerPath)) {
+      if (!file.endsWith(".html")) continue;
+      const key = `${od.name}/${file}`;
+      if (!canonical.has(key)) {
+        fs.unlinkSync(path.join(ownerPath, file));
+        orphansRemoved++;
+        console.log(`  Removed orphan: projects/${key}`);
+      }
+    }
+    if (fs.readdirSync(ownerPath).length === 0) {
+      fs.rmdirSync(ownerPath);
+      console.log(`  Removed empty owner dir: projects/${od.name}`);
+    }
+  }
+  if (orphansRemoved > 0) {
+    console.log(`  Cleaned up ${orphansRemoved} orphan project page(s)\n`);
+  }
+
   // Generate list pages
   console.log("Generating list pages...");
   for (const list of lists) {


### PR DESCRIPTION
## Summary
After generating project pages, scan `projects/` for any `*.html` whose `{owner}/{repo}` no longer appears in `data/repos.json` and delete it. Removes the owner directory too if it ends up empty.

## Why
Without this, removing a repo from `data/repos.json` leaves a stale project page on the live site indefinitely. Vercel hosts the committed HTML as a static file, so it survives every redeploy.

Concrete case: PR #148 removed `Web3CZ/Web3Hermes` from `data/repos.json` (account deleted on GitHub), but [`/projects/Web3CZ/Web3Hermes`](https://hermesatlas.com/projects/Web3CZ/Web3Hermes) still serves the pre-removal HTML.

## What it deletes
- Any file matching `projects/{owner}/{repo}.html` whose `{owner}/{repo}` key is not in `repos.json`.
- Owner directories that end up empty after cleanup.

Safe by construction: only walks `projects/{owner}/*.html` and matches against the canonical list — won't delete unrelated files.

## Test plan
- [x] Local syntax check (`node -c`)
- [ ] Merge → next build-pages run logs "Removed orphan: projects/Web3CZ/Web3Hermes.html" and commits the deletion
- [ ] Confirm `https://hermesatlas.com/projects/Web3CZ/Web3Hermes` returns 404 after the rebuild lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)