### PR TITLE
Sync homepage repo-rows from data/repos.json (closes 14-repo gap)

### DIFF
--- a/index.html
+++ b/index.html
@@ -312,7 +312,7 @@
     <div class="cat-num">§02</div>
     <h2 class="cat-title">Workspaces &amp; GUIs</h2>
     <p class="cat-desc">Web and desktop interfaces — chat UIs, memory browsers, config dashboards.</p>
-    <div class="cat-count"><span class="cat-count-n">9</span> repos</div>
+    <div class="cat-count"><span class="cat-count-n">11</span> repos</div>
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/nesquena/hermes-webui" data-github="https://github.com/nesquena/hermes-webui" data-desc="Hermes WebUI: The best way to use Hermes Agent from the web or from your phone!">
@@ -387,6 +387,22 @@
       </div>
       <div class="repo-delta">— / wk</div>
     </a>
+    <a class="repo-row" href="/projects/EKKOLearnAI/hermes-web-ui" data-github="https://github.com/EKKOLearnAI/hermes-web-ui" data-desc="Web dashboard for Hermes Agent — multi-platform AI chat, session management, scheduled jobs, usage analytics &amp; channel configuration (Telegram, Discord, Slack, WhatsApp)">
+      <div class="repo-stars">★ 1,844</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">EKKOLearnAI /</span> hermes-web-ui</div>
+        <div class="repo-desc">Web dashboard for Hermes Agent — multi-platform AI chat, session management, scheduled jobs, usage analytics &amp; channel configuration (Telegram, Discord, Slack, WhatsApp).</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/aivrar/portable-hermes-agent" data-github="https://github.com/aivrar/portable-hermes-agent" data-desc="Hermes Agent made portable desktop for Windows — 100 tools, GUI, local models via LM Studio, TTS, Music, ComfyUI, workflows, tool maker. No install. No Docker. No admin rights.">
+      <div class="repo-stars">★ 81</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">aivrar /</span> portable-hermes-agent</div>
+        <div class="repo-desc">Hermes Agent made portable desktop for Windows — 100 tools, GUI, local models via LM Studio, TTS, Music, ComfyUI, workflows, tool maker. No install. No Docker. No admin rights.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
   </div>
 </section>
 
@@ -395,7 +411,7 @@
     <div class="cat-num">§03</div>
     <h2 class="cat-title">Skills &amp; skill registries</h2>
     <p class="cat-desc">Reusable capabilities following the agentskills.io open standard — libraries, registries, and meta-tools.</p>
-    <div class="cat-count"><span class="cat-count-n">17</span> repos</div>
+    <div class="cat-count"><span class="cat-count-n">20</span> repos</div>
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills" data-github="https://github.com/mukul975/Anthropic-Cybersecurity-Skills" data-desc="754 structured cybersecurity skills mapped to MITRE ATT&CK, NIST CSF 2.0, ATLAS, D3FEND & NIST AI RMF">
@@ -534,6 +550,30 @@
       </div>
       <div class="repo-delta">— / wk</div>
     </a>
+    <a class="repo-row" href="/projects/AMAP-ML/SkillClaw" data-github="https://github.com/AMAP-ML/SkillClaw" data-desc="Let Skills Evolve Collectively with Agentic Evolver">
+      <div class="repo-stars">★ 1,103</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">AMAP-ML /</span> SkillClaw</div>
+        <div class="repo-desc">Let Skills Evolve Collectively with Agentic Evolver.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Cranot/super-hermes" data-github="https://github.com/Cranot/super-hermes" data-desc="Skills that teach Hermes Agent to write its own analytical prompts">
+      <div class="repo-stars">★ 122</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Cranot /</span> super-hermes</div>
+        <div class="repo-desc">Skills that teach Hermes Agent to write its own analytical prompts.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/adnw-vinc/hermes-nextcloud" data-github="https://github.com/adnw-vinc/hermes-nextcloud" data-desc="Hermes Agent skill for Nextcloud — manage files, notes, calendar, tasks, and contacts via WebDAV and CalDAV.">
+      <div class="repo-stars">★ 1</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">adnw-vinc /</span> hermes-nextcloud</div>
+        <div class="repo-desc">Hermes Agent skill for Nextcloud — manage files, notes, calendar, tasks, and contacts via WebDAV and CalDAV.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
   </div>
 </section>
 
