### PR TITLE
Add SignetAI to memory providers

### DIFF
--- a/data/repos.json
+++ b/data/repos.json
@@ -320,6 +320,16 @@
     "category": "Memory & Context"
   },
   {
+    "owner": "Signet-AI",
+    "repo": "signetai",
+    "name": "signetai",
+    "description": "Local-first identity, memory, and secrets layer for AI agents — portable state across Hermes Agent, Claude Code, Codex, OpenCode, OpenClaw, and MCP clients",
+    "stars": 169,
+    "url": "https://github.com/Signet-AI/signetai",
+    "official": false,
+    "category": "Memory & Context"
+  },
+  {
     "owner": "plur-ai",
     "repo": "plur",
     "name": "plur",

--- a/index.html
+++ b/index.html
@@ -582,7 +582,7 @@
     <div class="cat-num">§04</div>
     <h2 class="cat-title">Memory &amp; context</h2>
     <p class="cat-desc">Long-term semantic memory, graph-based retrieval, cross-session persistence.</p>
-    <div class="cat-count"><span class="cat-count-n">21</span> repos</div>
+    <div class="cat-count"><span class="cat-count-n">22</span> repos</div>
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/mem0ai/mem0" data-github="https://github.com/mem0ai/mem0" data-desc="Universal memory layer for AI Agents — official Hermes Agent memory provider, managed cloud or Apache-2.0 self-hosted OSS">
@@ -638,6 +638,14 @@
       <div class="repo-body">
         <div class="repo-name"><span class="org">yoloshii /</span> ClawMem</div>
         <div class="repo-desc">On-device memory and context engine — local-first, no cloud dependencies.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Signet-AI/signetai" data-github="https://github.com/Signet-AI/signetai" data-desc="Local-first identity, memory, and secrets layer for AI agents — portable state across Hermes Agent, Claude Code, Codex, OpenCode, OpenClaw, and MCP clients">
+      <div class="repo-stars">★ 169</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Signet-AI /</span> signetai</div>
+        <div class="repo-desc">Local-first identity, memory, and secrets layer for AI agents — portable state across Hermes Agent, Claude Code, Codex, OpenCode, OpenClaw, and MCP clients.</div>
       </div>
       <div class="repo-delta">— / wk</div>
     </a>


### PR DESCRIPTION
## Summary

Adds SignetAI to the Hermes Atlas Memory & Context category.

Disclosure: I maintain/build SignetAI, so this is a self-submission rather than a neutral third-party nomination.

SignetAI is a local-first identity, memory, and secrets layer for AI agents with portable state across Hermes Agent, Claude Code, Codex, OpenCode, OpenClaw, and MCP clients.

## Changes

- Add `Signet-AI/signetai` to `data/repos.json`
- Add SignetAI to the homepage Memory & Context section

## Validation

- JSON parses successfully
- PR diff is limited to `data/repos.json` and `index.html`
