### PR TITLE
Phase 3 ship 1: /reports/ index page

### DIFF
--- a/404.html
+++ b/404.html
@@ -33,7 +33,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/#curated-lists">lists</a>
-    <a href="/reports/state-of-hermes-april-2026">reports</a>
+    <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>

--- a/assets/css/page.css
+++ b/assets/css/page.css
@@ -541,6 +541,14 @@
   letter-spacing: 0.02em;
 }
 .list-cell-body { min-width: 0; }
+.list-cell-kicker {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--ink-mute);
+  margin-bottom: 4px;
+}
 .list-cell-name {
   font-family: var(--font-display);
   font-size: 16px;

--- a/data/reports.json
+++ b/data/reports.json
@@ -1,0 +1,10 @@
+[
+  {
+    "slug": "state-of-hermes-april-2026",
+    "title": "The State of Hermes Agent — April 2026",
+    "date": "2026-04-11",
+    "summary": "A community report on the first six weeks of Nous Research's self-improving AI agent. 57,200 stars, 80+ ecosystem projects, and what to watch for in Q2.",
+    "readTime": "10 min",
+    "kicker": "community report · q1 2026"
+  }
+]

--- a/guide/index.html
+++ b/guide/index.html
@@ -221,7 +221,7 @@
     <a href="/">map</a>
     <a href="/#curated-lists">lists</a>
     <a href="/guide/" class="active">handbook</a>
-    <a href="/reports/state-of-hermes-april-2026">reports</a>
+    <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>

--- a/guide/install/index.html
+++ b/guide/install/index.html
@@ -204,7 +204,7 @@
     <a href="/">map</a>
     <a href="/#curated-lists">lists</a>
     <a href="/guide/" class="active">handbook</a>
-    <a href="/reports/state-of-hermes-april-2026">reports</a>
+    <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>

--- a/guide/vs-claude-code/index.html
+++ b/guide/vs-claude-code/index.html
@@ -136,7 +136,7 @@
     <a href="/">map</a>
     <a href="/#curated-lists">lists</a>
     <a href="/guide/" class="active">handbook</a>
-    <a href="/reports/state-of-hermes-april-2026">reports</a>
+    <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>

--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@
     <a href="/" class="active">map</a>
     <a href="#curated-lists">lists</a>
     <a href="/guide/">handbook</a>
-    <a href="/reports/state-of-hermes-april-2026">reports</a>
+    <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>

--- a/llms.txt
+++ b/llms.txt
@@ -41,7 +41,10 @@ Hermes Atlas tracks every open-source project in the Hermes Agent ecosystem acro
 - [Full context bundle](https://hermesatlas.com/llms-full.txt): Concatenated content of every guide, report, and summary for direct LLM ingestion.
 - [Sitemap](https://hermesatlas.com/sitemap.xml): All URLs with last-modified dates.
 
+## Reports
+- [Reports index](https://hermesatlas.com/reports/): Quarterly community reports on the Hermes Agent ecosystem.
+- [The State of Hermes Agent — April 2026](https://hermesatlas.com/reports/state-of-hermes-april-2026): A community report on the first six weeks of Nous Research's self-improving AI agent. 57,200 stars, 80+ ecosystem projects, and what to watch for in Q2.
+
 ## Optional
-- [State of Hermes — April 2026 report](https://hermesatlas.com/reports/state-of-hermes-april-2026): Quarterly ecosystem snapshot.
 - [Privacy policy](https://hermesatlas.com/privacy): How the site handles visitor data.
 - [GitHub source](https://github.com/ksimback/hermes-ecosystem): The repo backing this site.

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -56,7 +56,7 @@
     <a href="/">map</a>
     <a href="/#curated-lists">lists</a>
     <a href="/guide/">handbook</a>
-    <a href="/reports/state-of-hermes-april-2026">reports</a>
+    <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>

--- a/reports/index.html
+++ b/reports/index.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Reports | Hermes Atlas</title>
+<meta name="description" content="Quarterly community reports on the Hermes Agent ecosystem — growth, releases, what's been built, and what to watch for next.">
+<link rel="canonical" href="https://hermesatlas.com/reports/">
+<meta property="og:title" content="Reports — Hermes Atlas">
+<meta property="og:description" content="Quarterly community reports on the Hermes Agent ecosystem — growth, releases, what's been built, and what to watch for next.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://hermesatlas.com/reports/">
+<meta property="og:site_name" content="Hermes Atlas">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=Reports+%E2%80%94+Hermes+Atlas&amp;subtitle=Quarterly+community+reports+on+the+Hermes+Agent+ecosystem.&amp;kind=reports">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Reports — Hermes Atlas">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Reports+%E2%80%94+Hermes+Atlas&amp;subtitle=Quarterly+community+reports+on+the+Hermes+Agent+ecosystem.&amp;kind=reports">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "map",
+      "item": "https://hermesatlas.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "reports"
+    }
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "@id": "https://hermesatlas.com/reports/",
+  "name": "Hermes Atlas Reports",
+  "description": "Quarterly community reports on the Hermes Agent ecosystem — growth, releases, what's been built, and what to watch for next.",
+  "url": "https://hermesatlas.com/reports/",
+  "isPartOf": {
+    "@id": "https://hermesatlas.com/#website"
+  },
+  "mainEntity": {
+    "@type": "ItemList",
+    "numberOfItems": 1,
+    "itemListOrder": "https://schema.org/ItemListOrderDescending",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "url": "https://hermesatlas.com/reports/state-of-hermes-april-2026",
+        "name": "The State of Hermes Agent — April 2026"
+      }
+    ]
+  }
+}
+</script>
+<link rel="alternate" type="application/rss+xml" title="Hermes Atlas — new projects" href="/rss.xml">
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' fill='%23d49a4f'/><text x='16' y='23' font-family='Space Grotesk,sans-serif' font-size='22' font-weight='700' fill='%230e0d0b' text-anchor='middle'>H</text></svg>">
+<script>(function(){try{var s=localStorage.getItem('theme');var o=window.matchMedia&&window.matchMedia('(prefers-color-scheme: light)').matches;var t=s||(o?'light':'dark');document.documentElement.setAttribute('data-theme',t)}catch(e){document.documentElement.setAttribute('data-theme','dark')}})();</script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap">
+<link rel="stylesheet" href="/assets/css/tokens.css">
+<link rel="stylesheet" href="/assets/css/base.css">
+<link rel="stylesheet" href="/assets/css/page.css">
+</head>
+<body>
+
+<a class="skip-link" href="#main">Skip to content</a>
+
+<header class="masthead">
+  <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
+  <div class="mast-meta" aria-label="Site metadata">
+    <span>apr·2026</span>
+    <span id="meta-count">111·repos</span>
+    <span>hermes·v0.10.0</span>
+    <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
+  </div>
+  <nav class="mast-nav" aria-label="Primary">
+    <a href="/">map</a>
+    <a href="/#curated-lists">lists</a>
+    <a href="/guide/">handbook</a>
+    <a href="/reports/" class="active">reports</a>
+    <a href="/#newsletter">newsletter</a>
+    <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
+  </nav>
+  <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
+    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+  </button>
+</header>
+
+<div class="breadcrumb" aria-label="Breadcrumb">
+  <a href="/">map</a><span class="sep">/</span>reports
+</div>
+
+<main id="main">
+
+<section class="list-page">
+  <h1 class="list-title">Reports</h1>
+  <p class="list-intro">Quarterly community reports on the Hermes Agent ecosystem — growth, releases, what's been built, and what to watch for next.</p>
+</section>
+
+<div class="list-table" aria-label="Report list">
+  <div class="list-table-head">
+    <div>#</div>
+    <div>report</div>
+    <div style="text-align:right">published</div>
+  </div>
+  <a class="list-row" href="/reports/state-of-hermes-april-2026">
+    <div class="list-rank">01</div>
+    <div class="list-cell-body">
+      <div class="list-cell-kicker">community report · q1 2026</div>
+      <div class="list-cell-name">The State of Hermes Agent — April 2026</div>
+      <div class="list-cell-desc">A community report on the first six weeks of Nous Research's self-improving AI agent. 57,200 stars, 80+ ecosystem projects, and what to watch for in Q2.</div>
+    </div>
+    <div class="list-cell-stars">apr 11, 2026 · 10 min read</div>
+  </a>
+</div>
+
+<div class="back-link"><a href="/">← back to the map</a></div>
+
+</main>
+
+<footer class="page-footer">
+  <div class="fn-left">hermes atlas · curated by <a href="https://github.com/ksimback">ksimback</a> · <a href="https://github.com/ksimback/hermes-ecosystem/issues">suggest a repo</a> · <a href="/privacy">privacy</a></div>
+  <div>v2 · 2026.04</div>
+</footer>
+
+<script>(function(){var t=document.getElementById('theme-toggle');if(!t)return;function render(){var c=document.documentElement.getAttribute('data-theme');t.querySelector('.tt-light').classList.toggle('tt-active',c==='light');t.querySelector('.tt-dark').classList.toggle('tt-active',c!=='light');}render();t.addEventListener('click',function(){var c=document.documentElement.getAttribute('data-theme');var n=c==='light'?'dark':'light';document.documentElement.setAttribute('data-theme',n);try{localStorage.setItem('theme',n)}catch(e){}render();});})();</script>
+<script>(function(){fetch('/api/stars').then(function(r){return r.ok&&r.json()}).then(function(d){if(!d)return;var a=document.getElementById('meta-atlas');if(a&&d.atlas&&d.atlas.stars)a.textContent='★ '+d.atlas.stars+' · star this repo';var c=document.getElementById('meta-count');if(c&&d.totals&&d.totals.count)c.textContent=d.totals.count+'·repos'}).catch(function(){});})();</script>
+<!-- Cloudflare Web Analytics -->
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js"
+        data-cf-beacon='{"token": "fe0d4d79280b4386b6b0cd99b2d94dbc"}'></script>
+<!-- End Cloudflare Web Analytics -->
+</body>
+</html>

--- a/reports/state-of-hermes-april-2026.html
+++ b/reports/state-of-hermes-april-2026.html
@@ -93,6 +93,17 @@
   ]
 }
 </script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "map", "item": "https://hermesatlas.com/" },
+    { "@type": "ListItem", "position": 2, "name": "reports", "item": "https://hermesatlas.com/reports/" },
+    { "@type": "ListItem", "position": 3, "name": "state-of-hermes-april-2026" }
+  ]
+}
+</script>
 <link rel="alternate" type="application/rss+xml" title="Hermes Atlas — new projects" href="/rss.xml">
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' fill='%23d49a4f'/><text x='16' y='23' font-family='Space Grotesk,sans-serif' font-size='22' font-weight='700' fill='%230e0d0b' text-anchor='middle'>H</text></svg>">
 <script>