@@ -542,7 +582,7 @@
     <div class="cat-num">§04</div>
     <h2 class="cat-title">Memory &amp; context</h2>
     <p class="cat-desc">Long-term semantic memory, graph-based retrieval, cross-session persistence.</p>
-    <div class="cat-count"><span class="cat-count-n">9</span> repos</div>
+    <div class="cat-count"><span class="cat-count-n">13</span> repos</div>
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/mem0ai/mem0" data-github="https://github.com/mem0ai/mem0" data-desc="Universal memory layer for AI Agents — official Hermes Agent memory provider, managed cloud or Apache-2.0 self-hosted OSS">
@@ -617,6 +657,38 @@
       </div>
       <div class="repo-delta">— / wk</div>
     </a>
+    <a class="repo-row" href="/projects/plastic-labs/honcho" data-github="https://github.com/plastic-labs/honcho" data-desc="Memory library for building stateful agents — the upstream library that the elkimek/honcho-self-hosted Hermes wrapper builds on.">
+      <div class="repo-stars">★ 3,143</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">plastic-labs /</span> honcho <span class="repo-flag">official</span></div>
+        <div class="repo-desc">Memory library for building stateful agents — the upstream library that the elkimek/honcho-self-hosted Hermes wrapper builds on.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/EfficientContext/ContextPilot" data-github="https://github.com/EfficientContext/ContextPilot" data-desc="Accelerating Long Context LLM Inference with Accuracy-Preserving Context Optimization in SGLang, vLLM, llama.cpp, OpenClaw, RAG, and Agentic AI.">
+      <div class="repo-stars">★ 82</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">EfficientContext /</span> ContextPilot</div>
+        <div class="repo-desc">Accelerating Long Context LLM Inference with Accuracy-Preserving Context Optimization in SGLang, vLLM, llama.cpp, OpenClaw, RAG, and Agentic AI.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/keepnotes-ai/keep" data-github="https://github.com/keepnotes-ai/keep" data-desc="Reflective memory for AI agents">
+      <div class="repo-stars">★ 31</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">keepnotes-ai /</span> keep</div>
+        <div class="repo-desc">Reflective memory for AI agents.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/AxDSan/mnemosyne" data-github="https://github.com/AxDSan/mnemosyne" data-desc="The Zero-Dependency, Sub-Millisecond AI Memory System for Hermes Agents">
+      <div class="repo-stars">★ 29</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">AxDSan /</span> mnemosyne</div>
+        <div class="repo-desc">The Zero-Dependency, Sub-Millisecond AI Memory System for Hermes Agents.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
   </div>
 </section>
 
@@ -625,7 +697,7 @@
     <div class="cat-num">§05</div>
     <h2 class="cat-title">Plugins &amp; extensions</h2>
     <p class="cat-desc">Drop-in modules that add tools, safety, payments, or new capabilities.</p>
-    <div class="cat-count"><span class="cat-count-n">7</span> repos</div>
+    <div class="cat-count"><span class="cat-count-n">9</span> repos</div>
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/clawshell/clawshell" data-github="https://github.com/clawshell/clawshell" data-desc="Runtime Security Layer for OpenClaw/Hermes — PII & sensitive credentials protection">
@@ -681,6 +753,22 @@
       <div class="repo-body">
         <div class="repo-name"><span class="org">raulvidis /</span> hermes-cloudflare</div>
         <div class="repo-desc">Cloudflare Browser Rendering — crawl, scrape, extract content from web pages.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/335234131/agent-browser-mcp" data-github="https://github.com/335234131/agent-browser-mcp" data-desc="让 Agent 直接操作真实 Chrome 的 MCP 服务，支持页面扫描、CDP、截图与物理输入">
