### PR TITLE
Fix silent star-count staleness in repos.json + homepage

### DIFF
--- a/.github/workflows/build-pages.yml
+++ b/.github/workflows/build-pages.yml
@@ -52,7 +52,10 @@ jobs:
         run: |
           # index.html is mutated by syncHomepageRepos() in build-pages.js
           # — must be staged or homepage drifts silently (bug pre-2026-05-17).
-          git add index.html projects/ lists/ sitemap.xml robots.txt llms.txt llms-full.txt rss.xml data/summaries.json data/list-summaries.json
+          # data/repos.json is mutated by the GraphQL stars-refresh step in
+          # build-pages.js — must be staged or per-repo stars in the public
+          # dataset stay frozen at submitter time (bug pre-2026-05-24).
+          git add index.html projects/ lists/ sitemap.xml robots.txt llms.txt llms-full.txt rss.xml data/repos.json data/summaries.json data/list-summaries.json
           if git diff --cached --quiet; then
             echo "changed=false" >> $GITHUB_OUTPUT
           else

--- a/data/repos.json
+++ b/data/repos.json
@@ -4,7 +4,7 @@
     "repo": "hermes-agent",
     "name": "hermes-agent",
     "description": "The self-improving AI agent that grows with you — persistent memory, auto-generated skills, 14 platforms, 6 execution backends",
-    "stars": 83290,
+    "stars": 165058,
     "url": "https://github.com/NousResearch/hermes-agent",
     "official": true,
     "category": "Core & Official"
@@ -14,7 +14,7 @@
     "repo": "Hermes-Function-Calling",
     "name": "Hermes-Function-Calling",
     "description": "Function calling examples and training data for Hermes LLM models",
-    "stars": 1249,
+    "stars": 1358,
     "url": "https://github.com/NousResearch/Hermes-Function-Calling",
     "official": true,
     "category": "Core & Official"
@@ -24,7 +24,7 @@
     "repo": "atropos",
     "name": "atropos",
     "description": "RL training environments framework for tool-calling models",
-    "stars": 997,
+    "stars": 1224,
     "url": "https://github.com/NousResearch/atropos",
     "official": true,
     "category": "Core & Official"
@@ -34,7 +34,7 @@
     "repo": "hermes-agent-self-evolution",
     "name": "hermes-agent-self-evolution",
     "description": "Evolutionary self-improvement using DSPy + GEPA — optimizes skills, prompts, and code",
-    "stars": 778,
+    "stars": 3501,
     "url": "https://github.com/NousResearch/hermes-agent-self-evolution",
     "official": true,
     "category": "Core & Official"
@@ -44,7 +44,7 @@
     "repo": "hermes-paperclip-adapter",
     "name": "hermes-paperclip-adapter",
     "description": "Run Hermes as a managed employee in Paperclip company systems",
-    "stars": 663,
+    "stars": 1373,
     "url": "https://github.com/NousResearch/hermes-paperclip-adapter",
     "official": true,
     "category": "Core & Official"
@@ -54,7 +54,7 @@
     "repo": "autonovel",
     "name": "autonovel",
     "description": "Autonomous novel-writing pipeline generating 100k+ word manuscripts",
-    "stars": 401,
+    "stars": 989,
     "url": "https://github.com/NousResearch/autonovel",
     "official": true,
     "category": "Core & Official"
@@ -64,7 +64,7 @@
     "repo": "hermes-workspace",
     "name": "hermes-workspace",
     "description": "Native web workspace — chat, terminal, memory browser, skills manager, and inspector panel",
-    "stars": 830,
+    "stars": 4784,
     "url": "https://github.com/outsourc-e/hermes-workspace",
     "official": false,
     "category": "Workspaces & GUIs"
@@ -74,7 +74,7 @@
     "repo": "hermes-desktop",
     "name": "hermes-desktop",
     "description": "Desktop companion app for installing, configuring, and chatting with Hermes Agent",
-    "stars": 65,
+    "stars": 6702,
     "url": "https://github.com/fathah/hermes-desktop",
     "official": false,
     "category": "Workspaces & GUIs"
@@ -84,7 +84,7 @@
     "repo": "hermes-webui",
     "name": "hermes-webui",
     "description": "Process monitoring and configuration dashboard for Hermes",
-    "stars": 57,
+    "stars": 97,
     "url": "https://github.com/sanchomuzax/hermes-webui",
     "official": false,
     "category": "Workspaces & GUIs"
@@ -94,7 +94,7 @@
     "repo": "pan-ui",
     "name": "pan-ui",
     "description": "Self-hosted AI workspace with chat, skills, extensions, memory, profiles, and runtime controls",
-    "stars": 27,
+    "stars": 69,
     "url": "https://github.com/Euraika-Labs/pan-ui",
     "official": false,
     "category": "Workspaces & GUIs"
@@ -104,7 +104,7 @@
     "repo": "Anthropic-Cybersecurity-Skills",
     "name": "Anthropic-Cybersecurity-Skills",
     "description": "754 structured cybersecurity skills mapped to MITRE ATT&CK, NIST CSF 2.0, ATLAS, D3FEND & NIST AI RMF",
-    "stars": 4132,
+    "stars": 7846,
     "url": "https://github.com/mukul975/Anthropic-Cybersecurity-Skills",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -114,7 +114,7 @@
     "repo": "avoid-ai-writing",
     "name": "avoid-ai-writing",
     "description": "Audits and rewrites content to eliminate detectable AI writing patterns",
-    "stars": 759,
+    "stars": 1552,
     "url": "https://github.com/conorbronsdon/avoid-ai-writing",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -124,7 +124,7 @@
     "repo": "skills",
     "name": "wondelai/skills",
     "description": "Cross-platform skills library for Claude Code and agentskills.io-compatible agents",
-    "stars": 480,
+    "stars": 1078,
     "url": "https://github.com/wondelai/skills",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -134,7 +134,7 @@
     "repo": "pydantic-ai-skills",
     "name": "pydantic-ai-skills",
     "description": "Type-safe agentskills.io support with progressive disclosure for Pydantic AI",
-    "stars": 220,
+    "stars": 297,
     "url": "https://github.com/DougTrajano/pydantic-ai-skills",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -144,7 +144,7 @@
     "repo": "drawio-skill",
     "name": "drawio-skill",
     "description": "Generate draw.io diagrams from natural language descriptions",
-    "stars": 131,
+    "stars": 1826,
     "url": "https://github.com/Agents365-ai/drawio-skill",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -154,7 +154,7 @@
     "repo": "chainlink-agent-skills",
     "name": "chainlink-agent-skills",
     "description": "Oracle network and smart contract interaction skills (agentskills.io spec)",
-    "stars": 85,
+    "stars": 103,
     "url": "https://github.com/smartcontractkit/chainlink-agent-skills",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -164,7 +164,7 @@
     "repo": "litprog-skill",
     "name": "litprog-skill",
     "description": "Literate programming skill — weave code and documentation across agents",
-    "stars": 81,
+    "stars": 153,
     "url": "https://github.com/tlehman/litprog-skill",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -174,7 +174,7 @@
     "repo": "icarus-plugin",
     "name": "icarus-plugin",
     "description": "Self-memory and replacement models — remember your work, train your replacement",
-    "stars": 51,
+    "stars": 122,
     "url": "https://github.com/esaradev/icarus-plugin",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -184,7 +184,7 @@
     "repo": "skilldock.io",
     "name": "skilldock.io",
     "description": "Registry of reusable AI skills based on AgentSkills specification",
-    "stars": 50,
+    "stars": 69,
     "url": "https://github.com/chigwell/skilldock.io",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -194,7 +194,7 @@
     "repo": "skills",
     "name": "black-forest-labs/skills",
     "description": "Official FLUX image generation skills — prompting guidelines and API integration",
-    "stars": 44,
+    "stars": 71,
     "url": "https://github.com/black-forest-labs/skills",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -204,7 +204,7 @@
     "repo": "hermes-skill-factory",
     "name": "hermes-skill-factory",
     "description": "Meta-skill plugin that watches workflows and auto-generates reusable skills",
-    "stars": 34,
+    "stars": 330,
     "url": "https://github.com/Romanescu11/hermes-skill-factory",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -214,7 +214,7 @@
     "repo": "maestro",
     "name": "maestro",
     "description": "Harness for long-running AI agents — structured memory, cross-feature learning, plan-approve-execute",
-    "stars": 25,
+    "stars": 172,
     "url": "https://github.com/ReinaMacCredy/maestro",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -224,7 +224,7 @@
     "repo": "execplan-skill",
     "name": "execplan-skill",
     "description": "Complex multi-step task execution with checkpoints and recovery",
-    "stars": 24,
+    "stars": 43,
     "url": "https://github.com/tiann/execplan-skill",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -234,7 +234,7 @@
     "repo": "Agentic-MCP-Skill",
     "name": "Agentic-MCP-Skill",
     "description": "Progressive MCP client with three-layer lazy loading — validates agentskills.io pattern",
-    "stars": 22,
+    "stars": 33,
     "url": "https://github.com/cablate/Agentic-MCP-Skill",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -244,7 +244,7 @@
     "repo": "bmad-module-skill-forge",
     "name": "bmad-module-skill-forge",
     "description": "Converts repos, docs, and developer discourse into agentskills.io-compliant skills",
-    "stars": 17,
+    "stars": 79,
     "url": "https://github.com/armelhbobdad/bmad-module-skill-forge",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -254,7 +254,7 @@
     "repo": "hermeshub",
     "name": "hermeshub",
     "description": "Community skill browsing, search, and one-click installation hub",
-    "stars": 15,
+    "stars": 193,
     "url": "https://github.com/amanning3390/hermeshub",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -264,7 +264,7 @@
     "repo": "skillsdotnet",
     "name": "skillsdotnet",
     "description": "C# / .NET implementation of agentskills.io with MCP integration",
-    "stars": 6,
+    "stars": 11,
     "url": "https://github.com/PederHP/skillsdotnet",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -274,7 +274,7 @@
     "repo": "mem0",
     "name": "mem0",
     "description": "Universal memory layer for AI Agents — official Hermes Agent memory provider, available as managed cloud or Apache-2.0 self-hosted OSS",
-    "stars": 53915,
+    "stars": 56570,
     "url": "https://github.com/mem0ai/mem0",
     "official": false,
     "category": "Memory & Context"
@@ -284,7 +284,7 @@
     "repo": "hindsight",
     "name": "hindsight",
     "description": "Agent memory that learns — long-term retain/recall/reflect workflows",
-    "stars": 8362,
+    "stars": 14369,
     "url": "https://github.com/vectorize-io/hindsight",
     "official": true,
     "category": "Memory & Context"
@@ -294,7 +294,7 @@
     "repo": "autocontext",
     "name": "autocontext",
     "description": "Recursive self-improving context harness — helps agents succeed on complex tasks",
-    "stars": 711,
+    "stars": 1016,
     "url": "https://github.com/greyhaven-ai/autocontext",
     "official": false,
     "category": "Memory & Context"
@@ -304,7 +304,7 @@
     "repo": "honcho-self-hosted",
     "name": "honcho-self-hosted",
     "description": "Self-hosted Honcho memory backend for cross-session persistence",
-    "stars": 126,
+    "stars": 257,
     "url": "https://github.com/elkimek/honcho-self-hosted",
     "official": false,
     "category": "Memory & Context"
@@ -314,7 +314,7 @@
     "repo": "ClawMem",
     "name": "ClawMem",
     "description": "On-device memory and context engine for agents — local-first, no cloud dependencies",
-    "stars": 86,
+    "stars": 172,
     "url": "https://github.com/yoloshii/ClawMem",
     "official": false,
     "category": "Memory & Context"
@@ -324,7 +324,7 @@
     "repo": "plur",
     "name": "plur",
     "description": "Shared memory layer with open engram YAML format for multi-agent systems",
-    "stars": 31,
+    "stars": 135,
     "url": "https://github.com/plur-ai/plur",
     "official": false,
     "category": "Memory & Context"
@@ -334,7 +334,7 @@
     "repo": "flowstate-qmd",
     "name": "flowstate-qmd",
     "description": "Anticipatory memory with RAG and vector search — Hermes 2026 Hackathon entry",
-    "stars": 5,
+    "stars": 26,
     "url": "https://github.com/amanning3390/flowstate-qmd",
     "official": false,
     "category": "Memory & Context"
@@ -344,7 +344,7 @@
     "repo": "hermes-web-search-plus",
     "name": "hermes-web-search-plus",
     "description": "Multi-provider web search (Serper, Tavily, Exa, Querit, Perplexity) with auto-routing",
-    "stars": 21,
+    "stars": 190,
     "url": "https://github.com/robbyczgw-cla/hermes-web-search-plus",
     "official": false,
     "category": "Plugins & Extensions"
@@ -354,7 +354,7 @@
     "repo": "hermes-plugins",
     "name": "hermes-plugins",
     "description": "Goal management, inter-agent bridge, model selection, and cost control plugins",
-    "stars": 16,
+    "stars": 140,
     "url": "https://github.com/42-evey/hermes-plugins",
     "official": false,
     "category": "Plugins & Extensions"
