### PR TITLE
Stage reports/ in build-pages workflow

### DIFF
--- a/.github/workflows/build-pages.yml
+++ b/.github/workflows/build-pages.yml
@@ -55,7 +55,10 @@ jobs:
           # data/repos.json is mutated by the GraphQL stars-refresh step in
           # build-pages.js — must be staged or per-repo stars in the public
           # dataset stay frozen at submitter time (bug pre-2026-05-24).
-          git add index.html projects/ lists/ sitemap.xml robots.txt llms.txt llms-full.txt rss.xml data/repos.json data/summaries.json data/list-summaries.json
+          # reports/index.html is rendered from data/reports.json on every
+          # build but was never staged — meant /reports/ silently missed
+          # new entries until the workflow was edited (bug pre-2026-05-25).
+          git add index.html projects/ lists/ reports/ sitemap.xml robots.txt llms.txt llms-full.txt rss.xml data/repos.json data/summaries.json data/list-summaries.json
           if git diff --cached --quiet; then
             echo "changed=false" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
## Summary

- **Bug surfaced by PR #245** (May 2026 report): May appeared in `sitemap.xml` and `llms.txt`, and the page at `/reports/state-of-hermes-may-2026` worked — but `/reports/` index still showed only April.
- **Root cause:** `build-pages.js` renders `reports/index.html` from `data/reports.json` on every build, but the workflow's `git add` line never included `reports/`. Same class of bug as #232 (repos.json staleness) and the pre-2026-05-17 `index.html` bug.
- **Fix:** add `reports/` to the workflow's staged set + comment documenting why.

## After merge

The build-pages workflow runs on push (triggered by `.github/workflows/build-pages.yml` path? actually only `data/repos.json`, `data/lists.json`, `scripts/build-pages.js` — so the workflow file change alone won't trigger build). I'll manually `workflow_dispatch` after merge to regenerate `/reports/index.html` with both April and May entries.

## Test plan

- [ ] Merge
- [ ] `gh workflow run build-pages.yml --ref main`
- [ ] Check `https://hermesatlas.com/reports/` shows May first, April second

🤖 Generated with [Claude Code](https://claude.com/claude-code)