### PR TITLE
build-pages: stage index.html (homepage drift fix) + harden rebase retry

### DIFF
--- a/.github/workflows/build-pages.yml
+++ b/.github/workflows/build-pages.yml
@@ -47,7 +47,9 @@ jobs:
       - name: Check for changes
         id: diff
         run: |
-          git add projects/ lists/ sitemap.xml robots.txt llms.txt llms-full.txt rss.xml data/summaries.json data/list-summaries.json
+          # index.html is mutated by syncHomepageRepos() in build-pages.js
+          # — must be staged or homepage drifts silently (bug pre-2026-05-17).
+          git add index.html projects/ lists/ sitemap.xml robots.txt llms.txt llms-full.txt rss.xml data/summaries.json data/list-summaries.json
           if git diff --cached --quiet; then
             echo "changed=false" >> $GITHUB_OUTPUT
           else
@@ -69,13 +71,25 @@ jobs:
           # bot workflow committing) — vanilla `git push` then fails with
           # `! [rejected] main -> main (fetch first)`. Retry up to 3 times,
           # rebasing onto the new remote tip between attempts.
+          #
+          # Stash any unstaged working-tree changes before the rebase. Without
+          # this, the rebase aborts with "cannot pull with rebase: You have
+          # unstaged changes" if any build step writes a file outside the
+          # staged set — and the entire build's work gets thrown away silently
+          # (this is what cancelled all 5 burst-merge builds on 2026-05-15).
           for attempt in 1 2 3; do
             if git push; then
               echo "Pushed on attempt $attempt"
               exit 0
             fi
-            echo "Push rejected (attempt $attempt) — pulling --rebase and retrying"
-            git pull --rebase origin main || { echo "Rebase failed — aborting"; exit 1; }
+            echo "Push rejected (attempt $attempt) — rebasing onto new remote tip"
+            git stash --include-untracked --quiet || true
+            if ! git pull --rebase origin main; then
+              echo "Rebase failed — aborting"
+              git stash pop --quiet 2>/dev/null || true
+              exit 1
+            fi
+            git stash pop --quiet 2>/dev/null || true
           done
           echo "Push failed after 3 attempts"
           exit 1


### PR DESCRIPTION
## Summary

Two interacting bugs that have been silently dropping homepage updates since 2026-05-07. Both fixed in one workflow patch.

### Bug 1 — Primary: `index.html` was never staged

PR #171 (merged 2026-05-07) added `syncHomepageRepos()` to `scripts/build-pages.js:1059` so the static homepage card grid would auto-catch-up to new repos in `data/repos.json`. The function works — verified locally against the 5 repos added 2026-05-15:

\`\`\`
Syncing homepage repo-rows from repos.json...
  Plugins & Extensions: +3
  Memory & Context: +1
  Integrations & Bridges: +1
  ✓ Wrote index.html (+5 new rows)
\`\`\`

But **PR #171 only touched `index.html` and `scripts/build-pages.js` — it never updated `.github/workflows/build-pages.yml`**. The workflow's `git add` line stages `projects/`, `lists/`, `sitemap.xml`, etc., but never `index.html`. So every scheduled build since 2026-05-07 has mutated `index.html` correctly and then **silently discarded the changes at job cleanup**.

This is why the 5 May-15 additions (#169, #200, #201, #203, #204) appeared in project pages, list pages, sitemap, RSS, and llms.txt — but not on the homepage card grid.

### Bug 2 — Secondary: rebase retry trips on unstaged work

On 2026-05-15 19:42–19:47 UTC, the auto-validator merged 5 PRs in 5 minutes. Each push triggered build-pages.yml, and the racing pushes started colliding on `! [rejected] main -> main (fetch first)`. The retry block does `git pull --rebase` — which aborts with:

\`\`\`
error: cannot pull with rebase: You have unstaged changes.
Rebase failed — aborting
\`\`\`

…because the unstaged `index.html` from `syncHomepageRepos()` (Bug 1) sits in the working tree at that moment. The build's entire work — including all 5 newly-generated project pages — got thrown away. Fixing Bug 1 closes today's vector, but a future build-step write outside the staged set would repeat the same silent-drop pattern.

## Changes

**`git add` line** — add `index.html` so `syncHomepageRepos()` mutations actually commit:

\`\`\`diff
- git add projects/ lists/ sitemap.xml robots.txt llms.txt llms-full.txt rss.xml data/summaries.json data/list-summaries.json
+ git add index.html projects/ lists/ sitemap.xml robots.txt llms.txt llms-full.txt rss.xml data/summaries.json data/list-summaries.json
\`\`\`

**Rebase retry** — stash unstaged before `pull --rebase`, pop after. Future file writes outside the staged set will rebase cleanly instead of aborting the whole build.

## Verification

| Check | Result |
|---|---|
| `syncHomepageRepos()` correctly identifies all 5 missing repos | ✓ (local run logged `+5 new rows`) |
| Diff inserts 5 `<a class="repo-row">` blocks under correct categories | ✓ (Plugins & Extensions +3, Memory & Context +1, Integrations & Bridges +1) |
| `git add index.html` now stages those mutations | ✓ (workflow patch) |
| Stash/pop wrapper around rebase isolates unstaged from staged | ✓ (handles burst-merge races) |

## Test plan

- [ ] Workflow file lints (no `actionlint` config in repo — relying on GitHub parser)
- [ ] After merge: trigger `workflow_dispatch` on Build Project & List Pages and confirm the resulting commit touches `index.html` with the 5 May-15 repo-rows
- [ ] Visit hermesatlas.com after the bot push and confirm all 5 new projects appear in their category sections
- [ ] On next auto-validator burst merge, confirm push-retry rebases cleanly without "unstaged changes" abort

## Follow-up worth considering (not in this PR)

A tripwire: after the staging step, fail loudly if `git status --porcelain` is non-empty for repo-output files. Would have caught PR #171's gap on day 1 instead of day 10. Risk is false positives from `package-lock.json` drift; scope it to `index.html` + the staged glob to keep noise low.

🤖 Generated with [Claude Code](https://claude.com/claude-code)