@@ -364,7 +364,7 @@
     "repo": "hermes-weather-plugin",
     "name": "hermes-weather-plugin",
     "description": "NWS-grade model imagery, NEXRAD radar, and verified meteorological calculations. Pure Rust.",
-    "stars": 7,
+    "stars": 21,
     "url": "https://github.com/FahrenheitResearch/hermes-weather-plugin",
     "official": false,
     "category": "Plugins & Extensions"
@@ -374,7 +374,7 @@
     "repo": "evey-bridge-plugin",
     "name": "evey-bridge-plugin",
     "description": "Claude Code and Hermes context sharing bridge — auto-checks messages, Mother Mode loop",
-    "stars": 4,
+    "stars": 12,
     "url": "https://github.com/42-evey/evey-bridge-plugin",
     "official": false,
     "category": "Plugins & Extensions"
@@ -384,7 +384,7 @@
     "repo": "hermes-payguard",
     "name": "hermes-payguard",
     "description": "Safe-by-design USDC and x402 payment plugin for Hermes Agent",
-    "stars": 4,
+    "stars": 7,
     "url": "https://github.com/nativ3ai/hermes-payguard",
     "official": false,
     "category": "Plugins & Extensions"
@@ -394,7 +394,7 @@
     "repo": "hermes-cloudflare",
     "name": "hermes-cloudflare",
     "description": "Cloudflare Browser Rendering plugin — crawl, scrape, extract content from web pages",
-    "stars": 1,
+    "stars": 19,
     "url": "https://github.com/raulvidis/hermes-cloudflare",
     "official": false,
     "category": "Plugins & Extensions"
@@ -404,7 +404,7 @@
     "repo": "mission-control",
     "name": "mission-control",
     "description": "Self-hosted AI agent orchestration — dispatch tasks, run multi-agent workflows, monitor spend",
-    "stars": 3875,
+    "stars": 4953,
     "url": "https://github.com/builderz-labs/mission-control",
     "official": false,
     "category": "Multi-Agent & Orchestration"
@@ -414,7 +414,7 @@
     "repo": "swarmclaw",
     "name": "swarmclaw",
     "description": "Build autonomous AI agent swarms with orchestration, skills, and multiple model providers",
-    "stars": 285,
+    "stars": 518,
     "url": "https://github.com/swarmclawai/swarmclaw",
     "official": false,
     "category": "Multi-Agent & Orchestration"
@@ -424,7 +424,7 @@
     "repo": "hermes-agent-metaharness",
     "name": "hermes-agent-metaharness",
     "description": "Meta-harness for Hermes Agent — meta-optimization with arxiv paper reference",
-    "stars": 46,
+    "stars": 85,
     "url": "https://github.com/howdymary/hermes-agent-metaharness",
     "official": false,
     "category": "Multi-Agent & Orchestration"
@@ -434,7 +434,7 @@
     "repo": "gladiator",
     "name": "gladiator",
     "description": "Autonomous AI companies competing for GitHub stars — agent-vs-agent arena",
-    "stars": 29,
+    "stars": 50,
     "url": "https://github.com/runtimenoteslabs/gladiator",
     "official": false,
     "category": "Multi-Agent & Orchestration"
@@ -444,7 +444,7 @@
     "repo": "opencode-hermes-multiagent",
     "name": "opencode-hermes-multiagent",
     "description": "17 specialized agents for research, planning, implementation, quality, and infrastructure",
-    "stars": 28,
+    "stars": 111,
     "url": "https://github.com/1ilkhamov/opencode-hermes-multiagent",
     "official": false,
     "category": "Multi-Agent & Orchestration"
@@ -454,7 +454,7 @@
     "repo": "bigiron",
     "name": "bigiron",
     "description": "AI-native SDLC — Hermes Agent + Supermodel code graph, graph-gated at every phase",
-    "stars": 7,
+    "stars": 11,
     "url": "https://github.com/supermodeltools/bigiron",
     "official": false,
     "category": "Multi-Agent & Orchestration"
@@ -464,7 +464,7 @@
     "repo": "hermes-agent-acp-skill",
     "name": "hermes-agent-acp-skill",
     "description": "ACP-style multi-agent delegation — routes tasks to Hermes, Codex, or Claude Code",
-    "stars": 4,
+    "stars": 33,
     "url": "https://github.com/Rainhoole/hermes-agent-acp-skill",
     "official": false,
     "category": "Multi-Agent & Orchestration"
@@ -474,7 +474,7 @@
     "repo": "llm-agents.nix",
     "name": "llm-agents.nix",
     "description": "Nix packages for AI coding agents including Hermes",
-    "stars": 967,
+    "stars": 1291,
     "url": "https://github.com/numtide/llm-agents.nix",
     "official": false,
     "category": "Deployment & Infra"
@@ -484,7 +484,7 @@
     "repo": "hermesclaw",
     "name": "hermesclaw",
     "description": "Hermes Agent sandboxed with hardware-level enforcement",
-    "stars": 16,
+    "stars": 45,
     "url": "https://github.com/TheAiSingularity/hermesclaw",
     "official": false,
     "category": "Deployment & Infra"
@@ -494,7 +494,7 @@
     "repo": "nix-hermes-agent",
     "name": "nix-hermes-agent",
     "description": "Nix package and NixOS module for reproducible Hermes deployment",
-    "stars": 11,
+    "stars": 21,
     "url": "https://github.com/0xrsydn/nix-hermes-agent",
     "official": false,
     "category": "Deployment & Infra"
@@ -504,7 +504,7 @@
     "repo": "portable-hermes-agent",
     "name": "portable-hermes-agent",
     "description": "Windows desktop agent — 100 tools, GUI, local models, TTS, ComfyUI. No install, no Docker.",
-    "stars": 7,
+    "stars": 133,
     "url": "https://github.com/rookiemann/portable-hermes-agent",
     "official": false,
     "category": "Deployment & Infra"
@@ -514,7 +514,7 @@
     "repo": "hermes-agent-docker",
     "name": "hermes-agent-docker",
     "description": "Simple Docker sandbox image for Hermes Agent",
-    "stars": 6,
+    "stars": 28,
     "url": "https://github.com/xmbshwll/hermes-agent-docker",
     "official": false,
     "category": "Deployment & Infra"
@@ -524,7 +524,7 @@
     "repo": "hermes-autonomous-server",
     "name": "hermes-autonomous-server",
     "description": "Headless systemd deployment with Nous Portal integration — production-ready",
-    "stars": 2,
+    "stars": 10,
     "url": "https://github.com/JackTheGit/hermes-autonomous-server",
     "official": false,
     "category": "Deployment & Infra"
@@ -534,7 +534,7 @@
     "repo": "portainer-stack-hermes",
     "name": "portainer-stack-hermes",
     "description": "Docker Compose stack with Portainer UI and ttyd web terminal",
-    "stars": 1,
+    "stars": 5,
     "url": "https://github.com/ellickjohnson/portainer-stack-hermes",
     "official": false,
     "category": "Deployment & Infra"
@@ -544,7 +544,7 @@
     "repo": "hermes-android",
     "name": "hermes-android",
     "description": "Android device control — bridge app + Python toolset for mobile automation",
-    "stars": 38,
+    "stars": 204,
     "url": "https://github.com/raulvidis/hermes-android",
     "official": false,
     "category": "Integrations & Bridges"
@@ -554,7 +554,7 @@
     "repo": "hermes-miniverse",
     "name": "hermes-miniverse",
     "description": "Bridge Hermes to Miniverse pixel worlds — agent embodiment in virtual environments",
-    "stars": 8,
+    "stars": 35,
     "url": "https://github.com/teknium1/hermes-miniverse",
     "official": false,
     "category": "Integrations & Bridges"
@@ -564,7 +564,7 @@
     "repo": "hermes-council",
     "name": "hermes-council",
     "description": "Adversarial multi-perspective council MCP server for decision-making",
-    "stars": 6,
+    "stars": 29,
     "url": "https://github.com/Ridwannurudeen/hermes-council",
     "official": false,
     "category": "Integrations & Bridges"
@@ -574,7 +574,7 @@
     "repo": "zouroboros-swarm-executors",
     "name": "zouroboros-swarm-executors",
     "description": "Claude Code and Hermes task handoff bridge for zo-swarm-orchestrator",
-    "stars": 4,
+    "stars": 6,
     "url": "https://github.com/marlandoj/zouroboros-swarm-executors",
     "official": false,
     "category": "Integrations & Bridges"
@@ -584,7 +584,7 @@
     "repo": "hermes-blockchain-oracle",
     "name": "hermes-blockchain-oracle",
     "description": "Solana blockchain intelligence MCP server — wallets, whales, tokens, NFTs, network health",
-    "stars": 3,
+    "stars": 4,
     "url": "https://github.com/gizdusum/hermes-blockchain-oracle",
     "official": false,
     "category": "Integrations & Bridges"
@@ -594,7 +594,7 @@
     "repo": "tokscale",
     "name": "tokscale",
     "description": "CLI tool for tracking token usage from Claude Code, OpenClaw, Hermes, Codex, Gemini, and more",
-    "stars": 1690,
+    "stars": 3158,
     "url": "https://github.com/junhoyeo/tokscale",
     "official": false,
     "category": "Developer Tools"
@@ -604,7 +604,7 @@
     "repo": "hermes-skins",
     "name": "hermes-skins",
     "description": "Community CLI skins and themes for Hermes terminal UI",
-    "stars": 76,
+    "stars": 390,
     "url": "https://github.com/joeynyc/hermes-skins",
     "official": false,
     "category": "Developer Tools"
@@ -614,7 +614,7 @@
     "repo": "hermes-CCC",
     "name": "hermes-CCC",
     "description": "Hermes Agent ported to Claude Code Channel — 46 native skills, no OAuth, no external process",
-    "stars": 56,
+    "stars": 107,
     "url": "https://github.com/AlexAI-MCP/hermes-CCC",
     "official": false,
     "category": "Developer Tools"
@@ -624,7 +624,7 @@
     "repo": "vessel-browser",
     "name": "vessel-browser",
     "description": "AI-native browser built for autonomous agent control via MCP",
-    "stars": 44,
+    "stars": 81,
     "url": "https://github.com/unmodeled-tyler/vessel-browser",
     "official": false,
     "category": "Developer Tools"
@@ -634,7 +634,7 @@
     "repo": "Ankh.md",
     "name": "Ankh.md",
     "description": "TAW Agent framework for creating scoped Hermes Agents",
-    "stars": 25,
+    "stars": 54,
     "url": "https://github.com/Abruptive/Ankh.md",
     "official": false,
     "category": "Developer Tools"
@@ -644,7 +644,7 @@
     "repo": "lintlang",
     "name": "lintlang",
     "description": "Static linter for AI agent configs, tool descriptions, and system prompts. HERM v1.1 scoring.",
-    "stars": 24,
+    "stars": 36,
     "url": "https://github.com/roli-lpci/lintlang",
     "official": false,
     "category": "Developer Tools"
@@ -654,7 +654,7 @@
     "repo": "openclaw-to-hermes",
     "name": "openclaw-to-hermes",
     "description": "Migration tool from OpenClaw to Hermes Agent",
-    "stars": 21,
+    "stars": 30,
     "url": "https://github.com/0xNyk/openclaw-to-hermes",
     "official": false,
     "category": "Developer Tools"
@@ -664,7 +664,7 @@
     "repo": "evey-setup",
     "name": "evey-setup",
     "description": "Get a hermes-agent stack running in minutes — free models, 29 plugins, zero cost",
-    "stars": 7,
+    "stars": 35,
     "url": "https://github.com/42-evey/evey-setup",
     "official": false,
     "category": "Developer Tools"
@@ -674,7 +674,7 @@
     "repo": "DashClaw",
     "name": "DashClaw",
     "description": "Decision infrastructure with guard policies and risk assessment for agents",
-    "stars": 204,
+    "stars": 266,
     "url": "https://github.com/ucsandman/DashClaw",
     "official": false,
     "category": "Domain Applications"
@@ -684,7 +684,7 @@
     "repo": "hermes-incident-commander",
     "name": "hermes-incident-commander",
     "description": "Autonomous SRE agent — detects, heals, and learns from production incidents",
-    "stars": 11,
+    "stars": 35,
     "url": "https://github.com/Lethe044/hermes-incident-commander",
     "official": false,
     "category": "Domain Applications"
@@ -694,7 +694,7 @@
     "repo": "job-scout-agent",
     "name": "job-scout-agent",
     "description": "Autonomous job hunting — scans listings, writes cover letters, tracks applications",
-    "stars": 11,
+    "stars": 33,
     "url": "https://github.com/Christabel337/job-scout-agent",
     "official": false,
     "category": "Domain Applications"
@@ -704,7 +704,7 @@
     "repo": "anihermes",
     "name": "anihermes",
     "description": "Local anime server and tracker via natural language for Hermes Agent",
-    "stars": 9,
+    "stars": 15,
     "url": "https://github.com/rodmarkun/anihermes",
     "official": false,
     "category": "Domain Applications"
@@ -714,7 +714,7 @@
     "repo": "hermes-ai-infrastructure-monitoring-toolkit",
     "name": "infra-monitoring-toolkit",
     "description": "Autonomous monitoring — cron-based research ingestion, cost forecasting, headless systemd",
