### PR TITLE
Add post-deploy production smoke test

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -1,0 +1,201 @@
+name: Post-Deploy Smoke Test
+
+# Runs the production smoke test after a Vercel deploy completes for any push
+# to main that touched site-affecting files. Posts a commit status so the
+# result is visible right next to the Vercel deploy in the GitHub UI, and
+# opens (or updates) a tracking issue if anything fails.
+#
+# Trigger paths are intentionally broad - it's cheaper to run smoke unnecessarily
+# than to miss a real regression. Add new paths here if you introduce a new
+# build input that can affect rendered pages.
+#
+# Override the target URL for manual runs via workflow_dispatch (handy for
+# testing against a Vercel preview deployment before merging).
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'data/**'
+      - 'index.html'
+      - 'lib/**'
+      - 'api/**'
+      - 'scripts/build-pages.js'
+      - 'scripts/build-chunks.js'
+      - 'scripts/smoke-test-prod.js'
+      - '.github/workflows/post-deploy-smoke.yml'
+  workflow_dispatch:
+    inputs:
+      base:
+        description: 'Base URL to test (default https://hermesatlas.com)'
+        required: false
+        default: 'https://hermesatlas.com'
+      sample:
+        description: 'Number of project pages to sample'
+        required: false
+        default: '25'
+
+# Serialize - we don't want two smoke runs racing each other against the same
+# deploy. Cancel pending duplicate runs since only the latest deploy matters.
+concurrency:
+  group: post-deploy-smoke
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      statuses: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      # Vercel posts a commit status with context="Vercel" once the deploy
+      # completes. Poll for it. On workflow_dispatch we skip the wait because
+      # the user-supplied base URL might already be live.
+      - name: Wait for Vercel deploy to be ready
+        if: github.event_name == 'push'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = context.sha;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const MAX_WAIT_MS = 10 * 60 * 1000; // 10 minutes
+            const INTERVAL_MS = 15 * 1000;
+            const start = Date.now();
+            let lastState = null;
+
+            core.info(`Polling Vercel deploy status for ${sha} (max 10min)`);
+
+            while (Date.now() - start < MAX_WAIT_MS) {
+              const { data } = await github.rest.repos.getCombinedStatusForRef({
+                owner, repo, ref: sha,
+              });
+              const vercel = data.statuses.find(s => s.context === 'Vercel');
+              const state = vercel ? vercel.state : 'no-status-yet';
+              if (state !== lastState) {
+                core.info(`Vercel status: ${state}`);
+                lastState = state;
+              }
+              if (state === 'success') {
+                core.info(`Vercel deploy ready in ${Math.round((Date.now()-start)/1000)}s`);
+                return;
+              }
+              if (state === 'failure' || state === 'error') {
+                core.setFailed(`Vercel deploy failed for ${sha} - skipping smoke test`);
+                return;
+              }
+              await new Promise(r => setTimeout(r, INTERVAL_MS));
+            }
+            core.setFailed(`Timed out waiting for Vercel deploy (10min)`);
+
+      # Known-broken-but-deferred check IDs go here. Each entry is a substring
+      # match against the failing check name. When a smoke check matches one of
+      # these, the failure becomes a WARN instead of a FAIL (still reported,
+      # doesn't fail the job). Audit and prune this list quarterly - issues
+      # acknowledged here should become tracked bugs to fix, not permanent.
+      #
+      # Current entries (audit before extending):
+      #   /lists/                 - /lists/ index page returns 404; only /lists/<slug>
+      #                             pages exist. Decide: build an index or remove from test.
+      #   Core & Official count   - homepage shows 5 in Core & Official but
+      #                             repos.json has 6 entries. Fix is a single
+      #                             character in index.html. Track separately.
+      - name: Run smoke test
+        id: smoke
+        env:
+          SMOKE_ALLOW_FAILURES: '/lists/,Core & Official count'
+        run: |
+          node scripts/smoke-test-prod.js \
+            --base "${{ inputs.base || 'https://hermesatlas.com' }}" \
+            --sample "${{ inputs.sample || '25' }}" \
+            --continue \
+            | tee smoke-output.txt
+
+      - name: Post commit status (success)
+        if: success() && github.event_name == 'push'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.sha,
+              state: 'success',
+              context: 'Smoke Test (production)',
+              description: 'All production smoke checks passed',
+              target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });
+
+      - name: Post commit status (failure) and open / update tracking issue
+        if: failure() && github.event_name == 'push'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let smokeOutput = '';
+            try {
+              smokeOutput = fs.readFileSync('smoke-output.txt', 'utf8');
+            } catch (e) {
+              smokeOutput = '(smoke-output.txt not produced - check the job log)';
+            }
+
+            // Commit status
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.sha,
+              state: 'failure',
+              context: 'Smoke Test (production)',
+              description: 'Production smoke test failed - see Actions log',
+              target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });
+
+            // Find or open the tracking issue. We keep one issue open at a time
+            // so successive failures comment on the same thread instead of
+            // spamming N separate issues.
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'smoke-test-failure',
+            });
+            const body = [
+              `Production smoke test failed on commit ${context.sha.slice(0,7)}.`,
+              '',
+              `**Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              '',
+              '```',
+              smokeOutput.slice(-3500),
+              '```',
+            ].join('\n');
+
+            if (issues.data.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issues.data[0].number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: 'Smoke test failure on production',
+                body,
+                labels: ['smoke-test-failure'],
+              });
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,15 @@ If you'd rather open a PR instead of an issue:
 | Guides & Docs | Curated lists, tutorials, optimization guides |
 | Forks & Derivatives | Meaningful forks with added functionality |
 