+      <div class="repo-stars">★ 167</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">335234131 /</span> agent-browser-mcp</div>
+        <div class="repo-desc">让 Agent 直接操作真实 Chrome 的 MCP 服务，支持页面扫描、CDP、截图与物理输入.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/briancaffey/hermes-otel" data-github="https://github.com/briancaffey/hermes-otel" data-desc="OTel Plugin for Hermes Agent">
+      <div class="repo-stars">★ 4</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">briancaffey /</span> hermes-otel</div>
+        <div class="repo-desc">OTel Plugin for Hermes Agent.</div>
       </div>
       <div class="repo-delta">— / wk</div>
     </a>
@@ -759,7 +847,7 @@
     <div class="cat-num">§07</div>
     <h2 class="cat-title">Deployment &amp; infra</h2>
     <p class="cat-desc">Docker, Nix, systemd, and managed cloud templates — from a $5 VPS to enterprise Kubernetes.</p>
-    <div class="cat-count"><span class="cat-count-n">7</span> repos</div>
+    <div class="cat-count"><span class="cat-count-n">8</span> repos</div>
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/numtide/llm-agents.nix" data-github="https://github.com/numtide/llm-agents.nix" data-desc="Nix packages for AI coding agents including Hermes">
@@ -815,6 +903,14 @@
       <div class="repo-body">
         <div class="repo-name"><span class="org">ellickjohnson /</span> portainer-stack-hermes</div>
         <div class="repo-desc">Docker Compose stack with Portainer UI and ttyd web terminal.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/jpalmae/hermeshq" data-github="https://github.com/jpalmae/hermeshq" data-desc="HermesHQ is a Docker-first control plane for running and operating multiple Hermes Agent instances from one web application.">
+      <div class="repo-stars">★ 5</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">jpalmae /</span> hermeshq</div>
+        <div class="repo-desc">HermesHQ is a Docker-first control plane for running and operating multiple Hermes Agent instances from one web application.</div>
       </div>
       <div class="repo-delta">— / wk</div>
     </a>
@@ -1051,7 +1147,7 @@
     <div class="cat-num">§11</div>
     <h2 class="cat-title">Guides &amp; docs</h2>
     <p class="cat-desc">Curated lists, optimization playbooks, setup walkthroughs, and community wikis.</p>
-    <div class="cat-count"><span class="cat-count-n">7</span> repos</div>
+    <div class="cat-count"><span class="cat-count-n">9</span> repos</div>
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/0xNyk/awesome-hermes-agent" data-github="https://github.com/0xNyk/awesome-hermes-agent" data-desc="Curated list of awesome skills, tools, integrations, and resources for Hermes Agent">
@@ -1107,6 +1203,22 @@
       <div class="repo-body">
         <div class="repo-name"><span class="org">martymcenroe /</span> HermesWiki</div>
         <div class="repo-desc">Community wiki with deployment patterns and recipes.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/jwangkun/hermes-agent-guide" data-github="https://github.com/jwangkun/hermes-agent-guide" data-desc="A systematic Chinese-language guide to Hermes Agent — 16 books, 300K+ words, covering installation, advanced development, single- and multi-agent orchestration.">
+      <div class="repo-stars">★ 130</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">jwangkun /</span> hermes-agent-guide</div>
+        <div class="repo-desc">A systematic Chinese-language guide to Hermes Agent — 16 books, 300K+ words, covering installation, advanced development, single- and multi-agent orchestration.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/longyunfeigu/learn-hermes-agent" data-github="https://github.com/longyunfeigu/learn-hermes-agent" data-desc="A 27-chapter hands-on tutorial for building an autonomous AI agent from zero in Python — agent loop, tool system, memory, skills, MCP, multi-platform gateway, and self-evolution.">
+      <div class="repo-stars">★ 73</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">longyunfeigu /</span> learn-hermes-agent</div>
+        <div class="repo-desc">A 27-chapter hands-on tutorial for building an autonomous AI agent from zero in Python — agent loop, tool system, memory, skills, MCP, multi-platform gateway, and self-evolution.</div>
       </div>
       <div class="repo-delta">— / wk</div>
     </a>

