### PR TITLE
Phase 3 ship 2: 'Featured this week' rotating community pick

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -267,6 +267,90 @@
   margin-top: 8px;
 }
 
+/* ─── Featured · this week (rotating community pick) ──────── */
+.featured-week {
+  padding: 40px 40px 44px;
+  border-bottom: 1px solid var(--rule-strong);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  background: var(--bg-elev);
+}
+.featured-week-meta {
+  display: flex;
+  align-items: baseline;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.featured-week-meta .featured-label {
+  margin-bottom: 0;
+}
+.featured-week-date {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--ink-mute);
+  text-transform: lowercase;
+  letter-spacing: 0.04em;
+}
+.featured-week-name {
+  font-size: 32px;
+  font-weight: 600;
+  letter-spacing: -0.025em;
+  line-height: 1.05;
+  color: var(--ink);
+  text-decoration: none;
+}
+.featured-week-name:hover {
+  color: var(--accent);
+}
+.featured-week-name .org {
+  color: var(--ink-mute);
+  font-weight: 400;
+}
+.featured-week-name .slash {
+  color: var(--rule-strong);
+  margin: 0 4px;
+}
+.featured-week-desc {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--ink-dim);
+  line-height: 1.7;
+  max-width: 70ch;
+}
+.featured-week-foot {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+  margin-top: 4px;
+}
+.featured-week-tag {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--ink-mute);
+  padding: 4px 10px;
+  border: 1px solid var(--rule-strong);
+}
+.featured-week-tag--star {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.featured-week-link {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--accent);
+  letter-spacing: 0.02em;
+  margin-left: auto;
+}
+@media (max-width: 720px) {
+  .featured-week { padding: 28px 20px 32px; }
+  .featured-week-name { font-size: 24px; }
+  .featured-week-link { margin-left: 0; }
+}
+
 /* ─── Controls (search + sort) ─────────────────────────────── */
 .controls {
   padding: 20px 40px;

--- a/data/featured.json
+++ b/data/featured.json
@@ -1,7 +1,7 @@
 [
   {
-    "slug": "vectorize-io/hindsight",
+    "slug": "outsourc-e/hermes-workspace",
     "weekStart": "2026-04-27",
-    "addedAt": "2026-05-01T18:51:12.394Z"
+    "addedAt": "2026-05-01T22:04:28.218Z"
   }
 ]

--- a/data/featured.json
+++ b/data/featured.json
@@ -1,0 +1,7 @@
+[
+  {
+    "slug": "vectorize-io/hindsight",
+    "weekStart": "2026-04-27",
+    "addedAt": "2026-05-01T18:51:12.394Z"
+  }
+]

--- a/index.html
+++ b/index.html
@@ -170,14 +170,14 @@
     <div class="featured-label">featured · this week</div>
     <span class="featured-week-date">apr 27, 2026</span>
   </div>
-  <a class="featured-week-name" href="/projects/vectorize-io/hindsight">
-    <span class="org">vectorize-io</span><span class="slash">/</span>hindsight <span class="repo-flag">official</span>
+  <a class="featured-week-name" href="/projects/outsourc-e/hermes-workspace">
+    <span class="org">outsourc-e</span><span class="slash">/</span>hermes-workspace
   </a>
-  <p class="featured-week-desc">Hindsight is an agent memory system designed to help AI agents learn from experiences rather than just storing conversation history. It utilizes a retain, recall, and reflect workflow to build mental models that improve performance on long-term memory tasks.…</p>
+  <p class="featured-week-desc">Hermes Workspace is a native web-based command center designed to orchestrate Hermes Agents through a unified graphical interface. It connects to the Hermes Agent gateway to provide real-time agent interaction, memory browsing, and skill management. The…</p>
   <div class="featured-week-foot">
-    <span class="featured-week-tag featured-week-tag--star">★ 8.4K</span>
-    <span class="featured-week-tag">memory &amp; context</span>
-    <a class="featured-week-link" href="/projects/vectorize-io/hindsight">read the full breakdown →</a>
+    <span class="featured-week-tag featured-week-tag--star">★ 830</span>
+    <span class="featured-week-tag">workspaces &amp; guis</span>
+    <a class="featured-week-link" href="/projects/outsourc-e/hermes-workspace">read the full breakdown →</a>
   </div>
 </section>
 <!-- END featured-week -->

--- a/index.html
+++ b/index.html
@@ -164,6 +164,24 @@
   </div>
 </section>
 
+<!-- BEGIN featured-week (auto-managed by scripts/rotate-featured.js) -->
+<section class="featured-week" aria-label="Featured project this week">
+  <div class="featured-week-meta">
+    <div class="featured-label">featured · this week</div>
+    <span class="featured-week-date">apr 27, 2026</span>
+  </div>
+  <a class="featured-week-name" href="/projects/vectorize-io/hindsight">
+    <span class="org">vectorize-io</span><span class="slash">/</span>hindsight <span class="repo-flag">official</span>
+  </a>
+  <p class="featured-week-desc">Hindsight is an agent memory system designed to help AI agents learn from experiences rather than just storing conversation history. It utilizes a retain, recall, and reflect workflow to build mental models that improve performance on long-term memory tasks.…</p>
+  <div class="featured-week-foot">
+    <span class="featured-week-tag featured-week-tag--star">★ 8.4K</span>
+    <span class="featured-week-tag">memory &amp; context</span>
+    <a class="featured-week-link" href="/projects/vectorize-io/hindsight">read the full breakdown →</a>
+  </div>
+</section>
+<!-- END featured-week -->
+
 <!-- Newsletter capture (compact, above-the-fold) -->
 <aside class="email-cta email-cta--compact" id="newsletter" aria-label="Newsletter signup">
   <div class="email-cta-kicker">newsletter · free · 1–2× / month</div>

--- a/scripts/rotate-featured.js
+++ b/scripts/rotate-featured.js
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+/**
+ * rotate-featured.js
+ *
+ * Rotate the homepage "Featured this week" pick.
+ *
+ * Usage: node scripts/rotate-featured.js <owner>/<repo>
+ *
+ * Effects:
+ *   - Validates the slug exists in data/repos.json
+ *   - Prepends the new pick to data/featured.json (newest first)
+ *   - Rewrites the <!-- BEGIN featured-week --> / <!-- END featured-week -->
+ *     block in index.html with HTML rendered from repos.json + summaries.json
+ *
+ * Re-running with the same slug is a no-op for featured.json (deduped by
+ * weekStart) but always re-renders index.html, which is useful when the
+ * blurb or stats have changed upstream.
+ */
+
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "..");
+
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function formatStars(n) {
+  if (!n || n < 1000) return String(n || 0);
+  return (n / 1000).toFixed(1) + "K";
+}
+
+function formatDate(iso) {
+  const d = new Date(iso + "T00:00:00Z");
+  const months = ["jan","feb","mar","apr","may","jun","jul","aug","sep","oct","nov","dec"];
+  return `${months[d.getUTCMonth()]} ${d.getUTCDate()}, ${d.getUTCFullYear()}`;
+}
+
+// Snap a date to the most recent Monday so weekly rotations stay aligned.
+function mondayOf(date) {
+  const d = new Date(date);
+  const day = d.getUTCDay(); // 0=Sun, 1=Mon, ...
+  const offset = day === 0 ? -6 : 1 - day;
+  d.setUTCDate(d.getUTCDate() + offset);
+  return d.toISOString().slice(0, 10);
+}
+
+function truncate(s, max = 240) {
+  if (!s || s.length <= max) return s || "";
+  const cut = s.slice(0, max);
+  const lastSpace = cut.lastIndexOf(" ");
+  return cut.slice(0, lastSpace > max - 40 ? lastSpace : max).trimEnd() + "…";
+}
+
+function renderFeaturedSection(pick, repo, summary, weekStart) {
+  const slug = `${repo.owner}/${repo.repo}`;
+  const blurb = truncate(summary?.summary || repo.description || "", 260);
+  const stars = formatStars(repo.stars);
+  const category = (repo.category || "").toLowerCase();
+  const dateLabel = formatDate(weekStart);
+
+  return `<!-- BEGIN featured-week (auto-managed by scripts/rotate-featured.js) -->
+<section class="featured-week" aria-label="Featured project this week">
+  <div class="featured-week-meta">
+    <div class="featured-label">featured · this week</div>
+    <span class="featured-week-date">${escapeHtml(dateLabel)}</span>
+  </div>
+  <a class="featured-week-name" href="/projects/${escapeHtml(repo.owner)}/${escapeHtml(repo.repo)}">
+    <span class="org">${escapeHtml(repo.owner)}</span><span class="slash">/</span>${escapeHtml(repo.repo)}${repo.official ? ' <span class="repo-flag">official</span>' : ""}
+  </a>
+  <p class="featured-week-desc">${escapeHtml(blurb)}</p>
+  <div class="featured-week-foot">
+    <span class="featured-week-tag featured-week-tag--star">★ ${escapeHtml(stars)}</span>
+    <span class="featured-week-tag">${escapeHtml(category)}</span>
+    <a class="featured-week-link" href="/projects/${escapeHtml(repo.owner)}/${escapeHtml(repo.repo)}">read the full breakdown →</a>
+  </div>
+</section>
+<!-- END featured-week -->`;
+}
+
+function main() {
+  const arg = process.argv[2];
+  if (!arg || !arg.includes("/")) {
+    console.error("Usage: node scripts/rotate-featured.js <owner>/<repo>");
+    process.exit(1);
+  }
+  const [owner, repoName] = arg.split("/", 2);
+
+  // Load repos
+  const repos = JSON.parse(fs.readFileSync(path.join(ROOT, "data", "repos.json"), "utf-8"));
+  const repo = repos.find((r) => r.owner === owner && r.repo === repoName);
+  if (!repo) {
+    console.error(`✗ ${arg} not found in data/repos.json`);
+    process.exit(1);
+  }
+
+  // Load summary (optional)
+  let summary = null;
+  try {
+    const summaries = JSON.parse(fs.readFileSync(path.join(ROOT, "data", "summaries.json"), "utf-8"));
+    summary = summaries[`${owner}/${repoName}`] || null;
+  } catch {}
+  if (!summary?.summary) {
+    console.warn(`⚠ No generated summary for ${arg} — falling back to repo.description`);
+  }
+
+  // Load + update featured.json
+  const featuredPath = path.join(ROOT, "data", "featured.json");
+  let featured = [];
+  if (fs.existsSync(featuredPath)) {
+    featured = JSON.parse(fs.readFileSync(featuredPath, "utf-8"));
+  }
+  const weekStart = mondayOf(new Date());
+  const slug = `${owner}/${repoName}`;
+  // Drop any existing entry for this same week (re-running same week shouldn't
+  // create duplicates) and prepend the new pick.
+  featured = featured.filter((e) => e.weekStart !== weekStart);
+  featured.unshift({ slug, weekStart, addedAt: new Date().toISOString() });
+  fs.writeFileSync(featuredPath, JSON.stringify(featured, null, 2) + "\n", "utf-8");
+  console.log(`✓ data/featured.json updated (${featured.length} entries; current: ${slug} for week of ${weekStart})`);
+
+  // Update index.html
+  const indexPath = path.join(ROOT, "index.html");
+  const indexHtml = fs.readFileSync(indexPath, "utf-8");
+  const block = renderFeaturedSection({ slug, weekStart }, repo, summary, weekStart);
+  const re = /<!-- BEGIN featured-week[\s\S]*?<!-- END featured-week -->/;
+  if (!re.test(indexHtml)) {
+    console.error("✗ Could not find <!-- BEGIN featured-week --> / <!-- END featured-week --> markers in index.html");
+    console.error("  Add a placeholder containing those exact comment markers and try again.");
+    process.exit(1);
+  }
+  const updated = indexHtml.replace(re, block);
+  fs.writeFileSync(indexPath, updated, "utf-8");
+  console.log(`✓ index.html featured-week section replaced (${slug})`);
+  console.log("\nNext: review the diff, commit, and push.");
+}
+
+main();