-    "stars": 9,
+    "stars": 18,
     "url": "https://github.com/JackTheGit/hermes-ai-infrastructure-monitoring-toolkit",
     "official": false,
     "category": "Domain Applications"
@@ -724,7 +724,7 @@
     "repo": "hermescraft",
     "name": "hermescraft",
     "description": "Embodied AI companion for Minecraft — persistent memory, vision, learning, multi-agent",
-    "stars": 8,
+    "stars": 31,
     "url": "https://github.com/bigph00t/hermescraft",
     "official": false,
     "category": "Domain Applications"
@@ -734,7 +734,7 @@
     "repo": "mercury",
     "name": "mercury",
     "description": "Blockchain cash flow analyzer — multi-chain analysis, fraud detection, WebGL dashboard",
-    "stars": 5,
+    "stars": 16,
     "url": "https://github.com/hxsteric/mercury",
     "official": false,
     "category": "Domain Applications"
@@ -744,7 +744,7 @@
     "repo": "hermes-embodied",
     "name": "hermes-embodied",
     "description": "Self-improving robotics via VLA model fine-tuning on cloud GPUs",
-    "stars": 2,
+    "stars": 7,
     "url": "https://github.com/bryercowan/hermes-embodied",
     "official": false,
     "category": "Domain Applications"
@@ -754,7 +754,7 @@
     "repo": "awesome-hermes-agent",
     "name": "awesome-hermes-agent",
     "description": "Curated list of awesome skills, tools, integrations, and resources for Hermes Agent",
-    "stars": 898,
+    "stars": 3343,
     "url": "https://github.com/0xNyk/awesome-hermes-agent",
     "official": false,
     "category": "Guides & Docs"
@@ -764,7 +764,7 @@
     "repo": "hermes-agent-orange-book",
     "name": "hermes-agent-orange-book",
     "description": "Hermes Agent practical guide — Orange Book series (Chinese language)",
-    "stars": 315,
+    "stars": 3851,
     "url": "https://github.com/alchaincyf/hermes-agent-orange-book",
     "official": false,
     "category": "Guides & Docs"
@@ -774,7 +774,7 @@
     "repo": "hermes-optimization-guide",
     "name": "hermes-optimization-guide",
     "description": "Performance optimization guide for Hermes deployments",
-    "stars": 51,
+    "stars": 327,
     "url": "https://github.com/OnlyTerp/hermes-optimization-guide",
     "official": false,
     "category": "Guides & Docs"
@@ -784,7 +784,7 @@
     "repo": "hermes-wsl-ubuntu",
     "name": "hermes-wsl-ubuntu",
     "description": "Step-by-step WSL2 Ubuntu setup guide for Windows users",
-    "stars": 8,
+    "stars": 35,
     "url": "https://github.com/metantonio/hermes-wsl-ubuntu",
     "official": false,
     "category": "Guides & Docs"
@@ -794,7 +794,7 @@
     "repo": "hermes-agent-docs",
     "name": "hermes-agent-docs",
     "description": "Community documentation covering deployment patterns and v0.2.0+ workflows",
-    "stars": 6,
+    "stars": 44,
     "url": "https://github.com/mudrii/hermes-agent-docs",
     "official": false,
     "category": "Guides & Docs"
@@ -804,7 +804,7 @@
     "repo": "HermesWiki",
     "name": "HermesWiki",
     "description": "Community wiki with deployment patterns and recipes",
-    "stars": 2,
+    "stars": 13,
     "url": "https://github.com/martymcenroe/HermesWiki",
     "official": false,
     "category": "Guides & Docs"
@@ -814,7 +814,7 @@
     "repo": "hermes-agent-camel",
     "name": "hermes-agent-camel",
     "description": "Hermes with integrated CaMeL trust boundaries for safer autonomous execution",
-    "stars": 12,
+    "stars": 182,
     "url": "https://github.com/nativ3ai/hermes-agent-camel",
     "official": false,
     "category": "Forks & Derivatives"
@@ -824,7 +824,7 @@
     "repo": "hermes-alpha",
     "name": "hermes-alpha",
     "description": "Cloud-deployed Hermes with pre-configured templates and managed infrastructure",
-    "stars": 8,
+    "stars": 208,
     "url": "https://github.com/kaminocorp/hermes-alpha",
     "official": false,
     "category": "Forks & Derivatives"
@@ -834,7 +834,7 @@
     "repo": "hermes-skill-distillation",
     "name": "hermes-skill-distillation",
     "description": "Generate agentic training trajectories from real-world tasks for Hermes 4 fine-tuning",
-    "stars": 1,
+    "stars": 7,
     "url": "https://github.com/beardthelion/hermes-skill-distillation",
     "official": false,
     "category": "Forks & Derivatives"
@@ -844,7 +844,7 @@
     "repo": "hermes-control-interface",
     "name": "hermes-control-interface",
     "description": "A self-hosted web dashboard for the Hermes AI agent stack. Provides a browser-based terminal, file explorer, session overview, cron management, system metrics, and an agent status panel — all behind a",
-    "stars": 323,
+    "stars": 692,
     "url": "https://github.com/xaspx/hermes-control-interface",
     "official": false,
     "category": "Workspaces & GUIs"
@@ -854,7 +854,7 @@
     "repo": "hermes-ecosystem",
     "name": "hermes-ecosystem",
     "description": "Hermes Atlas — the community map of every tool, skill, and integration for Hermes Agent by Nous Research",
-    "stars": 263,
+    "stars": 881,
     "url": "https://github.com/ksimback/hermes-ecosystem",
     "official": false,
     "category": "Guides & Docs"
@@ -864,7 +864,7 @@
     "repo": "hermes-desktop",
     "name": "hermes-desktop",
     "description": "A native Mac workspace for Hermes: real SSH, real terminal, real session data.",
-    "stars": 313,
+    "stars": 1544,
     "url": "https://github.com/dodo-reach/hermes-desktop",
     "official": false,
     "category": "Workspaces & GUIs"
@@ -874,7 +874,7 @@
     "repo": "clawshell",
     "name": "clawshell",
     "description": "The Runtime Security Layer for OpenClaw/Hermes-agent, the essential safety harness for PII & sensitive credentials protection.",
-    "stars": 255,
+    "stars": 281,
     "url": "https://github.com/clawshell/clawshell",
     "official": false,
     "category": "Plugins & Extensions"
@@ -884,7 +884,7 @@
     "repo": "hermes-webui",
     "name": "hermes-webui",
     "description": "Hermes WebUI: The best way to use Hermes Agent from the web or from your phone!",
-    "stars": 2479,
+    "stars": 8468,
     "url": "https://github.com/nesquena/hermes-webui",
     "official": false,
     "category": "Workspaces & GUIs"
@@ -894,7 +894,7 @@
     "repo": "gbrain",
     "name": "gbrain",
     "description": "Garry's Opinionated OpenClaw/Hermes Agent Brain",
-    "stars": 8857,
+    "stars": 18608,
     "url": "https://github.com/garrytan/gbrain",
     "official": false,
     "category": "Memory & Context"
@@ -904,7 +904,7 @@
     "repo": "hermes-ui",
     "name": "hermes-ui",
     "description": "Glassmorphic web interface for Hermes Agent — your self-hosted AI assistant",
-    "stars": 25,
+    "stars": 139,
     "url": "https://github.com/pyrate-llama/hermes-ui",
     "official": false,
     "category": "Workspaces & GUIs"
@@ -914,7 +914,7 @@
     "repo": "hermes-claude-code-rc",
     "name": "hermes-claude-code-rc",
     "description": "Hermes Agent plugin for remote controlling Claude Code sessions via Telegram",
-    "stars": 1,
+    "stars": 2,
     "url": "https://github.com/kevinmarmstrong/hermes-claude-code-rc",
     "official": false,
     "category": "Integrations & Bridges"
@@ -924,7 +924,7 @@
     "repo": "hermesclaw",
     "name": "hermesclaw",
     "description": "Run Hermes Agent and OpenClaw on the same WeChat account",
-    "stars": 112,
+    "stars": 535,
     "url": "https://github.com/AaronWong1999/hermesclaw",
     "official": false,
     "category": "Integrations & Bridges"
@@ -934,7 +934,7 @@
     "repo": "hermes-lcm",
     "name": "hermes-lcm",
     "description": "Lossless Context Management plugin for Hermes Agent — DAG-based context engine that never loses a message",
-    "stars": 178,
+    "stars": 573,
     "url": "https://github.com/stephenschoettler/hermes-lcm",
     "official": false,
     "category": "Memory & Context"
@@ -944,7 +944,7 @@
     "repo": "hermes-relay",
     "name": "hermes-relay",
     "description": "Hermes Companion — Android app for Hermes agent platform. Chat, terminal, and device control over WSS.",
-    "stars": 10,
+    "stars": 26,
     "url": "https://github.com/Codename-11/hermes-relay",
     "official": false,
     "category": "Integrations & Bridges"
@@ -954,7 +954,7 @@
     "repo": "hermes-telegram-miniapp",
     "name": "hermes-telegram-miniapp",
     "description": "React SPA dashboard for Telegram Mini App v2.0 — 10-page mobile-first UI. Runs locally.",
-    "stars": 194,
+    "stars": 224,
     "url": "https://github.com/clawvader-tech/hermes-telegram-miniapp",
     "official": false,
     "category": "Workspaces & GUIs"
@@ -964,7 +964,7 @@
     "repo": "hermes-otel",
     "name": "hermes-otel",
     "description": "OTel Plugin for Hermes Agent",
-    "stars": 4,
+    "stars": 18,
     "url": "https://github.com/briancaffey/hermes-otel",
     "official": false,
     "category": "Plugins & Extensions"
@@ -974,7 +974,7 @@
     "repo": "hermes-web-ui",
     "name": "hermes-web-ui",
     "description": "Web dashboard for Hermes Agent — multi-platform AI chat, session management, scheduled jobs, usage analytics & channel configuration (Telegram, Discord, Slack, WhatsApp)",
-    "stars": 1844,
+    "stars": 5887,
     "url": "https://github.com/EKKOLearnAI/hermes-web-ui",
     "official": false,
     "category": "Workspaces & GUIs"
@@ -984,7 +984,7 @@
     "repo": "keep",
     "name": "keep",
     "description": "Reflective memory for AI agents",
-    "stars": 31,
+    "stars": 35,
     "url": "https://github.com/keepnotes-ai/keep",
     "official": false,
     "category": "Memory & Context"
@@ -994,7 +994,7 @@
     "repo": "mnemosyne",
     "name": "mnemosyne",
     "description": "The Zero-Dependency, Sub-Millisecond AI Memory System for Hermes Agents",
-    "stars": 29,
+    "stars": 351,
     "url": "https://github.com/AxDSan/mnemosyne",
     "official": false,
     "category": "Memory & Context"
@@ -1004,7 +1004,7 @@
     "repo": "SkillClaw",
     "name": "SkillClaw",
     "description": "Let Skills Evolve Collectively with Agentic Evolver",
-    "stars": 1103,
+    "stars": 1453,
     "url": "https://github.com/AMAP-ML/SkillClaw",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -1014,7 +1014,7 @@
     "repo": "portable-hermes-agent",
     "name": "portable-hermes-agent",
     "description": "Hermes Agent made portable desktop for Windows — 100 tools, GUI, local models via LM Studio, TTS, Music, ComfyUI, workflows, tool maker. No install. No Docker. No admin rights.",
-    "stars": 81,
+    "stars": 133,
     "url": "https://github.com/aivrar/portable-hermes-agent",
     "official": false,
     "category": "Workspaces & GUIs"
@@ -1024,7 +1024,7 @@
     "repo": "super-hermes",
     "name": "super-hermes",
     "description": "Skills that teach Hermes Agent to write its own analytical prompts",
-    "stars": 122,
+    "stars": 187,
     "url": "https://github.com/Cranot/super-hermes",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -1034,7 +1034,7 @@
     "repo": "ContextPilot",
     "name": "ContextPilot",
     "description": "Accelerating Long Context LLM Inference with Accuracy-Preserving Context Optimization in SGLang, vLLM, llama.cpp, OpenClaw, RAG, and Agentic AI.",
-    "stars": 82,
+    "stars": 112,
     "url": "https://github.com/EfficientContext/ContextPilot",
     "official": false,
     "category": "Memory & Context"
@@ -1044,7 +1044,7 @@
     "repo": "agent-browser-mcp",
     "name": "agent-browser-mcp",
     "description": "让 Agent 直接操作真实 Chrome 的 MCP 服务，支持页面扫描、CDP、截图与物理输入",
-    "stars": 167,
+    "stars": 213,
     "url": "https://github.com/335234131/agent-browser-mcp",
     "official": false,
     "category": "Plugins & Extensions"
@@ -1054,7 +1054,7 @@
     "repo": "hermes-agent-guide",
     "name": "hermes-agent-guide",
     "description": "A systematic Chinese-language guide to Hermes Agent — 16 books, 300K+ words, covering installation, advanced development, single- and multi-agent orchestration.",
-    "stars": 130,
+    "stars": 256,
     "url": "https://github.com/jwangkun/hermes-agent-guide",
     "official": false,
     "category": "Guides & Docs"
