### PR TITLE
Workflow hardening: release-monitor escalation + Node 24 opt-in across crons

### DIFF
--- a/.github/workflows/audit-repos.yml
+++ b/.github/workflows/audit-repos.yml
@@ -1,5 +1,10 @@
 name: Audit Repos
 
+# Opt actions into Node.js 24 now (becomes the default June 2 2026, Node 20
+# removed Sep 16 2026). Same value set across every workflow.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 # Weekly cron that pings each repo in data/repos.json against the
 # GitHub API and detects entries that are dead (deleted or owner
 # account gone), archived, or disabled. If any are found, opens or

--- a/.github/workflows/audit-summaries.yml
+++ b/.github/workflows/audit-summaries.yml
@@ -1,5 +1,8 @@
 name: Audit Summaries
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 concurrency:
   group: main-bot-push
   cancel-in-progress: false

--- a/.github/workflows/build-pages.yml
+++ b/.github/workflows/build-pages.yml
@@ -1,5 +1,8 @@
 name: Build Project & List Pages
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 concurrency:
   group: main-bot-push
   cancel-in-progress: false

--- a/.github/workflows/rebuild-chunks.yml
+++ b/.github/workflows/rebuild-chunks.yml
@@ -1,5 +1,8 @@
 name: Rebuild Knowledge Base Chunks
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 concurrency:
   group: main-bot-push
   cancel-in-progress: false

--- a/.github/workflows/refresh-docs.yml
+++ b/.github/workflows/refresh-docs.yml
@@ -1,5 +1,8 @@
 name: Refresh Hermes Docs Mirror
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 # Pulls the latest content from hermes-agent.nousresearch.com/docs into
 # research/docs/. Idempotent: only files whose upstream content changed are
 # rewritten. The push then triggers rebuild-chunks.yml downstream, so the

--- a/.github/workflows/release-monitor.yml
+++ b/.github/workflows/release-monitor.yml
@@ -1,5 +1,8 @@
 name: Daily Release Monitor
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 on:
   schedule:
     # Run daily at 06:00 UTC (checks releases + docs changes)
@@ -230,23 +233,44 @@ jobs:
             // GitHub release body) — not LLM-generated — so the human review
             // checkpoint here was guarding against zero hallucination risk.
             // With no required checks today this merges immediately; if a CI
-            // gate is ever added, auto-merge waits for it. Falls back to a
-            // manual-merge PR if the mutation fails for any reason.
-            try {
-              await github.graphql(
-                `mutation($pullRequestId: ID!) {
-                  enablePullRequestAutoMerge(input: {
-                    pullRequestId: $pullRequestId,
-                    mergeMethod: MERGE
-                  }) {
-                    pullRequest { autoMergeRequest { enabledAt } }
-                  }
-                }`,
-                { pullRequestId: pr.node_id }
-              );
-              console.log(`Auto-merge enabled on PR #${pr.number}`);
-            } catch (e) {
-              core.warning(`Could not enable auto-merge on PR #${pr.number}: ${e.message}. PR remains open for manual merge.`);
+            // gate is ever added, auto-merge waits for it.
+            //
+            // Retry once on failure; if still failing, open a tracking issue
+            // so the orphaned PR is visible. The old try/catch with just
+            // `core.warning` left PR #173 (v0.13.0 release notes) orphan for
+            // 14 hours — warnings only surface in workflow run logs nobody
+            // routinely checks.
+            let autoMergeEnabled = false;
+            for (let attempt = 1; attempt <= 2; attempt++) {
+              try {
+                await github.graphql(
+                  `mutation($pullRequestId: ID!) {
+                    enablePullRequestAutoMerge(input: {
+                      pullRequestId: $pullRequestId,
+                      mergeMethod: MERGE
+                    }) {
+                      pullRequest { autoMergeRequest { enabledAt } }
+                    }
+                  }`,
+                  { pullRequestId: pr.node_id }
+                );
+                autoMergeEnabled = true;
+                console.log(`Auto-merge enabled on PR #${pr.number} (attempt ${attempt})`);
+                break;
+              } catch (e) {
+                if (attempt === 2) {
+                  await github.rest.issues.create({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    title: `[Workflow] Auto-merge failed on release PR #${pr.number}`,
+                    body: `Could not enable auto-merge on release-notes PR #${pr.number} for ${tag}.\n\nError: \`${e.message}\`\n\n**Action:** review and merge the PR manually.`,
+                    labels: ['workflow-issue']
+                  });
+                  core.warning(`Auto-merge failed after 2 attempts on PR #${pr.number}; tracking issue opened.`);
+                } else {
+                  await new Promise(r => setTimeout(r, 5000));
+                }
+              }
             }
 
       - name: Bust stars API cache so site shows new version immediately

--- a/.github/workflows/weekly-discovery.yml
+++ b/.github/workflows/weekly-discovery.yml
@@ -1,5 +1,8 @@
 name: Weekly Repo Discovery
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 on:
   schedule:
     # Run every Monday at 08:00 UTC


### PR DESCRIPTION
## Summary

Two workflow-hygiene fixes that cut across the cron/scheduler workflows.

### 1. Release-monitor: escalate auto-merge failures

`release-monitor.yml` enables auto-merge on the release-notes PR it opens. Previously, if the GraphQL mutation failed, the workflow only logged a `core.warning`. Warnings surface only in workflow run logs nobody routinely checks. **PR #173 (v0.13.0 release notes) sat orphan for 14 hours behind exactly this silent fail.**

**Fix:** retry once with a 5s gap; on second failure, open a `[Workflow]` tracking issue. The orphan PR becomes visible in the issue list within a minute of the workflow run.

### 2. Node 24 opt-in across all crons

GitHub Actions deprecates Node 20 actions. Default flips to Node 24 on **June 2, 2026**; Node 20 is removed **Sep 16, 2026**. Setting `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` at workflow level opts in now and is a no-op once the platform default flips.

Touched workflows: `audit-repos`, `audit-summaries`, `build-pages`, `rebuild-chunks`, `refresh-docs`, `release-monitor`, `weekly-discovery`.

> `validate-repo-suggestion.yml` is intentionally not touched here — its Node 24 opt-in lands in PR #202 (which deletes `auto-label-submissions.yml` and substantially edits the validator).

## Test plan

- [ ] Next scheduled workflow run does not emit the Node 20 deprecation annotation.
- [ ] Force a release-monitor auto-merge failure (e.g. revoke the relevant permission temporarily) and confirm a tracking issue is opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)