### PR TITLE
Add 6 memory providers from Memory Guidebook article

### DIFF
--- a/data/repos.json
+++ b/data/repos.json
@@ -1160,6 +1160,66 @@
     "category": "Memory & Context"
   },
   {
+    "owner": "volcengine",
+    "repo": "OpenViking",
+    "name": "OpenViking",
+    "description": "Open-source context database for AI agents — official Hermes Agent memory provider using viking:// URIs and tiered L0/L1/L2 loading; 91% token reduction and 43-49% task-completion gain over baseline on LoCoMo10. AGPL-3.0.",
+    "stars": 24584,
+    "url": "https://github.com/volcengine/OpenViking",
+    "official": false,
+    "category": "Memory & Context"
+  },
+  {
+    "owner": "supermemoryai",
+    "repo": "supermemory",
+    "name": "supermemory",
+    "description": "Memory engine and API — official Hermes Agent memory provider with sub-300ms recall sustained at 100B+ tokens/month, custom vector graph engine, context fencing, and byte-level dedupe with 100% prompt-cache discount.",
+    "stars": 22665,
+    "url": "https://github.com/supermemoryai/supermemory",
+    "official": false,
+    "category": "Memory & Context"
+  },
+  {
+    "owner": "campfirein",
+    "repo": "byterover-cli",
+    "name": "byterover-cli",
+    "description": "Memory as a git repo (formerly Cipher) — official Hermes Agent memory provider with 5-tier retrieval (4 tiers non-LLM, sub-100ms), brv vc commit/branch/merge versioning over plain markdown context tree. Elastic License 2.0.",
+    "stars": 4783,
+    "url": "https://github.com/campfirein/byterover-cli",
+    "official": false,
+    "category": "Memory & Context"
+  },
+  {
+    "owner": "yantrikos",
+    "repo": "yantrikdb-hermes-plugin",
+    "name": "yantrikdb-hermes-plugin",
+    "description": "Self-maintaining Hermes memory plugin with explainable retrieval — every recall comes back with a why_retrieved tag, plus canonicalization, contradiction tracking, and recency ranking. Embedded by default.",
+    "stars": 26,
+    "url": "https://github.com/yantrikos/yantrikdb-hermes-plugin",
+    "official": false,
+    "category": "Memory & Context"
+  },
+  {
+    "owner": "Ladybug-Memory",
+    "repo": "hermes-memory-plugin",
+    "name": "hermes-memory-plugin",
+    "description": "Local-only Hermes memory plugin with built-in 1-10 importance ranking so the things that matter most surface first. Columnar .lbdb embedded graph DB, BM25-first retrieval, optional GLiNER2 entity extraction.",
+    "stars": 15,
+    "url": "https://github.com/Ladybug-Memory/hermes-memory-plugin",
+    "official": false,
+    "category": "Memory & Context"
+  },
+  {
+    "owner": "MukundaKatta",
+    "repo": "hermes-agentmemory",
+    "name": "hermes-agentmemory",
+    "description": "Pull-model episodic memory plugin for Hermes Agent with real deletion (no persistent summaries that haunt future recall) and a trace.jsonl audit log of every memory operation. Community fix for issue #6715. MIT.",
+    "stars": 5,
+    "url": "https://github.com/MukundaKatta/hermes-agentmemory",
+    "official": false,
+    "category": "Memory & Context"
+  },
+  {
     "owner": "BORT-AGENTS",
     "repo": "hermes-bort",
     "name": "hermes-bort",

--- a/index.html
+++ b/index.html
@@ -582,7 +582,7 @@
     <div class="cat-num">§04</div>
     <h2 class="cat-title">Memory &amp; context</h2>
     <p class="cat-desc">Long-term semantic memory, graph-based retrieval, cross-session persistence.</p>
-    <div class="cat-count"><span class="cat-count-n">15</span> repos</div>
+    <div class="cat-count"><span class="cat-count-n">21</span> repos</div>
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/mem0ai/mem0" data-github="https://github.com/mem0ai/mem0" data-desc="Universal memory layer for AI Agents — official Hermes Agent memory provider, managed cloud or Apache-2.0 self-hosted OSS">
@@ -702,6 +702,54 @@
       <div class="repo-body">
         <div class="repo-name"><span class="org">alias8818 /</span> hermes-tool-slimmer</div>
         <div class="repo-desc">Reduce Hermes Agent tool-schema overhead with keyword selection and Tool Search support.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/volcengine/OpenViking" data-github="https://github.com/volcengine/OpenViking" data-desc="Filesystem-first context database — official Hermes memory provider with tiered loading and 91% token reduction on LoCoMo10">
+      <div class="repo-stars">★ 24,584</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">volcengine /</span> OpenViking</div>
+        <div class="repo-desc">Official Hermes memory provider — viking:// URIs, tiered L0/L1/L2 loading, 91% token reduction + 43-49% task gain over baseline on LoCoMo10. AGPL-3.0.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/supermemoryai/supermemory" data-github="https://github.com/supermemoryai/supermemory" data-desc="Memory engine and API — official Hermes provider with sub-300ms recall at 100B+ tokens/month and context fencing">
+      <div class="repo-stars">★ 22,665</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">supermemoryai /</span> supermemory</div>
+        <div class="repo-desc">Official Hermes memory provider — sub-300ms recall sustained at 100B+ tokens/month, custom vector graph engine, context fencing kills capture pollution, byte-level dedupe.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/campfirein/byterover-cli" data-github="https://github.com/campfirein/byterover-cli" data-desc="ByteRover CLI (brv) — official Hermes memory provider storing memory as a git-versionable markdown context tree">
+      <div class="repo-stars">★ 4,783</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">campfirein /</span> byterover-cli</div>
+        <div class="repo-desc">Memory as a git repo (formerly Cipher) — official Hermes provider with 5-tier retrieval (4 tiers non-LLM, sub-100ms), brv vc commit/branch/merge versioning.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/yantrikos/yantrikdb-hermes-plugin" data-github="https://github.com/yantrikos/yantrikdb-hermes-plugin" data-desc="Self-maintaining Hermes memory plugin with explainable retrieval — every recall comes with a why_retrieved tag">
+      <div class="repo-stars">★ 26</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">yantrikos /</span> yantrikdb-hermes-plugin</div>
+        <div class="repo-desc">Embedded-by-default Hermes plugin with canonicalization, contradiction tracking, recency ranking, and explainable why_retrieved tags on every recall.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Ladybug-Memory/hermes-memory-plugin" data-github="https://github.com/Ladybug-Memory/hermes-memory-plugin" data-desc="Local-only Hermes memory plugin with built-in 1-10 importance ranking so what matters most surfaces first">
+      <div class="repo-stars">★ 15</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Ladybug-Memory /</span> hermes-memory-plugin</div>
+        <div class="repo-desc">Local .lbdb columnar embedded graph DB, BM25-first retrieval, 1-10 importance scoring, optional GLiNER2 entity extraction.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/MukundaKatta/hermes-agentmemory" data-github="https://github.com/MukundaKatta/hermes-agentmemory" data-desc="Pull-model Hermes memory plugin with real deletion (no persistent summaries) and full audit trace">
+      <div class="repo-stars">★ 5</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">MukundaKatta /</span> hermes-agentmemory</div>
+        <div class="repo-desc">Real deletion (gone is gone), trace.jsonl audit log of every memory op, 200ms-2s first-turn cost. Community fix for issue #6715. MIT.</div>
       </div>
       <div class="repo-delta">— / wk</div>
     </a>


### PR DESCRIPTION
## Summary

Cross-referenced the providers listed in the upcoming *Hermes Agent Memory Guidebook* article against current Atlas inventory. **6 referenced repos were missing.** This PR adds them to the Memory & Context category.

## Cross-reference

| # | Tool | On Atlas? | Action |
|---|---|---|---|
| 1 | Honcho | ✓ `plastic-labs/honcho` | none |
| 2 | Mem0 | ✓ `mem0ai/mem0` | none |
| 3 | Hindsight | ✓ `vectorize-io/hindsight` | none |
| 4 | **Holographic** | ✗ in-tree | **skipped** — lives at `NousResearch/hermes-agent/plugins/memory/holographic`; parent already on Atlas as Core & Official |
| 5 | **OpenViking** | ✗ | **added** `volcengine/OpenViking` (24,584★) |
| 6 | **RetainDB** | ✗ no GH | **skipped** — cloud-only, no public GitHub repo |
| 7 | **ByteRover** | ✗ | **added** `campfirein/byterover-cli` (4,783★) |
| 8 | **Supermemory** | ✗ | **added** `supermemoryai/supermemory` (22,665★) |
| 9 | GBrain | ✓ `garrytan/gbrain` | none |
| 10 | Mnemosyne | ✓ `AxDSan/mnemosyne` | none |
| 11 | **Ladybug** | ✗ | **added** `Ladybug-Memory/hermes-memory-plugin` (15★) |
| 12 | **yantrikdb** | ✗ | **added** `yantrikos/yantrikdb-hermes-plugin` (26★) |
| 13 | **hermes-agentmemory** | ✗ | **added** `MukundaKatta/hermes-agentmemory` (5★) |
| 14 | PLUR | ✓ `plur-ai/plur` | none |
| 15 | FlowState-QMD | ✓ `amanning3390/flowstate-qmd` | none |

## What's in the diff

- `data/repos.json`: +6 entries (123 total, was 117)
- `index.html`: +6 anchor rows in Memory & Context section, count `15` → `21`
- All entries verified via `gh api repos/...` for live stars + descriptions
- All meet CONTRIBUTING criteria (1★ minimum, post-July-2025, Hermes-integrated, active)
- `official: false` for all 6 (matches `mem0ai/mem0`; the 3 official providers can be flipped to `true` later to match `vectorize-io/hindsight` and `plastic-labs/honcho` if you want consistency)

## Notes worth flagging

1. **Holographic + RetainDB gap.** Two of the 8 official Hermes memory providers can't be added cleanly to Atlas in its current schema. Worth considering: (a) a dedicated sub-section for "official providers without standalone repos," or (b) a small static docs page for them.
2. `build-pages.yml` should rebuild the per-project pages automatically on push to main, so no manual project-page work needed.

## Test plan

- [ ] Confirm Atlas builds successfully (no `validate-repo-suggestion` or `audit-repos` failures)
- [ ] Visit `/projects/volcengine/OpenViking`, `/projects/supermemoryai/supermemory`, `/projects/campfirein/byterover-cli`, `/projects/yantrikos/yantrikdb-hermes-plugin`, `/projects/Ladybug-Memory/hermes-memory-plugin`, `/projects/MukundaKatta/hermes-agentmemory` and confirm pages render after `build-pages.yml` runs
- [ ] Memory & Context category count shows 21
- [ ] Anchor rows render with correct stars / descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)