@@ -1064,7 +1064,7 @@
     "repo": "learn-hermes-agent",
     "name": "learn-hermes-agent",
     "description": "A 27-chapter hands-on tutorial for building an autonomous AI agent from zero in Python — agent loop, tool system, memory, skills, MCP, multi-platform gateway, and self-evolution.",
-    "stars": 73,
+    "stars": 119,
     "url": "https://github.com/longyunfeigu/learn-hermes-agent",
     "official": false,
     "category": "Guides & Docs"
@@ -1074,7 +1074,7 @@
     "repo": "hermeshq",
     "name": "hermeshq",
     "description": "HermesHQ is a Docker-first control plane for running and operating multiple Hermes Agent instances from one web application.",
-    "stars": 5,
+    "stars": 9,
     "url": "https://github.com/jpalmae/hermeshq",
     "official": false,
     "category": "Deployment & Infra"
@@ -1084,7 +1084,7 @@
     "repo": "honcho",
     "name": "honcho",
     "description": "Memory library for building stateful agents — the upstream library that the elkimek/honcho-self-hosted Hermes wrapper builds on.",
-    "stars": 3143,
+    "stars": 4141,
     "url": "https://github.com/plastic-labs/honcho",
     "official": true,
     "category": "Memory & Context"
@@ -1094,7 +1094,7 @@
     "repo": "hermes-nextcloud",
     "name": "hermes-nextcloud",
     "description": "Hermes Agent skill for Nextcloud — manage files, notes, calendar, tasks, and contacts via WebDAV and CalDAV.",
-    "stars": 1,
+    "stars": 10,
     "url": "https://github.com/adnw-vinc/hermes-nextcloud",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -1104,7 +1104,7 @@
     "repo": "hermes-tweet",
     "name": "hermes-tweet",
     "description": "Native Hermes Agent plugin for X automation through Xquik",
-    "stars": 1,
+    "stars": 7,
     "url": "https://github.com/Xquik-dev/hermes-tweet",
     "official": false,
     "category": "Plugins & Extensions"
@@ -1124,7 +1124,7 @@
     "repo": "Brainstack",
     "name": "Brainstack",
     "description": "Memory kernel stack for Hermes agent",
-    "stars": 27,
+    "stars": 34,
     "url": "https://github.com/yepyhun/Brainstack",
     "official": false,
     "category": "Memory & Context"
@@ -1144,7 +1144,7 @@
     "repo": "MeiGen-AI-Design-MCP",
     "name": "MeiGen-AI-Design-MCP",
     "description": "Supports GPT Image 2, Nanobanana & ComfyUI, with a 1,400+ prompt library, carefully crafted hooks and a multi-task orchestration system",
-    "stars": 1096,
+    "stars": 1190,
     "url": "https://github.com/jau123/MeiGen-AI-Design-MCP",
     "official": false,
     "category": "Plugins & Extensions"
@@ -1154,7 +1154,7 @@
     "repo": "hermes-tool-slimmer",
     "name": "hermes-tool-slimmer",
     "description": "Reduce Hermes Agent tool-schema overhead with keyword selection and Tool Search support",
-    "stars": 4,
+    "stars": 13,
     "url": "https://github.com/alias8818/hermes-tool-slimmer",
     "official": false,
     "category": "Memory & Context"
@@ -1164,7 +1164,7 @@
     "repo": "OpenViking",
     "name": "OpenViking",
     "description": "Open-source context database for AI agents — official Hermes Agent memory provider using viking:// URIs and tiered L0/L1/L2 loading; 91% token reduction and 43-49% task-completion gain over baseline on LoCoMo10. AGPL-3.0.",
-    "stars": 24584,
+    "stars": 24588,
     "url": "https://github.com/volcengine/OpenViking",
     "official": false,
     "category": "Memory & Context"
@@ -1184,7 +1184,7 @@
     "repo": "byterover-cli",
     "name": "byterover-cli",
     "description": "Memory as a git repo (formerly Cipher) — official Hermes Agent memory provider with 5-tier retrieval (4 tiers non-LLM, sub-100ms), brv vc commit/branch/merge versioning over plain markdown context tree. Elastic License 2.0.",
-    "stars": 4783,
+    "stars": 4784,
     "url": "https://github.com/campfirein/byterover-cli",
     "official": false,
     "category": "Memory & Context"

--- a/index.html
+++ b/index.html
@@ -265,7 +265,7 @@
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/NousResearch/Hermes-Function-Calling" data-github="https://github.com/NousResearch/Hermes-Function-Calling" data-desc="Function calling examples and training data for Hermes LLM models">
-      <div class="repo-stars">★ 1,249</div>
+      <div class="repo-stars">★ 1,358</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">NousResearch /</span> Hermes-Function-Calling <span class="repo-flag">official</span></div>
         <div class="repo-desc">Function calling examples and training data for Hermes LLM models.</div>
@@ -273,7 +273,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/NousResearch/atropos" data-github="https://github.com/NousResearch/atropos" data-desc="RL training environments framework for tool-calling models">
-      <div class="repo-stars">★ 997</div>
+      <div class="repo-stars">★ 1,224</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">NousResearch /</span> atropos <span class="repo-flag">official</span></div>
         <div class="repo-desc">RL training environments framework for tool-calling models.</div>
@@ -281,7 +281,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/NousResearch/hermes-agent-self-evolution" data-github="https://github.com/NousResearch/hermes-agent-self-evolution" data-desc="Evolutionary self-improvement using DSPy + GEPA — optimizes skills, prompts, and code">
-      <div class="repo-stars">★ 778</div>
+      <div class="repo-stars">★ 3,501</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">NousResearch /</span> hermes-agent-self-evolution <span class="repo-flag">official</span></div>
         <div class="repo-desc">Evolutionary self-improvement using DSPy + GEPA — optimizes skills, prompts, and code.</div>
@@ -289,7 +289,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/NousResearch/hermes-paperclip-adapter" data-github="https://github.com/NousResearch/hermes-paperclip-adapter" data-desc="Run Hermes as a managed employee in Paperclip company systems">
-      <div class="repo-stars">★ 663</div>
+      <div class="repo-stars">★ 1,373</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">NousResearch /</span> hermes-paperclip-adapter <span class="repo-flag">official</span></div>
         <div class="repo-desc">Run Hermes as a managed employee in Paperclip company systems.</div>
@@ -297,7 +297,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/NousResearch/autonovel" data-github="https://github.com/NousResearch/autonovel" data-desc="Autonomous novel-writing pipeline generating 100k+ word manuscripts">
-      <div class="repo-stars">★ 401</div>
+      <div class="repo-stars">★ 989</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">NousResearch /</span> autonovel <span class="repo-flag">official</span></div>
         <div class="repo-desc">Autonomous novel-writing pipeline generating 100k+ word manuscripts.</div>
@@ -316,7 +316,7 @@
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/nesquena/hermes-webui" data-github="https://github.com/nesquena/hermes-webui" data-desc="Hermes WebUI: The best way to use Hermes Agent from the web or from your phone!">
-      <div class="repo-stars">★ 2,479</div>
+      <div class="repo-stars">★ 8,468</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">nesquena /</span> hermes-webui</div>
         <div class="repo-desc">The best way to use Hermes Agent from the web or from your phone.</div>
@@ -324,7 +324,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/outsourc-e/hermes-workspace" data-github="https://github.com/outsourc-e/hermes-workspace" data-desc="Native web workspace — chat, terminal, memory browser, skills manager, and inspector panel">
-      <div class="repo-stars">★ 830</div>
+      <div class="repo-stars">★ 4,784</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">outsourc-e /</span> hermes-workspace</div>
         <div class="repo-desc">Native web workspace — chat, terminal, memory browser, skills manager, inspector panel.</div>
@@ -332,7 +332,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/clawvader-tech/hermes-telegram-miniapp" data-github="https://github.com/clawvader-tech/hermes-telegram-miniapp" data-desc="React SPA dashboard for Telegram Mini App v2.0 — 10-page mobile-first UI. Runs locally.">
-      <div class="repo-stars">★ 194</div>
+      <div class="repo-stars">★ 224</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">clawvader-tech /</span> hermes-telegram-miniapp</div>
         <div class="repo-desc">React SPA dashboard for Telegram Mini App v2.0 — 10-page mobile-first UI. Runs locally.</div>
@@ -340,7 +340,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/xaspx/hermes-control-interface" data-github="https://github.com/xaspx/hermes-control-interface" data-desc="Self-hosted web dashboard — terminal, file explorer, cron, metrics, and agent status panel">
-      <div class="repo-stars">★ 323</div>
+      <div class="repo-stars">★ 692</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">xaspx /</span> hermes-control-interface</div>
         <div class="repo-desc">Self-hosted dashboard — terminal, file explorer, cron, metrics, agent status panel.</div>
@@ -348,7 +348,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/dodo-reach/hermes-desktop" data-github="https://github.com/dodo-reach/hermes-desktop" data-desc="A native Mac workspace for Hermes: real SSH, real terminal, real session data">
-      <div class="repo-stars">★ 313</div>
+      <div class="repo-stars">★ 1,544</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">dodo-reach /</span> hermes-desktop</div>
         <div class="repo-desc">Native Mac workspace for Hermes — real SSH, real terminal, real session data.</div>
@@ -356,7 +356,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/fathah/hermes-desktop" data-github="https://github.com/fathah/hermes-desktop" data-desc="Desktop companion app for installing, configuring, and chatting with Hermes Agent">
-      <div class="repo-stars">★ 65</div>
+      <div class="repo-stars">★ 6,702</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">fathah /</span> hermes-desktop</div>
         <div class="repo-desc">Desktop companion for installing, configuring, and chatting with Hermes Agent.</div>
@@ -364,7 +364,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/sanchomuzax/hermes-webui" data-github="https://github.com/sanchomuzax/hermes-webui" data-desc="Process monitoring and configuration dashboard for Hermes">
-      <div class="repo-stars">★ 57</div>
+      <div class="repo-stars">★ 97</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">sanchomuzax /</span> hermes-webui</div>
         <div class="repo-desc">Process monitoring and configuration dashboard for Hermes.</div>
@@ -372,7 +372,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/Euraika-Labs/pan-ui" data-github="https://github.com/Euraika-Labs/pan-ui" data-desc="Self-hosted AI workspace with chat, skills, extensions, memory, profiles, and runtime controls">
-      <div class="repo-stars">★ 27</div>
+      <div class="repo-stars">★ 69</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">Euraika-Labs /</span> pan-ui</div>
         <div class="repo-desc">Self-hosted AI workspace with chat, skills, extensions, memory, profiles, runtime controls.</div>
@@ -380,7 +380,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/pyrate-llama/hermes-ui" data-github="https://github.com/pyrate-llama/hermes-ui" data-desc="Glassmorphic web interface for Hermes Agent — your self-hosted AI assistant">
-      <div class="repo-stars">★ 25</div>
+      <div class="repo-stars">★ 139</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">pyrate-llama /</span> hermes-ui</div>
         <div class="repo-desc">Glassmorphic web interface for Hermes Agent — your self-hosted AI assistant.</div>
@@ -388,7 +388,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/EKKOLearnAI/hermes-web-ui" data-github="https://github.com/EKKOLearnAI/hermes-web-ui" data-desc="Web dashboard for Hermes Agent — multi-platform AI chat, session management, scheduled jobs, usage analytics &amp; channel configuration (Telegram, Discord, Slack, WhatsApp)">
-      <div class="repo-stars">★ 1,844</div>
+      <div class="repo-stars">★ 5,887</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">EKKOLearnAI /</span> hermes-web-ui</div>
         <div class="repo-desc">Web dashboard for Hermes Agent — multi-platform AI chat, session management, scheduled jobs, usage analytics &amp; channel configuration (Telegram, Discord, Slack, WhatsApp).</div>
@@ -396,7 +396,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/aivrar/portable-hermes-agent" data-github="https://github.com/aivrar/portable-hermes-agent" data-desc="Hermes Agent made portable desktop for Windows — 100 tools, GUI, local models via LM Studio, TTS, Music, ComfyUI, workflows, tool maker. No install. No Docker. No admin rights.">
-      <div class="repo-stars">★ 81</div>
+      <div class="repo-stars">★ 133</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">aivrar /</span> portable-hermes-agent</div>
         <div class="repo-desc">Hermes Agent made portable desktop for Windows — 100 tools, GUI, local models via LM Studio, TTS, Music, ComfyUI, workflows, tool maker. No install. No Docker. No admin rights.</div>
@@ -415,7 +415,7 @@
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills" data-github="https://github.com/mukul975/Anthropic-Cybersecurity-Skills" data-desc="754 structured cybersecurity skills mapped to MITRE ATT&CK, NIST CSF 2.0, ATLAS, D3FEND & NIST AI RMF">
-      <div class="repo-stars">★ 4,132</div>
+      <div class="repo-stars">★ 7,846</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</div>
         <div class="repo-desc">754 structured cybersecurity skills mapped to MITRE ATT&amp;CK, NIST CSF 2.0, ATLAS, D3FEND &amp; NIST AI RMF.</div>