@@ -130,7 +141,7 @@
     <a href="/">map</a>
     <a href="/#curated-lists">lists</a>
     <a href="/guide/">handbook</a>
-    <a href="/reports/state-of-hermes-april-2026" class="active">reports</a>
+    <a href="/reports/" class="active">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
@@ -140,7 +151,7 @@
 </header>
 
 <div class="breadcrumb" aria-label="Breadcrumb">
-  <a href="/">map</a><span class="sep">/</span>reports<span class="sep">/</span>state of hermes — april 2026
+  <a href="/">map</a><span class="sep">/</span><a href="/reports/">reports</a><span class="sep">/</span>state of hermes — april 2026
 </div>
 
 <main class="article" id="main">

--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -130,6 +130,14 @@ if (fs.existsSync(listsPath)) {
   lists = JSON.parse(fs.readFileSync(listsPath, "utf-8"));
 }
 
+let reports = [];
+const reportsPath = path.join(ROOT, "data", "reports.json");
+if (fs.existsSync(reportsPath)) {
+  reports = JSON.parse(fs.readFileSync(reportsPath, "utf-8"));
+  // Newest first by date (ISO YYYY-MM-DD sorts lexicographically)
+  reports.sort((a, b) => (b.date || "").localeCompare(a.date || ""));
+}
+
 // fetchAllMetadata and fetchReadme imported from lib/github.js
 
 // ── Format star count ──
