### PR TITLE
Homepage: promote May 2026 report, rotate featured pick to GBrain

### DIFF
--- a/data/featured.json
+++ b/data/featured.json
@@ -1,5 +1,10 @@
 [
   {
+    "slug": "garrytan/gbrain",
+    "weekStart": "2026-05-25",
+    "addedAt": "2026-05-25T11:55:30.574Z"
+  },
+  {
     "slug": "outsourc-e/hermes-workspace",
     "weekStart": "2026-04-27",
     "addedAt": "2026-05-01T22:04:28.218Z"

--- a/index.html
+++ b/index.html
@@ -123,11 +123,11 @@
   </button>
 </header>
 
-<!-- Hero banner · currently promoting the handbook -->
+<!-- Hero banner · currently promoting the May 2026 State of Hermes report -->
 <div class="report-banner" id="report-banner">
   <div class="report-banner-content">
-    <span class="report-banner-badge">new guide</span>
-    <span class="report-banner-text"><a href="/guide/">the hermes handbook</a> · the complete beginner's guide — install, pick a model, ship your first workflow, with the best community tool for every step.</span>
+    <span class="report-banner-badge">new report</span>
+    <span class="report-banner-text"><a href="/reports/state-of-hermes-may-2026">the state of hermes — may 2026</a> · six weeks later: 165K stars, the curator → tenacity → foundation release trilogy, and a memory category that grew 15x.</span>
   </div>
   <button class="report-banner-close" id="report-banner-close" title="Dismiss" aria-label="Dismiss banner">×</button>
 </div>
@@ -172,16 +172,16 @@
 <section class="featured-week" aria-label="Featured project this week">
   <div class="featured-week-meta">
     <div class="featured-label">featured · this week</div>
-    <span class="featured-week-date">apr 27, 2026</span>
+    <span class="featured-week-date">may 25, 2026</span>
   </div>
-  <a class="featured-week-name" href="/projects/outsourc-e/hermes-workspace">
-    <span class="org">outsourc-e</span><span class="slash">/</span>hermes-workspace
+  <a class="featured-week-name" href="/projects/garrytan/gbrain">
+    <span class="org">garrytan</span><span class="slash">/</span>gbrain
   </a>
-  <p class="featured-week-desc">Hermes Workspace is a native web-based command center designed to orchestrate Hermes Agents through a unified graphical interface. It connects to the Hermes Agent gateway to provide real-time agent interaction, memory browsing, and skill management. The…</p>
+  <p class="featured-week-desc">GBrain is an autonomous memory and synthesis layer designed to serve as the institutional or personal knowledge base for AI agents. It combines a self-wiring knowledge graph with a synthesis engine to provide cited prose answers and gap analysis rather than…</p>
   <div class="featured-week-foot">
-    <span class="featured-week-tag featured-week-tag--star">★ 830</span>
-    <span class="featured-week-tag">workspaces &amp; guis</span>
-    <a class="featured-week-link" href="/projects/outsourc-e/hermes-workspace">read the full breakdown →</a>
+    <span class="featured-week-tag featured-week-tag--star">★ 18.8K</span>
+    <span class="featured-week-tag">memory &amp; context</span>
+    <a class="featured-week-link" href="/projects/garrytan/gbrain">read the full breakdown →</a>
   </div>
 </section>
 <!-- END featured-week -->
@@ -1432,7 +1432,7 @@
   // ── Report banner dismiss ──
   const reportBanner = document.getElementById('report-banner');
   const reportBannerClose = document.getElementById('report-banner-close');
-  const BANNER_DISMISSED_KEY = 'hermes-banner-dismissed-handbook-2026-04';
+  const BANNER_DISMISSED_KEY = 'hermes-banner-dismissed-state-of-hermes-may-2026';
 
   if (reportBanner) {
     try {


### PR DESCRIPTION
Two homepage updates:

- **Hero banner:** handbook promo → May 2026 State of Hermes report. Updated badge ("new guide" → "new report"), link target (now `/reports/state-of-hermes-may-2026`), copy ("six weeks later: 165K stars, the curator → tenacity → foundation release trilogy, and a memory category that grew 15x"), and the localStorage dismissal key (`hermes-banner-dismissed-handbook-2026-04` → `hermes-banner-dismissed-state-of-hermes-may-2026`) so users who already dismissed the handbook banner still see this one.
- **"Featured this week":** `outsourc-e/hermes-workspace` → `garrytan/gbrain` (Memory & Context, 18.8K stars). Ran via `scripts/rotate-featured.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)