@@ -423,7 +423,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/conorbronsdon/avoid-ai-writing" data-github="https://github.com/conorbronsdon/avoid-ai-writing" data-desc="Audits and rewrites content to eliminate detectable AI writing patterns">
-      <div class="repo-stars">★ 759</div>
+      <div class="repo-stars">★ 1,552</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">conorbronsdon /</span> avoid-ai-writing</div>
         <div class="repo-desc">Audits and rewrites content to eliminate detectable AI writing patterns.</div>
@@ -431,7 +431,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/wondelai/skills" data-github="https://github.com/wondelai/skills" data-desc="Cross-platform skills library for Claude Code and agentskills.io-compatible agents">
-      <div class="repo-stars">★ 480</div>
+      <div class="repo-stars">★ 1,078</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">wondelai /</span> skills</div>
         <div class="repo-desc">Cross-platform skills library for Claude Code and agentskills.io-compatible agents.</div>
@@ -439,7 +439,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/DougTrajano/pydantic-ai-skills" data-github="https://github.com/DougTrajano/pydantic-ai-skills" data-desc="Type-safe agentskills.io support with progressive disclosure for Pydantic AI">
-      <div class="repo-stars">★ 220</div>
+      <div class="repo-stars">★ 297</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">DougTrajano /</span> pydantic-ai-skills</div>
         <div class="repo-desc">Type-safe agentskills.io support with progressive disclosure for Pydantic AI.</div>
@@ -447,7 +447,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/Agents365-ai/drawio-skill" data-github="https://github.com/Agents365-ai/drawio-skill" data-desc="Generate draw.io diagrams from natural language descriptions">
-      <div class="repo-stars">★ 131</div>
+      <div class="repo-stars">★ 1,826</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">Agents365-ai /</span> drawio-skill</div>
         <div class="repo-desc">Generate draw.io diagrams from natural language descriptions.</div>
@@ -455,7 +455,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/smartcontractkit/chainlink-agent-skills" data-github="https://github.com/smartcontractkit/chainlink-agent-skills" data-desc="Oracle network and smart contract interaction skills (agentskills.io spec)">
-      <div class="repo-stars">★ 85</div>
+      <div class="repo-stars">★ 103</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
         <div class="repo-desc">Oracle network and smart contract interaction skills (agentskills.io spec).</div>
@@ -463,7 +463,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/tlehman/litprog-skill" data-github="https://github.com/tlehman/litprog-skill" data-desc="Literate programming skill — weave code and documentation across agents">
-      <div class="repo-stars">★ 81</div>
+      <div class="repo-stars">★ 153</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">tlehman /</span> litprog-skill</div>
         <div class="repo-desc">Literate programming — weave code and documentation across agents.</div>
@@ -471,7 +471,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/esaradev/icarus-plugin" data-github="https://github.com/esaradev/icarus-plugin" data-desc="Self-memory and replacement models — remember your work, train your replacement">
-      <div class="repo-stars">★ 51</div>
+      <div class="repo-stars">★ 122</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">esaradev /</span> icarus-plugin</div>
         <div class="repo-desc">Self-memory and replacement models — remember your work, train your replacement.</div>
@@ -479,7 +479,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/chigwell/skilldock.io" data-github="https://github.com/chigwell/skilldock.io" data-desc="Registry of reusable AI skills based on AgentSkills specification">
-      <div class="repo-stars">★ 50</div>
+      <div class="repo-stars">★ 69</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">chigwell /</span> skilldock.io</div>
         <div class="repo-desc">Registry of reusable AI skills based on AgentSkills specification.</div>
@@ -487,7 +487,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/black-forest-labs/skills" data-github="https://github.com/black-forest-labs/skills" data-desc="Official FLUX image generation skills — prompting guidelines and API integration">
-      <div class="repo-stars">★ 44</div>
+      <div class="repo-stars">★ 71</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">black-forest-labs /</span> skills</div>
         <div class="repo-desc">Official FLUX image generation skills — prompting guidelines and API integration.</div>
@@ -495,7 +495,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/Romanescu11/hermes-skill-factory" data-github="https://github.com/Romanescu11/hermes-skill-factory" data-desc="Meta-skill plugin that watches workflows and auto-generates reusable skills">
-      <div class="repo-stars">★ 34</div>
+      <div class="repo-stars">★ 330</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">Romanescu11 /</span> hermes-skill-factory</div>
         <div class="repo-desc">Meta-skill plugin that watches workflows and auto-generates reusable skills.</div>
@@ -503,7 +503,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/ReinaMacCredy/maestro" data-github="https://github.com/ReinaMacCredy/maestro" data-desc="Harness for long-running AI agents — structured memory, cross-feature learning, plan-approve-execute">
-      <div class="repo-stars">★ 25</div>
+      <div class="repo-stars">★ 172</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">ReinaMacCredy /</span> maestro</div>
         <div class="repo-desc">Harness for long-running AI agents — structured memory, cross-feature learning, plan-approve-execute.</div>
@@ -511,7 +511,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/tiann/execplan-skill" data-github="https://github.com/tiann/execplan-skill" data-desc="Complex multi-step task execution with checkpoints and recovery">
-      <div class="repo-stars">★ 24</div>
+      <div class="repo-stars">★ 43</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">tiann /</span> execplan-skill</div>
         <div class="repo-desc">Complex multi-step task execution with checkpoints and recovery.</div>
@@ -519,7 +519,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/cablate/Agentic-MCP-Skill" data-github="https://github.com/cablate/Agentic-MCP-Skill" data-desc="Progressive MCP client with three-layer lazy loading — validates agentskills.io pattern">
-      <div class="repo-stars">★ 22</div>
+      <div class="repo-stars">★ 33</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">cablate /</span> Agentic-MCP-Skill</div>
         <div class="repo-desc">Progressive MCP client with three-layer lazy loading — validates agentskills.io pattern.</div>
@@ -527,7 +527,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/armelhbobdad/bmad-module-skill-forge" data-github="https://github.com/armelhbobdad/bmad-module-skill-forge" data-desc="Converts repos, docs, and developer discourse into agentskills.io-compliant skills">
-      <div class="repo-stars">★ 17</div>
+      <div class="repo-stars">★ 79</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">armelhbobdad /</span> bmad-module-skill-forge</div>
         <div class="repo-desc">Converts repos, docs, and developer discourse into agentskills.io-compliant skills.</div>
@@ -535,7 +535,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/amanning3390/hermeshub" data-github="https://github.com/amanning3390/hermeshub" data-desc="Community skill browsing, search, and one-click installation hub">
-      <div class="repo-stars">★ 15</div>
+      <div class="repo-stars">★ 193</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">amanning3390 /</span> hermeshub</div>
         <div class="repo-desc">Community skill browsing, search, and one-click installation hub.</div>
@@ -543,7 +543,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/PederHP/skillsdotnet" data-github="https://github.com/PederHP/skillsdotnet" data-desc="C# / .NET implementation of agentskills.io with MCP integration">
-      <div class="repo-stars">★ 6</div>
+      <div class="repo-stars">★ 11</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">PederHP /</span> skillsdotnet</div>
         <div class="repo-desc">C# / .NET implementation of agentskills.io with MCP integration.</div>
@@ -551,7 +551,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/AMAP-ML/SkillClaw" data-github="https://github.com/AMAP-ML/SkillClaw" data-desc="Let Skills Evolve Collectively with Agentic Evolver">
-      <div class="repo-stars">★ 1,103</div>
+      <div class="repo-stars">★ 1,453</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">AMAP-ML /</span> SkillClaw</div>
         <div class="repo-desc">Let Skills Evolve Collectively with Agentic Evolver.</div>
@@ -559,7 +559,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/Cranot/super-hermes" data-github="https://github.com/Cranot/super-hermes" data-desc="Skills that teach Hermes Agent to write its own analytical prompts">
-      <div class="repo-stars">★ 122</div>
+      <div class="repo-stars">★ 187</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">Cranot /</span> super-hermes</div>
         <div class="repo-desc">Skills that teach Hermes Agent to write its own analytical prompts.</div>
@@ -567,7 +567,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/adnw-vinc/hermes-nextcloud" data-github="https://github.com/adnw-vinc/hermes-nextcloud" data-desc="Hermes Agent skill for Nextcloud — manage files, notes, calendar, tasks, and contacts via WebDAV and CalDAV.">
-      <div class="repo-stars">★ 1</div>
+      <div class="repo-stars">★ 10</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">adnw-vinc /</span> hermes-nextcloud</div>
         <div class="repo-desc">Hermes Agent skill for Nextcloud — manage files, notes, calendar, tasks, and contacts via WebDAV and CalDAV.</div>
@@ -586,7 +586,7 @@
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/mem0ai/mem0" data-github="https://github.com/mem0ai/mem0" data-desc="Universal memory layer for AI Agents — official Hermes Agent memory provider, managed cloud or Apache-2.0 self-hosted OSS">
-      <div class="repo-stars">★ 53,915</div>
+      <div class="repo-stars">★ 56,570</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">mem0ai /</span> mem0</div>
         <div class="repo-desc">Universal memory layer — official Hermes provider with mem0_profile / mem0_search / mem0_conclude tools; runs managed (app.mem0.ai) or self-hosted Apache-2.0 OSS.</div>
@@ -594,7 +594,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/garrytan/gbrain" data-github="https://github.com/garrytan/gbrain" data-desc="Garry's Opinionated OpenClaw/Hermes Agent Brain">
-      <div class="repo-stars">★ 8,857</div>
+      <div class="repo-stars">★ 18,608</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">garrytan /</span> gbrain</div>
         <div class="repo-desc">Garry's opinionated OpenClaw / Hermes Agent brain.</div>
@@ -602,7 +602,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/vectorize-io/hindsight" data-github="https://github.com/vectorize-io/hindsight" data-desc="Agent memory that learns — long-term retain/recall/reflect workflows">
-      <div class="repo-stars">★ 8,362</div>
+      <div class="repo-stars">★ 14,369</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">vectorize-io /</span> hindsight</div>
         <div class="repo-desc">Agent memory that learns — long-term retain, recall, reflect workflows.</div>
@@ -610,7 +610,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/greyhaven-ai/autocontext" data-github="https://github.com/greyhaven-ai/autocontext" data-desc="Recursive self-improving context harness — helps agents succeed on complex tasks">
-      <div class="repo-stars">★ 711</div>
+      <div class="repo-stars">★ 1,016</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">greyhaven-ai /</span> autocontext</div>
         <div class="repo-desc">Recursive self-improving context harness — helps agents succeed on complex tasks.</div>
@@ -618,7 +618,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/stephenschoettler/hermes-lcm" data-github="https://github.com/stephenschoettler/hermes-lcm" data-desc="Lossless Context Management — DAG-based context engine that never loses a message">
-      <div class="repo-stars">★ 178</div>
+      <div class="repo-stars">★ 573</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">stephenschoettler /</span> hermes-lcm</div>
         <div class="repo-desc">Lossless context management — DAG-based engine that never loses a message.</div>
@@ -626,7 +626,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/elkimek/honcho-self-hosted" data-github="https://github.com/elkimek/honcho-self-hosted" data-desc="Self-hosted Honcho memory backend for cross-session persistence">
-      <div class="repo-stars">★ 126</div>
+      <div class="repo-stars">★ 257</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">elkimek /</span> honcho-self-hosted</div>
         <div class="repo-desc">Self-hosted Honcho memory backend for cross-session persistence.</div>
@@ -634,7 +634,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/yoloshii/ClawMem" data-github="https://github.com/yoloshii/ClawMem" data-desc="On-device memory and context engine for agents — local-first, no cloud dependencies">
-      <div class="repo-stars">★ 86</div>
+      <div class="repo-stars">★ 172</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">yoloshii /</span> ClawMem</div>
         <div class="repo-desc">On-device memory and context engine — local-first, no cloud dependencies.</div>
@@ -642,7 +642,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/plur-ai/plur" data-github="https://github.com/plur-ai/plur" data-desc="Shared memory layer with open engram YAML format for multi-agent systems">
-      <div class="repo-stars">★ 31</div>
+      <div class="repo-stars">★ 135</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">plur-ai /</span> plur</div>
         <div class="repo-desc">Shared memory layer with open engram YAML format for multi-agent systems.</div>
@@ -650,7 +650,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/amanning3390/flowstate-qmd" data-github="https://github.com/amanning3390/flowstate-qmd" data-desc="Anticipatory memory with RAG and vector search — Hermes 2026 Hackathon entry">
-      <div class="repo-stars">★ 5</div>
+      <div class="repo-stars">★ 26</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">amanning3390 /</span> flowstate-qmd</div>
         <div class="repo-desc">Anticipatory memory with RAG and vector search — Hermes 2026 Hackathon entry.</div>
@@ -658,7 +658,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/plastic-labs/honcho" data-github="https://github.com/plastic-labs/honcho" data-desc="Memory library for building stateful agents — the upstream library that the elkimek/honcho-self-hosted Hermes wrapper builds on.">
-      <div class="repo-stars">★ 3,143</div>
+      <div class="repo-stars">★ 4,141</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">plastic-labs /</span> honcho <span class="repo-flag">official</span></div>
         <div class="repo-desc">Memory library for building stateful agents — the upstream library that the elkimek/honcho-self-hosted Hermes wrapper builds on.</div>