+## Testing
+
+We run a production smoke test after every deploy. See [`TESTING.md`](./TESTING.md)
+for what gets checked, how to run it locally against a Vercel preview, and how
+to acknowledge known-broken-but-deferred issues without blocking CI.
+
+If you're adding a new build step, data file, or page layout, consider whether
+it warrants a new smoke check — `TESTING.md` walks through the pattern.
+
 ## Questions?
 
 - Try the [Ask the Atlas](https://hermesatlas.com) chatbot

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,211 @@
+# Testing & Production Health Checks
+
+This doc covers how we verify the Atlas site stays healthy as it grows. There
+are two layers: **pre-merge gates** (catch bugs before they reach `main`) and
+**post-deploy smoke tests** (verify production is actually healthy after each
+deploy).
+
+## TL;DR
+
+| When | What runs | What it catches |
+|---|---|---|
+| Pre-merge | Existing workflows (`audit-repos`, `validate-repo-suggestion`, Vercel preview build) | Schema errors, dead repos, build failures, bad submissions |
+| Post-deploy | `post-deploy-smoke.yml` ← **new** | Drift between `data/repos.json` and rendered HTML, missing project pages, broken sitemap/RSS, 404s on critical pages, broken internal links |
+
+The post-deploy smoke test runs automatically on every push to `main` that
+touches site-affecting files. Results show up as a commit status next to
+the Vercel deploy. Failures open (or update) a tracking issue labeled
+`smoke-test-failure` so nothing rots silently in the Actions tab.
+
+## Running the smoke test locally
+
+```bash
+# Against production (default)
+node scripts/smoke-test-prod.js
+
+# Against a Vercel preview URL
+node scripts/smoke-test-prod.js --base https://hermes-ecosystem-git-mybranch-kevins-projects.vercel.app
+
+# Test more project pages, keep going past failures
+node scripts/smoke-test-prod.js --sample 50 --continue --verbose
+
+# Acknowledge known-broken checks (becomes WARN, exit stays 0)
+node scripts/smoke-test-prod.js --allow '/lists/,Core & Official count'
+# or
+SMOKE_ALLOW_FAILURES='/lists/,Core & Official count' node scripts/smoke-test-prod.js
+```
+
+**Windows / Git Bash note:** MSYS path conversion will mangle tokens that
+start with a slash (e.g. `/lists/` becomes `C:/Program Files/Git/lists/`).
+Prefix the invocation with `MSYS_NO_PATHCONV=1` or run from `cmd.exe` /
+PowerShell. The Linux runner used by GitHub Actions isn't affected.
+
+## What the smoke test checks
+
+Each check below corresponds to a real failure mode the site has hit or could
+plausibly hit. Add new checks here when we discover a new failure pattern that
+the existing ones don't catch.
+
+### 1. Critical pages return 2xx
+
+Hits `/`, `/guide/`, `/lists/`, `/reports/`, `/privacy/`, `/sitemap.xml`,
+`/rss.xml`, `/robots.txt`. Catches:
+
+- A redirect chain breaking
+- A build skipping a top-level page
+- Vercel routing config (`vercel.json`) regressing
+- A page rename that wasn't propagated to the menu
+
+### 2. Homepage category counts match `data/repos.json`
+
+For each `<section class="cat" data-category="...">` on the homepage, asserts
+the count in `<span class="cat-count-n">N</span>` equals the number of repos
+in `data/repos.json` with that category. Catches:
+
+- The exact drift that bit PR #231 (bumped JSON, forgot to bump the
+  homepage count span)
+- A category renamed in JSON but not on homepage
+- A category added in JSON with no homepage section yet
+
+### 3. Project pages return 2xx (sample + recent)
+
+Hits a sample of `/projects/<owner>/<repo>` URLs - all entries newer than
+14 days plus a random 25 from the rest. Catches:
+
+- `build-pages.js` skipped a repo
+- A renamed `owner` or `repo` field left a stale page reference
+- Vercel cache serving a stale 404 for a new project
+
+### 4. Sitemap covers every project URL in `data/repos.json`
+
+Parses `/sitemap.xml`, extracts every `<loc>` starting with `/projects/`,
+asserts every repo in `data/repos.json` has a corresponding entry.
+Catches sitemap generation drift.
+
+### 5. RSS feed is well-formed
+
+Quick XML well-formedness check on `/rss.xml`. Catches broken templating in
+the RSS generator without needing a full XML schema validator.
+
+### 6. Sample of internal links from homepage resolve
+
+Pulls every `<a href="/...">` on the homepage, samples 25, asserts each
+resolves. Catches stale internal anchor refs (e.g. a list URL pointing at a
+slug we renamed).
+
+## Adding a check
+
+Open `scripts/smoke-test-prod.js`. Each check is a `section("label", async () => { ... })`
+block. Add a new one following the pattern:
+
+```js
+await section("7. My new check description", async () => {
+  // ...do the check...
+  if (somethingIsBroken) {
+    fail("specific check id", "what went wrong", "extra detail for triage");
+  } else {
+    pass("specific check id", "what passed and how much");
+  }
+});
+```
+
+Use unique strings for the check ID - the allow-list mechanism uses substring
+match on it.
+
+## Acknowledged failures
+
+When the smoke test flags something that's a known issue we're not yet ready
+to fix, we acknowledge it via the `SMOKE_ALLOW_FAILURES` env var in the
+workflow. Acknowledgements convert FAIL → WARN (still reported, doesn't
+block CI).
+
+**Current acknowledgements** (audit quarterly; either fix or document why
+they're permanent):
+
+| Check ID | What | Fix path |
+|---|---|---|
+| `/lists/` | The `/lists/` index page 404s; only `/lists/<slug>` pages exist | Decide: build a list-index page, or remove from critical-pages set |
+| `Core & Official count` | Homepage shows 5 in Core & Official; `data/repos.json` has 6 entries | Bump `<span class="cat-count-n">` from 5 to 6 in `index.html` Core & Official section |
+
+When adding or removing entries from this list, **update the comment block in
+`.github/workflows/post-deploy-smoke.yml` to match.** That comment block is
+the human-readable triage source for what we're knowingly carrying.
+
+## Pre-merge gates that already exist
+
+These run on PRs and pushes:
+
+| Workflow | What it does |
+|---|---|
+| `validate-repo-suggestion.yml` | Validates incoming repo-suggestion issues, generates a PR if they pass |
+| `audit-repos.yml` | Periodic dead-repo check (GraphQL against GitHub) |
+| `audit-summaries.yml` | Weekly LLM audit of generated summaries against current READMEs |
+| `build-pages.yml` | Rebuilds project pages on push to `main` |
+| `rebuild-chunks.yml` | Rebuilds the RAG chunks corpus |
+| Vercel preview build | Catches build/deploy failures on PRs before merge |
+
+## Recommended next-step hardening
+
+In priority order, these are worth adding when the site complexity warrants:
+
+### High value, low cost
+
+1. **JSON schema validation for `data/repos.json`** as a PR gate. Catch
+   missing required fields, invalid category names, duplicates, and bad
+   URLs *before* CI merges them. Add a `pre-commit` hook or a tiny
+   `validate-repos.yml` workflow that runs on PRs touching `data/repos.json`.
+   Failure mode it would catch: a bad entry that builds but produces a
+   misshapen project page.
+
+2. **Run the smoke test against the Vercel preview deploy on every PR**, not
+   just on `main` after deploy. Today the smoke test runs *after* merge,
+   which means a regression has to be caught and reverted. If it ran on the
+   preview URL, we'd catch the regression in the PR review cycle.
+   Implementation: add a second job in `post-deploy-smoke.yml` triggered on
+   `pull_request`, with `base` set to the Vercel preview URL pulled from
+   the deploy event.
+
+3. **Daily scheduled smoke run** (cron). Catches drift introduced by
+   external sources (a project repo we list got deleted; GitHub renamed an
+   org; Vercel cache poisoned). Already a known pattern via `audit-repos`.
+
+### Medium value, medium cost
+
+4. **HTML lint** on PRs. Use `html-validate` or similar to catch broken
+   markup, unclosed tags, missing alt text, etc. The site is hand-edited
+   HTML; this is a real failure mode.
+
+5. **Lighthouse CI** as a PR comment. Track Core Web Vitals trends so we
+   notice when something regresses page load or accessibility.
+
+6. **Visual regression test** on the homepage and a sample of project pages
+   (Playwright + Percy or Argos). Worth it if you start doing meaningful
+   CSS/layout work; overkill until then.
+
+### Lower priority / situational
+
+7. **API smoke test** for `/api/chat` (the RAG chatbot). Needs an
+   `OPENROUTER_API_KEY` secret in the workflow and consumes credits, so add
+   only if the chatbot becomes load-bearing for the value proposition.
+
+8. **External-link audit** (separate workflow, daily). Walk `data/repos.json`
+   URLs and a sample of citation links in `research/` markdown. Distinct
+   from `check-dead-repos.js` (which only checks the repo entries
+   themselves); this would cover documentation rot.
+
+9. **Status page** at `/status` (or a separate domain) that shows the last
+   smoke run, last `build-pages` run, and any open `smoke-test-failure`
+   issues. Useful once we get other people contributing.
+
+## When the smoke test fails
+
+1. Open the failing GitHub Action run from the commit status check
+2. Look at the **Failures** section at the bottom of the smoke job log
+3. If it's a real regression: revert the offending commit or push a fix
+4. If it's a flake (network blip): rerun the workflow
+5. If it's a known-issue we're deferring: add it to `SMOKE_ALLOW_FAILURES`
+   in `.github/workflows/post-deploy-smoke.yml` with a comment in the
+   triage block above explaining why and what would resolve it
+
+The tracking issue (labeled `smoke-test-failure`) gets a new comment per
+failed run, so check the timestamp before assuming it's the most recent.

--- a/scripts/smoke-test-prod.js
+++ b/scripts/smoke-test-prod.js
@@ -1,0 +1,462 @@
+#!/usr/bin/env node
+/**
+ * smoke-test-prod.js
+ *
+ * Post-deploy smoke test for the Hermes Atlas production site (or any preview
+ * deploy). Confirms the deploy is functionally healthy before we walk away from
+ * it. Designed to be cheap, fast (< 60s typical), and reusable on every push.
+ *
+ * What it checks (in order, stops on first hard failure unless --continue):
+ *
+ *   1. Critical pages return 2xx (homepage + guide + lists + reports + privacy
+ *      + sitemap.xml + rss.xml).
+ *   2. Homepage category counts match the live `data/repos.json` grouping
+ *      (catches the "I bumped repos.json but forgot to bump <span class=
+ *      'cat-count-n'>" drift that hit PR #231).
+ *   3. Statistical sample of project pages return 2xx. Covers the worst
+ *      failure mode: build-pages.js skipped an entry and the project page
+ *      404s on prod. Defaults to 25 random + 100% of entries added in the
+ *      last 14 days (whichever is larger).
+ *   4. Sitemap.xml lists every /projects/<owner>/<repo> URL in repos.json.
+ *      Catches build-pages.js / generate-sitemap drift.
+ *   5. RSS feed parses as valid XML.
+ *   6. Sample of internal links on the homepage resolve (no 404 anchors
+ *      pointing at renamed/deleted projects).
+ *
+ * Each check prints a single-line PASS/FAIL with a count. Failures get
+ * appended to a report block at the end so the run-log stays scannable.
+ *
+ * Exit codes:
+ *   0  - all checks passed
+ *   1  - at least one check failed (CI gate)
+ *   2  - script aborted (missing env, can't read repos.json, etc.)
+ *
+ * Usage:
+ *   node scripts/smoke-test-prod.js
+ *   node scripts/smoke-test-prod.js --base https://hermes-ecosystem-git-xxx.vercel.app
+ *   node scripts/smoke-test-prod.js --sample 50
+ *   node scripts/smoke-test-prod.js --continue   # don't stop on first failure
+ *   node scripts/smoke-test-prod.js --verbose
+ *
+ * Acknowledging known-broken checks (downgrade FAIL → WARN, exit stays 0):
+ *   SMOKE_ALLOW_FAILURES='/lists/,Core & Official count' node scripts/smoke-test-prod.js
+ *   node scripts/smoke-test-prod.js --allow '/lists/,Core & Official count'
+ *
+ * Windows/Git-Bash note: MSYS path conversion will mangle tokens that start
+ * with a slash (e.g. `/lists/` becomes `C:/Program Files/Git/lists/`). Prefix
+ * the invocation with `MSYS_NO_PATHCONV=1` or run from cmd.exe / PowerShell.
+ * Linux runners (GitHub Actions) are unaffected.
+ *
+ * No external runtime deps required beyond what's already in package.json
+ * (uses node-html-parser for HTML; built-in fetch + DOMParser-less XML check).
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse as parseHtml } from "node-html-parser";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "..");
+
+// ---------- CLI args ----------
+
+const args = process.argv.slice(2);
+function flag(name) {
+  return args.includes(`--${name}`);
+}
+function opt(name, def) {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 && args[i + 1] ? args[i + 1] : def;
+}
+
+const BASE = (opt("base", "https://hermesatlas.com")).replace(/\/$/, "");
+const SAMPLE_SIZE = parseInt(opt("sample", "25"), 10);
+const RECENT_DAYS = parseInt(opt("recent-days", "14"), 10);
+const CONCURRENCY = parseInt(opt("concurrency", "10"), 10);
+const TIMEOUT_MS = parseInt(opt("timeout", "15000"), 10);
+const CONTINUE_ON_FAIL = flag("continue");
+const VERBOSE = flag("verbose");
+const USER_AGENT = "HermesAtlas-SmokeTest/1.0";
+
+// Acknowledged failures: substring-matched against the `check` name. Anything
+// matched becomes a WARN instead of a FAIL (still printed, doesn't affect exit
+// code). Use to acknowledge known-broken-but-deferred issues so the test stays
+// green on green while we fix them. Source via env or --allow.
+const ALLOW_LIST = (
+  process.env.SMOKE_ALLOW_FAILURES ||
+  opt("allow", "")
+)
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+// ---------- Helpers ----------
+
+const supportsColor = process.stdout.isTTY && !process.env.NO_COLOR;
+const c = {
+  green: (s) => (supportsColor ? `\x1b[32m${s}\x1b[0m` : s),
+  red: (s) => (supportsColor ? `\x1b[31m${s}\x1b[0m` : s),
+  yellow: (s) => (supportsColor ? `\x1b[33m${s}\x1b[0m` : s),
+  dim: (s) => (supportsColor ? `\x1b[2m${s}\x1b[0m` : s),
+  bold: (s) => (supportsColor ? `\x1b[1m${s}\x1b[0m` : s),
+};
+
+const failures = [];
+const warnings = [];
+const results = []; // { check, status, message, detail }
+
+function isAllowed(check) {
+  return ALLOW_LIST.some((token) => check.includes(token));
+}
+
+function pass(check, message) {
+  results.push({ check, status: "pass", message });
+  console.log(`  ${c.green("PASS")}  ${check} ${c.dim(`- ${message}`)}`);
+}
+function fail(check, message, detail) {
+  if (isAllowed(check)) {
+    results.push({ check, status: "warn", message, detail });
+    warnings.push({ check, message, detail });
+    console.log(`  ${c.yellow("WARN")}  ${check} ${c.dim(`- ${message} [acknowledged]`)}`);
+    if (VERBOSE && detail) console.log(c.dim(`        ${detail}`));
+    return;
+  }
+  results.push({ check, status: "fail", message, detail });
+  failures.push({ check, message, detail });
+  console.log(`  ${c.red("FAIL")}  ${check} ${c.dim(`- ${message}`)}`);
+  if (VERBOSE && detail) console.log(c.dim(`        ${detail}`));
+}
+function info(msg) {
+  if (VERBOSE) console.log(c.dim(`  ${msg}`));
+}
+
+async function fetchWithTimeout(url, opts = {}) {
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      ...opts,
+      signal: controller.signal,
+      redirect: "follow",
+      headers: { "User-Agent": USER_AGENT, ...(opts.headers || {}) },
+    });
+    return res;
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+async function head(url) {
+  // Many CDNs return 405 to HEAD; fall back to GET if needed.
+  try {
+    const r = await fetchWithTimeout(url, { method: "HEAD" });
+    if (r.status === 405) {
+      return await fetchWithTimeout(url, { method: "GET" });
+    }
+    return r;
+  } catch (e) {
+    return { ok: false, status: 0, statusText: e.message };
+  }
+}
+
+// Run N async tasks with bounded concurrency
+async function pool(items, n, fn) {
+  const out = [];
+  let i = 0;
+  const workers = Array.from({ length: Math.min(n, items.length) }, async () => {
+    while (i < items.length) {
+      const idx = i++;
+      out[idx] = await fn(items[idx], idx);
+    }
+  });
+  await Promise.all(workers);
+  return out;
+}
+
+function sample(arr, n) {
+  if (arr.length <= n) return [...arr];
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a.slice(0, n);
+}
+
+// ---------- Load reference data ----------
+
+const repos = JSON.parse(
+  await fs.readFile(path.join(ROOT, "data/repos.json"), "utf8")
+);
+
+// ---------- Section runners ----------
+
+console.log(c.bold(`\nHermes Atlas smoke test`));
+console.log(c.dim(`  base: ${BASE}`));
+console.log(c.dim(`  repos.json entries: ${repos.length}`));
+console.log(c.dim(`  sample size: ${SAMPLE_SIZE} (plus all entries newer than ${RECENT_DAYS}d in repos.json if dated)`));
+console.log("");
+
+let aborted = false;
+
+async function section(title, fn) {
+  if (aborted) return;
+  console.log(c.bold(title));
+  const before = failures.length;
+  const t0 = Date.now();
+  await fn();
+  const dt = Date.now() - t0;
+  console.log(c.dim(`  (${dt}ms)\n`));
+  if (failures.length > before && !CONTINUE_ON_FAIL) {
+    aborted = true;
+    console.log(c.yellow(`  aborting remaining checks - rerun with --continue to see everything`));
+  }
+}
+
+// 1. Critical pages
+await section("1. Critical pages return 2xx", async () => {
+  const paths = [
+    "/",
+    "/guide/",
+    "/lists/",
+    "/reports/",
+    "/privacy/",
+    "/sitemap.xml",
+    "/rss.xml",
+    "/robots.txt",
+  ];
+  const results = await pool(paths, CONCURRENCY, async (p) => {
+    const url = `${BASE}${p}`;
+    const r = await head(url);
+    return { path: p, status: r.status, ok: r.ok };
+  });
+  for (const r of results) {
+    if (r.ok) {
+      pass(r.path, `HTTP ${r.status}`);
+    } else {
+      fail(r.path, `HTTP ${r.status}`, `${BASE}${r.path}`);
+    }
+  }
+});
+
+// 2. Homepage category counts match repos.json
+await section("2. Homepage category counts match data/repos.json", async () => {
+  const r = await fetchWithTimeout(`${BASE}/`);
+  if (!r.ok) {
+    fail("homepage fetch", `HTTP ${r.status}`, `${BASE}/`);
+    return;
+  }
+  const html = await r.text();
+  const root = parseHtml(html);
+
+  // Group repos.json by category for the reference count.
+  const byCat = new Map();
+  for (const repo of repos) {
+    const cat = repo.category || "(uncategorized)";
+    byCat.set(cat, (byCat.get(cat) || 0) + 1);
+  }
+
+  const sections = root.querySelectorAll('section.cat[data-category]');
+  if (sections.length === 0) {
+    fail("homepage sections", "no <section.cat[data-category]> found on homepage", "is the homepage structure unchanged?");
+    return;
+  }
+
+  const seenCats = new Set();
+  for (const sec of sections) {
+    const cat = sec.getAttribute("data-category");
+    seenCats.add(cat);
+    const span = sec.querySelector(".cat-count-n");
+    const rendered = span ? parseInt(span.text, 10) : NaN;
+    const expected = byCat.get(cat) || 0;
+    if (rendered === expected) {
+      pass(`${cat} count`, `${rendered}`);
+    } else {
+      fail(
+        `${cat} count`,
+        `homepage shows ${rendered}, repos.json has ${expected}`,
+        `bump <span class="cat-count-n">${expected}</span> in index.html`
+      );
+    }
+  }
+
+  // Cats in JSON but not on the homepage:
+  for (const cat of byCat.keys()) {
+    if (!seenCats.has(cat)) {
+      fail(
+        `${cat} section`,
+        `category exists in repos.json (${byCat.get(cat)} entries) but no <section> for it on homepage`,
+        `add a <section class="cat" data-category="${cat}"> to index.html`
+      );
+    }
+  }
+});
+
+// 3. Project-page coverage
+await section("3. Project pages return 2xx (sample + recent)", async () => {
+  // Use ingested_at / created_at if present; else fall back to pure random sample.
+  const dated = repos.filter((r) => r.added_at || r.first_seen);
+  const recentCutoff = Date.now() - RECENT_DAYS * 24 * 3600 * 1000;
+  const recent = dated.filter((r) => {
+    const d = Date.parse(r.added_at || r.first_seen);
+    return Number.isFinite(d) && d >= recentCutoff;
+  });
+
+  const randomSlice = sample(
+    repos.filter((r) => !recent.includes(r)),
+    Math.max(0, SAMPLE_SIZE - recent.length)
+  );
+  const checkSet = [...recent, ...randomSlice];
+  info(`testing ${checkSet.length} project pages (${recent.length} recent + ${randomSlice.length} random)`);
+
+  const checked = await pool(checkSet, CONCURRENCY, async (repo) => {
+    const url = `${BASE}/projects/${repo.owner}/${repo.repo}`;
+    const r = await head(url);
+    return { repo: `${repo.owner}/${repo.repo}`, status: r.status, ok: r.ok };
+  });
+
+  const dead = checked.filter((c) => !c.ok);
+  if (dead.length === 0) {
+    pass(`project pages`, `${checked.length}/${checked.length} returned 2xx`);
+  } else {
+    for (const d of dead) {
+      fail(`/projects/${d.repo}`, `HTTP ${d.status}`, `${BASE}/projects/${d.repo}`);
+    }
+    pass(
+      `project pages (rollup)`,
+      `${checked.length - dead.length}/${checked.length} returned 2xx`
+    );
+  }
+});
+
+// 4. Sitemap covers every project
+await section("4. Sitemap covers every /projects/<owner>/<repo> in repos.json", async () => {
+  const r = await fetchWithTimeout(`${BASE}/sitemap.xml`);
+  if (!r.ok) {
+    fail("sitemap fetch", `HTTP ${r.status}`, `${BASE}/sitemap.xml`);
+    return;
+  }
+  const xml = await r.text();
+
+  // Cheap XML extraction - we don't need a full parser for <loc> elements.
+  const locs = Array.from(xml.matchAll(/<loc>([^<]+)<\/loc>/g)).map((m) => m[1]);
+  const projectLocs = new Set(
+    locs
+      .map((u) => {
+        try {
+          return new URL(u).pathname.replace(/\/$/, "");
+        } catch {
+          return null;
+        }
+      })
+      .filter((p) => p && p.startsWith("/projects/"))
+  );
+
+  const expected = repos.map((r) => `/projects/${r.owner}/${r.repo}`);
+  const missing = expected.filter((p) => !projectLocs.has(p));
+
+  if (missing.length === 0) {
+    pass("sitemap coverage", `${expected.length}/${expected.length} project URLs present`);
+  } else {
+    for (const m of missing.slice(0, 5)) {
+      fail("sitemap missing", m);
+    }
+    if (missing.length > 5) {
+      fail("sitemap missing (rollup)", `${missing.length} project URLs missing from sitemap (showing first 5)`);
+    }
+  }
+});
+
+// 5. RSS feed parses
+await section("5. RSS feed is well-formed", async () => {
+  const r = await fetchWithTimeout(`${BASE}/rss.xml`);
+  if (!r.ok) {
+    fail("rss fetch", `HTTP ${r.status}`, `${BASE}/rss.xml`);
+    return;
+  }
+  const xml = await r.text();
+  // Minimal well-formedness check - count opening/closing item tags, ensure <rss> wrapper.
+  if (!/<rss\b/.test(xml) || !/<\/rss>/.test(xml)) {
+    fail("rss wrapper", "missing <rss>...</rss> wrapper", `${BASE}/rss.xml`);
+    return;
+  }
+  const opens = (xml.match(/<item\b/g) || []).length;
+  const closes = (xml.match(/<\/item>/g) || []).length;
+  if (opens !== closes) {
+    fail("rss items", `mismatched <item> tags (${opens} open vs ${closes} close)`, `${BASE}/rss.xml`);
+    return;
+  }
+  pass("rss.xml", `well-formed, ${opens} items`);
+});
+
+// 6. Internal link integrity (homepage anchors)
+await section("6. Sample of internal links from homepage resolve", async () => {
+  const r = await fetchWithTimeout(`${BASE}/`);
+  if (!r.ok) {
+    fail("homepage fetch (links check)", `HTTP ${r.status}`);
+    return;
+  }
+  const html = await r.text();
+  const root = parseHtml(html);
+  const anchors = root.querySelectorAll("a[href]");
+  const internal = new Set();
+  for (const a of anchors) {
+    const href = a.getAttribute("href") || "";
+    if (href.startsWith("/") && !href.startsWith("//")) internal.add(href.split("#")[0].split("?")[0]);
+  }
+  const list = Array.from(internal).filter(Boolean);
+  const checked = sample(list, Math.min(SAMPLE_SIZE, list.length));
+  info(`sampling ${checked.length}/${list.length} internal links`);
+
+  const results = await pool(checked, CONCURRENCY, async (p) => {
+    const url = `${BASE}${p}`;
+    const r = await head(url);
+    return { path: p, status: r.status, ok: r.ok };
+  });
+  const broken = results.filter((r) => !r.ok);
+  if (broken.length === 0) {
+    pass("internal links", `${checked.length}/${checked.length} resolved`);
+  } else {
+    for (const b of broken.slice(0, 5)) {
+      fail(`link ${b.path}`, `HTTP ${b.status}`, `${BASE}${b.path}`);
+    }
+    if (broken.length > 5) {
+      fail("link rollup", `${broken.length} broken links (showing first 5)`);
+    }
+  }
+});
+
+// ---------- Final report ----------
+
+console.log(c.bold("\nSummary"));
+const passed = results.filter((r) => r.status === "pass").length;
+const warned = results.filter((r) => r.status === "warn").length;
+const failed = results.filter((r) => r.status === "fail").length;
+const parts = [c.green(`${passed} passed`)];
+if (warned > 0) parts.push(c.yellow(`${warned} warned (acknowledged)`));
+parts.push(failed > 0 ? c.red(`${failed} failed`) : c.dim("0 failed"));
+console.log(`  ${parts.join(", ")}`);
+
+if (warnings.length > 0) {
+  console.log(c.bold("\nAcknowledged failures (not blocking)"));
+  for (const w of warnings) {
+    console.log(`  ${c.yellow("!")} ${w.check}: ${w.message}`);
+    if (w.detail) console.log(c.dim(`     ${w.detail}`));
+  }
+}
+
+if (failures.length > 0) {
+  console.log(c.bold("\nFailures"));
+  for (const f of failures.slice(0, 20)) {
+    console.log(`  ${c.red("X")} ${f.check}: ${f.message}`);
+    if (f.detail) console.log(c.dim(`     ${f.detail}`));
+  }
+  if (failures.length > 20) {
+    console.log(c.dim(`  ... and ${failures.length - 20} more`));
+  }
+  process.exit(1);
+}
+
+console.log(c.green("\n  all checks passed\n"));
+process.exit(0);


### PR DESCRIPTION
## Summary

Adds a reusable smoke-test framework that runs after every Vercel deploy to confirm production is functionally healthy. Catches the kind of drift that pre-merge CI won't surface: homepage count / JSON skew, missing project pages, broken sitemap/RSS, 404s on critical pages, broken internal links.

## What ships

| File | Purpose |
|---|---|
| `scripts/smoke-test-prod.js` | The test runner — configurable base URL, sample size, concurrency, plus a `SMOKE_ALLOW_FAILURES` allow-list for knowingly-deferred bugs (FAIL → WARN, exit stays 0). Only uses `package.json` deps. |
| `.github/workflows/post-deploy-smoke.yml` | Polls Vercel deploy completion via commit status, runs the smoke test, posts a `Smoke Test (production)` commit status, opens/updates a tracking issue labeled `smoke-test-failure` on failure. |
| `TESTING.md` | Procedure, what each check catches, how to run locally against a Vercel preview, current acknowledged failures with fix paths, recommended next-step hardening. |
| `CONTRIBUTING.md` | One-paragraph pointer to TESTING.md. |

## What the test catches (now)

1. Critical pages 2xx (`/`, `/guide/`, `/lists/`, `/reports/`, `/privacy/`, `/sitemap.xml`, `/rss.xml`, `/robots.txt`)
2. Homepage category counts match `data/repos.json` grouping
3. Project pages 2xx (newest 14d + 25 random sample)
4. Sitemap covers every `/projects/<owner>/<repo>` from `data/repos.json`
5. RSS feed is well-formed XML
6. Sample of internal anchor links resolve

## Local validation against prod

```
22 passed, 2 warned (acknowledged), 0 failed
```

The two warnings are pre-existing prod issues the script discovered on its first run and are documented in `TESTING.md`:

- `/lists/` returns 404 (only `/lists/<slug>` pages exist; decide whether to build an index or remove from critical-pages set)
- Core & Official count drift (homepage shows 5, `data/repos.json` has 6 — already being fixed on branch `fix-repos-json-stars-refresh`)

Both are listed in `SMOKE_ALLOW_FAILURES` in the workflow with a comment block explaining what would resolve each.

## Recommended next-step hardening

Full priority-ordered list lives in `TESTING.md`. Top 3 follow-ups (which I'll file as separate issues):

1. JSON schema validation on `data/repos.json` as a PR gate
2. Run the smoke test against Vercel preview deploys on every PR (not just on main post-deploy)
3. Daily scheduled smoke run (catches external drift — deleted repos, renamed orgs, cache poison)

## Test plan

- [ ] After merge, watch the `Post-Deploy Smoke Test` workflow run on the merge commit
- [ ] Confirm `Smoke Test (production)` commit status appears on the merge commit alongside `Vercel`
- [ ] Confirm summary shows `22 passed, 2 warned (acknowledged), 0 failed`
- [ ] When `fix-repos-json-stars-refresh` lands, drop the `Core & Official count` acknowledgement from `SMOKE_ALLOW_FAILURES`

🤖 Generated with [Claude Code](https://claude.com/claude-code)