--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -1028,6 +1028,114 @@ function generateSitemap(projectPages, listPages, reportPages = []) {
   return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}</urlset>\n`;
 }
 
+// ── Render a single homepage repo-row block ──
+function renderHomepageRepoRow(r) {
+  const stars = (r.stars || 0).toLocaleString("en-US");
+  const flag = r.official ? ' <span class="repo-flag">official</span>' : "";
+  const desc = (r.description || "").trim();
+  const descPunctuated = desc.endsWith(".") ? desc : desc + ".";
+  return `    <a class="repo-row" href="/projects/${r.owner}/${r.repo}" data-github="https://github.com/${r.owner}/${r.repo}" data-desc="${escapeHtml(desc)}">
+      <div class="repo-stars">★ ${stars}</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">${escapeHtml(r.owner)} /</span> ${escapeHtml(r.repo)}${flag}</div>
+        <div class="repo-desc">${escapeHtml(descPunctuated)}</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+`;
+}
+
+// ── Sync homepage repo-rows from data/repos.json (append-only) ──
+//
+// The homepage (index.html) is statically rendered HTML. Auto-discovered
+// repos that get merged via validate-repo-suggestion.yml only update
+// data/repos.json — they don't touch index.html, so the homepage drifts
+// behind the data file. This function detects every repo in repos.json
+// missing from index.html and appends a new <a class="repo-row"> block
+// into the matching <section class="cat" data-category="...">. Existing
+// rows are never modified, preserving hand-curated descriptions and
+// ordering. Each section's <span class="cat-count-n"> is also rewritten
+// from the live count.
+function syncHomepageRepos(repos) {
+  console.log("\nSyncing homepage repo-rows from repos.json...");
+  const indexPath = path.join(ROOT, "index.html");
+  let html = fs.readFileSync(indexPath, "utf-8");
+  const NL = html.includes("\r\n") ? "\r\n" : "\n";
+
+  const onPage = new Set(
+    [...html.matchAll(/href="\/projects\/([^"]+)"/g)].map((m) => m[1])
+  );
+
+  const missingByCategory = {};
+  for (const r of repos) {
+    if (!onPage.has(`${r.owner}/${r.repo}`)) {
+      (missingByCategory[r.category] = missingByCategory[r.category] || []).push(r);
+    }
+  }
+  const missingCount = Object.values(missingByCategory).reduce((a, b) => a + b.length, 0);
+
+  if (missingCount === 0) {
+    console.log("  Already in sync (0 entries to add)");
+  } else {
+    const closeNeedle = `${NL}  </div>${NL}`;
+    for (const [category, missing] of Object.entries(missingByCategory)) {
+      missing.sort((a, b) => (b.stars || 0) - (a.stars || 0));
+      let newRowsHtml = missing.map(renderHomepageRepoRow).join("");
+      if (NL === "\r\n") newRowsHtml = newRowsHtml.replace(/\n/g, "\r\n");
+
+      const sectionStartTag = `<section class="cat" data-category="${category}">`;
+      const sectionStart = html.indexOf(sectionStartTag);
+      if (sectionStart === -1) {
+        console.warn(`  ⚠ Section not found: ${category} — skipping ${missing.length} repos`);
+        continue;
+      }
+      const sectionEnd = html.indexOf("</section>", sectionStart);
+      const insertBefore = html.lastIndexOf(closeNeedle, sectionEnd);
+      if (insertBefore === -1 || insertBefore < sectionStart) {
+        console.warn(`  ⚠ Could not locate cat-list end in section: ${category}`);
+        continue;
+      }
+
+      html =
+        html.slice(0, insertBefore) +
+        NL +
+        newRowsHtml.trimEnd() +
+        html.slice(insertBefore);
+      console.log(`  ${category}: +${missing.length}`);
+    }
+  }
+
+  // Refresh per-category counts. Use ACTUAL rendered repo-rows in each
+  // section, not repos.json category totals — the homepage convention is
+  // that featured repos (NousResearch/hermes-agent) appear in the hero
+  // section, not as a category row, so counting repos.json would over-count.
+  const sectionRe = /<section class="cat" data-category="([^"]+)">([\s\S]*?)<\/section>/g;
+  let sm;
+  while ((sm = sectionRe.exec(html)) !== null) {
+    const category = sm[1];
+    const sectionContent = sm[2];
+    const renderedCount = (sectionContent.match(/<a class="repo-row"/g) || []).length;
+    const countMatch = sectionContent.match(/<span class="cat-count-n">(\d+)<\/span>/);
+    if (countMatch && parseInt(countMatch[1], 10) !== renderedCount) {
+      const absoluteIdx = sm.index + sm[0].indexOf(countMatch[0]);
+      html =
+        html.slice(0, absoluteIdx) +
+        `<span class="cat-count-n">${renderedCount}</span>` +
+        html.slice(absoluteIdx + countMatch[0].length);
+      // Re-prime the regex to re-scan from current position since string length changed
+      sectionRe.lastIndex = absoluteIdx;
+    }
+  }
+
+  if (missingCount > 0) {
+    fs.writeFileSync(indexPath, html, "utf-8");
+    console.log(`  ✓ Wrote index.html (+${missingCount} new rows)`);
+  } else {
+    // Still write back if counts changed
+    fs.writeFileSync(indexPath, html, "utf-8");
+  }
+}
+
 // ── Main ──
 async function main() {
   console.log(`Building pages for ${repos.length} repos + ${lists.length} lists...\n`);
@@ -1172,6 +1280,10 @@ async function main() {
   if (orphansRemoved > 0) {
     console.log(`  Cleaned up ${orphansRemoved} orphan project page(s)\n`);
   }
+
+  // Sync homepage repo-rows from repos.json (auto-discovered repos only update
+  // data/repos.json; index.html drifts unless this catches missing entries)
+  syncHomepageRepos(repos);
 
   // Generate list pages
   console.log("Generating list pages...");


### PR DESCRIPTION
## Summary

The homepage (`index.html`) is statically rendered, so the auto-validator workflow that merges new repos to `data/repos.json` left the homepage drifting. **14 repos were in the data file with project pages built but never appeared on the homepage** — including the entire May 1 batch from PRs #146 and #147 plus several earlier auto-discovered additions.

`scripts/build-pages.js` now runs `syncHomepageRepos()` after orphan cleanup. It detects every repo in `repos.json` missing from `index.html` and appends a new `<a class="repo-row">` block into the matching `<section class="cat" data-category="...">`. Future auto-validator additions catch up automatically — closes the gap durably, not just for tonight.

## Behavior

- **Append-only.** Existing repo-rows are never modified. Hand-curated descriptions (e.g., mem0's enriched copy with `mem0_profile / mem0_search / mem0_conclude`) are preserved verbatim. Existing ordering is preserved.
- **Cat-count auto-refresh.** Each section's `<span class="cat-count-n">` is re-derived from **actual rendered rows** (not `repos.json` totals), so featured-only entries like the hero's `NousResearch/hermes-agent` aren't double-counted.
- **CRLF-safe.** Detects line ending from the existing file and uses it consistently for both inserts and search needles.

## What this run added

14 rows across 6 categories:

| Category | + |
|---|---|
| Skills & Skill Registries | 3 |
| Memory & Context | 4 |
| Plugins & Extensions | 2 |
| Workspaces & GUIs | 2 |
| Guides & Docs | 2 |
| Deployment & Infra | 1 |

## Verification

| Check | Result |
|---|---|
| 12/12 cat-counts match rendered rows | ✓ |
| All 14 previously-missing repos now appear as repo-rows | ✓ |
| Hand-curated descriptions preserved (mem0 spot-checked) | ✓ |
| 109 repo-rows + 1 hero-only (`NousResearch/hermes-agent`) = 110 total | ✓ |
| Diff: 118 insertions, 6 deletions (only cat-count digit swaps) | ✓ |

## Test plan

- [ ] Vercel preview deploy renders all 110 repos correctly
- [ ] Verify spot-check repos (`AMAP-ML/SkillClaw`, `plastic-labs/honcho`, `EfficientContext/ContextPilot`) now appear under their categories on the homepage
- [ ] Confirm cat-count values match what's rendered visually
- [ ] mem0's enriched description still reads as before
- [ ] Trigger build-pages workflow → confirm it runs to "Already in sync (0 entries to add)" on the next pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)