@@ -666,7 +666,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/EfficientContext/ContextPilot" data-github="https://github.com/EfficientContext/ContextPilot" data-desc="Accelerating Long Context LLM Inference with Accuracy-Preserving Context Optimization in SGLang, vLLM, llama.cpp, OpenClaw, RAG, and Agentic AI.">
-      <div class="repo-stars">★ 82</div>
+      <div class="repo-stars">★ 112</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">EfficientContext /</span> ContextPilot</div>
         <div class="repo-desc">Accelerating Long Context LLM Inference with Accuracy-Preserving Context Optimization in SGLang, vLLM, llama.cpp, OpenClaw, RAG, and Agentic AI.</div>
@@ -674,7 +674,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/keepnotes-ai/keep" data-github="https://github.com/keepnotes-ai/keep" data-desc="Reflective memory for AI agents">
-      <div class="repo-stars">★ 31</div>
+      <div class="repo-stars">★ 35</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">keepnotes-ai /</span> keep</div>
         <div class="repo-desc">Reflective memory for AI agents.</div>
@@ -682,7 +682,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/AxDSan/mnemosyne" data-github="https://github.com/AxDSan/mnemosyne" data-desc="The Zero-Dependency, Sub-Millisecond AI Memory System for Hermes Agents">
-      <div class="repo-stars">★ 29</div>
+      <div class="repo-stars">★ 351</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">AxDSan /</span> mnemosyne</div>
         <div class="repo-desc">The Zero-Dependency, Sub-Millisecond AI Memory System for Hermes Agents.</div>
@@ -690,7 +690,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/yepyhun/Brainstack" data-github="https://github.com/yepyhun/Brainstack" data-desc="Memory kernel stack for Hermes agent">
-      <div class="repo-stars">★ 27</div>
+      <div class="repo-stars">★ 34</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">yepyhun /</span> Brainstack</div>
         <div class="repo-desc">Memory kernel stack for Hermes agent.</div>
@@ -698,7 +698,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/alias8818/hermes-tool-slimmer" data-github="https://github.com/alias8818/hermes-tool-slimmer" data-desc="Reduce Hermes Agent tool-schema overhead with keyword selection and Tool Search support">
-      <div class="repo-stars">★ 4</div>
+      <div class="repo-stars">★ 13</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">alias8818 /</span> hermes-tool-slimmer</div>
         <div class="repo-desc">Reduce Hermes Agent tool-schema overhead with keyword selection and Tool Search support.</div>
@@ -706,7 +706,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/volcengine/OpenViking" data-github="https://github.com/volcengine/OpenViking" data-desc="Filesystem-first context database — official Hermes memory provider with tiered loading and 91% token reduction on LoCoMo10">
-      <div class="repo-stars">★ 24,584</div>
+      <div class="repo-stars">★ 24,588</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">volcengine /</span> OpenViking</div>
         <div class="repo-desc">Official Hermes memory provider — viking:// URIs, tiered L0/L1/L2 loading, 91% token reduction + 43-49% task gain over baseline on LoCoMo10. AGPL-3.0.</div>
@@ -722,7 +722,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/campfirein/byterover-cli" data-github="https://github.com/campfirein/byterover-cli" data-desc="ByteRover CLI (brv) — official Hermes memory provider storing memory as a git-versionable markdown context tree">
-      <div class="repo-stars">★ 4,783</div>
+      <div class="repo-stars">★ 4,784</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">campfirein /</span> byterover-cli</div>
         <div class="repo-desc">Memory as a git repo (formerly Cipher) — official Hermes provider with 5-tier retrieval (4 tiers non-LLM, sub-100ms), brv vc commit/branch/merge versioning.</div>
@@ -765,7 +765,7 @@
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/clawshell/clawshell" data-github="https://github.com/clawshell/clawshell" data-desc="Runtime Security Layer for OpenClaw/Hermes — PII & sensitive credentials protection">
-      <div class="repo-stars">★ 255</div>
+      <div class="repo-stars">★ 281</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">clawshell /</span> clawshell</div>
         <div class="repo-desc">Runtime security layer — PII and sensitive credentials protection.</div>
@@ -773,7 +773,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/robbyczgw-cla/hermes-web-search-plus" data-github="https://github.com/robbyczgw-cla/hermes-web-search-plus" data-desc="Multi-provider web search (Serper, Tavily, Exa, Querit, Perplexity) with auto-routing">
-      <div class="repo-stars">★ 21</div>
+      <div class="repo-stars">★ 190</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
         <div class="repo-desc">Multi-provider web search — Serper, Tavily, Exa, Querit, Perplexity with auto-routing.</div>
@@ -781,7 +781,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/42-evey/hermes-plugins" data-github="https://github.com/42-evey/hermes-plugins" data-desc="Goal management, inter-agent bridge, model selection, and cost control plugins">
-      <div class="repo-stars">★ 16</div>
+      <div class="repo-stars">★ 140</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">42-evey /</span> hermes-plugins</div>
         <div class="repo-desc">Goal management, inter-agent bridge, model selection, cost control plugins.</div>
@@ -789,7 +789,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/FahrenheitResearch/hermes-weather-plugin" data-github="https://github.com/FahrenheitResearch/hermes-weather-plugin" data-desc="NWS-grade model imagery, NEXRAD radar, and verified meteorological calculations. Pure Rust.">
-      <div class="repo-stars">★ 7</div>
+      <div class="repo-stars">★ 21</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">FahrenheitResearch /</span> hermes-weather-plugin</div>
         <div class="repo-desc">NWS-grade model imagery, NEXRAD radar, verified meteorological calculations. Pure Rust.</div>
@@ -797,7 +797,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/42-evey/evey-bridge-plugin" data-github="https://github.com/42-evey/evey-bridge-plugin" data-desc="Claude Code and Hermes context sharing bridge — auto-checks messages, Mother Mode loop">
-      <div class="repo-stars">★ 4</div>
+      <div class="repo-stars">★ 12</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">42-evey /</span> evey-bridge-plugin</div>
         <div class="repo-desc">Claude Code and Hermes context sharing bridge — auto-checks messages, Mother Mode loop.</div>
@@ -805,7 +805,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/nativ3ai/hermes-payguard" data-github="https://github.com/nativ3ai/hermes-payguard" data-desc="Safe-by-design USDC and x402 payment plugin for Hermes Agent">
-      <div class="repo-stars">★ 4</div>
+      <div class="repo-stars">★ 7</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">nativ3ai /</span> hermes-payguard</div>
         <div class="repo-desc">Safe-by-design USDC and x402 payment plugin for Hermes Agent.</div>
@@ -813,7 +813,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/raulvidis/hermes-cloudflare" data-github="https://github.com/raulvidis/hermes-cloudflare" data-desc="Cloudflare Browser Rendering plugin — crawl, scrape, extract content from web pages">
-      <div class="repo-stars">★ 1</div>
+      <div class="repo-stars">★ 19</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">raulvidis /</span> hermes-cloudflare</div>
         <div class="repo-desc">Cloudflare Browser Rendering — crawl, scrape, extract content from web pages.</div>
@@ -821,7 +821,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/335234131/agent-browser-mcp" data-github="https://github.com/335234131/agent-browser-mcp" data-desc="让 Agent 直接操作真实 Chrome 的 MCP 服务，支持页面扫描、CDP、截图与物理输入">
-      <div class="repo-stars">★ 167</div>
+      <div class="repo-stars">★ 213</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">335234131 /</span> agent-browser-mcp</div>
         <div class="repo-desc">让 Agent 直接操作真实 Chrome 的 MCP 服务，支持页面扫描、CDP、截图与物理输入.</div>
@@ -829,7 +829,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/briancaffey/hermes-otel" data-github="https://github.com/briancaffey/hermes-otel" data-desc="OTel Plugin for Hermes Agent">
-      <div class="repo-stars">★ 4</div>
+      <div class="repo-stars">★ 18</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">briancaffey /</span> hermes-otel</div>
         <div class="repo-desc">OTel Plugin for Hermes Agent.</div>
@@ -837,7 +837,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/jau123/MeiGen-AI-Design-MCP" data-github="https://github.com/jau123/MeiGen-AI-Design-MCP" data-desc="Supports GPT Image 2, Nanobanana &amp; ComfyUI, with a 1,400+ prompt library, carefully crafted hooks and a multi-task orchestration system">
-      <div class="repo-stars">★ 1,096</div>
+      <div class="repo-stars">★ 1,190</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">jau123 /</span> MeiGen-AI-Design-MCP</div>
         <div class="repo-desc">Supports GPT Image 2, Nanobanana &amp; ComfyUI, with a 1,400+ prompt library, carefully crafted hooks and a multi-task orchestration system.</div>
@@ -853,7 +853,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/Xquik-dev/hermes-tweet" data-github="https://github.com/Xquik-dev/hermes-tweet" data-desc="Native Hermes Agent plugin for X automation through Xquik">
-      <div class="repo-stars">★ 1</div>
+      <div class="repo-stars">★ 7</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">Xquik-dev /</span> hermes-tweet</div>
         <div class="repo-desc">Native Hermes Agent plugin for X automation through Xquik.</div>
@@ -872,7 +872,7 @@
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/builderz-labs/mission-control" data-github="https://github.com/builderz-labs/mission-control" data-desc="Self-hosted AI agent orchestration — dispatch tasks, run multi-agent workflows, monitor spend">
-      <div class="repo-stars">★ 3,875</div>
+      <div class="repo-stars">★ 4,953</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">builderz-labs /</span> mission-control</div>
         <div class="repo-desc">Self-hosted orchestration — dispatch tasks, run multi-agent workflows, monitor spend.</div>
@@ -880,7 +880,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/swarmclawai/swarmclaw" data-github="https://github.com/swarmclawai/swarmclaw" data-desc="Build autonomous AI agent swarms with orchestration, skills, and multiple model providers">
-      <div class="repo-stars">★ 285</div>
+      <div class="repo-stars">★ 518</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">swarmclawai /</span> swarmclaw</div>
         <div class="repo-desc">Build autonomous AI agent swarms — orchestration, skills, multiple model providers.</div>
@@ -888,7 +888,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/howdymary/hermes-agent-metaharness" data-github="https://github.com/howdymary/hermes-agent-metaharness" data-desc="Meta-harness for Hermes Agent — meta-optimization with arxiv paper reference">
-      <div class="repo-stars">★ 46</div>
+      <div class="repo-stars">★ 85</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">howdymary /</span> hermes-agent-metaharness</div>
         <div class="repo-desc">Meta-harness for Hermes Agent — meta-optimization with arxiv paper reference.</div>
@@ -896,7 +896,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/runtimenoteslabs/gladiator" data-github="https://github.com/runtimenoteslabs/gladiator" data-desc="Autonomous AI companies competing for GitHub stars — agent-vs-agent arena">
-      <div class="repo-stars">★ 29</div>
+      <div class="repo-stars">★ 50</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">runtimenoteslabs /</span> gladiator</div>
         <div class="repo-desc">Autonomous AI companies competing for GitHub stars — agent-vs-agent arena.</div>
@@ -904,7 +904,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/1ilkhamov/opencode-hermes-multiagent" data-github="https://github.com/1ilkhamov/opencode-hermes-multiagent" data-desc="17 specialized agents for research, planning, implementation, quality, and infrastructure">
-      <div class="repo-stars">★ 28</div>
+      <div class="repo-stars">★ 111</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">1ilkhamov /</span> opencode-hermes-multiagent</div>
         <div class="repo-desc">17 specialized agents — research, planning, implementation, quality, infrastructure.</div>
@@ -912,7 +912,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/supermodeltools/bigiron" data-github="https://github.com/supermodeltools/bigiron" data-desc="AI-native SDLC — Hermes Agent + Supermodel code graph, graph-gated at every phase">
-      <div class="repo-stars">★ 7</div>
+      <div class="repo-stars">★ 11</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">supermodeltools /</span> bigiron</div>
         <div class="repo-desc">AI-native SDLC — Hermes Agent + Supermodel code graph, graph-gated at every phase.</div>
@@ -920,7 +920,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/Rainhoole/hermes-agent-acp-skill" data-github="https://github.com/Rainhoole/hermes-agent-acp-skill" data-desc="ACP-style multi-agent delegation — routes tasks to Hermes, Codex, or Claude Code">
-      <div class="repo-stars">★ 4</div>
+      <div class="repo-stars">★ 33</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">Rainhoole /</span> hermes-agent-acp-skill</div>
         <div class="repo-desc">ACP-style multi-agent delegation — routes tasks to Hermes, Codex, or Claude Code.</div>
@@ -939,7 +939,7 @@
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/numtide/llm-agents.nix" data-github="https://github.com/numtide/llm-agents.nix" data-desc="Nix packages for AI coding agents including Hermes">
-      <div class="repo-stars">★ 967</div>
+      <div class="repo-stars">★ 1,291</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">numtide /</span> llm-agents.nix</div>
         <div class="repo-desc">Nix packages for AI coding agents including Hermes.</div>
@@ -947,7 +947,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/TheAiSingularity/hermesclaw" data-github="https://github.com/TheAiSingularity/hermesclaw" data-desc="Hermes Agent sandboxed with hardware-level enforcement">
-      <div class="repo-stars">★ 16</div>
+      <div class="repo-stars">★ 45</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">TheAiSingularity /</span> hermesclaw</div>
         <div class="repo-desc">Hermes Agent sandboxed with hardware-level enforcement.</div>
