### PR TITLE
Report fixes: drop newsletter row, clarify §5 header

### DIFF
--- a/reports/state-of-hermes-may-2026.html
+++ b/reports/state-of-hermes-may-2026.html
@@ -212,7 +212,6 @@
 <tr><td>Memory &amp; Context (repos / stars)</td><td>6 / ~10k</td><td><strong>21 / 148,450</strong></td><td>~15x in stars</td></tr>
 <tr><td>Workspaces &amp; GUIs (repos / stars)</td><td>4</td><td><strong>11 / 28,727</strong></td><td>+7 repos</td></tr>
 <tr><td>Skills &amp; Registries</td><td>17</td><td><strong>20</strong></td><td>+3</td></tr>
-<tr><td>Newsletter subscribers</td><td>0</td><td><strong>185</strong></td><td>new channel</td></tr>
 </tbody>
 </table>
 
@@ -318,7 +317,7 @@
 
 <hr>
 
-<h2>5. The ecosystem at 123 projects</h2>
+<h2>5. The ecosystem at 123 curated projects</h2>
 
 <p>Updated category breakdown as of today:</p>
 


### PR DESCRIPTION
Two small content fixes to the May 2026 State of Hermes report, spotted in production review.

- **§1 delta table:** Remove the "Newsletter subscribers" row. The newsletter is covered in §6 and called out in the closing CTA; including it as an ecosystem metric in the headline comparison mixed audience signal with growth metrics.
- **§5 header:** "The ecosystem at 123 projects" → "**The ecosystem at 123 curated projects**" — emphasizes the editorial curation that distinguishes the atlas count from a raw GitHub search.

Diff is exactly those two lines (one removal, one rewording).

🤖 Generated with [Claude Code](https://claude.com/claude-code)