### PR DESCRIPTION
## Summary
- New homepage module: **Featured · this week** (rotating community pick), placed between the existing "Featured · core" hero and the newsletter capture
- One-command rotation: \`node scripts/rotate-featured.js <owner>/<repo>\`
- Blurb auto-pulled from \`data/summaries.json\` (existing AI summary pipeline) — no new editorial work
- \`data/featured.json\` keeps the rotation history, newest first; \`weekStart\` snapped to Monday so mid-week reruns are idempotent

## How rotation works (for future me)
The rotator:
1. Validates \`<owner>/<repo>\` exists in \`data/repos.json\`
2. Looks up the blurb in \`data/summaries.json\` (falls back to repo description)
3. Prepends a new entry to \`data/featured.json\` (deduped by week)
4. Rewrites the section between \`<!-- BEGIN featured-week -->\` / \`<!-- END featured-week -->\` markers in \`index.html\`

So when you say "rotate featured project to X", it's a single command — no HTML/CSS rewrite needed.

## Seed pick
\`vectorize-io/hindsight\` (Memory & Context, 8.4K stars). Fits the Hermes memory thesis from the April report. Swap any time with the rotator.

## Files
- New: \`data/featured.json\`, \`scripts/rotate-featured.js\`
- Modified: \`index.html\` (placeholder markers + initial render), \`assets/css/index.css\` (.featured-week styles + responsive)

## Phase 3 wrap
This closes the Phase 3 (Reports + Featured Projects) scope from the roadmap.

## Test plan
- [ ] Preview deploy: featured-week section renders between core-featured and newsletter
- [ ] \`vectorize-io/hindsight\` link → \`/projects/vectorize-io/hindsight\` works
- [ ] Mobile: section reflows cleanly at 375px (CSS has a 720px breakpoint)
- [ ] Run \`node scripts/rotate-featured.js NousResearch/atropos\` on a throwaway branch → confirm featured.json + index.html update; revert
- [ ] No JSON-LD or sitemap changes needed (homepage already has WebSite/Organization/Dataset; the pick is just secondary content)

🤖 Generated with [Claude Code](https://claude.com/claude-code)