@@ -955,7 +955,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/0xrsydn/nix-hermes-agent" data-github="https://github.com/0xrsydn/nix-hermes-agent" data-desc="Nix package and NixOS module for reproducible Hermes deployment">
-      <div class="repo-stars">★ 11</div>
+      <div class="repo-stars">★ 21</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">0xrsydn /</span> nix-hermes-agent</div>
         <div class="repo-desc">Nix package and NixOS module for reproducible Hermes deployment.</div>
@@ -963,7 +963,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/rookiemann/portable-hermes-agent" data-github="https://github.com/rookiemann/portable-hermes-agent" data-desc="Windows desktop agent — 100 tools, GUI, local models, TTS, ComfyUI. No install, no Docker.">
-      <div class="repo-stars">★ 7</div>
+      <div class="repo-stars">★ 133</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">rookiemann /</span> portable-hermes-agent</div>
         <div class="repo-desc">Windows desktop agent — 100 tools, GUI, local models, TTS, ComfyUI. No install, no Docker.</div>
@@ -971,7 +971,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/xmbshwll/hermes-agent-docker" data-github="https://github.com/xmbshwll/hermes-agent-docker" data-desc="Simple Docker sandbox image for Hermes Agent">
-      <div class="repo-stars">★ 6</div>
+      <div class="repo-stars">★ 28</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">xmbshwll /</span> hermes-agent-docker</div>
         <div class="repo-desc">Simple Docker sandbox image for Hermes Agent.</div>
@@ -979,7 +979,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/JackTheGit/hermes-autonomous-server" data-github="https://github.com/JackTheGit/hermes-autonomous-server" data-desc="Headless systemd deployment with Nous Portal integration — production-ready">
-      <div class="repo-stars">★ 2</div>
+      <div class="repo-stars">★ 10</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">JackTheGit /</span> hermes-autonomous-server</div>
         <div class="repo-desc">Headless systemd deployment with Nous Portal integration — production-ready.</div>
@@ -987,7 +987,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/ellickjohnson/portainer-stack-hermes" data-github="https://github.com/ellickjohnson/portainer-stack-hermes" data-desc="Docker Compose stack with Portainer UI and ttyd web terminal">
-      <div class="repo-stars">★ 1</div>
+      <div class="repo-stars">★ 5</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">ellickjohnson /</span> portainer-stack-hermes</div>
         <div class="repo-desc">Docker Compose stack with Portainer UI and ttyd web terminal.</div>
@@ -995,7 +995,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/jpalmae/hermeshq" data-github="https://github.com/jpalmae/hermeshq" data-desc="HermesHQ is a Docker-first control plane for running and operating multiple Hermes Agent instances from one web application.">
-      <div class="repo-stars">★ 5</div>
+      <div class="repo-stars">★ 9</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">jpalmae /</span> hermeshq</div>
         <div class="repo-desc">HermesHQ is a Docker-first control plane for running and operating multiple Hermes Agent instances from one web application.</div>
@@ -1014,7 +1014,7 @@
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/AaronWong1999/hermesclaw" data-github="https://github.com/AaronWong1999/hermesclaw" data-desc="Run Hermes Agent and OpenClaw on the same WeChat account">
-      <div class="repo-stars">★ 112</div>
+      <div class="repo-stars">★ 535</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">AaronWong1999 /</span> hermesclaw</div>
         <div class="repo-desc">Run Hermes Agent and OpenClaw on the same WeChat account.</div>
@@ -1022,7 +1022,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/raulvidis/hermes-android" data-github="https://github.com/raulvidis/hermes-android" data-desc="Android device control — bridge app + Python toolset for mobile automation">
-      <div class="repo-stars">★ 38</div>
+      <div class="repo-stars">★ 204</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">raulvidis /</span> hermes-android</div>
         <div class="repo-desc">Android device control — bridge app + Python toolset for mobile automation.</div>
@@ -1030,7 +1030,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/Codename-11/hermes-relay" data-github="https://github.com/Codename-11/hermes-relay" data-desc="Hermes Companion — Android app for Hermes agent platform. Chat, terminal, and device control over WSS.">
-      <div class="repo-stars">★ 10</div>
+      <div class="repo-stars">★ 26</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">Codename-11 /</span> hermes-relay</div>
         <div class="repo-desc">Hermes Companion — Android app for Hermes agent platform. Chat, terminal, device control over WSS.</div>
@@ -1038,7 +1038,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/teknium1/hermes-miniverse" data-github="https://github.com/teknium1/hermes-miniverse" data-desc="Bridge Hermes to Miniverse pixel worlds — agent embodiment in virtual environments">
-      <div class="repo-stars">★ 8</div>
+      <div class="repo-stars">★ 35</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">teknium1 /</span> hermes-miniverse</div>
         <div class="repo-desc">Bridge Hermes to Miniverse pixel worlds — agent embodiment in virtual environments.</div>
@@ -1046,7 +1046,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/Ridwannurudeen/hermes-council" data-github="https://github.com/Ridwannurudeen/hermes-council" data-desc="Adversarial multi-perspective council MCP server for decision-making">
-      <div class="repo-stars">★ 6</div>
+      <div class="repo-stars">★ 29</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">Ridwannurudeen /</span> hermes-council</div>
         <div class="repo-desc">Adversarial multi-perspective council MCP server for decision-making.</div>
@@ -1054,7 +1054,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/marlandoj/zouroboros-swarm-executors" data-github="https://github.com/marlandoj/zouroboros-swarm-executors" data-desc="Claude Code and Hermes task handoff bridge for zo-swarm-orchestrator">
-      <div class="repo-stars">★ 4</div>
+      <div class="repo-stars">★ 6</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">marlandoj /</span> zouroboros-swarm-executors</div>
         <div class="repo-desc">Claude Code and Hermes task handoff bridge for zo-swarm-orchestrator.</div>
@@ -1062,7 +1062,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/gizdusum/hermes-blockchain-oracle" data-github="https://github.com/gizdusum/hermes-blockchain-oracle" data-desc="Solana blockchain intelligence MCP server — wallets, whales, tokens, NFTs, network health">
-      <div class="repo-stars">★ 3</div>
+      <div class="repo-stars">★ 4</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">gizdusum /</span> hermes-blockchain-oracle</div>
         <div class="repo-desc">Solana blockchain intelligence MCP — wallets, whales, tokens, NFTs, network health.</div>
@@ -1070,7 +1070,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/kevinmarmstrong/hermes-claude-code-rc" data-github="https://github.com/kevinmarmstrong/hermes-claude-code-rc" data-desc="Hermes Agent plugin for remote controlling Claude Code sessions via Telegram">
-      <div class="repo-stars">★ 1</div>
+      <div class="repo-stars">★ 2</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">kevinmarmstrong /</span> hermes-claude-code-rc</div>
         <div class="repo-desc">Hermes Agent plugin for remote controlling Claude Code sessions via Telegram.</div>
@@ -1105,7 +1105,7 @@
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/junhoyeo/tokscale" data-github="https://github.com/junhoyeo/tokscale" data-desc="CLI tool for tracking token usage from Claude Code, OpenClaw, Hermes, Codex, Gemini, and more">
-      <div class="repo-stars">★ 1,690</div>
+      <div class="repo-stars">★ 3,158</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">junhoyeo /</span> tokscale</div>
         <div class="repo-desc">CLI for tracking token usage — Claude Code, OpenClaw, Hermes, Codex, Gemini, and more.</div>
@@ -1113,7 +1113,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/joeynyc/hermes-skins" data-github="https://github.com/joeynyc/hermes-skins" data-desc="Community CLI skins and themes for Hermes terminal UI">
-      <div class="repo-stars">★ 76</div>
+      <div class="repo-stars">★ 390</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">joeynyc /</span> hermes-skins</div>
         <div class="repo-desc">Community CLI skins and themes for Hermes terminal UI.</div>
@@ -1121,7 +1121,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/AlexAI-MCP/hermes-CCC" data-github="https://github.com/AlexAI-MCP/hermes-CCC" data-desc="Hermes Agent ported to Claude Code Channel — 46 native skills, no OAuth, no external process">
-      <div class="repo-stars">★ 56</div>
+      <div class="repo-stars">★ 107</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">AlexAI-MCP /</span> hermes-CCC</div>
         <div class="repo-desc">Hermes ported to Claude Code Channel — 46 native skills, no OAuth, no external process.</div>
@@ -1129,7 +1129,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/unmodeled-tyler/vessel-browser" data-github="https://github.com/unmodeled-tyler/vessel-browser" data-desc="AI-native browser built for autonomous agent control via MCP">
-      <div class="repo-stars">★ 44</div>
+      <div class="repo-stars">★ 81</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">unmodeled-tyler /</span> vessel-browser</div>
         <div class="repo-desc">AI-native browser built for autonomous agent control via MCP.</div>
@@ -1137,7 +1137,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/Abruptive/Ankh.md" data-github="https://github.com/Abruptive/Ankh.md" data-desc="TAW Agent framework for creating scoped Hermes Agents">
-      <div class="repo-stars">★ 25</div>
+      <div class="repo-stars">★ 54</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">Abruptive /</span> Ankh.md</div>
         <div class="repo-desc">TAW Agent framework for creating scoped Hermes Agents.</div>
@@ -1145,7 +1145,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/roli-lpci/lintlang" data-github="https://github.com/roli-lpci/lintlang" data-desc="Static linter for AI agent configs, tool descriptions, and system prompts. HERM v1.1 scoring.">
-      <div class="repo-stars">★ 24</div>
+      <div class="repo-stars">★ 36</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">roli-lpci /</span> lintlang</div>
         <div class="repo-desc">Static linter for agent configs, tool descriptions, system prompts. HERM v1.1 scoring.</div>
@@ -1153,7 +1153,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/0xNyk/openclaw-to-hermes" data-github="https://github.com/0xNyk/openclaw-to-hermes" data-desc="Migration tool from OpenClaw to Hermes Agent">
-      <div class="repo-stars">★ 21</div>
+      <div class="repo-stars">★ 30</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">0xNyk /</span> openclaw-to-hermes</div>
         <div class="repo-desc">Migration tool from OpenClaw to Hermes Agent.</div>
@@ -1161,7 +1161,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/42-evey/evey-setup" data-github="https://github.com/42-evey/evey-setup" data-desc="Get a hermes-agent stack running in minutes — free models, 29 plugins, zero cost">
-      <div class="repo-stars">★ 7</div>
+      <div class="repo-stars">★ 35</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">42-evey /</span> evey-setup</div>
         <div class="repo-desc">Get a hermes-agent stack running in minutes — free models, 29 plugins, zero cost.</div>
@@ -1180,7 +1180,7 @@
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/ucsandman/DashClaw" data-github="https://github.com/ucsandman/DashClaw" data-desc="Decision infrastructure with guard policies and risk assessment for agents">
-      <div class="repo-stars">★ 204</div>
+      <div class="repo-stars">★ 266</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">ucsandman /</span> DashClaw</div>
         <div class="repo-desc">Decision infrastructure with guard policies and risk assessment for agents.</div>
@@ -1188,7 +1188,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/Lethe044/hermes-incident-commander" data-github="https://github.com/Lethe044/hermes-incident-commander" data-desc="Autonomous SRE agent — detects, heals, and learns from production incidents">
-      <div class="repo-stars">★ 11</div>
+      <div class="repo-stars">★ 35</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">Lethe044 /</span> hermes-incident-commander</div>
         <div class="repo-desc">Autonomous SRE agent — detects, heals, and learns from production incidents.</div>
@@ -1196,7 +1196,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/Christabel337/job-scout-agent" data-github="https://github.com/Christabel337/job-scout-agent" data-desc="Autonomous job hunting — scans listings, writes cover letters, tracks applications">
-      <div class="repo-stars">★ 11</div>
+      <div class="repo-stars">★ 33</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">Christabel337 /</span> job-scout-agent</div>
         <div class="repo-desc">Autonomous job hunting — scans listings, writes cover letters, tracks applications.</div>
@@ -1204,7 +1204,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/rodmarkun/anihermes" data-github="https://github.com/rodmarkun/anihermes" data-desc="Local anime server and tracker via natural language for Hermes Agent">
-      <div class="repo-stars">★ 9</div>
+      <div class="repo-stars">★ 15</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">rodmarkun /</span> anihermes</div>
         <div class="repo-desc">Local anime server and tracker via natural language for Hermes Agent.</div>
@@ -1212,7 +1212,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/JackTheGit/hermes-ai-infrastructure-monitoring-toolkit" data-github="https://github.com/JackTheGit/hermes-ai-infrastructure-monitoring-toolkit" data-desc="Autonomous monitoring — cron-based research ingestion, cost forecasting, headless systemd">
-      <div class="repo-stars">★ 9</div>
+      <div class="repo-stars">★ 18</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">JackTheGit /</span> hermes-ai-infrastructure-monitoring-toolkit</div>
         <div class="repo-desc">Autonomous monitoring — cron-based research, cost forecasting, headless systemd.</div>