@@ -178,7 +186,7 @@ function renderMasthead(activeNav) {
     { href: "/", label: "map", id: "map" },
     { href: "/#curated-lists", label: "lists", id: "lists" },
     { href: "/guide/", label: "handbook", id: "handbook" },
-    { href: "/reports/state-of-hermes-april-2026", label: "reports", id: "reports" },
+    { href: "/reports/", label: "reports", id: "reports" },
     { href: "/#newsletter", label: "newsletter", id: "newsletter" },
     { href: "https://github.com/ksimback/hermes-ecosystem", label: "source", id: "source" },
   ];
@@ -459,7 +467,7 @@ ${items}
 }
 
 // ── GEO: write llms.txt (concise index) + llms-full.txt (full bundle) ──
-function writeLlmsFiles(repos, lists, summaries) {
+function writeLlmsFiles(repos, lists, summaries, reports = []) {
   const today = new Date().toISOString().slice(0, 10);
   const sorted = repos.slice().sort((a, b) => (b.stars || 0) - (a.stars || 0));
   const topProjects = sorted.slice(0, 15);
@@ -490,8 +498,11 @@ ${lists.map((l) => `- [${l.title}](${SITE_URL}/lists/${l.slug}): ${l.description
 - [Full context bundle](${SITE_URL}/llms-full.txt): Concatenated content of every guide, report, and summary for direct LLM ingestion.
 - [Sitemap](${SITE_URL}/sitemap.xml): All URLs with last-modified dates.
 
+## Reports
+- [Reports index](${SITE_URL}/reports/): Quarterly community reports on the Hermes Agent ecosystem.
+${reports.map((r) => `- [${r.title}](${SITE_URL}/reports/${r.slug}): ${r.summary}`).join("\n")}
+
 ## Optional
-- [State of Hermes — April 2026 report](${SITE_URL}/reports/state-of-hermes-april-2026): Quarterly ecosystem snapshot.
 - [Privacy policy](${SITE_URL}/privacy): How the site handles visitor data.
 - [GitHub source](https://github.com/ksimback/hermes-ecosystem): The repo backing this site.
 `;
@@ -848,15 +859,157 @@ ${PAGE_FOOTER}
 </html>`;
 }
 
+// ── Reports index (/reports/) ──
+function formatReportDate(iso) {
+  if (!iso) return "";
+  const d = new Date(iso + "T00:00:00Z");
+  if (Number.isNaN(d.getTime())) return iso;
+  const months = ["jan","feb","mar","apr","may","jun","jul","aug","sep","oct","nov","dec"];
+  return `${months[d.getUTCMonth()]} ${d.getUTCDate()}, ${d.getUTCFullYear()}`;
+}
+
+function renderReportsIndex(reports) {
+  const title = "Reports | Hermes Atlas";
+  const desc = "Quarterly community reports on the Hermes Agent ecosystem — growth, releases, what's been built, and what to watch for next.";
+  const canonicalUrl = `${SITE_URL}/reports/`;
+  const ogTitle = "Reports — Hermes Atlas";
+  const ogSubtitle = "Quarterly community reports on the Hermes Agent ecosystem.";
+
+  const itemListLD = {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "@id": canonicalUrl,
+    name: "Hermes Atlas Reports",
+    description: desc,
+    url: canonicalUrl,
+    isPartOf: { "@id": "https://hermesatlas.com/#website" },
+    mainEntity: {
+      "@type": "ItemList",
+      numberOfItems: reports.length,
+      itemListOrder: "https://schema.org/ItemListOrderDescending",
+      itemListElement: reports.map((r, i) => ({
+        "@type": "ListItem",
+        position: i + 1,
+        url: `${SITE_URL}/reports/${r.slug}`,
+        name: r.title,
+      })),
+    },
+  };
+
+  const breadcrumbLD = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "map", item: "https://hermesatlas.com/" },
+      { "@type": "ListItem", position: 2, name: "reports" },
+    ],
+  };
+
+  const reportRows = reports.map((r, i) => {
+    const rank = String(i + 1).padStart(2, "0");
+    const dateStr = escapeHtml(formatReportDate(r.date));
+    const readTime = r.readTime ? ` · ${escapeHtml(r.readTime)} read` : "";
+    const kicker = r.kicker ? `<div class="list-cell-kicker">${escapeHtml(r.kicker)}</div>` : "";
+    return `<a class="list-row" href="/reports/${escapeHtml(r.slug)}">
+    <div class="list-rank">${rank}</div>
+    <div class="list-cell-body">
+      ${kicker}
+      <div class="list-cell-name">${escapeHtml(r.title)}</div>
+      <div class="list-cell-desc">${escapeHtml(r.summary || "")}</div>
+    </div>
+    <div class="list-cell-stars">${dateStr}${readTime}</div>
+  </a>`;
+  }).join("\n  ");
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>${escapeHtml(title)}</title>
+<meta name="description" content="${escapeHtml(desc)}">
+<link rel="canonical" href="${canonicalUrl}">
+<meta property="og:title" content="${escapeHtml(ogTitle)}">
+<meta property="og:description" content="${escapeHtml(desc)}">
+<meta property="og:type" content="website">
+<meta property="og:url" content="${canonicalUrl}">
+<meta property="og:site_name" content="Hermes Atlas">
+<meta property="og:image" content="${escapeHtml(ogImageUrl({ title: ogTitle, subtitle: ogSubtitle, kind: "reports" }))}">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="${escapeHtml(ogTitle)}">
+<meta name="twitter:image" content="${escapeHtml(ogImageUrl({ title: ogTitle, subtitle: ogSubtitle, kind: "reports" }))}">
+<script type="application/ld+json">
+${JSON.stringify(breadcrumbLD, null, 2)}
+</script>
+<script type="application/ld+json">
+${JSON.stringify(itemListLD, null, 2)}
+</script>
+<link rel="alternate" type="application/rss+xml" title="Hermes Atlas — new projects" href="/rss.xml">
+<link rel="icon" href="${FAVICON}">
+<script>${THEME_INIT}</script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap">
+<link rel="stylesheet" href="/assets/css/tokens.css">
+<link rel="stylesheet" href="/assets/css/base.css">
+<link rel="stylesheet" href="/assets/css/page.css">
+</head>
+<body>
+
+<a class="skip-link" href="#main">Skip to content</a>
+
+${renderMasthead("reports")}
+
+<div class="breadcrumb" aria-label="Breadcrumb">
+  <a href="/">map</a><span class="sep">/</span>reports
+</div>
+
+<main id="main">
+
+<section class="list-page">
+  <h1 class="list-title">Reports</h1>
+  <p class="list-intro">Quarterly community reports on the Hermes Agent ecosystem — growth, releases, what's been built, and what to watch for next.</p>
+</section>
+
+<div class="list-table" aria-label="Report list">
+  <div class="list-table-head">
+    <div>#</div>
+    <div>report</div>
+    <div style="text-align:right">published</div>
+  </div>
+  ${reportRows}
+</div>
+
+<div class="back-link"><a href="/">← back to the map</a></div>
+
+</main>
+
+${PAGE_FOOTER}
+
+<script>${THEME_TOGGLE_SCRIPT}</script>
+<script>(function(){fetch('/api/stars').then(function(r){return r.ok&&r.json()}).then(function(d){if(!d)return;var a=document.getElementById('meta-atlas');if(a&&d.atlas&&d.atlas.stars)a.textContent='★ '+d.atlas.stars+' · star this repo';var c=document.getElementById('meta-count');if(c&&d.totals&&d.totals.count)c.textContent=d.totals.count+'·repos'}).catch(function(){});})();</script>
+<!-- Cloudflare Web Analytics -->
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js"
+        data-cf-beacon='{"token": "fe0d4d79280b4386b6b0cd99b2d94dbc"}'></script>
+<!-- End Cloudflare Web Analytics -->
+</body>
+</html>`;
+}
+
 // ── Generate sitemap.xml ──
-function generateSitemap(projectPages, listPages) {
+function generateSitemap(projectPages, listPages, reportPages = []) {
   const today = new Date().toISOString().slice(0, 10);
 
   let urls = `  <url><loc>${SITE_URL}/</loc><changefreq>daily</changefreq><priority>1.0</priority><lastmod>${today}</lastmod></url>\n`;
   urls += `  <url><loc>${SITE_URL}/guide/</loc><changefreq>monthly</changefreq><priority>0.9</priority><lastmod>${today}</lastmod></url>\n`;
   urls += `  <url><loc>${SITE_URL}/guide/vs-claude-code/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>${today}</lastmod></url>\n`;
   urls += `  <url><loc>${SITE_URL}/guide/install/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>${today}</lastmod></url>\n`;
-  urls += `  <url><loc>${SITE_URL}/reports/state-of-hermes-april-2026</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>\n`;
+  urls += `  <url><loc>${SITE_URL}/reports/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>${today}</lastmod></url>\n`;
+  for (const r of reportPages) {
+    urls += `  <url><loc>${SITE_URL}/reports/${r.slug}</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>\n`;
+  }
   urls += `  <url><loc>${SITE_URL}/privacy</loc><changefreq>yearly</changefreq><priority>0.3</priority></url>\n`;
 
   for (const page of projectPages) {
@@ -1033,18 +1186,27 @@ async function main() {
     console.log(`  ${list.slug} (${matchedRepos.length} repos)`);
   }
 
+  // Generate reports index page
+  if (reports.length > 0) {
+    console.log("\nGenerating reports index...");
+    const reportsDir = path.join(ROOT, "reports");
+    fs.mkdirSync(reportsDir, { recursive: true });
+    fs.writeFileSync(path.join(reportsDir, "index.html"), renderReportsIndex(reports), "utf-8");
+    console.log(`  reports/index.html (${reports.length} reports)`);
+  }
+
   // Generate sitemap
   console.log("\nGenerating sitemap.xml...");
-  const sitemap = generateSitemap(repos, lists);
+  const sitemap = generateSitemap(repos, lists, reports);
   fs.writeFileSync(path.join(ROOT, "sitemap.xml"), sitemap, "utf-8");
-  console.log(`  ${repos.length + lists.length + 2} URLs`);
+  console.log(`  ${repos.length + lists.length + reports.length + 3} URLs`);
 
   // Generate robots.txt (explicit multi-bot allowlist + wildcard default)
   fs.writeFileSync(path.join(ROOT, "robots.txt"), buildRobotsTxt(), "utf-8");
 
   // Generate llms.txt + llms-full.txt for LLM / agent ingestion (llmstxt.org)
   console.log("\nGenerating llms.txt + llms-full.txt...");
-  writeLlmsFiles(repos, lists, summaries);
+  writeLlmsFiles(repos, lists, summaries, reports);
 
   // Generate rss.xml — last-30 new repo additions (addedAt derived from git log)
   console.log("\nGenerating rss.xml...");

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -4,6 +4,7 @@
   <url><loc>https://hermesatlas.com/guide/</loc><changefreq>monthly</changefreq><priority>0.9</priority><lastmod>2026-05-01</lastmod></url>
   <url><loc>https://hermesatlas.com/guide/vs-claude-code/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>2026-05-01</lastmod></url>
   <url><loc>https://hermesatlas.com/guide/install/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>2026-05-01</lastmod></url>
+  <url><loc>https://hermesatlas.com/reports/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>2026-05-01</lastmod></url>
   <url><loc>https://hermesatlas.com/reports/state-of-hermes-april-2026</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://hermesatlas.com/privacy</loc><changefreq>yearly</changefreq><priority>0.3</priority></url>
   <url><loc>https://hermesatlas.com/projects/NousResearch/hermes-agent</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-05-01</lastmod></url>


### PR DESCRIPTION
## Summary
- New **/reports/** index page driven by `data/reports.json` — adding the next report becomes a one-line entry
- Masthead nav updated site-wide (`/reports/state-of-hermes-april-2026` → `/reports/`); the existing report still works at its canonical URL
- Report detail page gets a real breadcrumb link to `/reports/` plus matching `BreadcrumbList` JSON-LD

## Why this matters
The single existing report had no index — its breadcrumb showed "reports" as plain text and the masthead nav linked directly to the one report. This sets up the URL pattern for May 2026, June 2026, etc.

## Phase 3 scope
This is **ship 1 of 2** for Phase 3 (Reports + Featured Projects). Featured Projects follows in a separate PR.

## Files
- New: `data/reports.json`, `reports/index.html`
- Modified renderer: `scripts/build-pages.js` (adds `renderReportsIndex()`, updates masthead nav, sitemap, llms.txt)
- Modified styles: `assets/css/page.css` (new `.list-cell-kicker` for the kicker badge)
- 7 hand-authored masthead edits: `index.html`, `404.html`, `guide/index.html`, `guide/install/index.html`, `guide/vs-claude-code/index.html`, `privacy/index.html`, `reports/state-of-hermes-april-2026.html`
- Auto-generated artifacts (`projects/*.html`, `lists/*.html`, `rss.xml`, `robots.txt`, `llms-full.txt`) intentionally excluded — `build-pages.yml` rebuilds them on merge since `scripts/build-pages.js` is in its `paths:` filter

## Test plan
- [ ] Preview deploy: confirm `/reports/` renders with industrial-brutalist list-page styling
- [ ] Click `reports` in the masthead from any of the 7 hand-authored pages → lands on `/reports/`
- [ ] On `/reports/`, click the row → lands on `/reports/state-of-hermes-april-2026`
- [ ] Confirm the report's new breadcrumb `map / reports / state of hermes — april 2026` has a working link on `reports`
- [ ] After merge: confirm `build-pages.yml` runs and project + list pages get the new nav
- [ ] After merge: confirm `/reports/` is in the live `sitemap.xml` and gets pinged via IndexNow

🤖 Generated with [Claude Code](https://claude.com/claude-code)