@@ -1220,7 +1220,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/bigph00t/hermescraft" data-github="https://github.com/bigph00t/hermescraft" data-desc="Embodied AI companion for Minecraft — persistent memory, vision, learning, multi-agent">
-      <div class="repo-stars">★ 8</div>
+      <div class="repo-stars">★ 31</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">bigph00t /</span> hermescraft</div>
         <div class="repo-desc">Embodied AI companion for Minecraft — persistent memory, vision, learning, multi-agent.</div>
@@ -1228,7 +1228,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/hxsteric/mercury" data-github="https://github.com/hxsteric/mercury" data-desc="Blockchain cash flow analyzer — multi-chain analysis, fraud detection, WebGL dashboard">
-      <div class="repo-stars">★ 5</div>
+      <div class="repo-stars">★ 16</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">hxsteric /</span> mercury</div>
         <div class="repo-desc">Blockchain cash flow analyzer — multi-chain analysis, fraud detection, WebGL dashboard.</div>
@@ -1236,7 +1236,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/bryercowan/hermes-embodied" data-github="https://github.com/bryercowan/hermes-embodied" data-desc="Self-improving robotics via VLA model fine-tuning on cloud GPUs">
-      <div class="repo-stars">★ 2</div>
+      <div class="repo-stars">★ 7</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">bryercowan /</span> hermes-embodied</div>
         <div class="repo-desc">Self-improving robotics via VLA model fine-tuning on cloud GPUs.</div>
@@ -1255,7 +1255,7 @@
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/0xNyk/awesome-hermes-agent" data-github="https://github.com/0xNyk/awesome-hermes-agent" data-desc="Curated list of awesome skills, tools, integrations, and resources for Hermes Agent">
-      <div class="repo-stars">★ 898</div>
+      <div class="repo-stars">★ 3,343</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">0xNyk /</span> awesome-hermes-agent</div>
         <div class="repo-desc">Curated list of skills, tools, integrations, and resources for Hermes Agent.</div>
@@ -1263,7 +1263,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/alchaincyf/hermes-agent-orange-book" data-github="https://github.com/alchaincyf/hermes-agent-orange-book" data-desc="Hermes Agent practical guide — Orange Book series (Chinese language)">
-      <div class="repo-stars">★ 315</div>
+      <div class="repo-stars">★ 3,851</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">alchaincyf /</span> hermes-agent-orange-book</div>
         <div class="repo-desc">Hermes Agent practical guide — Orange Book series (Chinese language).</div>
@@ -1271,7 +1271,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/ksimback/hermes-ecosystem" data-github="https://github.com/ksimback/hermes-ecosystem" data-desc="Hermes Atlas — the community map of every tool, skill, and integration for Hermes Agent">
-      <div class="repo-stars">★ 263</div>
+      <div class="repo-stars">★ 881</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">ksimback /</span> hermes-ecosystem</div>
         <div class="repo-desc">Hermes Atlas — the community map of every tool, skill, and integration for Hermes Agent.</div>
@@ -1279,7 +1279,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/OnlyTerp/hermes-optimization-guide" data-github="https://github.com/OnlyTerp/hermes-optimization-guide" data-desc="Performance optimization guide for Hermes deployments">
-      <div class="repo-stars">★ 51</div>
+      <div class="repo-stars">★ 327</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">OnlyTerp /</span> hermes-optimization-guide</div>
         <div class="repo-desc">Performance optimization guide for Hermes deployments.</div>
@@ -1287,7 +1287,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/metantonio/hermes-wsl-ubuntu" data-github="https://github.com/metantonio/hermes-wsl-ubuntu" data-desc="Step-by-step WSL2 Ubuntu setup guide for Windows users">
-      <div class="repo-stars">★ 8</div>
+      <div class="repo-stars">★ 35</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">metantonio /</span> hermes-wsl-ubuntu</div>
         <div class="repo-desc">Step-by-step WSL2 Ubuntu setup guide for Windows users.</div>
@@ -1295,7 +1295,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/mudrii/hermes-agent-docs" data-github="https://github.com/mudrii/hermes-agent-docs" data-desc="Community documentation covering deployment patterns and v0.2.0+ workflows">
-      <div class="repo-stars">★ 6</div>
+      <div class="repo-stars">★ 44</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">mudrii /</span> hermes-agent-docs</div>
         <div class="repo-desc">Community documentation — deployment patterns and v0.2.0+ workflows.</div>
@@ -1303,7 +1303,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/martymcenroe/HermesWiki" data-github="https://github.com/martymcenroe/HermesWiki" data-desc="Community wiki with deployment patterns and recipes">
-      <div class="repo-stars">★ 2</div>
+      <div class="repo-stars">★ 13</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">martymcenroe /</span> HermesWiki</div>
         <div class="repo-desc">Community wiki with deployment patterns and recipes.</div>
@@ -1311,7 +1311,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/jwangkun/hermes-agent-guide" data-github="https://github.com/jwangkun/hermes-agent-guide" data-desc="A systematic Chinese-language guide to Hermes Agent — 16 books, 300K+ words, covering installation, advanced development, single- and multi-agent orchestration.">
-      <div class="repo-stars">★ 130</div>
+      <div class="repo-stars">★ 256</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">jwangkun /</span> hermes-agent-guide</div>
         <div class="repo-desc">A systematic Chinese-language guide to Hermes Agent — 16 books, 300K+ words, covering installation, advanced development, single- and multi-agent orchestration.</div>
@@ -1319,7 +1319,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/longyunfeigu/learn-hermes-agent" data-github="https://github.com/longyunfeigu/learn-hermes-agent" data-desc="A 27-chapter hands-on tutorial for building an autonomous AI agent from zero in Python — agent loop, tool system, memory, skills, MCP, multi-platform gateway, and self-evolution.">
-      <div class="repo-stars">★ 73</div>
+      <div class="repo-stars">★ 119</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">longyunfeigu /</span> learn-hermes-agent</div>
         <div class="repo-desc">A 27-chapter hands-on tutorial for building an autonomous AI agent from zero in Python — agent loop, tool system, memory, skills, MCP, multi-platform gateway, and self-evolution.</div>
@@ -1338,7 +1338,7 @@
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/nativ3ai/hermes-agent-camel" data-github="https://github.com/nativ3ai/hermes-agent-camel" data-desc="Hermes with integrated CaMeL trust boundaries for safer autonomous execution">
-      <div class="repo-stars">★ 12</div>
+      <div class="repo-stars">★ 182</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">nativ3ai /</span> hermes-agent-camel</div>
         <div class="repo-desc">Hermes with integrated CaMeL trust boundaries for safer autonomous execution.</div>
@@ -1346,7 +1346,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/kaminocorp/hermes-alpha" data-github="https://github.com/kaminocorp/hermes-alpha" data-desc="Cloud-deployed Hermes with pre-configured templates and managed infrastructure">
-      <div class="repo-stars">★ 8</div>
+      <div class="repo-stars">★ 208</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">kaminocorp /</span> hermes-alpha</div>
         <div class="repo-desc">Cloud-deployed Hermes with pre-configured templates and managed infrastructure.</div>
@@ -1354,7 +1354,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/beardthelion/hermes-skill-distillation" data-github="https://github.com/beardthelion/hermes-skill-distillation" data-desc="Generate agentic training trajectories from real-world tasks for Hermes 4 fine-tuning">
-      <div class="repo-stars">★ 1</div>
+      <div class="repo-stars">★ 7</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">beardthelion /</span> hermes-skill-distillation</div>
         <div class="repo-desc">Generate agentic training trajectories from real-world tasks for Hermes 4 fine-tuning.</div>

--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -1066,6 +1066,29 @@ function syncHomepageRepos(repos) {
     [...html.matchAll(/href="\/projects\/([^"]+)"/g)].map((m) => m[1])
   );
 
+  // Refresh stale star counts on existing rendered rows. The append-only
+  // policy preserves hand-curated descriptions, but star counts are pure
+  // live data — without this pass they stay frozen at the value the row
+  // had when first added, even after data/repos.json gets refreshed by
+  // the GraphQL pass in main(). Touches only the ★ NNNN text inside each
+  // <div class="repo-stars">; everything else is left as-is.
+  const repoByKey = new Map(repos.map((r) => [`${r.owner}/${r.repo}`, r]));
+  let rowsRefreshed = 0;
+  html = html.replace(
+    /(data-github="https:\/\/github\.com\/([^"]+)"[^>]*>\s*<div class="repo-stars">★ )([0-9,]+)(<\/div>)/g,
+    (full, prefix, key, oldStars, suffix) => {
+      const r = repoByKey.get(key);
+      if (!r || typeof r.stars !== "number") return full;
+      const newStars = r.stars.toLocaleString("en-US");
+      if (newStars === oldStars) return full;
+      rowsRefreshed++;
+      return prefix + newStars + suffix;
+    }
+  );
+  if (rowsRefreshed > 0) {
+    console.log(`  Refreshed star counts on ${rowsRefreshed} existing rows`);
+  }
+
   const missingByCategory = {};
   for (const r of repos) {
     if (!onPage.has(`${r.owner}/${r.repo}`)) {
@@ -1146,6 +1169,29 @@ async function main() {
     console.log("Fetching metadata via GraphQL...");
     metadata = await fetchAllMetadata(repos, GITHUB_HEADERS);
     console.log(`  Got metadata for ${Object.keys(metadata).length} repos\n`);
+
+    // Persist refreshed stars back into repos.json. Project HTML pages render
+    // from `meta.stars`, but the homepage repo-rows and any external consumer
+    // of /data/repos.json (e.g. the MCP server) read `r.stars` — so without
+    // this writeback the public dataset silently drifts (entries added months
+    // ago kept their submitter-time star count). Scope is stars-only; every
+    // other field on the repo entry is curator-managed.
+    let starsRefreshed = 0;
+    for (const r of repos) {
+      const liveStars = metadata[`${r.owner}/${r.repo}`]?.stars;
+      if (typeof liveStars === "number" && liveStars !== r.stars) {
+        r.stars = liveStars;
+        starsRefreshed++;
+      }
+    }
+    if (starsRefreshed > 0) {
+      const reposPath = path.join(ROOT, "data", "repos.json");
+      // Preserve CRLF + trailing newline so the diff is stars-only and
+      // doesn't churn the whole file on every build.
+      const body = JSON.stringify(repos, null, 2).replace(/\n/g, "\r\n") + "\r\n";
+      fs.writeFileSync(reposPath, body);
+      console.log(`  Refreshed stars on ${starsRefreshed} repos in data/repos.json\n`);
+    }
   } else {
     console.log("Skipping GitHub metadata fetch (no token).\n");
   }


### PR DESCRIPTION
## Summary

- **Bug:** `build-pages.js` fetched fresh stars via GraphQL each build but only used them in the in-memory `metadata` object for HTML rendering — never wrote them back to `data/repos.json`. Public consumers of `/data/repos.json` (the MCP server, anyone hitting the JSON directly) saw star counts frozen at the value entries had when first submitted, sometimes months old.
- **Severity:** Caught during a live audit for the May State-of-Hermes report. **Total ecosystem stars understated by 63% (239K vs actual 390K)** because most entries kept their submitter-time star count. GBrain showed 8,857 vs live 18,604; hermes-webui 2,479 vs 8,468; hermes-agent-self-evolution 778 vs 3,501. Newer entries (mem0, OpenViking, supermemory) were near-current because they were added recently.
- **Fix:** Three small changes — `build-pages.js` now writes refreshed stars back to `data/repos.json`, refreshes the ★ NNNN text on existing homepage rows in-place, and the workflow stages `data/repos.json` for commit.

## What changed

1. **`scripts/build-pages.js`** — after `fetchAllMetadata` succeeds, write fresh stars back to `data/repos.json`. Scope is stars-only; `description` and every other field stay curator-managed. CRLF + trailing newline preserved so the diff is exactly N stars-changed lines.

2. **`scripts/build-pages.js` (`syncHomepageRepos`)** — homepage repo-rows are append-only by design (preserves hand-curated descriptions). Star counts on existing rendered rows stayed stale even after `repos.json` was refreshed. New in-place pass updates only the `★ NNNN` text inside each `<div class="repo-stars">`, matched via the `data-github` attribute.

3. **`.github/workflows/build-pages.yml`** — adds `data/repos.json` to the staged set so the daily build actually commits the refreshed stars. Without this, the writeback would have been thrown away.

## Verified locally

Ran `node scripts/build-pages.js` with `GITHUB_TOKEN`:
- ✅ Refreshed stars on **116 repos** in `data/repos.json` (first run)
- ✅ Refreshed star counts on **115 existing homepage rows**
- ✅ Diff is exclusively `★ NNNN` swaps — no description churn, no CRLF flips
- ✅ Re-run refreshed 6 more (live drift in the intervening minutes — expected)

## Test plan

- [ ] Merge → `build-pages` workflow runs on push (triggered by `scripts/build-pages.js` path filter) → confirm the auto-commit refreshes star counts across `projects/*.html` + `lists/*.html` + `llms.txt` + `rss.xml` downstream
- [ ] Verify homepage stars on hermesatlas.com match GitHub live counts after deploy
- [ ] Confirm the next scheduled 06:30 UTC daily build catches incremental drift without churn (should refresh ~10-20 repos per day, not 100+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)