### PR TITLE
feat: add source-aware Atlas RAG retrieval

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -1,4 +1,5 @@
 import { kvIncr, kvExpireNx } from "../lib/redis.js";
+import { combinedRetrievalScore, enrichChunkMetadata } from "../lib/rag-scoring.js";
 import { readFileSync } from "fs";
 import { join } from "path";
 
@@ -11,7 +12,7 @@ function loadChunks() {
   if (chunks) return chunks;
   try {
     const raw = readFileSync(join(process.cwd(), "data", "chunks.json"), "utf-8");
-    chunks = JSON.parse(raw);
+    chunks = JSON.parse(raw).map(enrichChunkMetadata);
     bm25Index = buildBM25Index(chunks);
     return chunks;
   } catch (e) {
@@ -324,9 +325,10 @@ export default async function handler(req, res) {
     // 3. Embed the rewritten query
     const queryEmbedding = await getEmbedding(searchQuery);
 
-    // 4. Hybrid search: combine BM25 (keyword) and cosine (semantic) scores
-    // Normalize both to 0-1 then weighted sum: 0.7 vector + 0.3 keyword
-    // Vector dominates for semantic understanding; BM25 boosts exact term matches.
+    // 4. Hybrid search: combine BM25 (keyword), cosine (semantic), and
+    // source-aware Atlas policy. Official docs are favored, catalog/generated
+    // pages are suppressed for broad questions, and query-specific boosts keep
+    // Skills Hub and TUI session docs available when explicitly relevant.
     const cosineScores = allChunks.map(c => cosineSimilarity(queryEmbedding, c.embedding));
     const bm25Scores = bm25Index ? bm25Score(searchQuery, bm25Index) : cosineScores.map(() => 0);
 
@@ -337,9 +339,16 @@ export default async function handler(req, res) {
     const candidates = allChunks
       .map((chunk, i) => ({
         ...chunk,
-        score: 0.7 * normCosine[i] + 0.3 * normBM25[i],
+        score: combinedRetrievalScore({
+          query: searchQuery,
+          chunk,
+          normCosine: normCosine[i],
+          normBM25: normBM25[i],
+        }),
         _cosine: cosineScores[i],
         _bm25: bm25Scores[i],
+        _authority: chunk.metadata?.authority,
+        _contentKind: chunk.metadata?.contentKind,
       }))
       .sort((a, b) => b.score - a.score)
       .slice(0, 20);
@@ -348,7 +357,7 @@ export default async function handler(req, res) {
     // Prevents returning 8 near-duplicate paragraphs from the same section
     const scored = mmrSelect(candidates, queryEmbedding, 8, 0.6);
 
-    console.log(`[RAG] Top result: ${scored[0]?.source} (cos=${scored[0]?._cosine.toFixed(3)}, bm25=${scored[0]?._bm25.toFixed(3)}); ${new Set(scored.map(s => s.source)).size} unique sources`);
+    console.log(`[RAG] Top result: ${scored[0]?.source} (${scored[0]?._authority}/${scored[0]?._contentKind}, cos=${scored[0]?._cosine.toFixed(3)}, bm25=${scored[0]?._bm25.toFixed(3)}); ${new Set(scored.map(s => s.source)).size} unique sources`);
 
     // 6. Detect ranking/comparison queries and inject repo metadata
     // This gives the LLM live star counts to actually rank/compare repos
@@ -387,7 +396,7 @@ Then run \`hermes\` to start. Only Git is required as a prerequisite — the ins
 **Links:** https://github.com/NousResearch/hermes-agent | https://hermes-agent.nousresearch.com/docs`;
 
     const retrievedContext = scored
-      .map(c => `[Source: ${c.source}${c.section ? `, Section: "${c.section}"` : ""}]\n${c.text}`)
+      .map(c => `[Source: ${c.source}${c.section ? `, Section: "${c.section}"` : ""}${c.metadata?.authority ? `, Authority: ${c.metadata.authority}` : ""}${c.metadata?.contentKind ? `, Kind: ${c.metadata.contentKind}` : ""}]\n${c.text}`)
       .join("\n\n---\n\n");
 
     // 5. Build messages for LLM
@@ -398,6 +407,7 @@ ANSWER RULES:
 - Don't hedge with "based on the context" or "based on the available records."
 - Use the CORE FACTS section as your baseline — those are always true. The "Latest release" line in CORE FACTS contains headline features that you MUST use when asked about the latest or newest release.
 - Use the RETRIEVED CONTEXT section for specific details, recent updates, and tool recommendations.
+- Prefer official_docs and curated_atlas sources when context conflicts. Treat catalog/generated pages as lookup sources, not broad product overviews, unless the user is asking about skills/catalogs.
 - For ranking/comparison/recommendation questions, use the REPO METADATA section for accurate star counts.
 - Cite sources from RETRIEVED CONTEXT using [Source: filename.md] format in brackets.
 - For "what is" questions, give a proper 2-3 sentence overview first, THEN details.

--- a/lib/rag-scoring.js
+++ b/lib/rag-scoring.js
@@ -1,0 +1,121 @@
+const OFFICIAL_DOC_PREFIX = "research/docs/";
+const CURATED_PREFIX = "research/";
+const REPO_PREFIX = "repos/";
+
+const SKILLS_TERMS = [
+  "skill", "skills", "skills hub", "catalog", "registry", "source", "sources",
+  "install skill", "clawhub", "skills.sh", "browse.sh", "openai skills", "anthropic skills",
+  "huggingface", "lobehub",
+];
+
+const TUI_SESSION_TERMS = [
+  "tui", "session", "sessions", "switch session", "session switch", "orchestrator",
+  "active session", "launch session", "close session", "model pick", "model picker",
+  "+new", "ink tui",
+];
+
+function textFor(chunk) {
+  return `${chunk?.source || ""}\n${chunk?.section || ""}\n${chunk?.text || ""}`.toLowerCase();
+}
+
+function queryHasAny(query, terms) {
+  const q = String(query || "").toLowerCase();
+  return terms.some((term) => q.includes(term));
+}
+
+function isSkillsCatalog(chunk) {
+  const haystack = textFor(chunk);
+  const source = String(chunk?.source || "").toLowerCase();
+  return (
+    source.includes("research/docs/skills") ||
+    source.includes("skills/index") ||
+    source.endsWith("/skills.md") ||
+    (haystack.includes("skills hub") && (haystack.includes("source pill") || haystack.includes("catalog"))) ||
+    haystack.includes("skills.sh") ||
+    haystack.includes("clawhub") ||
+    haystack.includes("browse.sh")
+  );
+}
+
+function isTuiSessionFeature(chunk) {
+  const haystack = textFor(chunk);
+  return (
+    haystack.includes("tui") &&
+    (haystack.includes("session") || haystack.includes("orchestrator") || haystack.includes("+new"))
+  );
+}
+
+export function classifyChunkSource(chunk) {
+  const source = String(chunk?.source || "");
+  const existing = chunk?.metadata || {};
+  let authority = "community";
+  let contentKind = "general";
+
+  if (source.startsWith(OFFICIAL_DOC_PREFIX)) {
+    authority = "official_docs";
+  } else if (source.startsWith(CURATED_PREFIX)) {
+    authority = "curated_atlas";
+  } else if (source.startsWith(REPO_PREFIX) || source === "ECOSYSTEM.md") {
+    authority = "atlas_data";
+  }
+
+  if (isSkillsCatalog(chunk)) {
+    contentKind = "catalog";
+  } else if (source.startsWith(REPO_PREFIX) || source === "ECOSYSTEM.md") {
+    contentKind = "repo_metadata";
+  } else if (isTuiSessionFeature(chunk)) {
+    contentKind = "product_feature";
+  }
+
+  return {
+    ...existing,
+    authority: existing.authority || authority,
+    contentKind: existing.contentKind || contentKind,
+    official: existing.official ?? authority === "official_docs",
+  };
+}
+
+export function sourceAuthorityBoost(chunk) {
+  const meta = classifyChunkSource(chunk);
+  if (meta.authority === "official_docs") return 0.12;
+  if (meta.authority === "curated_atlas") return 0.10;
+  if (meta.authority === "atlas_data") return 0.03;
+  return 0;
+}
+
+export function querySourceAdjustment(query, chunk) {
+  const meta = classifyChunkSource(chunk);
+  let adjustment = 0;
+
+  if (meta.contentKind === "catalog") {
+    adjustment += queryHasAny(query, SKILLS_TERMS) ? 0.10 : -0.07;
+  }
+
+  if (isTuiSessionFeature(chunk)) {
+    adjustment += queryHasAny(query, TUI_SESSION_TERMS) ? 0.08 : 0;
+  }
+
+  // Official docs are preferred for operational/how-to queries, but keep this
+  // small so semantic/BM25 relevance still dominates.
+  if (meta.authority === "official_docs" && /\b(how|install|configure|setup|use|docs?|official)\b/i.test(query || "")) {
+    adjustment += 0.03;
+  }
+
+  return adjustment;
+}
+
+export function combinedRetrievalScore({ query, chunk, normCosine, normBM25 }) {
+  return (
+    0.65 * normCosine +
+    0.25 * normBM25 +
+    sourceAuthorityBoost(chunk) +
+    querySourceAdjustment(query, chunk)
+  );
+}
+
+export function enrichChunkMetadata(chunk) {
+  return {
+    ...chunk,
+    metadata: classifyChunkSource(chunk),
+  };
+}

--- a/research/atlas-official-docs-update-policy.md
+++ b/research/atlas-official-docs-update-policy.md
@@ -1,0 +1,24 @@
+# Official Docs Update Policy for Ask the Atlas
+
+**Source:** Atlas curation note based on official Hermes Agent docs updates from May 26-27, 2026.
+
+Ask the Atlas should mirror official Hermes Agent docs continuously, but official-doc chunks are not all equally valuable for retrieval. Official product-feature docs should be preferred for capability questions; generated catalog/index pages should remain available for lookup queries without overwhelming broad product answers.
+
+## Retrieval policy
+
+- **Official docs:** prefer over community notes when relevance is similar.
+- **Curated Atlas summaries:** prefer for broad conceptual answers and conflict resolution.
+- **Catalog/generated pages:** use as lookup sources for explicit catalog, skills, registry, and install-source questions; suppress for broad “what is Hermes?” style questions.
+- **Repo metadata:** use for rankings, recommendations, star counts, and ecosystem comparisons.
+
+## Skills Hub catalog-source update
+
+The official Skills Hub now aggregates a much broader multi-source catalog instead of the older partial snapshot. Sources include built-in and optional Hermes skills plus external/catalog sources such as skills.sh, ClawHub, browse.sh, OpenAI, HuggingFace, Anthropic, LobeHub, GitHub taps, and Claude Marketplace.
+
+**Ask the Atlas handling:** ingest this as official docs, but treat it as catalog metadata. It should rank highly for skills, Skills Hub, catalog, registry, and install-source queries, but should not crowd out core Hermes overview or feature answers.
+
+## TUI session orchestrator update
+
+Hermes Agent's Ink TUI includes an active-session orchestrator for managing live process-local TUI sessions. It supports listing, activating/switching, closing, and launching sessions; hydrating committed and in-flight output when switching; dispatching a new prompt session from the `+new` row with session-scoped model picks; exposing a clickable live-session count in the status chrome; and mouse-aware floating orchestrator overlays.
+
+**Ask the Atlas handling:** treat this as product-feature knowledge. It should rank highly for TUI, session switching, active sessions, session-scoped model picks, and `+new` session-launch queries.

--- a/research/docs/developer-guide/architecture.md
+++ b/research/docs/developer-guide/architecture.md
@@ -207,7 +207,7 @@ A shared runtime resolver used by CLI, gateway, cron, ACP, and auxiliary calls. 
 
 ### Tool System
 
-Central tool registry (`tools/registry.py`) with 70+ registered tools across ~28 toolsets. Each tool file self-registers at import time. The registry handles schema collection, dispatch, availability checking, and error wrapping. Terminal tools support 7 backends (local, Docker, SSH, Daytona, Modal, Singularity, Vercel Sandbox).
+Central tool registry (`tools/registry.py`) with 70+ registered tools across ~28 toolsets. Each tool file self-registers at import time. The registry handles schema collection, dispatch, availability checking, and error wrapping. Terminal tools support 6 backends (local, Docker, SSH, Daytona, Modal, Singularity).
 
 → [Tools Runtime](/docs/developer-guide/tools-runtime)
 

--- a/research/docs/developer-guide/programmatic-integration.md
+++ b/research/docs/developer-guide/programmatic-integration.md
@@ -63,7 +63,8 @@ hermes acp --bootstrap      # print install snippet for an ACP-capable IDE
 
 ```
 prompt.submit           prompt.background       session.steer
-session.create          session.list            session.interrupt
+session.create          session.list            session.active_list
+session.activate        session.close           session.interrupt
 session.history         session.compress        session.branch
 session.title           session.usage           session.status
 clarify.respond         sudo.respond            secret.respond
@@ -73,6 +74,8 @@ reload.mcp              reload.env              process.stop
 delegation.status       subagent.interrupt      spawn_tree.save / list / load
 terminal.resize         clipboard.paste         image.attach
 ```
+
+`session.active_list`, `session.activate`, and `session.close` are the process-local live-session controls used by the TUI session switcher. Use `session.list` / `/resume` for saved transcript discovery; use the active-session methods only for sessions that are currently open in the TUI gateway process.
 
 ### Events streamed back
 

--- a/research/docs/developer-guide/provider-runtime.md
+++ b/research/docs/developer-guide/provider-runtime.md
@@ -38,7 +38,6 @@ That ordering matters because Hermes treats the saved model/provider choice as t
 
 Current provider families include (see `plugins/model-providers/` for the complete bundled set):
 
--   AI Gateway (Vercel)
 -   OpenRouter
 -   Nous Portal
 -   OpenAI Codex
@@ -89,18 +88,13 @@ This resolver is the main reason Hermes can share auth/runtime logic between:
 -   ACP editor sessions
 -   auxiliary model tasks
 
-## AI Gateway
+## OpenRouter and custom OpenAI-compatible base URLs
 
-Set `AI_GATEWAY_API_KEY` in `~/.hermes/.env` and run with `--provider ai-gateway`. Hermes fetches available models from the gateway's `/models` endpoint, filtering to language models with tool-use support.
-
-## OpenRouter, AI Gateway, and custom OpenAI-compatible base URLs
-
-Hermes contains logic to avoid leaking the wrong API key to a custom endpoint when multiple provider keys exist (e.g. `OPENROUTER_API_KEY`, `AI_GATEWAY_API_KEY`, and `OPENAI_API_KEY`).
+Hermes contains logic to avoid leaking the wrong API key to a custom endpoint when multiple provider keys exist (e.g. `OPENROUTER_API_KEY` and `OPENAI_API_KEY`).
 
 Each provider's API key is scoped to its own base URL:
 
 -   `OPENROUTER_API_KEY` is only sent to `openrouter.ai` endpoints
--   `AI_GATEWAY_API_KEY` is only sent to `ai-gateway.vercel.sh` endpoints
 -   `OPENAI_API_KEY` is used for custom endpoints and as a fallback
 
 Hermes also distinguishes between:
@@ -111,7 +105,7 @@ Hermes also distinguishes between:
 That distinction is especially important for:
 
 -   local model servers
--   non-OpenRouter/non-AI Gateway OpenAI-compatible APIs
+-   non-OpenRouter OpenAI-compatible APIs
 -   switching providers without re-running setup
 -   config-saved custom endpoints that should keep working even when `OPENAI_BASE_URL` is not exported in the current shell
 

--- a/research/docs/developer-guide/tools-runtime.md
+++ b/research/docs/developer-guide/tools-runtime.md
@@ -213,7 +213,6 @@ The terminal system supports multiple backends:
 -   singularity
 -   modal
 -   daytona
--   vercel\_sandbox
 
 It also supports:
 

--- a/research/docs/getting-started/nix-setup.md
+++ b/research/docs/getting-started/nix-setup.md
@@ -60,6 +60,22 @@ hermes chat
 
 After `nix profile install`, `hermes`, `hermes-agent`, and `hermes-acp` are on your PATH. From here, the workflow is identical to the [standard installation](/docs/getting-started/installation) — `hermes setup` walks you through provider selection, `hermes gateway install` sets up a launchd (macOS) or systemd user service, and config lives in `~/.hermes/`.
 
+Messaging platforms (Discord, Telegram, Slack)
+
+The default package doesn't include messaging platform libraries — they were moved to on-demand installation, which can't work in Nix's read-only environment. If you plan to connect the agent to Discord, Telegram, or Slack, install the `messaging` variant:
+
+```
+nix profile install github:NousResearch/hermes-agent#messaging
+```
+
+For all optional extras (voice, all providers, all platforms):
+
+```
+nix profile install github:NousResearch/hermes-agent#full
+```
+
+The `full` variant adds ~700 MB to the closure. If you only need messaging platforms, `#messaging` adds just ~33 MB.
+
 **Building from a local clone**
 
 ```
@@ -381,6 +397,12 @@ Add MCP tool servers
 `mcpServers.<name>`
 
 See [MCP Servers](#mcp-servers)
+
+Enable Discord/Telegram/Slack
+
+`extraDependencyGroups`
+
+`[ "messaging" ]`
 
 Mount host directories into container
 
@@ -837,16 +859,96 @@ The package's `site-packages` is added to PYTHONPATH in the hermes wrapper. `imp
 
 ### Optional Dependency Groups (`extraDependencyGroups`)
 
-For optional extras already declared in hermes-agent's `pyproject.toml` (e.g., memory providers like `hindsight` or `honcho`), use `extraDependencyGroups` to include them in the sealed venv at build time:
+For optional extras declared in hermes-agent's `pyproject.toml`, use `extraDependencyGroups` to include them in the sealed venv at build time. This is required for any extra not in the default `[all]` set — on Nix, runtime installation into the read-only store is not possible.
 
 ```
+# Enable Discord, Telegram, Slack
+services.hermes-agent.extraDependencyGroups = [ "messaging" ];
+```
+
+```
+# Enable a memory provider
 services.hermes-agent = {
   extraDependencyGroups = [ "hindsight" ];
   settings.memory.provider = "hindsight";
 };
 ```
 
-This is resolved by uv alongside core dependencies in a single pass — no PYTHONPATH patching, no collision risk. Available groups match the `[project.optional-dependencies]` keys in `pyproject.toml` (e.g., `"hindsight"`, `"honcho"`, `"voice"`, `"matrix"`, `"mistral"`, `"bedrock"`).
+This is resolved by uv alongside core dependencies — no PYTHONPATH patching, no collision risk. Available groups:
+
+Group
+
+What it enables
+
+`messaging`
+
+Discord, Telegram, Slack
+
+`matrix`
+
+Matrix/Element (mautrix with encryption; Linux only)
+
+`dingtalk`
+
+DingTalk
+
+`feishu`
+
+Feishu/Lark
+
+`voice`
+
+Local speech-to-text (faster-whisper)
+
+`edge-tts`
+
+Edge TTS provider
+
+`tts-premium`
+
+ElevenLabs TTS
+
+`anthropic`
+
+Native Anthropic SDK (not needed via OpenRouter)
+
+`bedrock`
+
+AWS Bedrock (boto3)
+
+`azure-identity`
+
+Azure Entra ID auth
+
+`honcho`
+
+Honcho memory provider
+
+`hindsight`
+
+Hindsight memory provider
+
+`modal`
+
+Modal terminal backend
+
+`daytona`
+
+Daytona terminal backend
+
+`exa`
+
+Exa web search
+
+`firecrawl`
+
+Firecrawl web search
+
+`fal`
+
+FAL image generation
+
+Or use the pre-built `#messaging` or `#full` flake packages instead of per-extra configuration (see [Quick Start](#quick-start-any-nix-user)).
 
 **When to use which:**
 
@@ -1541,6 +1643,12 @@ Fix
 CLI guards active
 
 Edit `configuration.nix` and `nixos-rebuild switch`
+
+`No adapter available for discord` (or telegram/slack)
+
+Messaging deps missing from the sealed Nix venv
+
+Install `#messaging` variant: `nix profile install ...#messaging`. For NixOS module: `extraDependencyGroups = [ "messaging" ]`. Check `journalctl -u hermes-agent` for `FeatureUnavailable` or `requirements not met` for the underlying error.
 
 Container recreated unexpectedly
 

--- a/research/docs/getting-started/quickstart.md
+++ b/research/docs/getting-started/quickstart.md
@@ -251,12 +251,6 @@ Copilot ACP agent backend (spawns local `copilot` CLI)
 
 `hermes model` (requires `copilot` CLI + `copilot login`)
 
-**Vercel AI Gateway**
-
-Vercel AI Gateway routing
-
-Set `AI_GATEWAY_API_KEY`
-
 **Custom Endpoint**
 
 VLLM, SGLang, Ollama, or any OpenAI-compatible API

--- a/research/docs/guides/local-llm-on-mac.md
+++ b/research/docs/guides/local-llm-on-mac.md
@@ -176,9 +176,9 @@ q8\_0
 
 **~4 GB**
 
-On an 8 GB Mac, use `q4_0` KV cache and reduce context to `-c 32768` (32K). On 16 GB, you can comfortably do 128K context. On 32 GB+, you can run larger models or multiple parallel slots.
+On an 8 GB Mac, use `q4_0` KV cache and choose a smaller model that can still fit Hermes' 64K minimum context. On 16 GB, you can comfortably do 128K context. On 32 GB+, you can run larger models or multiple parallel slots.
 
-If you're still running out of memory, reduce context size first (`-c`), then try a smaller quantization (Q3\_K\_M instead of Q4\_K\_M).
+If you're still running out of memory, reduce context only while staying at or above Hermes' 64K minimum; otherwise switch to a smaller model or smaller quantization (Q3\_K\_M instead of Q4\_K\_M).
 
 ### Test it
 

--- a/research/docs/guides/oauth-over-ssh.md
+++ b/research/docs/guides/oauth-over-ssh.md
@@ -2,7 +2,7 @@
 
 **Source:** https://hermes-agent.nousresearch.com/docs/guides/oauth-over-ssh
 
-Some Hermes providers — currently **xAI Grok OAuth** and **Spotify** — use a _loopback redirect_ OAuth flow. The auth server (xAI, Spotify) redirects your browser to `http://127.0.0.1:<port>/callback` so a tiny HTTP listener started by the `hermes auth ...` command can grab the authorization code.
+Some Hermes providers — **xAI Grok OAuth**, **Spotify**, and **remote MCP servers** (Linear, Sentry, Atlassian, Asana, Figma, …) — use a _loopback redirect_ OAuth flow. The auth server redirects your browser to `http://127.0.0.1:<port>/callback` so a tiny HTTP listener started by Hermes can grab the authorization code.
 
 This works perfectly when Hermes and your browser are on the same machine. It breaks the moment they aren't: your laptop's browser tries to reach `127.0.0.1` on **your laptop**, but the listener is bound to `127.0.0.1` on **the remote server**.
 
@@ -60,6 +60,12 @@ Spotify
 
 Yes, when Hermes is remote
 
+MCP servers (`auth: oauth`)
+
+auto-picked per server
+
+Yes, when Hermes is remote
+
 `anthropic` (Claude Pro/Max)
 
 n/a
@@ -79,6 +85,37 @@ n/a
 No — device code flow
 
 If your provider isn't in the table, you don't need a tunnel.
+
+## MCP Servers
+
+Remote MCP servers (Linear, Sentry, Atlassian, Asana, Figma, etc.) use the same loopback redirect flow. Hermes auto-picks a free port per server and prints the authorize URL when the OAuth flow kicks off — either at startup (when a new server appears in `mcp_servers:`) or when you run `hermes mcp login <server>`.
+
+You have two ways to complete it from a remote host:
+
+**Option 1 — paste the redirect URL back (no setup, works anywhere).** On an interactive terminal, Hermes prompts you to paste the redirect URL alongside running the local listener. After approving in your browser, the redirect to `http://127.0.0.1:<port>/callback` will show a connection error — that's expected. Copy the **full URL from the browser's address bar** and paste it at the Hermes prompt:
+
+```
+  MCP OAuth: authorization required.
+  Open this URL in your browser:
+
+    https://mcp.linear.app/authorize?response_type=code&...
+
+  Or paste the redirect URL here (or the ?code=...&state=... portion) and press Enter:
+> https://mcp.linear.app/callback?code=abc123&state=xyz
+  Got authorization code from paste — completing flow.
+```
+
+A bare `?code=...&state=...` query string is accepted too. This works for any MCP server with `auth: oauth` and requires no SSH config changes.
+
+**Option 2 — SSH port forward (same as xAI / Spotify).** Hermes prints the exact port it bound to in the SSH-session hint. Open a separate terminal on your laptop:
+
+```
+ssh -N -L <port>:127.0.0.1:<port> user@remote-host
+```
+
+Then open the authorize URL in your browser as normal; the redirect tunnels through and the listener picks it up. Use this when you need the flow to complete unattended (e.g. scripted re-auth where you can't paste interactively).
+
+**Pitfall — the 30s config-reload race.** If you edit `~/.hermes/config.yaml` to add an OAuth MCP server from inside a running Hermes session, the CLI auto-reloads MCP connections with a 30s timeout. That's not enough time to complete an interactive OAuth flow, and the reload will give up. Use `hermes mcp login <server>` from a fresh terminal instead — it has no such cap and waits the full 5 min for you to paste back.
 
 ## Why the listener can't just bind 0.0.0.0
 
@@ -175,4 +212,5 @@ The tokens are written under the Linux user that ran `hermes auth add ...`. If y
 
 -   [xAI Grok OAuth](/docs/guides/xai-grok-oauth)
 -   [Spotify (`Running over SSH`)](/docs/user-guide/features/spotify#running-over-ssh--in-a-headless-environment)
+-   [Native MCP client (OAuth section)](/docs/user-guide/features/mcp#oauth-authenticated-http-servers)
 -   [SSH `-J` / ProxyJump (man page)](https://man.openbsd.org/ssh#J)

--- a/research/docs/index.md
+++ b/research/docs/index.md
@@ -120,6 +120,6 @@ Common questions and solutions
 Machine-readable entry points to this documentation:
 
 -   **[`/llms.txt`](/docs/assets/files/llms-bcf65f79b33e57e6c0cce5b9627945d4.txt)** — curated index of every doc page with short descriptions. ~17 KB, safe to load into an LLM context.
--   **[`/llms-full.txt`](/docs/assets/files/llms-full-5ef55acbcec1661a112fb6e77a7c5ea5.txt)** — every doc page concatenated into a single markdown file for one-shot ingestion. ~1.8 MB.
+-   **[`/llms-full.txt`](/docs/assets/files/llms-full-1a9fc8671bab03c652f97c9c9d1f07d7.txt)** — every doc page concatenated into a single markdown file for one-shot ingestion. ~1.8 MB.
 
 Both files also resolve at `/docs/llms.txt` and `/docs/llms-full.txt`. Generated fresh on every deploy.

--- a/research/docs/integrations/providers.md
+++ b/research/docs/integrations/providers.md
@@ -40,10 +40,6 @@ Setup
 
 `NOVITA_API_KEY` in `~/.hermes/.env` (provider: `novita`, 200+ models, Model API, Agent Sandbox, GPU Cloud)
 
-**AI Gateway**
-
-`AI_GATEWAY_API_KEY` in `~/.hermes/.env` (provider: `ai-gateway`)
-
 **z.ai / GLM**
 
 `GLM_API_KEY` in `~/.hermes/.env` (provider: `zai`)
@@ -392,7 +388,7 @@ When using the Z.AI / GLM provider, Hermes automatically probes multiple endpoin
 
 ### xAI (Grok) — Responses API + Prompt Caching
 
-xAI is wired through the Responses API (`codex_responses` transport) for automatic reasoning support on Grok 4 models — no `reasoning_effort` parameter needed, the server reasons by default. Set `XAI_API_KEY` in `~/.hermes/.env` and pick xAI in `hermes model`, or drop `grok` as a shortcut into `/model grok-4-1-fast-reasoning`.
+xAI is wired through the Responses API (`codex_responses` transport) for automatic reasoning support on Grok 4 models — no `reasoning_effort` parameter needed, the server reasons by default. Set `XAI_API_KEY` in `~/.hermes/.env` and pick xAI in `hermes model`, or drop `grok` as a shortcut into `/model grok-4-fast-reasoning`.
 
 SuperGrok and X Premium+ subscribers can sign in with browser OAuth instead of using an API key — pick **xAI Grok OAuth (SuperGrok / Premium+)** in `hermes model`, or run `hermes auth add xai-oauth`. The same OAuth bearer token is automatically reused by direct-to-xAI tools (TTS, image gen, video gen, transcription). See the [xAI Grok OAuth guide](/docs/guides/xai-grok-oauth) for the full flow — and if Hermes runs on a remote host, also see [OAuth over SSH / Remote Hosts](/docs/guides/oauth-over-ssh) for the required `ssh -L` tunnel.
 
@@ -828,7 +824,7 @@ model:
   default: qwen2.5-coder:32b
   provider: custom
   base_url: http://localhost:11434/v1
-  context_length: 32768   # See warning below
+  context_length: 64000   # See warning below
 ```
 
 Ollama defaults to very low context lengths
@@ -851,22 +847,22 @@ Less than 24 GB
 
 256,000 tokens
 
-For agent use with tools, **you need at least 16k–32k context**. At 4k, the system prompt + tool schemas alone can fill the window, leaving no room for conversation.
+Hermes Agent requires at least **64,000 tokens** of context for agent use with tools. Smaller windows are rejected at startup because the system prompt, tool schemas, and working conversation state need enough room for reliable multi-step workflows.
 
 **How to increase it** (pick one):
 
 ```
 # Option 1: Set server-wide via environment variable (recommended)
-OLLAMA_CONTEXT_LENGTH=32768 ollama serve
+OLLAMA_CONTEXT_LENGTH=64000 ollama serve
 
 # Option 2: For systemd-managed Ollama
 sudo systemctl edit ollama.service
-# Add: Environment="OLLAMA_CONTEXT_LENGTH=32768"
+# Add: Environment="OLLAMA_CONTEXT_LENGTH=64000"
 # Then: sudo systemctl daemon-reload && sudo systemctl restart ollama
 
 # Option 3: Bake it into a custom model (persistent per-model)
-echo -e "FROM qwen2.5-coder:32b\nPARAMETER num_ctx 32768" > Modelfile
-ollama create qwen2.5-coder-32k -f Modelfile
+echo -e "FROM qwen2.5-coder:32b\nPARAMETER num_ctx 64000" > Modelfile
+ollama create qwen2.5-coder-64k -f Modelfile
 ```
 
 **You cannot set context length through the OpenAI-compatible API** (`/v1/chat/completions`). It must be configured server-side or via a Modelfile. This is the #1 source of confusion when integrating Ollama with tools like Hermes.
@@ -974,13 +970,13 @@ If responses seem truncated, add `max_tokens` to your requests or set `--default
 cmake -B build && cmake --build build --config Release
 ./build/bin/llama-server \
   --jinja -fa \
-  -c 32768 \
+  -c 64000 \
   -ngl 99 \
   -m models/qwen2.5-coder-32b-instruct-Q4_K_M.gguf \
   --port 8080 --host 0.0.0.0
 ```
 
-**Context length (`-c`):** Recent builds default to `0` which reads the model's training context from the GGUF metadata. For models with 128k+ training context, this can OOM trying to allocate the full KV cache. Set `-c` explicitly to what you need (32k–64k is a good range for agent use). If using parallel slots (`-np`), the total context is divided among slots — with `-c 32768 -np 4`, each slot only gets 8k.
+**Context length (`-c`):** Recent builds default to `0` which reads the model's training context from the GGUF metadata. For models with 128k+ training context, this can OOM trying to allocate the full KV cache. Set `-c` explicitly to at least 64,000 tokens for Hermes. If using parallel slots (`-np`), the total context is divided among slots — with `-c 64000 -np 4`, each slot only gets 16k, which is below Hermes' minimum per active session.
 
 Then configure Hermes to point at it:
 
@@ -1016,7 +1012,7 @@ Start the server from the LM Studio app (Developer tab → Start Server), or use
 
 ```
 lms server start                        # Starts on port 1234
-lms load qwen2.5-coder --context-length 32768
+lms load qwen2.5-coder --context-length 64000
 ```
 
 Then configure Hermes:
@@ -1249,7 +1245,7 @@ Update to 0.3.6+ and use a model with native tool support
 # vLLM: check --max-model-len in startup args
 ```
 
-**Fix:** Set context to at least **32,768 tokens** for agent use. See each server's section above for the specific flag.
+**Fix:** Set context to at least **64,000 tokens** for agent use. See each server's section above for the specific flag.
 
 #### "Context limit: 2048 tokens" at startup
 
@@ -1262,7 +1258,7 @@ model:
   default: your-model
   provider: custom
   base_url: http://localhost:11434/v1
-  context_length: 32768
+  context_length: 64000
 ```
 
 #### Responses get cut off mid-sentence
@@ -1491,7 +1487,7 @@ custom_providers:
     base_url: "http://localhost:11434/v1"
     models:
       qwen3.5:27b:
-        context_length: 32768
+        context_length: 64000
       deepseek-r1:70b:
         context_length: 65536
 ```
@@ -1857,7 +1853,7 @@ fallback_model:
 
 When activated, the fallback swaps the model and provider mid-session without losing your conversation. The chain is tried entry-by-entry; activation is one-shot per session.
 
-Supported providers: `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `gemini`, `google-gemini-cli`, `qwen-oauth`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `deepseek`, `nvidia`, `xai`, `xai-oauth`, `ollama-cloud`, `bedrock`, `ai-gateway`, `azure-foundry`, `opencode-zen`, `opencode-go`, `kilocode`, `xiaomi`, `arcee`, `gmi`, `stepfun`, `lmstudio`, `alibaba`, `alibaba-coding-plan`, `tencent-tokenhub`, `custom`.
+Supported providers: `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `gemini`, `google-gemini-cli`, `qwen-oauth`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `deepseek`, `nvidia`, `xai`, `xai-oauth`, `ollama-cloud`, `bedrock`, `azure-foundry`, `opencode-zen`, `opencode-go`, `kilocode`, `xiaomi`, `arcee`, `gmi`, `stepfun`, `lmstudio`, `alibaba`, `alibaba-coding-plan`, `tencent-tokenhub`, `custom`.
 
 tip
 

--- a/research/docs/reference/cli-commands.md
+++ b/research/docs/reference/cli-commands.md
@@ -274,7 +274,7 @@ Enable a comma-separated set of toolsets.
 
 `--provider <provider>`
 
-Force a provider: `auto`, `openrouter`, `nous`, `openai-codex`, `copilot-acp`, `copilot`, `anthropic`, `gemini`, `google-gemini-cli`, `huggingface`, `novita`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `kilocode`, `xiaomi`, `arcee`, `gmi`, `alibaba`, `alibaba-coding-plan` (alias `alibaba_coding`), `deepseek`, `nvidia`, `ollama-cloud`, `xai` (alias `grok`), `xai-oauth` (alias `grok-oauth`), `qwen-oauth`, `bedrock`, `opencode-zen`, `opencode-go`, `ai-gateway`, `azure-foundry`, `lmstudio`, `stepfun`, `tencent-tokenhub` (alias `tencent`, `tokenhub`).
+Force a provider: `auto`, `openrouter`, `nous`, `openai-codex`, `copilot-acp`, `copilot`, `anthropic`, `gemini`, `google-gemini-cli`, `huggingface`, `novita`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `kilocode`, `xiaomi`, `arcee`, `gmi`, `alibaba`, `alibaba-coding-plan` (alias `alibaba_coding`), `deepseek`, `nvidia`, `ollama-cloud`, `xai` (alias `grok`), `xai-oauth` (alias `grok-oauth`), `qwen-oauth`, `bedrock`, `opencode-zen`, `opencode-go`, `azure-foundry`, `lmstudio`, `stepfun`, `tencent-tokenhub` (alias `tencent`, `tokenhub`).
 
 `-s`, `--skills <name>`
 
@@ -1824,13 +1824,25 @@ Subcommand
 
 Description
 
+_(none)_ or `picker`
+
+Interactive catalog picker — browse Nous-approved MCPs and install/enable/disable.
+
+`catalog`
+
+List Nous-approved MCPs (plain text, scriptable).
+
+`install <name>`
+
+Install a catalog entry (e.g. `hermes mcp install n8n`).
+
 `serve [-v|--verbose]`
 
 Run Hermes as an MCP server — expose conversations to other agents.
 
 `add <name> [--url URL] [--command CMD] [--args ...] [--auth oauth|header]`
 
-Add an MCP server with automatic tool discovery.
+Add a custom MCP server with automatic tool discovery.
 
 `remove <name>` (alias: `rm`)
 

--- a/research/docs/reference/environment-variables.md
+++ b/research/docs/reference/environment-variables.md
@@ -34,14 +34,6 @@ Override Nous Portal base URL (rarely needed; development/testing only)
 
 Override Nous inference endpoint directly
 
-`AI_GATEWAY_API_KEY`
-
-Vercel AI Gateway API key ([ai-gateway.vercel.sh](https://ai-gateway.vercel.sh))
-
-`AI_GATEWAY_BASE_URL`
-
-Override AI Gateway base URL (default: `https://ai-gateway.vercel.sh/v1`)
-
 `OPENAI_API_KEY`
 
 API key for custom OpenAI-compatible endpoints (used with `OPENAI_BASE_URL`)
@@ -552,22 +544,6 @@ Semantic long-term memory with profile recall and session ingest ([supermemory.a
 
 Daytona cloud sandboxes ([daytona.io](https://daytona.io/))
 
-`VERCEL_TOKEN`
-
-Vercel Sandbox access token ([vercel.com](https://vercel.com/))
-
-`VERCEL_PROJECT_ID`
-
-Vercel project ID (required with `VERCEL_TOKEN`)
-
-`VERCEL_TEAM_ID`
-
-Vercel team ID (required with `VERCEL_TOKEN`)
-
-`VERCEL_OIDC_TOKEN`
-
-Vercel short-lived OIDC token (development-only alternative)
-
 ### Langfuse Observability
 
 Environment variables for the bundled [`observability/langfuse`](/docs/user-guide/features/built-in-plugins#observabilitylangfuse) plugin. Set these in `~/.hermes/.env`. The plugin must also be enabled (`hermes plugins enable observability/langfuse`, or check the box in `hermes plugins`) before any of these take effect.
@@ -644,7 +620,7 @@ Description
 
 `TERMINAL_ENV`
 
-Backend: `local`, `docker`, `ssh`, `singularity`, `modal`, `daytona`, `vercel_sandbox`
+Backend: `local`, `docker`, `ssh`, `singularity`, `modal`, `daytona`
 
 `HERMES_DOCKER_BINARY`
 
@@ -677,10 +653,6 @@ Modal container image
 `TERMINAL_DAYTONA_IMAGE`
 
 Daytona sandbox image
-
-`TERMINAL_VERCEL_RUNTIME`
-
-Vercel Sandbox runtime (`node24`, `node22`, `python3.13`)
 
 `TERMINAL_TIMEOUT`
 
@@ -1462,7 +1434,7 @@ Enable the OpenAI-compatible API server (`true`/`false`). Runs alongside other p
 
 `API_SERVER_KEY`
 
-Bearer token for API server authentication. Enforced for non-loopback binding.
+Bearer token for API server authentication. Required whenever the API server is enabled.
 
 `API_SERVER_CORS_ORIGINS`
 
@@ -1474,7 +1446,7 @@ Port for the API server (default: `8642`)
 
 `API_SERVER_HOST`
 
-Host/bind address for the API server (default: `127.0.0.1`). Use `0.0.0.0` for network access — requires `API_SERVER_KEY` and a narrow `API_SERVER_CORS_ORIGINS` allowlist.
+Host/bind address for the API server (default: `127.0.0.1`). `API_SERVER_KEY` is still required on loopback; use a narrow `API_SERVER_CORS_ORIGINS` allowlist for browser access.
 
 `API_SERVER_MODEL_NAME`
 

--- a/research/docs/reference/faq.md
+++ b/research/docs/reference/faq.md
@@ -15,7 +15,7 @@ Hermes Agent works with any OpenAI-compatible API. Supported providers include:
 -   **[OpenRouter](https://openrouter.ai/)** — access hundreds of models through one API key (recommended for flexibility)
 -   **Nous Portal** — Nous Research's own inference endpoint
 -   **OpenAI** — GPT-5.4, GPT-5-codex, GPT-4.1, GPT-4o, etc.
--   **Anthropic** — Claude models (direct API, OAuth via `hermes login anthropic`, OpenRouter, or any compatible proxy)
+-   **Anthropic** — Claude models (direct API, OAuth via `hermes auth add anthropic`, OpenRouter, or any compatible proxy)
 -   **Google** — Gemini models (direct API via `gemini` provider, the `google-gemini-cli` OAuth provider, OpenRouter, or compatible proxy)
 -   **z.ai / ZhipuAI** — GLM models
 -   **Kimi / Moonshot AI** — Kimi models
@@ -78,7 +78,7 @@ hermes model
 # API base URL: http://localhost:11434/v1
 # API key: ollama
 # Model name: qwen3.5:27b
-# Context length: 32768   ← set this to match your server's actual context window
+# Context length: 64000   ← Hermes minimum; set this to match your server's actual context window
 ```
 
 Or configure it directly in `config.yaml`:
@@ -96,7 +96,7 @@ This works with Ollama, vLLM, llama.cpp server, SGLang, LocalAI, and others. See
 
 Ollama users
 
-If you set a custom `num_ctx` in Ollama (e.g., `ollama run --num_ctx 16384`), make sure to set the matching context length in Hermes — Ollama's `/api/show` reports the model's _maximum_ context, not the effective `num_ctx` you configured.
+If you set a custom `num_ctx` in Ollama (e.g., `ollama run --num_ctx 64000`), make sure to set the matching context length in Hermes — Ollama's `/api/show` reports the model's _maximum_ context, not the effective `num_ctx` you configured.
 
 Timeouts with local models
 
@@ -358,7 +358,7 @@ custom_providers:
     base_url: "http://localhost:11434/v1"
     models:
       qwen3.5:27b:
-        context_length: 32768
+        context_length: 64000
 ```
 
 See [Context Length Detection](/docs/integrations/providers#context-length-detection) for how auto-detection works and all override options.

--- a/research/docs/reference/optional-skills-catalog.md
+++ b/research/docs/reference/optional-skills-catalog.md
@@ -37,6 +37,10 @@ Delegate coding tasks to Blackbox AI CLI agent. Multi-model agent with built-in 
 
 Configure and use Honcho memory with Hermes -- cross-session user modeling, multi-profile peer isolation, observation config, dialectic reasoning, session summaries, and context budget enforcement. Use when setting up Honcho, troubleshoo...
 
+[**openhands**](/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-openhands)
+
+Delegate coding to OpenHands CLI (model-agnostic, LiteLLM).
+
 ## blockchain
 
 Skill
@@ -429,11 +433,19 @@ Supply chain investigation, evidence recovery, and forensic analysis for GitHub 
 
 OSINT username search across 400+ social networks. Hunt down social media accounts by username.
 
+[**web-pentest**](/docs/user-guide/skills/optional/security/security-web-pentest)
+
+Authorized web application penetration testing — reconnaissance, vulnerability analysis, proof-based exploitation, and professional reporting. Adapts Shannon's "No Exploit, No Report" methodology with hard guardrails for scope, authoriza...
+
 ## software-development
 
 Skill
 
 Description
+
+[**code-wiki**](/docs/user-guide/skills/optional/software-development/software-development-code-wiki)
+
+Generate wiki docs + Mermaid diagrams for any codebase.
 
 [**rest-graphql-debug**](/docs/user-guide/skills/optional/software-development/software-development-rest-graphql-debug)
 

--- a/research/docs/reference/slash-commands.md
+++ b/research/docs/reference/slash-commands.md
@@ -98,9 +98,9 @@ Append a user-supplied criterion to the active goal mid-loop. The continuation p
 
 Resume a previously-named session
 
-`/sessions`
+`/sessions` (TUI alias: `/switch`)
 
-Browse and resume previous sessions in an interactive picker
+Classic CLI: browse and resume previous sessions in an interactive picker. TUI: open the live session switcher for currently open TUI sessions. Use `/sessions new` in the TUI to start another live session immediately.
 
 `/redraw`
 
@@ -538,6 +538,7 @@ Invoke any installed skill by name.
 -   `/sethome`, `/update`, `/restart`, `/approve`, `/deny`, `/topic`, and `/commands` are **messaging-only** commands.
 -   `/status`, `/background`, `/queue`, `/steer`, `/voice`, `/reload-mcp`, `/reload-skills`, `/rollback`, `/debug`, `/fast`, `/footer`, `/curator`, `/kanban`, `/sessions`, and `/yolo` work in **both** the CLI and the messaging gateway.
 -   `/voice join`, `/voice channel`, and `/voice leave` are only meaningful on Discord.
+-   In the TUI, `/sessions` shows live sessions in the current TUI process. Use `/resume [name]` or `hermes --tui --resume <id-or-title>` for saved or closed transcripts.
 
 ## Confirmation prompts for destructive commands
 

--- a/research/docs/skills.md
+++ b/research/docs/skills.md
@@ -412,6 +412,16 @@ Clone/create/fork repos; manage remotes, releases.
 
 GitHub🐧 Linux macOSwindows
 
+🔌
+
+### native-mcp
+
+✓ Built-in
+
+MCP client: connect servers, register tools (stdio/HTTP).
+
+MCP🐧 Linux macOSwindows
+
 🎵
 
 ### gif-search
@@ -592,14 +602,4 @@ Geocode, POIs, routes, timezones via OpenStreetMap/OSRM.
 
 Productivity🐧 Linux macOSwindows
 
-✅
-
-### nano-pdf
-
-✓ Built-in
-
-Edit PDF text/typos/titles via nano-pdf CLI (NL prompts).
-
-Productivity🐧 Linux macOSwindows
-
-Show more (632 remaining)
+Show more (2136 remaining)

--- a/research/docs/skills/index.md
+++ b/research/docs/skills/index.md
@@ -412,6 +412,16 @@ Clone/create/fork repos; manage remotes, releases.
 
 GitHub🐧 Linux macOSwindows
 
+🔌
+
+### native-mcp
+
+✓ Built-in
+
+MCP client: connect servers, register tools (stdio/HTTP).
+
+MCP🐧 Linux macOSwindows
+
 🎵
 
 ### gif-search
@@ -592,14 +602,4 @@ Geocode, POIs, routes, timezones via OpenStreetMap/OSRM.
 
 Productivity🐧 Linux macOSwindows
 
-✅
-
-### nano-pdf
-
-✓ Built-in
-
-Edit PDF text/typos/titles via nano-pdf CLI (NL prompts).
-
-Productivity🐧 Linux macOSwindows
-
-Show more (632 remaining)
+Show more (2136 remaining)

--- a/research/docs/user-guide/configuration.md
+++ b/research/docs/user-guide/configuration.md
@@ -79,11 +79,11 @@ Leaving these unset keeps the legacy defaults (`HERMES_API_TIMEOUT=1800`s, `HERM
 
 ## Terminal Backend Configuration
 
-Hermes supports seven terminal backends. Each determines where the agent's shell commands actually execute — your local machine, a Docker container, a remote server via SSH, a Modal cloud sandbox (direct or via the Nous-managed gateway), a Daytona workspace, a Vercel Sandbox, or a Singularity/Apptainer container.
+Hermes supports six terminal backends. Each determines where the agent's shell commands actually execute — your local machine, a Docker container, a remote server via SSH, a Modal cloud sandbox (direct or via the Nous-managed gateway), a Daytona workspace, or a Singularity/Apptainer container.
 
 ```
 terminal:
-  backend: local    # local | docker | ssh | modal | daytona | vercel_sandbox | singularity
+  backend: local    # local | docker | ssh | modal | daytona | singularity
   cwd: "."          # Gateway/cron working directory (CLI always uses launch dir)
   timeout: 180      # Per-command timeout in seconds
   env_passthrough: []  # Env var names to forward to sandboxed execution (terminal + execute_code)
@@ -92,7 +92,7 @@ terminal:
   daytona_image: "nikolaik/python-nodejs:python3.11-nodejs20"               # Container image for Daytona backend
 ```
 
-For cloud sandboxes such as Modal, Daytona, and Vercel Sandbox, `container_persistent: true` means Hermes will try to preserve filesystem state across sandbox recreation. It does not promise that the same live sandbox, PID space, or background processes will still be running later.
+For cloud sandboxes such as Modal and Daytona, `container_persistent: true` means Hermes will try to preserve filesystem state across sandbox recreation. It does not promise that the same live sandbox, PID space, or background processes will still be running later.
 
 ### Backend Overview
 
@@ -143,14 +143,6 @@ Daytona workspace
 Full (cloud container)
 
 Managed cloud dev environments
-
-**vercel\_sandbox**
-
-Vercel Sandbox
-
-Full (cloud microVM)
-
-Cloud execution with snapshot-backed filesystem persistence
 
 **singularity**
 
@@ -300,49 +292,6 @@ terminal:
 **Persistence:** When enabled, sandboxes are stopped (not deleted) on cleanup and resumed on next session. Sandbox names follow the pattern `hermes-{task_id}`.
 
 **Disk limit:** Daytona enforces a 10 GiB maximum. Requests above this are capped with a warning.
-
-### Vercel Sandbox Backend
-
-Runs commands in a [Vercel Sandbox](https://vercel.com/docs/vercel-sandbox) cloud microVM. Hermes uses the normal terminal and file tool surfaces; there are no Vercel-specific model-facing tools.
-
-```
-terminal:
-  backend: vercel_sandbox
-  vercel_runtime: node24          # node24 | node22 | python3.13
-  cwd: /vercel/sandbox            # default workspace root
-  container_persistent: true      # Snapshot/restore filesystem
-  container_disk: 51200           # Shared default only; custom disk is unsupported
-```
-
-**Required install:** Install the optional SDK extra:
-
-```
-pip install 'hermes-agent[vercel]'
-```
-
-**Required authentication:** Configure access-token auth with all three of `VERCEL_TOKEN`, `VERCEL_PROJECT_ID`, and `VERCEL_TEAM_ID`. This is the supported setup for deployments and normal long-running Hermes processes on Render, Railway, Docker, and similar hosts.
-
-For one-off local development, Hermes also accepts short-lived Vercel OIDC tokens:
-
-```
-VERCEL_OIDC_TOKEN="$(vc project token <project-name>)" hermes chat
-```
-
-From a linked Vercel project directory, you can omit the project name:
-
-```
-VERCEL_OIDC_TOKEN="$(vc project token)" hermes chat
-```
-
-OIDC tokens are short-lived and should not be used as the documented deployment path.
-
-**Runtime:** `terminal.vercel_runtime` supports `node24`, `node22`, and `python3.13`. If unset, Hermes defaults to `node24`.
-
-**Persistence:** When `container_persistent: true`, Hermes snapshots the sandbox filesystem during cleanup and restores a later sandbox for the same task from that snapshot. Snapshot contents can include Hermes-synced credentials, skills, and cache files that were copied into the sandbox. This preserves filesystem state only; it does not preserve live sandbox identity, PID space, shell state, or running background processes.
-
-**Background commands:** `terminal(background=true)` uses Hermes' generic non-local background process flow. You can spawn, poll, wait, view logs, and kill processes through the normal process tool while the sandbox is alive. Hermes does not provide native Vercel detached-process recovery after cleanup or restart.
-
-**Disk sizing:** Vercel Sandbox does not currently support Hermes' `container_disk` resource knob. Leave `container_disk` unset or at the shared default `51200`; non-default values fail diagnostics and backend creation instead of being silently ignored.
 
 ### Singularity/Apptainer Backend
 
@@ -1000,7 +949,7 @@ not set
 
 When `base_url` is set, Hermes ignores the provider and calls that endpoint directly (using `api_key` or `OPENAI_API_KEY` for auth). When only `provider` is set, Hermes uses that provider's built-in auth and base URL.
 
-Available providers for auxiliary tasks: `auto`, `main`, plus any provider in the [provider registry](/docs/reference/environment-variables) — `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `gemini`, `google-gemini-cli`, `qwen-oauth`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `deepseek`, `nvidia`, `xai`, `xai-oauth`, `ollama-cloud`, `alibaba`, `bedrock`, `huggingface`, `arcee`, `xiaomi`, `kilocode`, `opencode-zen`, `opencode-go`, `ai-gateway`, `azure-foundry` — or any named custom provider from your `custom_providers` list (e.g. `provider: "beans"`).
+Available providers for auxiliary tasks: `auto`, `main`, plus any provider in the [provider registry](/docs/reference/environment-variables) — `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `gemini`, `google-gemini-cli`, `qwen-oauth`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `minimax-oauth`, `deepseek`, `nvidia`, `xai`, `xai-oauth`, `ollama-cloud`, `alibaba`, `bedrock`, `huggingface`, `arcee`, `xiaomi`, `kilocode`, `opencode-zen`, `opencode-go`, `azure-foundry` — or any named custom provider from your `custom_providers` list (e.g. `provider: "beans"`).
 
 MiniMax OAuth
 

--- a/research/docs/user-guide/docker.md
+++ b/research/docs/user-guide/docker.md
@@ -37,6 +37,23 @@ docker run -d \
 
 Port 8642 exposes the gateway's [OpenAI-compatible API server](/docs/user-guide/features/api-server) and health endpoint. It's optional if you only use chat platforms (Telegram, Discord, etc.), but required if you want the dashboard or external tools to reach the gateway.
 
+Gateway runs supervised
+
+Inside the official Docker image, `gateway run` is **automatically supervised by s6-overlay**: if the gateway process crashes it's restarted within a couple of seconds without losing the container, and the dashboard (when `HERMES_DASHBOARD=1` is set) is supervised alongside it. The `gateway run` CMD process itself is a `sleep infinity` heartbeat that keeps the container alive while s6 manages the actual gateway process — so `docker stop` still shuts everything down cleanly, but `docker logs` shows the supervised gateway's output.
+
+You'll see a one-line breadcrumb in `docker logs` confirming the upgrade. To opt out — and get the historical "gateway is the container's main process, container exit = gateway exit" semantics — pass `--no-supervise` or set `HERMES_GATEWAY_NO_SUPERVISE=1`. The opt-out is useful for CI smoke tests that want the container to exit with the gateway's status code; for production deployments the supervised default is strictly better.
+
+This behavior applies to the s6-based image only. Earlier (tini-based) images still run `gateway run` as the foreground main process.
+
+Where gateway logs go
+
+Inside the s6 image, the supervised gateway's output is tee'd to two destinations:
+
+-   **`docker logs <container>`** — every line in real time (raw, no extra prefix). This is the same stream you'd get from a foreground gateway, so existing `docker logs --follow` / `--timestamps` / log-shipper integrations work unchanged.
+-   **`${HERMES_HOME}/logs/gateways/<profile>/current`** (mapped to `~/.hermes/logs/gateways/<profile>/current` on the host via the volume mount) — rotated, with an ISO 8601 timestamp prepended per line. Rotation is 10 archives × 1 MB each, so it can't fill the disk. This is what `hermes logs` reads and what survives container restarts.
+
+The per-profile reconciler keeps a separate audit log at `${HERMES_HOME}/logs/container-boot.log` — one line per profile per container boot, recording whether each gateway was restored to its prior state.
+
 Note: the API server is gated on `API_SERVER_ENABLED=true`. To expose it beyond `127.0.0.1` inside the container, also set `API_SERVER_HOST=0.0.0.0` and an `API_SERVER_KEY` (minimum 8 characters — generate one with `openssl rand -hex 32`). Example:
 
 ```
@@ -156,6 +173,10 @@ Persistent memory store
 
 Installed skills
 
+`home/`
+
+Per-profile HOME for Hermes tool subprocesses (`git`, `ssh`, `gh`, `npm`, and skill CLIs)
+
 `cron/`
 
 Scheduled job definitions
@@ -171,6 +192,8 @@ Runtime logs
 `skins/`
 
 Custom CLI skins
+
+Skill CLIs that store credentials under `~` must be initialized against the subprocess HOME, not just the data-volume root. For example, the [xurl skill](/docs/user-guide/skills/bundled/social-media/social-media-xurl) stores OAuth state in `~/.xurl`; in the official Docker layout, Hermes tool calls read that as `/opt/data/home/.xurl`, so run manual xurl auth with `HOME=/opt/data/home` and verify with `HOME=/opt/data/home xurl auth status`.
 
 warning
 
@@ -281,6 +304,88 @@ services:
 ```
 
 Start with `docker compose up -d` and view logs with `docker compose logs -f`. Dashboard output is prefixed with `[dashboard]` so it's easy to filter from gateway logs.
+
+## Optional: Linux desktop audio bridge
+
+Voice mode in Docker needs two separate things to work: Hermes must be allowed to probe audio devices inside the container, and the container must be able to reach your host audio server. The setup below covers the host audio plumbing for Linux desktops that expose a PulseAudio-compatible socket, including many PipeWire setups.
+
+caution
+
+This is a Linux desktop workaround, not a general Docker Desktop feature. It is useful when you already have host audio working and want CLI voice mode inside the Hermes container. If Hermes still reports `Running inside Docker container -- no audio devices`, use a build that includes Docker audio probing support for `PULSE_SERVER` / `PIPEWIRE_REMOTE`.
+
+First, create an ALSA config next to your Compose file:
+
+asound.conf
+
+```
+pcm.!default {
+    type pulse
+    hint {
+        show on
+        description "Default ALSA Output (PulseAudio)"
+    }
+}
+
+pcm.pulse {
+    type pulse
+}
+
+ctl.!default {
+    type pulse
+}
+```
+
+Then build a small derived image with the ALSA PulseAudio plugin installed:
+
+Dockerfile.audio
+
+```
+FROM nousresearch/hermes-agent:latest
+
+USER root
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libasound2-plugins \
+    && rm -rf /var/lib/apt/lists/*
+```
+
+Use that image in Compose and pass through the host user's PulseAudio socket and cookie:
+
+```
+services:
+  hermes:
+    build:
+      context: .
+      dockerfile: Dockerfile.audio
+    image: hermes-agent-audio
+    container_name: hermes
+    restart: unless-stopped
+    command: gateway run
+    volumes:
+      - ~/.hermes:/opt/data
+      - /run/user/${HERMES_UID}/pulse:/run/user/${HERMES_UID}/pulse
+      - ~/.config/pulse/cookie:/tmp/pulse-cookie:ro
+      - ./asound.conf:/etc/asound.conf:ro
+    environment:
+      - HERMES_UID=${HERMES_UID}
+      - HERMES_GID=${HERMES_GID}
+      - XDG_RUNTIME_DIR=/run/user/${HERMES_UID}
+      - PULSE_SERVER=unix:/run/user/${HERMES_UID}/pulse/native
+      - PULSE_COOKIE=/tmp/pulse-cookie
+```
+
+Start it with your host UID/GID so the container process can access the per-user audio socket:
+
+```
+export HERMES_UID="$(id -u)"
+export HERMES_GID="$(id -g)"
+docker compose up -d --build
+```
+
+To verify what PortAudio sees inside the container:
+
+```
+docker exec hermes /opt/hermes/.venv/bin/python -c "import sounddevice as sd; print(sd.query_devices())"
+```
 
 ## Resource limits
 

--- a/research/docs/user-guide/features/api-server.md
+++ b/research/docs/user-guide/features/api-server.md
@@ -330,9 +330,7 @@ Configure the key via `API_SERVER_KEY` env var. If you need a browser to call He
 
 Security
 
-The API server gives full access to hermes-agent's toolset, **including terminal commands**. When binding to a non-loopback address like `0.0.0.0`, `API_SERVER_KEY` is **required**. Also keep `API_SERVER_CORS_ORIGINS` narrow to control browser access.
-
-The default bind address (`127.0.0.1`) is for local-only use. Browser access is disabled by default; enable it only for explicit trusted origins.
+The API server gives full access to hermes-agent's toolset, **including terminal commands**. `API_SERVER_KEY` is **required for every deployment**, including the default loopback bind on `127.0.0.1`. Keep `API_SERVER_CORS_ORIGINS` narrow to control browser access when you explicitly allow browser callers.
 
 ## Configuration
 
@@ -364,7 +362,7 @@ Bind address (localhost only by default)
 
 `API_SERVER_KEY`
 
-_(none)_
+_(required)_
 
 Bearer token for auth
 

--- a/research/docs/user-guide/features/built-in-plugins.md
+++ b/research/docs/user-guide/features/built-in-plugins.md
@@ -60,6 +60,12 @@ hooks + slash command
 
 Auto-track ephemeral files and clean them on session end
 
+`security-guidance`
+
+hooks
+
+Pattern-match dangerous code on `write_file`/`patch` and append a security warning (or block) — 25 rules (Apache-2.0 fork of Anthropic's `claude-plugins-official` patterns)
+
 `observability/langfuse`
 
 hooks
@@ -212,6 +218,38 @@ Append-only audit trail of every track / skip / reject / delete
 **Enabling:** `hermes plugins enable disk-cleanup` (or check the box in `hermes plugins`).
 
 **Disabling again:** `hermes plugins disable disk-cleanup`.
+
+### security-guidance
+
+Fast pattern-matched security warnings on file writes. When the agent's `write_file` / `patch` / `skill_manage` calls carry content matching a known-dangerous code pattern — `pickle.load`, `yaml.load` without `SafeLoader`, `eval(`, `os.system`, `subprocess(..., shell=True)`, JS `child_process.exec`, React `dangerouslySetInnerHTML`, raw `.innerHTML =` / `.outerHTML =` / `document.write`, Node `crypto.createCipher`, AES ECB mode, TLS verification disabled, XXE-prone `xml.etree` / `minidom` parsers, `<script src="//..." >` without SRI, `torch.load` without `weights_only=True`, GitHub Actions `${{ github.event.* }}` injection — the plugin appends a `⚠️ Security guidance` block to the tool's result.
+
+The file is still written. The model reads the warning in the next turn's tool message and can either fix the code or document why the construct is safe in this context. Pattern matching has a non-trivial false-positive rate, which is why warn (not block) is the default.
+
+**Coverage:** 25 rules total, covering unsafe deserialization, command injection, XSS sinks, crypto footguns, XXE, supply-chain (SRI), and CI/CD workflow injection. The pattern data is a verbatim Apache-2.0 fork of [Anthropic's `claude-plugins-official`](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/security-guidance/hooks) — see the plugin's `LICENSE` and `NOTICE` files for attribution.
+
+**Modes:**
+
+Env var
+
+Effect
+
+(unset)
+
+**warn mode** (default) — file is written, warning appended to result
+
+`SECURITY_GUIDANCE_BLOCK=1`
+
+**block mode** — write refused, warning returned as the block reason
+
+`SECURITY_GUIDANCE_DISABLE=1`
+
+kill switch — plugin loads but does nothing
+
+**Enabling:** `hermes plugins enable security-guidance` (or check the box in `hermes plugins`).
+
+**Disabling again:** `hermes plugins disable security-guidance`.
+
+**What it does not do (yet):** the upstream Anthropic plugin has two more layers — an LLM diff review on each agent turn that touched files, and an agentic commit-time review that traces data flow across files. Neither is ported. The agent can already run those reviews on demand via `delegate_task`.
 
 ### observability/langfuse
 

--- a/research/docs/user-guide/features/credential-pools.md
+++ b/research/docs/user-guide/features/credential-pools.md
@@ -269,6 +269,8 @@ Persisted in auth.json
 
 Auto-seeded entries are updated on each pool load — if you remove an env var, its pool entry is automatically pruned. Manual entries (added via `hermes auth add`) are never auto-pruned.
 
+Borrowed runtime secrets (for example env vars, Bitwarden/Vault/keyring/systemd references, and custom config values) are reference-only at the `auth.json` boundary. Hermes can use the resolved value in memory for the current run, but it persists only metadata such as the source ref, label, status, request counters, and a non-reversible fingerprint. Manual entries and Hermes-owned OAuth/device-code state keep the durable tokens they need to refresh.
+
 ## Delegation & Subagent Sharing
 
 When the agent spawns subagents via `delegate_task`, the parent's credential pool is automatically shared with children:
@@ -309,14 +311,27 @@ Pool state is stored in `~/.hermes/auth.json` under the `credential_pool` key:
         "auth_type": "api_key",
         "priority": 0,
         "source": "env:OPENROUTER_API_KEY",
-        "access_token": "sk-or-v1-...",
+        "secret_source": "bitwarden",
+        "secret_fingerprint": "sha256:12ab34cd56ef7890",
         "last_status": "ok",
         "request_count": 142
       }
+    ],
+    "anthropic": [
+      {
+        "id": "manual1",
+        "label": "personal-api-key",
+        "auth_type": "api_key",
+        "priority": 0,
+        "source": "manual",
+        "access_token": "sk-ant-api03-..."
+      }
     ]
-  },
+  }
 }
 ```
+
+The OpenRouter entry above was borrowed from an external source, so the raw key is not stored in `auth.json`. The manual Anthropic entry was intentionally added to Hermes' credential store, so its token remains persistable.
 
 Strategies are stored in `config.yaml` (not `auth.json`):
 

--- a/research/docs/user-guide/features/curator.md
+++ b/research/docs/user-guide/features/curator.md
@@ -28,7 +28,7 @@ If you want to see what the curator _would_ do before it runs for real, run `her
 A run has two phases:
 
 1.  **Automatic transitions** (deterministic, no LLM). Skills unused for `stale_after_days` (30) become `stale`; skills unused for `archive_after_days` (90) are moved to `~/.hermes/skills/.archive/`.
-2.  **LLM review** (single aux-model pass, `max_iterations=8`). The forked agent surveys the agent-created skills, can read any of them with `skill_view`, and decides per-skill whether to keep, patch (via `skill_manage`), consolidate overlapping ones, or archive via the terminal tool.
+2.  **LLM review** (single aux-model pass, `max_iterations=8`). The forked agent surveys the agent-created skills, can read any of them with `skill_view`, and decides per-skill whether to keep, patch (via `skill_manage`), consolidate overlapping ones, or archive via the terminal tool. Consolidation treats a skill as a full package: if a skill has `references/`, `templates/`, `scripts/`, `assets/`, or relative links to those paths, the curator must either keep it standalone, re-home the needed support files and rewrite paths, or archive the entire package unchanged — not flatten only `SKILL.md` into another skill's `references/` file.
 
 Pinned skills are off-limits to both the curator's auto-transitions and the agent's own `skill_manage` tool. See [Pinning a skill](#pinning-a-skill) below.
 

--- a/research/docs/user-guide/features/fallback-providers.md
+++ b/research/docs/user-guide/features/fallback-providers.md
@@ -46,12 +46,6 @@ Value
 
 Requirements
 
-AI Gateway
-
-`ai-gateway`
-
-`AI_GATEWAY_API_KEY`
-
 OpenRouter
 
 `openrouter`

--- a/research/docs/user-guide/features/mcp.md
+++ b/research/docs/user-guide/features/mcp.md
@@ -48,6 +48,85 @@ List the files in /home/user/projects and summarize the repo structure.
 
 Hermes will discover the MCP server's tools and use them like any other tool.
 
+## Catalog: one-click install for Nous-approved MCPs
+
+Hermes ships a curated catalog of MCP servers that Nous staff has reviewed and merged. They're disabled by default — install only what you actually want.
+
+```
+hermes mcp                # interactive picker (default)
+hermes mcp catalog        # plain-text list, scriptable
+hermes mcp install n8n    # install a catalog entry by name
+```
+
+The picker shows each entry with its current status:
+
+```
+n8n          available              Manage and inspect n8n workflows from Hermes
+linear       enabled                Linear issue/project management (remote OAuth)
+github       installed (disabled)   GitHub repo + PR tools
+```
+
+Hit `Enter` on a row to install (and walk through any required credentials), enable, disable, or uninstall. Catalog entries are stored under `optional-mcps/` in the hermes-agent repo — presence in that directory means Nous approval. There is no community submission tier; entries are added by merging a PR.
+
+Catalog entries can require:
+
+-   **API key** — Hermes prompts at install time and writes the value to `~/.hermes/.env`. Non-secret values (base URLs) go to the same file.
+-   **OAuth** (remote MCP) — written as `auth: oauth` in your config; the MCP client opens a browser on first connection.
+-   **OAuth** (third-party provider like Google/GitHub) — Hermes points you at `hermes auth <provider>` if you haven't authenticated already.
+
+### Tool selection at install time
+
+After credentials are configured, Hermes probes the MCP server to list every tool it exposes and presents a checklist:
+
+```
+Select tools for 'linear' (SPACE toggle, ENTER confirm)
+  [x] find_issues       Find issues matching a query
+  [x] get_issue         Get a single issue
+  [x] create_issue      Create a new issue
+  [ ] delete_workspace  Delete a Linear workspace
+  ...
+```
+
+The pre-checked rows come from:
+
+1.  **Your prior selection** if you've installed this entry before (reinstalls preserve what you had — the manifest's defaults don't override it)
+2.  **The manifest's `tools.default_enabled`** if the entry declares one (some catalog entries pre-prune mutating or rarely-useful tools)
+3.  **Everything** if neither applies
+
+Submit the checklist with ENTER. Only the checked tools end up in `mcp_servers.<name>.tools.include`. If you select everything, no filter is written (cleanest config shape, identical behavior).
+
+**If the probe fails** (server unreachable, OAuth not yet completed, backing service not running), the install still succeeds: the manifest's `tools.default_enabled` is applied directly (if declared), or no filter is written (if not). Re-run `hermes mcp configure <name>` once the server is reachable to refine.
+
+### Trust model
+
+Installing a catalog entry runs whatever the manifest specifies — `git clone`, the entry's `bootstrap` commands (`pip install`, `npm install`, etc.), and ultimately the MCP server's own code. Manifests are gated by PR review into the hermes-agent repo, so Nous has reviewed each entry before it shipped — **but you should still read the manifest before installing**, especially the `source:` field's repository, the `install.bootstrap:` commands, and any `transport.command:` invocation.
+
+Manifests live at [`optional-mcps/<name>/manifest.yaml`](https://github.com/NousResearch/hermes-agent/tree/main/optional-mcps) on GitHub. The picker also prints the manifest's `source:` URL at install time so you can quickly verify the upstream repo.
+
+### Manifest version compatibility
+
+Manifests pin a `manifest_version`. The catalog is forward-compatible: if a PR adds an entry with a newer `manifest_version` than your installed Hermes understands, the picker will surface a warning (`⚠ '<name>' requires a newer Hermes`) for that entry instead of silently hiding it. Run `hermes update` to install the latest Hermes when you see that.
+
+### Runtime `${ENV_VAR}` substitution
+
+Inside an entry's `transport.command`, `transport.args`, `transport.url`, and `headers`, `${VAR}` placeholders are resolved at server-connect time from environment variables (which include everything in `~/.hermes/.env`). This is useful when a catalog entry wants to reference a value the user configured elsewhere — e.g. `${HOME}/foo` or `${MY_PROVIDER_TOKEN}`.
+
+Note this is distinct from `${INSTALL_DIR}` in catalog manifests, which is substituted at install-time with the path the catalog cloned the entry's repo into.
+
+### Updating tool selection later
+
+```
+hermes mcp configure linear
+```
+
+Reopens the same checklist with your current selection pre-checked. Use this when you want more tools enabled, or when the server has added new tools that you want to opt into.
+
+### Updating the catalog manifest
+
+MCPs are never auto-updated. Re-run `hermes mcp install <name>` to refresh after a Hermes update if a manifest version changed.
+
+To add an MCP to the catalog, open a PR against [`optional-mcps/`](https://github.com/NousResearch/hermes-agent/tree/main/optional-mcps).
+
 ## Two kinds of MCP servers
 
 ### Stdio servers
@@ -86,6 +165,28 @@ Use HTTP servers when:
 -   the MCP server is hosted elsewhere
 -   your organization exposes internal MCP endpoints
 -   you do not want Hermes spawning a local subprocess for that integration
+
+### OAuth-authenticated HTTP servers
+
+Most hosted MCP servers (Linear, Sentry, Atlassian, Asana, Figma, Stripe, …) require OAuth 2.1 instead of a static bearer token. Set `auth: oauth` and Hermes handles discovery, dynamic client registration, PKCE, token exchange, refresh, and step-up auth via the MCP Python SDK.
+
+```
+mcp_servers:
+  linear:
+    url: "https://mcp.linear.app/mcp"
+    auth: oauth
+```
+
+On first connect, Hermes prints an authorize URL, opens your browser when possible, and waits for the OAuth callback on a local loopback port. Tokens are cached at `~/.hermes/mcp-tokens/<server>.json` with 0o600 perms; subsequent runs reuse them silently until refresh fails.
+
+**Remote / headless hosts.** When Hermes runs on a different machine than your browser, the loopback callback can't reach your laptop. Two ways to complete the flow:
+
+-   **Paste-back (no setup):** on an interactive terminal Hermes prints "Or paste the redirect URL here…" alongside the authorize URL. Open the URL in your browser, approve, copy the full URL the browser ends up on (the redirect will show a connection error — that's expected), paste it at the prompt. Bare `?code=…&state=…` query strings work too.
+-   **SSH port forward:** `ssh -N -L <port>:127.0.0.1:<port> user@host` in a separate terminal, then let the redirect flow normally.
+
+See [OAuth over SSH / Remote Hosts](/docs/guides/oauth-over-ssh#mcp-servers) for the full walkthrough, including DCR-less servers (e.g. Slack), pre-registered `client_id`/`client_secret`, scope customization, and re-auth via `hermes mcp login <server>`.
+
+**Pitfall — config auto-reload race.** When you edit `~/.hermes/config.yaml` from inside a running Hermes session, the CLI auto-reloads MCP connections with a 30s timeout. That's not enough for an interactive OAuth flow. Add the entry, then run `hermes mcp login <server>` from a fresh terminal — it waits the full 5 minutes for you to complete auth.
 
 ## Basic configuration reference
 

--- a/research/docs/user-guide/features/plugins.md
+++ b/research/docs/user-guide/features/plugins.md
@@ -490,11 +490,11 @@ Config-driven (recommended) — declare under `tts.providers.<name>` with `type:
 
 [TTS Setup](/docs/user-guide/features/tts#custom-command-providers) · [Python plugin guide](/docs/user-guide/features/tts#python-plugin-providers)
 
-An **STT backend** (custom whisper binary, local ASR CLI)
+An **STT backend** (any CLI — whisper.cpp, custom whisper binary, local ASR CLI)
 
-Config-driven — set `HERMES_LOCAL_STT_COMMAND` env var to a shell template
+Config-driven (recommended) — declare under `stt.providers.<name>` with `type: command` in `config.yaml`, or set `HERMES_LOCAL_STT_COMMAND` for the legacy single-command escape hatch. OR Python backend plugin — `ctx.register_transcription_provider()` for Python-SDK engines (OpenRouter, SenseAudio, Gemini-STT, etc.).
 
-[Voice Message Transcription (STT)](/docs/user-guide/features/tts#voice-message-transcription-stt)
+[STT Setup](/docs/user-guide/features/tts#stt-custom-command-providers) · [Python plugin guide](/docs/user-guide/features/tts#python-plugin-providers-stt)
 
 **External tools via MCP** (filesystem, GitHub, Linear, Notion, any MCP server)
 

--- a/research/docs/user-guide/features/skills.md
+++ b/research/docs/user-guide/features/skills.md
@@ -558,8 +558,6 @@ Default taps (browsable without any setup):
     
 -   [huggingface/skills](https://github.com/huggingface/skills)
     
--   [VoltAgent/awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills)
-    
 -   [garrytan/gstack](https://github.com/garrytan/gstack)
     
 -   Example:

--- a/research/docs/user-guide/features/subscription-proxy.md
+++ b/research/docs/user-guide/features/subscription-proxy.md
@@ -41,7 +41,7 @@ Use the API server when you want the **agent** as a backend. Use the proxy when 
 ### 1\. Log into your provider (one-time)
 
 ```
-hermes login nous
+hermes auth add nous
 ```
 
 This opens your browser for the Nous Portal OAuth flow. Hermes stores the refresh token in `~/.hermes/auth.json` — the same place all Hermes provider logins live.
@@ -93,7 +93,7 @@ Hermes proxy upstream adapters
   [nous    ] Nous Portal — ready (bearer expires 2026-05-15T06:43:21Z)
 ```
 
-If you see `not logged in`, run `hermes login nous`. If you see `credentials need attention`, your refresh token was revoked (rare — happens if you signed out from the Portal web UI) — just re-run `hermes login nous`.
+If you see `not logged in`, run `hermes auth add nous`. If you see `credentials need attention`, your refresh token was revoked (rare — happens if you signed out from the Portal web UI) — just re-run `hermes auth add nous`.
 
 ## Allowed paths
 

--- a/research/docs/user-guide/features/tools.md
+++ b/research/docs/user-guide/features/tools.md
@@ -143,18 +143,12 @@ Cloud sandbox workspace
 
 Persistent remote dev environments
 
-`vercel_sandbox`
-
-Vercel Sandbox cloud microVM
-
-Cloud execution with snapshot-backed filesystem persistence
-
 ### Configuration
 
 ```
 # In ~/.hermes/config.yaml
 terminal:
-  backend: local    # or: docker, ssh, singularity, modal, daytona, vercel_sandbox
+  backend: local    # or: docker, ssh, singularity, modal, daytona
   cwd: "."          # Working directory
   timeout: 180      # Command timeout in seconds
 ```
@@ -206,41 +200,13 @@ modal setup
 hermes config set terminal.backend modal
 ```
 
-### Vercel Sandbox
-
-```
-pip install 'hermes-agent[vercel]'
-hermes config set terminal.backend vercel_sandbox
-hermes config set terminal.vercel_runtime node24
-```
-
-Authenticate with all three of `VERCEL_TOKEN`, `VERCEL_PROJECT_ID`, and `VERCEL_TEAM_ID`. This access-token setup is the supported path for deployments and normal long-running Hermes processes on Render, Railway, Docker, and similar hosts. Supported runtimes are `node24`, `node22`, and `python3.13`; Hermes defaults to `/vercel/sandbox` as the remote workspace root.
-
-For one-off local development, Hermes also accepts short-lived Vercel OIDC tokens:
-
-```
-VERCEL_OIDC_TOKEN="$(vc project token <project-name>)" hermes chat
-```
-
-From a linked Vercel project directory:
-
-```
-VERCEL_OIDC_TOKEN="$(vc project token)" hermes chat
-```
-
-With `container_persistent: true`, Hermes uses Vercel snapshots to preserve filesystem state across sandbox recreation for the same task. This can include Hermes-synced credentials, skills, and cache files inside the sandbox. Snapshots do not preserve live processes, PID space, or the same live sandbox identity.
-
-Background terminal commands use Hermes' generic non-local process flow: spawn, poll, wait, log, and kill work through the normal process tool while the sandbox is alive, but Hermes does not provide native Vercel detached-process recovery after cleanup or restart.
-
-Leave `container_disk` unset or at the shared default `51200`; custom disk sizing is unsupported for Vercel Sandbox and will fail diagnostics/backend creation.
-
 ### Container Resources
 
 Configure CPU, memory, disk, and persistence for all container backends:
 
 ```
 terminal:
-  backend: docker  # or singularity, modal, daytona, vercel_sandbox
+  backend: docker  # or singularity, modal, daytona
   container_cpu: 1              # CPU cores (default: 1)
   container_memory: 5120        # Memory in MB (default: 5GB)
   container_disk: 51200         # Disk in MB (default: 50GB)

--- a/research/docs/user-guide/features/tts.md
+++ b/research/docs/user-guide/features/tts.md
@@ -729,3 +729,248 @@ If your configured provider isn't available, Hermes automatically falls back:
 -   **OpenAI key not set** → Falls back to local transcription, then Groq
 -   **Mistral key/SDK not set** → Skipped in auto-detect; falls through to next available provider
 -   **Nothing available** → Voice messages pass through with an accurate note to the user
+
+### STT custom command providers
+
+If the STT engine you want isn't natively supported (Doubao ASR, NVIDIA Parakeet, a whisper.cpp build, an open-source SenseVoice CLI, anything else that exposes a shell command), wire it in as a **command-type provider** without writing any Python. Hermes runs your shell command against the audio file and reads back the transcript.
+
+Declare one or more providers under `stt.providers.<name>` and switch between them with `stt.provider: <name>` — same shape as the TTS [command-provider registry](#custom-command-providers), adapted for the input=audio → output=transcript direction.
+
+```
+stt:
+  provider: parakeet                # pick any name under stt.providers
+  providers:
+    parakeet:
+      type: command
+      command: "parakeet-asr --model nvidia/parakeet-tdt-0.6b-v2 --in {input_path} --out {output_path}"
+      format: txt
+      language: en
+      timeout: 300
+
+    whispercpp:
+      type: command
+      command: "whisper-cli -m ~/models/ggml-large-v3.bin -f {input_path} -otxt -of {output_dir}/transcript"
+      format: txt
+
+    sensevoice:
+      type: command
+      command: "sensevoice-cli {input_path} --json | tee {output_path}"
+      format: json
+```
+
+This complements the legacy `HERMES_LOCAL_STT_COMMAND` escape hatch — that env var still works untouched via the built-in `local_command` path. Use `stt.providers.<name>` when you want **multiple** shell-driven STT engines, a name you can pick via `stt.provider`, or anything that needs per-provider `language` / `model` / `timeout`.
+
+#### STT placeholders
+
+Your command template can reference these placeholders. Hermes substitutes them at render time and shell-quotes each value for the surrounding context (bare / single-quoted / double-quoted), so paths with spaces are safe.
+
+Placeholder
+
+Meaning
+
+`{input_path}`
+
+Absolute path to the input audio file (original location, read-only)
+
+`{output_path}`
+
+Absolute path the command should write the transcript to
+
+`{output_dir}`
+
+Parent directory of `{output_path}` (handy for whisper-style tools)
+
+`{format}`
+
+Configured output format: `txt` / `json` / `srt` / `vtt`
+
+`{language}`
+
+Configured language code (defaults to `en`)
+
+`{model}`
+
+`stt.providers.<name>.model`, empty when unset
+
+Use `{{` and `}}` for literal braces (handy when embedding JSON snippets in the command).
+
+#### How the transcript is read back
+
+After your command exits successfully:
+
+1.  If `{output_path}` exists and is non-empty → Hermes reads it as UTF-8 text.
+2.  Otherwise, if the command wrote to stdout → Hermes uses that.
+3.  Otherwise → error: "Command STT provider wrote no output file and produced no stdout".
+
+This lets you use the registry for both file-writing CLIs (`whisper-cli`, `parakeet-asr`) and curl-style one-liners that emit transcript to stdout (`curl … | jq -r .text`).
+
+For `format: json` / `srt` / `vtt`, Hermes returns the raw file content as the `transcript` field. Extracting `.text` from JSON is out of scope for the runner — either configure `format: txt`, or post-process JSON downstream.
+
+#### STT command-provider optional keys
+
+Key
+
+Default
+
+Meaning
+
+`timeout`
+
+`300`
+
+Seconds; the process tree is killed on expiry (Unix `start_new_session`, Windows `taskkill /T`).
+
+`format`
+
+`txt`
+
+One of `txt` / `json` / `srt` / `vtt`. Sets the extension of `{output_path}`.
+
+`language`
+
+`en`
+
+Forwarded to `{language}`. Defaults to `stt.language` then `en`.
+
+`model`
+
+empty
+
+Forwarded to `{model}`. The `model=` argument to `transcribe_audio()` overrides this.
+
+#### STT command-provider behavior notes
+
+-   **Built-ins always win.** Declaring `stt.providers.openai: type: command` does NOT override the real OpenAI Whisper handler. The built-in name is short-circuited before the command-provider resolver runs.
+-   **Process-tree cleanup.** A command running over `timeout` has its entire process tree killed, not just the shell wrapper. Long-running ASR pipelines that fork model-loading subprocesses are reaped reliably.
+-   **Shell-quoting is automatic.** Placeholders inside `'…'` get single-quote-safe escaping; inside `"…"` get `$`/`` ` ``/`"` escaping; outside quotes get `shlex.quote`. Don't pre-quote placeholder values.
+
+#### STT command-provider security
+
+The shell command runs under the same user as Hermes with full filesystem access — same trust model as `tts.providers.<name>: type: command` and `HERMES_LOCAL_STT_COMMAND`. Only declare command providers from sources you trust.
+
+### Python plugin providers (STT)
+
+For STT engines that aren't built-in AND can't be expressed as a shell command (need a Python SDK, OAuth-refreshing auth, streaming chunks, etc.), register a Python plugin via `ctx.register_transcription_provider()`. The plugin **coexists with** the 6 built-in providers (`local`, `local_command`, `groq`, `openai`, `mistral`, `xai`) and the `stt.providers.<name>: type: command` registry — built-ins keep their native implementations and always win on name collision; command providers win over plugins of the same name (config is more local than plugin install).
+
+#### When to pick which (STT)
+
+Backend has…
+
+Use
+
+A single shell command that takes an audio file and emits text
+
+`stt.providers.<name>: type: command` (no Python needed)
+
+Only the legacy single-command escape hatch is wanted
+
+`HERMES_LOCAL_STT_COMMAND` env var (preserved for back-compat)
+
+A Python SDK with no CLI
+
+`register_transcription_provider()` plugin
+
+OAuth-refreshing auth, streaming chunks, voice-list metadata
+
+`register_transcription_provider()` plugin
+
+A built-in already covers it (`local`, `groq`, `openai`, …)
+
+Set `stt.provider: <name>` — built-ins are inline
+
+#### Resolution order
+
+1.  **`stt.provider` is a built-in name** → built-in dispatch. **Always wins.**
+2.  **`stt.provider` matches `stt.providers.<name>` with `command:` set** → command-provider runner (see [STT custom command providers](#stt-custom-command-providers)). Wins over a same-name plugin.
+3.  **`stt.provider` matches a plugin-registered `TranscriptionProvider`** → plugin dispatch:
+    -   if the plugin's `is_available()` returns `False` (missing creds or SDK), the call surfaces an unavailability error envelope identifying the plugin — **not** the generic "No STT provider available" message.
+    -   otherwise the plugin's `transcribe()` is called with `model` (from the public `model=` arg, falling back to `stt.<provider>.model`) and `language` (from `stt.<provider>.language`).
+4.  **No match** → "No STT provider available" error.
+
+#### Per-provider config namespace
+
+Plugins read their per-provider configuration from `stt.<provider>` in `config.yaml`, mirroring how built-ins read `stt.openai.model` / `stt.mistral.model`:
+
+```
+stt:
+  provider: my-stt
+  my-stt:
+    model: whisper-large-v3
+    language: ja          # forwarded as language= to transcribe()
+    # any other plugin-specific keys go here; read them via your
+    # own config.yaml access in __init__/is_available/transcribe
+```
+
+The dispatcher forwards `model` and `language` from this section; everything else, the plugin can read itself.
+
+#### Minimal plugin
+
+Drop this in `~/.hermes/plugins/my-stt/`:
+
+`plugin.yaml`:
+
+```
+name: my-stt
+version: 0.1.0
+description: "My custom Python STT backend"
+```
+
+`__init__.py`:
+
+```
+from agent.transcription_provider import TranscriptionProvider
+
+
+class MySTTProvider(TranscriptionProvider):
+    @property
+    def name(self) -> str:
+        return "my-stt"  # what stt.provider matches against
+
+    @property
+    def display_name(self) -> str:
+        return "My Custom STT"
+
+    def is_available(self) -> bool:
+        # Return False when credentials/deps are missing — picker skips
+        # this row but the dispatcher still routes here on explicit config.
+        import os
+        return bool(os.environ.get("MY_STT_API_KEY"))
+
+    def transcribe(self, file_path, *, model=None, language=None, **extra):
+        # Return the standard transcribe envelope:
+        #   {"success": bool, "transcript": str, "provider": str, "error": str}
+        # Do NOT raise — convert exceptions to the error envelope so the
+        # gateway/CLI caller sees a consistent shape on failure.
+        try:
+            import my_stt_sdk
+            client = my_stt_sdk.Client()
+            text = client.transcribe(open(file_path, "rb"))
+            return {
+                "success": True,
+                "transcript": text,
+                "provider": "my-stt",
+            }
+        except Exception as exc:
+            return {
+                "success": False,
+                "transcript": "",
+                "error": f"my-stt failed: {exc}",
+                "provider": "my-stt",
+            }
+
+
+def register(ctx):
+    ctx.register_transcription_provider(MySTTProvider())
+```
+
+Enable it (`hermes plugins enable my-stt`), set `stt.provider: my-stt` in `config.yaml`, and voice-message transcription will route through your plugin.
+
+#### Optional hooks
+
+Override these on your provider class for richer integration:
+
+-   `list_models()` → list of `{id, display, languages, max_audio_seconds}` dicts.
+-   `default_model()` → string returned when the user doesn't override the model.
+-   `get_setup_schema()` → return `{name, badge, tag, env_vars: [{key, prompt, url}]}` to power picker rows in `hermes tools` / `hermes setup` (the picker category for STT is not yet shipped — this metadata is available to plugins for forward compatibility).
+
+See `agent/transcription_provider.py` for the full ABC including docstrings.

--- a/research/docs/user-guide/features/voice-mode.md
+++ b/research/docs/user-guide/features/voice-mode.md
@@ -765,6 +765,8 @@ brew install portaudio    # macOS
 sudo apt install portaudio19-dev  # Ubuntu
 ```
 
+If you are running Hermes inside Docker on a Linux desktop, the container also needs access to your host audio socket. See the [Docker audio bridge](/docs/user-guide/docker#optional-linux-desktop-audio-bridge) notes for a PulseAudio/PipeWire-compatible setup.
+
 ### Bot doesn't respond in Discord server channels
 
 The bot requires an @mention by default in server channels. Make sure you:

--- a/research/docs/user-guide/features/web-dashboard.md
+++ b/research/docs/user-guide/features/web-dashboard.md
@@ -321,6 +321,255 @@ Enables or disables a skill. Body: `{"name": "skill-name", "enabled": true}`.
 
 Returns all toolsets with their label, description, tools list, and active/configured status.
 
+## OAuth Authentication (gated mode)
+
+When the dashboard is bound to a public address — anything other than `127.0.0.1` / `localhost` — Hermes Agent engages an OAuth-based auth gate. Every request must carry a verified session cookie or it's bounced through a full OAuth round-trip via the Nous Portal.
+
+This is intended for hosted deployments (typically Fly.io) where the dashboard is reachable over the public internet. Operator-owned dashboards bound to loopback are unaffected.
+
+### When the gate engages
+
+Flags
+
+Auth gate
+
+Use case
+
+`hermes dashboard` (default — binds to `127.0.0.1`)
+
+OFF
+
+Local development
+
+`hermes dashboard --host 0.0.0.0`
+
+**ON**
+
+Production / Fly.io deployment
+
+`hermes dashboard --host 192.168.1.10 --insecure`
+
+OFF
+
+Trusted LAN; user opts into legacy session-token auth
+
+The gate is on if and only if:
+
+1.  The bind host is not `127.0.0.1`, `::1`, `localhost`, or `0.0.0.0` AND
+2.  The `--insecure` flag is **not** set.
+
+Setting `--insecure` keeps the existing single-process session-token behaviour — no OAuth dance, no provider plugins required. Use only on networks where you trust every client.
+
+### Fail-closed semantics
+
+If the gate would engage but **no** `DashboardAuthProvider` is registered (no Nous plugin, no custom plugin), `hermes dashboard` refuses to bind with an explicit error message. There is no "default-deny but accept everything" fallback — a misconfigured gated dashboard never starts.
+
+### Default provider: Nous Research
+
+The bundled `plugins/dashboard_auth/nous` plugin is **always installed** and auto-loaded. It auto-registers a `DashboardAuthProvider` named `nous` when a client ID is configured.
+
+#### Configuration
+
+The plugin reads from two surfaces, with the environment variable winning when set non-empty:
+
+**`config.yaml`** — the canonical surface:
+
+```
+dashboard:
+  oauth:
+    client_id: agent:01HXYZ…             # required to engage the gate
+    portal_url: https://portal.nousresearch.com  # optional; defaults to production
+```
+
+**Environment variables** — operator overrides:
+
+Env var
+
+Overrides
+
+Format
+
+Provisioned by
+
+`HERMES_DASHBOARD_OAUTH_CLIENT_ID`
+
+`dashboard.oauth.client_id`
+
+`agent:{instance_id}`
+
+Nous Portal at Fly.io provisioning time
+
+`HERMES_DASHBOARD_PORTAL_URL`
+
+`dashboard.oauth.portal_url`
+
+URL (default: `https://portal.nousresearch.com`)
+
+Portal — override only for staging or a custom deployment
+
+Per the Hermes Agent convention (`~/.hermes/.env` is for API keys / secrets only), **`config.yaml` is the recommended place to set these values** for local dev, on-prem, and any deployment you control directly. The environment-variable path exists so Fly.io's platform-secret injection can push per-deploy `client_id`s without anyone having to edit `config.yaml` inside the image — that's its primary purpose.
+
+Empty environment values are treated as unset, so a provisioned-but-not-populated Fly secret can't accidentally shadow a valid `config.yaml` entry.
+
+If neither source provides a client\_id, the plugin reports the specific reason and the dashboard's fail-closed bind error tells you exactly what to fix:
+
+```
+Refusing to bind dashboard to 0.0.0.0 — the OAuth auth gate engages on
+non-loopback binds, but no auth providers are registered.
+
+Bundled providers reported these issues:
+  • nous: HERMES_DASHBOARD_OAUTH_CLIENT_ID is not set (and
+    dashboard.oauth.client_id in config.yaml is empty). The Nous Portal
+    provisions this env var (shape 'agent:{instance_id}') when it
+    deploys a Hermes Agent instance — set it to your provisioned
+    client id (either as an env var or under dashboard.oauth.client_id
+    in config.yaml), or pass --insecure to skip the OAuth gate entirely.
+
+Or pass --insecure to skip the auth gate (NOT recommended on untrusted
+networks).
+```
+
+### Public URL override
+
+By default, the dashboard reconstructs the OAuth callback URL from the request — `X-Forwarded-Host` + `X-Forwarded-Proto` + `X-Forwarded-Prefix` (when uvicorn is configured with `proxy_headers=True`, which `start_server` enables under the gate). This works out of the box on Fly.io, which sets all three headers correctly.
+
+For deploys behind reverse proxies that don't reliably forward those headers (manual nginx setups, on-prem ingresses, custom-domain Fly deploys with partial proxy chains), set `dashboard.public_url` (or `HERMES_DASHBOARD_PUBLIC_URL`) to the **complete public URL** the dashboard is reached at:
+
+```
+dashboard:
+  public_url: "https://dashboard.example.com/hermes"
+```
+
+When set, the OAuth callback URL becomes `<public_url>/auth/callback` verbatim — `X-Forwarded-Prefix` is ignored on that code path because the operator has explicitly declared the public URL. This is intentional: stacking the prefix on top would double-prefix the common case where the prefix is already baked into `public_url`.
+
+Same precedence as the other dashboard settings — env wins over `config.yaml`:
+
+Surface
+
+Override path
+
+When to use
+
+`dashboard.public_url` in `config.yaml`
+
+`HERMES_DASHBOARD_PUBLIC_URL`
+
+Local dev / on-prem (canonical)
+
+`HERMES_DASHBOARD_PUBLIC_URL` env var
+
+—
+
+Fly.io platform secrets / CI
+
+(unset)
+
+—
+
+Default — reconstruct from `X-Forwarded-*` headers
+
+Validation rejects values without `http://` / `https://` scheme, without a host, or containing quote / angle / whitespace / control characters. A malformed value silently falls through to header reconstruction so the login flow keeps working rather than dispatching the user to a hostile URL.
+
+> **Note:** `public_url` overrides the OAuth callback URL only. The `Secure` cookie flag is still controlled by `request.url.scheme` (X-Forwarded-Proto under proxy\_headers), so an `http://` `public_url` on a TLS-terminated public deploy will produce non-Secure cookies. This is an operator footgun — pair `public_url` with proper TLS termination upstream.
+
+### OAuth flow
+
+The provider implements the [Nous Portal OAuth contract v1](https://github.com/NousResearch/nous-account-service/blob/main/docs/agent-dashboard-oauth-contract.md) — authorization-code grant with PKCE (S256):
+
+1.  User hits `/` without a session cookie → gate redirects to `/login`.
+2.  Login page shows a "Continue with Nous Research" button → `/auth/login?provider=nous`.
+3.  Server stashes PKCE state in a short-lived cookie, redirects user to `https://portal.nousresearch.com/oauth/authorize?…`.
+4.  User authenticates with Portal, lands at `/auth/callback?code=…&state=…`.
+5.  Server exchanges the code for an access token at `POST /api/oauth/token`, verifies the JWT signature against the Portal's JWKS (`/.well-known/jwks.json`), and sets the `hermes_session_at` cookie.
+6.  User is redirected to `/` (or to the original deep-link path via the `next=` query parameter).
+
+Access tokens have a 15-minute TTL. **There is no refresh token in contract v1** — when the token expires, the SPA's fetch wrapper detects the 401 envelope and full-page-navigates back to `/login` to re-run the flow.
+
+### Cookies set
+
+Name
+
+Lifetime
+
+Notes
+
+`hermes_session_at`
+
+Token TTL (15 min)
+
+HttpOnly, SameSite=Lax, Secure-when-HTTPS
+
+`hermes_session_pkce`
+
+10 min
+
+HttpOnly; holds the PKCE verifier + provider hint during the round trip
+
+`hermes_session_rt`
+
+unused in v1
+
+Reserved for forward-compat; not written when `refresh_token` is empty
+
+All three are `Path=/` and `SameSite=Lax`. The `Secure` flag is set when the dashboard is reached over HTTPS (detected via the request URL scheme — honours `X-Forwarded-Proto` from Fly's TLS terminator under `proxy_headers=True`).
+
+### Logout
+
+The sidebar widget shows `Logged in as <user_id…> via nous` with a logout icon. Clicking it POSTs `/auth/logout`, which clears all dashboard-auth cookies and redirects back to `/login`.
+
+### Audit log
+
+Every login start, success, failure, and session-verify failure is written as a JSON line to `$HERMES_HOME/logs/dashboard-auth.log`. Sensitive fields (`access_token`, `refresh_token`, `code`, `code_verifier`, `state`, `Authorization` header) are redacted before logging.
+
+### Custom providers
+
+To plug a non-Nous OAuth provider (e.g. Google, GitHub, custom OIDC), create a plugin that registers a `DashboardAuthProvider`:
+
+```
+# ~/.hermes/plugins/dashboard-auth-myidp/__init__.py
+from hermes_cli.dashboard_auth import DashboardAuthProvider, Session, LoginStart
+
+class MyIdPProvider(DashboardAuthProvider):
+    name = "myidp"
+    display_name = "My Identity Provider"
+
+    def start_login(self, *, redirect_uri): ...
+    def complete_login(self, *, code, state, code_verifier, redirect_uri): ...
+    def verify_session(self, *, access_token): ...
+    def refresh_session(self, *, refresh_token): ...
+    def revoke_session(self, *, refresh_token): ...
+
+def register(ctx):
+    ctx.register_dashboard_auth_provider(MyIdPProvider())
+```
+
+The login page lists all registered providers; multiple providers can be stacked and the user picks one at `/login`.
+
+### Verifying the gate is on
+
+```
+# Quick env-var path (Fly.io shape). HERMES_DASHBOARD_PORTAL_URL is
+# optional — defaults to production.
+HERMES_DASHBOARD_OAUTH_CLIENT_ID=agent:test \
+  hermes dashboard --host 0.0.0.0
+
+# Or the equivalent via config.yaml (recommended for local dev / on-prem):
+#
+#   dashboard:
+#     oauth:
+#       client_id: agent:test
+#
+# then just:
+hermes dashboard --host 0.0.0.0
+
+# Hit /api/status to see the gate state:
+curl -s http://127.0.0.1:9119/api/status | jq '.auth_required, .auth_providers'
+# true
+# ["nous"]
+```
+
+The dashboard's React StatusPage shows the same fields under "Web server". A sidebar AuthWidget surfaces the current identity once you've signed in.
+
 ## CORS
 
 The web server restricts CORS to localhost origins only:

--- a/research/docs/user-guide/messaging.md
+++ b/research/docs/user-guide/messaging.md
@@ -1009,9 +1009,33 @@ Scheduled auto-resume for N restart-interrupted session(s)
 
 No configuration is required. If you don't want the heads-up, set `gateway_restart_notification: false` on the platform.
 
+### Mobile-friendly progress defaults
+
+Telegram is usually a mobile inbox, so the defaults are tuned for that surface:
+
+-   **`tool_progress`** defaults to **`off`** — no per-tool breadcrumb stream filling up the chat.
+-   **`busy_ack_detail`** defaults to **`off`** — busy-state acknowledgments and long-running heartbeats stay terse (no `iteration 21/60` debug detail).
+-   **`interim_assistant_messages`** stays **on** — real mid-turn assistant commentary (the model literally telling you what it's about to do) is signal, not noise.
+-   **`long_running_notifications`** stays **on** — a single edit-in-place "⏳ Working — N min" bubble updates every few minutes so you have a heartbeat instead of staring at `typing…` for half an hour.
+
+Opt out of either of the kept-on defaults or opt back into verbose progress per platform:
+
+```
+display:
+  platforms:
+    telegram:
+      # Re-enable the tool-progress stream
+      tool_progress: new
+      # Show "iteration N/M, running: tool" in heartbeats and busy acks
+      busy_ack_detail: true
+      # Or quiet them entirely
+      interim_assistant_messages: false
+      long_running_notifications: false
+```
+
 ### Progress bubble cleanup (opt-in)
 
-Tool-progress messages, the "still working…" heartbeat, and status-callback bubbles can be auto-deleted after the final response lands. Enable per-platform via `display.platforms.<platform>.cleanup_progress`:
+Tool-progress messages, the "still working…" heartbeat, and status-callback bubbles can also be auto-deleted after the final response lands. Enable per-platform via `display.platforms.<platform>.cleanup_progress`:
 
 ```
 display:

--- a/research/docs/user-guide/messaging/index.md
+++ b/research/docs/user-guide/messaging/index.md
@@ -1009,9 +1009,33 @@ Scheduled auto-resume for N restart-interrupted session(s)
 
 No configuration is required. If you don't want the heads-up, set `gateway_restart_notification: false` on the platform.
 
+### Mobile-friendly progress defaults
+
+Telegram is usually a mobile inbox, so the defaults are tuned for that surface:
+
+-   **`tool_progress`** defaults to **`off`** — no per-tool breadcrumb stream filling up the chat.
+-   **`busy_ack_detail`** defaults to **`off`** — busy-state acknowledgments and long-running heartbeats stay terse (no `iteration 21/60` debug detail).
+-   **`interim_assistant_messages`** stays **on** — real mid-turn assistant commentary (the model literally telling you what it's about to do) is signal, not noise.
+-   **`long_running_notifications`** stays **on** — a single edit-in-place "⏳ Working — N min" bubble updates every few minutes so you have a heartbeat instead of staring at `typing…` for half an hour.
+
+Opt out of either of the kept-on defaults or opt back into verbose progress per platform:
+
+```
+display:
+  platforms:
+    telegram:
+      # Re-enable the tool-progress stream
+      tool_progress: new
+      # Show "iteration N/M, running: tool" in heartbeats and busy acks
+      busy_ack_detail: true
+      # Or quiet them entirely
+      interim_assistant_messages: false
+      long_running_notifications: false
+```
+
 ### Progress bubble cleanup (opt-in)
 
-Tool-progress messages, the "still working…" heartbeat, and status-callback bubbles can be auto-deleted after the final response lands. Enable per-platform via `display.platforms.<platform>.cleanup_progress`:
+Tool-progress messages, the "still working…" heartbeat, and status-callback bubbles can also be auto-deleted after the final response lands. Enable per-platform via `display.platforms.<platform>.cleanup_progress`:
 
 ```
 display:

--- a/research/docs/user-guide/security.md
+++ b/research/docs/user-guide/security.md
@@ -255,7 +255,7 @@ Prevents starting gateway outside service manager
 
 info
 
-**Container bypass**: When running in `docker`, `singularity`, `modal`, `daytona`, or `vercel_sandbox` backends, dangerous command checks are **skipped** because the container itself is the security boundary. Destructive commands inside a container can't harm the host.
+**Container bypass**: When running in `docker`, `singularity`, `modal`, or `daytona` backends, dangerous command checks are **skipped** because the container itself is the security boundary. Destructive commands inside a container can't harm the host.
 
 ### Approval Flow (CLI)
 
@@ -477,7 +477,7 @@ terminal:
 
 tip
 
-For production gateway deployments, use `docker`, `modal`, `daytona`, or `vercel_sandbox` backend to isolate agent commands from your host system. This eliminates the need for dangerous command approval entirely.
+For production gateway deployments, use `docker`, `modal`, or `daytona` backend to isolate agent commands from your host system. This eliminates the need for dangerous command approval entirely.
 
 warning
 
@@ -540,14 +540,6 @@ Cloud sandbox
 ❌ Skipped
 
 Persistent cloud workspaces
-
-**vercel\_sandbox**
-
-Cloud microVM
-
-❌ Skipped
-
-Cloud execution with snapshot persistence
 
 ## Environment Variable Passthrough
 

--- a/research/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
+++ b/research/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
@@ -132,8 +132,10 @@ hermes config path          Print config.yaml path
 hermes config env-path      Print .env path
 hermes config check         Check for missing/outdated config
 hermes config migrate       Update config with new options
-hermes login [--provider P] OAuth login (nous, openai-codex)
-hermes logout               Clear stored auth
+hermes auth                 Interactive credential manager
+hermes auth add PROVIDER    Add OAuth or API-key credential (e.g. nous, openai-codex, qwen-oauth)
+hermes auth list            List stored credentials
+hermes auth remove PROVIDER Remove a stored credential
 hermes doctor [--fix]       Check dependencies and config
 hermes status [--all]       Show component status
 ```
@@ -540,12 +542,6 @@ API key
 
 `KILOCODE_API_KEY`
 
-AI Gateway (Vercel)
-
-API key
-
-`AI_GATEWAY_API_KEY`
-
 OpenCode Zen
 
 API key
@@ -562,7 +558,7 @@ Qwen OAuth
 
 OAuth
 
-`hermes login --provider qwen-oauth`
+`hermes auth add qwen-oauth`
 
 Custom endpoint
 
@@ -1064,7 +1060,7 @@ Use the existing skip-pattern style (`sys.platform == "win32"` or `sys.platform.
 ### Model/provider issues
 
 1.  `hermes doctor` — check config and dependencies
-2.  `hermes login` — re-authenticate OAuth providers
+2.  `hermes auth` — re-authenticate OAuth providers (or `hermes auth add <provider>`)
 3.  Check `.env` has the right API key
 4.  **Copilot 403**: `gh auth login` tokens do NOT work for Copilot API. You must use the Copilot-specific OAuth device code flow via `hermes model` → GitHub Copilot.
 
@@ -1301,7 +1297,7 @@ See `tests/agent/test_prompt_builder.py::TestEnvironmentHints` for a worked exam
 Factual guidance about the host OS, user home, cwd, terminal backend, and shell (bash vs. PowerShell on Windows) is emitted from `agent/prompt_builder.py::build_environment_hints()`. This is also where the WSL hint and per-backend probe logic live. The convention:
 
 -   **Local terminal backend** → emit host info (OS, `$HOME`, cwd) + Windows-specific notes (hostname ≠ username, `terminal` uses bash not PowerShell).
--   **Remote terminal backend** (anything in `_REMOTE_TERMINAL_BACKENDS`: `docker, singularity, modal, daytona, ssh, vercel_sandbox, managed_modal`) → **suppress** host info entirely and describe only the backend. A live `uname`/`whoami`/`pwd` probe runs inside the backend via `tools.environments.get_environment(...).execute(...)`, cached per process in `_BACKEND_PROBE_CACHE`, with a static fallback if the probe times out.
+-   **Remote terminal backend** (anything in `_REMOTE_TERMINAL_BACKENDS`: `docker, singularity, modal, daytona, ssh, managed_modal`) → **suppress** host info entirely and describe only the backend. A live `uname`/`whoami`/`pwd` probe runs inside the backend via `tools.environments.get_environment(...).execute(...)`, cached per process in `_BACKEND_PROBE_CACHE`, with a static fallback if the probe times out.
 -   **Key fact for prompt authoring:** when `TERMINAL_ENV != "local"`, _every_ file tool (`read_file`, `write_file`, `patch`, `search_files`) runs inside the backend container, not on the host. The system prompt must never describe the host in that case — the agent can't touch it.
 
 Full design notes, the exact emitted strings, and testing pitfalls: `references/prompt-builder-environment-hints.md`.

--- a/research/docs/user-guide/skills/bundled/social-media/social-media-xurl.md
+++ b/research/docs/user-guide/skills/bundled/social-media/social-media-xurl.md
@@ -65,7 +65,7 @@ Critical rules when operating inside an agent/LLM session:
 
 -   **Never** read, print, parse, summarize, upload, or send `~/.xurl` to LLM context.
 -   **Never** ask the user to paste credentials/tokens into chat.
--   The user must fill `~/.xurl` with secrets manually on their own machine.
+-   The user must fill `~/.xurl` with secrets manually on their own machine. In Docker, this must be the `~` seen by Hermes tool subprocesses; see the Docker note below.
 -   **Never** recommend or execute auth commands with inline secrets in agent sessions.
 -   **Never** use `--verbose` / `-v` in agent sessions — it can expose auth headers/tokens.
 -   To verify credentials exist, only use: `xurl auth status`.
@@ -154,6 +154,17 @@ These steps must be performed by the user directly, NOT by the agent, because th
 After this, the agent can use any command below without further setup. OAuth 2.0 tokens auto-refresh.
 
 > **Common pitfall:** If you omit `--app my-app` from `xurl auth oauth2`, the OAuth token is saved to the built-in `default` app profile — which has no client-id or client-secret. Commands will fail with auth errors even though the OAuth flow appeared to succeed. If you hit this, re-run `xurl auth oauth2 --app my-app` and `xurl auth default my-app`.
+
+> **Docker HOME pitfall:** In the official Hermes Docker layout, `/opt/data` is `HERMES_HOME`, but Hermes tool subprocesses use `/opt/data/home` as `HOME`. That means `~/.xurl` resolves to `/opt/data/home/.xurl` for Hermes-run `xurl` commands, not `/opt/data/.xurl`. Run the user setup with the same HOME:
+> 
+> ```
+> HOME=/opt/data/home xurl auth apps add my-app --client-id YOUR_CLIENT_ID --client-secret YOUR_CLIENT_SECRET
+> HOME=/opt/data/home xurl auth oauth2 --app my-app YOUR_USERNAME
+> HOME=/opt/data/home xurl auth default my-app YOUR_USERNAME
+> HOME=/opt/data/home xurl auth status
+> ```
+> 
+> If `HOME=/opt/data xurl auth status` succeeds but `HOME=/opt/data/home xurl auth status` shows no apps or tokens, Hermes tool calls will not see the credentials.
 
 * * *
 
@@ -597,7 +608,7 @@ Confirm on the "Keys and tokens" page; ID ends in `MTpjaQ`
 -   **Token refresh:** OAuth 2.0 tokens auto-refresh. Nothing to do.
 -   **Multiple apps:** Each app has isolated credentials/tokens. Switch with `xurl auth default` or `--app`.
 -   **Multiple accounts per app:** Select with `-u / --username`, or set a default with `xurl auth default APP USER`.
--   **Token storage:** `~/.xurl` is YAML. Never read or send this file to LLM context.
+-   **Token storage:** `~/.xurl` is YAML. In Docker, use the Hermes subprocess HOME (`/opt/data/home` in the official image) so tokens land under `/opt/data/home/.xurl`. Never read or send this file to LLM context.
 -   **Cost:** X API access is typically paid for meaningful usage. Many failures are plan/permission problems, not code problems.
 
 * * *

--- a/research/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-openhands.md
+++ b/research/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-openhands.md
@@ -1,0 +1,217 @@
+# Openhands
+
+**Source:** https://hermes-agent.nousresearch.com/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-openhands
+
+Delegate coding to OpenHands CLI (model-agnostic, LiteLLM).
+
+## Skill metadata
+
+Source
+
+Optional — install with `hermes skills install official/autonomous-ai-agents/openhands`
+
+Path
+
+`optional-skills/autonomous-ai-agents/openhands`
+
+Version
+
+`0.1.0`
+
+Author
+
+Tim Koepsel (xzessmedia), Hermes Agent
+
+License
+
+MIT
+
+Platforms
+
+linux, macos
+
+Tags
+
+`Coding-Agent`, `OpenHands`, `Model-Agnostic`, `LiteLLM`
+
+Related skills
+
+[`claude-code`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-claude-code), [`codex`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-codex), [`opencode`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-opencode), [`hermes-agent`](/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent)
+
+## Reference: full SKILL.md
+
+info
+
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+
+# OpenHands CLI
+
+Delegate coding tasks to the [OpenHands CLI](https://github.com/All-Hands-AI/OpenHands) via the `terminal` tool. OpenHands is model-agnostic: any LiteLLM-supported provider (OpenAI, Anthropic, OpenRouter, DeepSeek, Ollama, vLLM, etc.).
+
+This skill is the headless-mode wrapper for batch / one-shot delegation. The interactive textual UI is not used from Hermes.
+
+## When to Use
+
+-   User wants a coding task delegated to OpenHands specifically.
+-   User wants a coding agent that can run on a non-Anthropic / non-OpenAI provider (DeepSeek, Qwen, Ollama, vLLM, Nous, etc.) — sibling skills `claude-code` and `codex` are tied to one vendor.
+-   Multi-step file edits + shell commands inside a workspace.
+
+For Claude-native, prefer `claude-code`. For OpenAI-native, prefer `codex`. For Hermes-native subagents, use `delegate_task`.
+
+## Prerequisites
+
+1.  Install upstream (requires Python 3.12+ and `uv`):
+    
+    ```
+    terminal(command="uv tool install openhands --python 3.12")
+    ```
+    
+    Verify: `openhands --version` (currently `OpenHands CLI 1.16.0` / `SDK v1.21.0` at time of writing).
+    
+2.  Pick a model and set env vars for `--override-with-envs`:
+    
+    ```
+    export LLM_MODEL=openrouter/openai/gpt-4o-mini       # or any LiteLLM slug
+    export LLM_API_KEY=$OPENROUTER_API_KEY
+    export LLM_BASE_URL=https://openrouter.ai/api/v1     # omit for native OpenAI
+    ```
+    
+    `LLM_MODEL` uses LiteLLM's full slug. When the provider is OpenRouter the slug is doubly-prefixed: `openrouter/<vendor>/<model>` (e.g. `openrouter/anthropic/claude-sonnet-4.5`). For native Anthropic: `anthropic/claude-sonnet-4-5`. For native OpenAI: `openai/gpt-4o-mini`.
+    
+3.  Suppress the startup banner so JSON output isn't preceded by ASCII art:
+    
+    ```
+    export OPENHANDS_SUPPRESS_BANNER=1
+    ```
+    
+
+## How to Run
+
+Always invoke through the `terminal` tool. Always pass `--headless --json --override-with-envs --exit-without-confirmation` for automation.
+
+### One-shot task
+
+```
+terminal(
+  command="OPENHANDS_SUPPRESS_BANNER=1 LLM_MODEL=openrouter/openai/gpt-4o-mini LLM_API_KEY=$OPENROUTER_API_KEY LLM_BASE_URL=https://openrouter.ai/api/v1 openhands --headless --json --override-with-envs --exit-without-confirmation -t 'Add error handling to all API calls in src/'",
+  workdir="/path/to/project",
+  timeout=600
+)
+```
+
+### Background for long tasks
+
+```
+terminal(command="<same as above>", workdir="/path/to/project", background=true, notify_on_complete=true)
+process(action="poll", session_id="<id>")
+process(action="log", session_id="<id>")
+```
+
+### Resume a previous conversation
+
+OpenHands prints `Conversation ID: <32-hex>` and a `Hint: openhands --resume <dashed-uuid>` line at the end of each run. Use the dashed form to resume:
+
+```
+terminal(
+  command="OPENHANDS_SUPPRESS_BANNER=1 LLM_MODEL=... openhands --headless --json --override-with-envs --exit-without-confirmation --resume <dashed-uuid> -t 'Now fix the bug you found'",
+  workdir="/path/to/project"
+)
+```
+
+## Real Flag List
+
+Verified against `openhands --help` (CLI 1.16.0). Anything not in this table is not a flag — pass it via env var or settings file.
+
+Flag
+
+Effect
+
+`--headless`
+
+No UI, requires `-t` or `-f`. Auto-approves all actions (no `--llm-approve` in this mode).
+
+`--json`
+
+JSONL event stream (requires `--headless`).
+
+`-t TEXT`
+
+Task prompt.
+
+`-f PATH`
+
+Read task from file.
+
+`--resume [ID]`
+
+Resume conversation. No ID → list recent.
+
+`--last`
+
+Resume most recent (with `--resume`).
+
+`--override-with-envs`
+
+Apply `LLM_API_KEY` / `LLM_BASE_URL` / `LLM_MODEL` env vars. Without this, OpenHands uses `~/.openhands/settings.json` and ignores the env.
+
+`--exit-without-confirmation`
+
+Don't show the "are you sure" exit dialog.
+
+`--always-approve` / `--yolo`
+
+Auto-approve every action (default in `--headless`).
+
+`--llm-approve`
+
+LLM-based security gate (interactive only — does NOT work in headless).
+
+`--version` / `-v`
+
+Print version and exit.
+
+**There is no `--model`, `--max-iterations`, `--workspace`, `--sandbox`, `--sandbox-type` flag.** Model is `LLM_MODEL`. Workspace is the `workdir` you pass to the `terminal` tool. Sandbox / runtime is the `RUNTIME` and `SANDBOX_VOLUMES` env vars.
+
+## JSON Event Schema
+
+With `--json --headless`, OpenHands emits JSONL — one JSON object per line, plus a handful of non-JSON status lines (`Initializing agent...`, `Agent is working`, `Agent finished`, the final summary box, `Goodbye!`, `Conversation ID:`, `Hint:`). Filter for lines starting with `{`.
+
+Top-level `kind` field discriminates events:
+
+-   `MessageEvent` — user / agent text turn. `source` is `user` or `agent`.
+-   `ActionEvent` — agent picked a tool. Read `tool_name` (`file_editor`, `terminal`, `finish`) and `action.kind` (`FileEditorAction`, `TerminalAction`, `FinishAction`).
+-   `ObservationEvent` — tool result. `observation.is_error` is the success flag. `source` is `environment`.
+-   `FinishAction` inside an `ActionEvent` carries the agent's final message in `action.message`.
+
+The cli prints all stderr from LiteLLM/Authlib first — see Pitfalls. Parse only stdout, line by line, ignoring lines that don't start with `{`.
+
+## Pitfalls
+
+-   **LiteLLM warnings on every invocation.** The CLI prints `bedrock-runtime` and `sagemaker-runtime` warnings to stderr because `botocore` isn't installed. Plus an Authlib deprecation. These are noise, not failures. Pipe stderr to `/dev/null` or filter it out before showing the user.
+-   **Banner spam.** Without `OPENHANDS_SUPPRESS_BANNER=1`, every run starts with a multi-line `+--+` ASCII box advertising the SDK. Always export it.
+-   **`--override-with-envs` is mandatory for automation.** Without it, OpenHands ignores `LLM_API_KEY` / `LLM_BASE_URL` / `LLM_MODEL` and falls back to `~/.openhands/settings.json`. On a fresh install this file doesn't exist and the CLI hangs waiting for first-run setup.
+-   **Model slug is LiteLLM's, not the provider's.** `openrouter/openai/gpt-4o-mini` works; `openai/gpt-4o-mini` while pointed at OpenRouter does not. `anthropic/claude-sonnet-4-5` (hyphen) is native Anthropic; `openrouter/anthropic/claude-sonnet-4.5` (dot) is via OpenRouter. Get it wrong → cryptic LiteLLM 400.
+-   **`pip install openhands-ai` is the wrong package.** That's the legacy V0 SDK. The new CLI is `uv tool install openhands --python 3.12`. There is no maintained conda package.
+-   **Resume ID format is fiddly.** The CLI ends with `Conversation ID: f46573d9cfdb45e492ca189bde40019b` (no dashes) and then a `Hint: openhands --resume f46573d9-cfdb-45e4-92ca-189bde40019b` (with dashes). Use the dashed form.
+-   **Headless ignores `--llm-approve`.** If you pass it, you get an argparse error. Headless mode hardcodes always-approve.
+-   **No Windows support upstream.** The OpenHands docs require WSL on Windows. This skill is gated `[linux, macos]` accordingly.
+-   **`~/.openhands/conversations/<id>/` accumulates.** Each run persists a trajectory. Clean it up if running batches.
+-   **Heavy install (~200 packages).** Use `uv tool install` (isolated venv) to avoid dependency conflicts with the active project.
+
+## Verification
+
+```
+terminal(
+  command="OPENHANDS_SUPPRESS_BANNER=1 LLM_MODEL=openrouter/openai/gpt-4o-mini LLM_API_KEY=$OPENROUTER_API_KEY LLM_BASE_URL=https://openrouter.ai/api/v1 openhands --headless --json --override-with-envs --exit-without-confirmation -t 'Print the string OPENHANDS_OK to stdout via the terminal tool.'",
+  workdir="/tmp",
+  timeout=120
+)
+```
+
+If the JSONL stream ends with a `FinishAction` whose `action.message` mentions `OPENHANDS_OK`, the install is working.
+
+## Related
+
+-   [OpenHands GitHub](https://github.com/All-Hands-AI/OpenHands)
+-   [OpenHands CLI command reference](https://docs.openhands.dev/openhands/usage/cli/command-reference)
+-   Sibling skills: `claude-code` (Anthropic-only), `codex` (OpenAI-only), `opencode` (multi-provider via OpenCode), `hermes-agent` (Hermes subagents via `delegate_task`).

--- a/research/docs/user-guide/skills/optional/security/security-web-pentest.md
+++ b/research/docs/user-guide/skills/optional/security/security-web-pentest.md
@@ -1,0 +1,290 @@
+# Web Pentest
+
+**Source:** https://hermes-agent.nousresearch.com/docs/user-guide/skills/optional/security/security-web-pentest
+
+Authorized web application penetration testing — reconnaissance, vulnerability analysis, proof-based exploitation, and professional reporting. Adapts Shannon's "No Exploit, No Report" methodology with hard guardrails for scope, authorization, and aux-client leakage. Active testing against running applications you own or have written authorization to test.
+
+## Skill metadata
+
+Source
+
+Optional — install with `hermes skills install official/security/web-pentest`
+
+Path
+
+`optional-skills/security/web-pentest`
+
+Platforms
+
+linux, macos
+
+## Reference: full SKILL.md
+
+info
+
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+
+# Web Application Penetration Testing
+
+A phased pentesting workflow for running web applications. Adapted from Shannon's pipeline (Keygraph, AGPL — concepts only, no code borrowed). Built around three rules:
+
+1.  No exploit, no report — every finding requires reproducible evidence.
+2.  Bounded scope — every active request goes against a target the operator pre-declared. Off-scope hosts are refused.
+3.  Bypass exhaustion before false-positive dismissal — a "blocked" payload is not a clean bill of health until you've tried the bypass set.
+
+* * *
+
+## ⚠️ Hard Guardrails — Read Before Every Engagement
+
+Violating any of these invalidates the engagement and may be illegal.
+
+1.  **Authorization gate.** Before the first active scan in a session, you MUST confirm with the user, in writing, that they own or have written authorization to test the target. Record the acknowledgement in `engagement/authorization.md` (see template). No acknowledgement → no active scanning. Reading public pages with `curl` is fine; sending payloads is not.
+    
+2.  **Scope allowlist.** Maintain `engagement/scope.txt` — one hostname or CIDR per line. Every `nmap`, `curl`, `whatweb`, browser navigation, or payload-bearing request MUST be against an entry in scope. If a target redirects you off-scope (3xx to a different host, a link in HTML), STOP and confirm with the user before following.
+    
+3.  **No production systems without paper.** If the user hasn't told you "yes, prod is in scope and I have written sign-off," assume not. Default targets are staging, local docker, dedicated test instances.
+    
+4.  **Cloud metadata is off by default.** Do not probe `169.254.169.254`, `metadata.google.internal`, `100.100.100.200`, `[fd00:ec2::254]`, or equivalent unless the engagement explicitly includes SSRF-to-metadata as a goal AND the target is one you control. The agent's browser tool can reach these from inside your own infrastructure — don't.
+    
+5.  **Destructive payloads need approval.** SQLi payloads that DROP/DELETE, filesystem-write SSTI, command injection with `rm`/`shutdown`/`mkfs`, anything that mutates beyond a single test row → ASK FIRST. The `approval.py` system catches some; don't rely on it alone.
+    
+6.  **Aux-client leakage risk (Hermes-specific).** This skill produces sessions full of SQLi/XSS/RCE payloads, captured credentials, JWT tokens. Hermes' compression and title-generation paths replay history through the auxiliary client (often the main model). Anything sensitive you write to the conversation can leave the box on the next compress. Mitigation:
+    
+    -   Redact captured tokens/credentials to the LAST 6 CHARS before logging them in any message. Full values go to `engagement/evidence/` files, never into chat history.
+    -   If the engagement is sensitive, set `auxiliary.title_generation.enabled: false` in `~/.hermes/config.yaml` for the session.
+7.  **Rate limit yourself.** Default 200ms between active requests against any single host. The recon-scan.sh script enforces this. Don't bypass it without operator approval.
+    
+8.  **Authority of the report.** This skill produces a security assessment, not a "PASS." Even a clean run is "no exploitable issues FOUND in scope X within time T using methods Y" — not "the application is secure." Mirror that language in the report.
+    
+
+* * *
+
+## Phase 0: Engagement Setup
+
+Before any scanning happens, create the engagement directory and authorization acknowledgement.
+
+```
+ENGAGEMENT=engagement-$(date +%Y%m%d-%H%M%S)
+mkdir -p "$ENGAGEMENT"/{evidence,findings,reports}
+cd "$ENGAGEMENT"
+```
+
+1.  **Ask the user (verbatim):**
+    
+    > "Confirm: (a) the target URL is \[X\], (b) you own this application or have written authorization to test it, and (c) the engagement may run for up to \[N\] hours starting now. Reply 'authorized' to proceed."
+    
+2.  **Wait for explicit `authorized` response.** Any other answer means STOP.
+    
+3.  **Record authorization** to `engagement/authorization.md` using the template in `templates/authorization.md`. Include:
+    
+    -   Target URL(s) and IP(s)
+    -   Authorization basis (ownership / written authz from $name)
+    -   Engagement window
+    -   Out-of-scope items (production, third-party services, etc.)
+    -   Operator name (the user driving this session)
+4.  **Build scope.txt:**
+    
+    ```
+    localhost
+    127.0.0.1
+    staging.example.com
+    192.168.1.0/24    # internal lab only, with operator OK
+    ```
+    
+5.  **Read** `references/scope-enforcement.md` before issuing the first active request — that doc has the host-extraction rules you apply to every command/URL before it goes out.
+    
+
+* * *
+
+## Phase 1: Pre-Recon (Code Analysis, optional)
+
+Skip if no source access (black-box engagement).
+
+If you have read access to the application source:
+
+1.  **Map the architecture** — framework, routing, middleware stack
+2.  **Inventory sinks** — every `execute(`, `os.system(`, `eval(`, template render, file read/write, redirect target
+3.  **Map auth** — session cookie vs JWT, OAuth flows, password reset, privileged endpoints
+4.  **Identify trust boundaries** — what's authenticated, what's not, what comes from `request.*`
+5.  **Backward taint** from each sink to a request source. Early-terminate when proper sanitization is found (parameterized queries, allowlists, `shlex.quote`, well-known escapers).
+
+Output: `evidence/pre-recon.md` — architecture map, sink inventory, suspected vulnerable code paths.
+
+This is OFFLINE work. No traffic to the target.
+
+* * *
+
+## Phase 2: Recon (Live, Read-Only)
+
+Maps the attack surface. All requests are GETs of public pages, no payloads yet. Still scope-bounded.
+
+1.  **Verify scope.** Resolve every target hostname → IP. Confirm IPs are in scope (avoids the "DNS points somewhere unexpected" trap).
+    
+2.  **Network surface** (only if scope permits port scanning):
+    
+    ```
+    nmap -sT -T3 --top-ports 100 -oN evidence/nmap.txt $TARGET
+    ```
+    
+    Use `-T3` (default), not `-T4/-T5`. Stealthier and avoids tripping IDS/IPS in shared environments.
+    
+3.  **Tech fingerprint:**
+    
+    ```
+    whatweb -v $TARGET_URL > evidence/whatweb.txt
+    curl -sIk $TARGET_URL > evidence/headers.txt
+    ```
+    
+4.  **Endpoint discovery:**
+    
+    -   Crawl the app with the browser tool (`browser_navigate`, `browser_get_images`, follow links).
+    -   Inspect `robots.txt`, `sitemap.xml`, `.well-known/*`.
+    -   Use the developer tools network panel via browser tool to capture XHR/fetch calls.
+5.  **Auth surface:** Identify login, registration, password reset, session cookie names, token formats. Do NOT send credentials yet — just observe.
+    
+6.  **Correlate with pre-recon** (if you have source). For each `evidence/pre-recon.md` finding, mark whether the live surface confirms it's reachable.
+    
+
+Output: `evidence/recon.md` — endpoints, technologies, auth model, input vectors.
+
+* * *
+
+## Phase 3: Vulnerability Analysis
+
+One delegate\_task per vulnerability class. Each agent reads `evidence/recon.md` (+ `evidence/pre-recon.md` if present), produces `findings/<class>-queue.json` using `templates/exploitation-queue.json`.
+
+Use `delegate_task` with these focused subagents (parallel where possible):
+
+Class
+
+Goal
+
+Reference
+
+`injection`
+
+SQLi, command, path traversal, SSTI, LFI/RFI, deserialization
+
+`references/vuln-taxonomy.md` (slot types)
+
+`xss`
+
+Reflected, stored, DOM-based
+
+`references/vuln-taxonomy.md` (render contexts)
+
+`auth`
+
+Login bypass, JWT confusion, session fixation, OAuth flaws
+
+`references/exploitation-techniques.md`
+
+`authz`
+
+IDOR, vertical/horizontal escalation, business logic
+
+`references/exploitation-techniques.md`
+
+`ssrf`
+
+Internal reachability, metadata, protocol smuggling
+
+Skip metadata unless explicitly authorized
+
+`infra`
+
+Misconfig, info disclosure, default creds, exposed admin
+
+`references/exploitation-techniques.md`
+
+Each queue entry has: id, vuln class, source (file:line if known), endpoint, parameter, slot type, suspected defense, verdict (`identified` / `partial` / `confirmed` / `critical`), witness payload, confidence (0-1), notes.
+
+The analysis phase doesn't send malicious payloads yet — it stages them. The exploitation phase actually fires them.
+
+* * *
+
+## Phase 4: Exploitation (Proof-Based, Conditional)
+
+Only run a sub-agent per class where the analysis queue has actionable entries (`identified` or `partial`).
+
+For each candidate:
+
+1.  **Pre-send check** — host in scope? auth gate satisfied? payload approved if destructive?
+2.  **Send the witness payload** — minimal proof. SQLi: `' AND 1=1--` then `' AND 1=2--`. XSS: a benign marker like `<svg/onload=console.log("HERMES-PENTEST-XSS")>`. Never `alert(1)` in stored XSS — it'll fire for other users in shared environments.
+3.  **Verify the witness fires** — for blind injection, use a sleep probe (`SLEEP(5)`) and time the response. For SSRF, use a tester-controlled callback host you own (NOT a public service like webhook.site for sensitive engagements — exfil paths).
+4.  **Promote level:**
+    -   **L1 Identified** — pattern matched, no behavior change
+    -   **L2 Partial** — sink reached, but defense in place
+    -   **L3 Confirmed** — payload changed app behavior in observable way
+    -   **L4 Critical** — data extracted, code executed, access escalated
+5.  **Bypass exhaustion before classifying as FP.** For each candidate that blocks: try at least the bypass set in `references/bypass-techniques.md` for that class. Only after the set is exhausted may you write `verdict: false_positive`.
+6.  **Record evidence** for every L3/L4:
+    -   Full request (method, URL, headers, body)
+    -   Response (status, headers, relevant body excerpt)
+    -   Reproducer command (curl one-liner)
+    -   Impact statement
+
+Output: `findings/exploitation-evidence.md`
+
+**Redact in evidence files:**
+
+-   Any captured credentials/tokens → last 6 chars only in chat; full value to `findings/secrets-vault.md` (gitignored).
+-   Other users' PII → redact.
+-   Your test credentials → fine to keep.
+
+* * *
+
+## Phase 5: Reporting
+
+Generate the final report using `templates/pentest-report.md`. Sections:
+
+1.  Executive summary
+2.  Engagement scope (from `engagement/scope.txt`)
+3.  Authorization (from `engagement/authorization.md`)
+4.  Findings (L3/L4 only — proof-required). Per finding:
+    -   Title, severity (CVSS 3.1), CWE
+    -   Affected endpoint(s)
+    -   Proof (request + response excerpt)
+    -   Reproduction steps
+    -   Impact
+    -   Remediation
+5.  Not-exploited candidates (L1/L2 with notes on what blocked them)
+6.  Out-of-scope observations
+7.  Methodology / tools used
+8.  Limitations and what was NOT tested
+
+**Severity policy:** CVSS only for L3/L4. L1/L2 are "candidates pending verification" — don't assign CVSS to unverified findings.
+
+* * *
+
+## When to Stop
+
+-   The user revokes authorization.
+-   A candidate finding clearly impacts production data and you don't have approval for destructive testing — STOP and ask.
+-   The target starts returning 503/429 storms — back off, reconvene with the operator.
+-   You discover something _outside_ the contracted scope (e.g. an exposed customer database while testing an unrelated endpoint). STOP, document, report to the operator. Do not pivot without explicit approval — that pivot is what makes pentesting illegal.
+
+* * *
+
+## What This Skill Does NOT Cover
+
+-   Network-layer pentesting beyond port scanning (no Metasploit, Cobalt Strike, AD attacks, network protocol fuzzing).
+-   Reverse engineering / binary analysis (see issue #383).
+-   Source-only static analysis (see issue #382).
+-   Active social engineering / phishing.
+-   Anything against systems the operator hasn't pre-authorized.
+
+If the engagement needs any of these, escalate to a professional pentester. This skill complements professional pentesting; it does not replace it.
+
+* * *
+
+## Further Reading
+
+-   `references/scope-enforcement.md` — how to bound every active request
+-   `references/vuln-taxonomy.md` — slot types, render contexts, OWASP map
+-   `references/exploitation-techniques.md` — per-class payload patterns
+-   `references/bypass-techniques.md` — common WAF/filter bypasses
+-   `templates/authorization.md` — engagement authorization template
+-   `templates/pentest-report.md` — final report template
+-   `templates/exploitation-queue.json` — per-class finding queue schema
+-   `scripts/recon-scan.sh` — rate-limited nmap+whatweb+headers wrapper

--- a/research/docs/user-guide/skills/optional/software-development/software-development-code-wiki.md
+++ b/research/docs/user-guide/skills/optional/software-development/software-development-code-wiki.md
@@ -1,0 +1,522 @@
+# Code Wiki
+
+**Source:** https://hermes-agent.nousresearch.com/docs/user-guide/skills/optional/software-development/software-development-code-wiki
+
+Generate wiki docs + Mermaid diagrams for any codebase.
+
+## Skill metadata
+
+Source
+
+Optional — install with `hermes skills install official/software-development/code-wiki`
+
+Path
+
+`optional-skills/software-development/code-wiki`
+
+Version
+
+`0.1.0`
+
+Author
+
+Teknium (teknium1), Hermes Agent
+
+License
+
+MIT
+
+Platforms
+
+linux, macos, windows
+
+Tags
+
+`Documentation`, `Mermaid`, `Architecture`, `Diagrams`, `Wiki`, `Code-Analysis`
+
+Related skills
+
+[`codebase-inspection`](/docs/user-guide/skills/bundled/github/github-codebase-inspection), [`github-repo-management`](/docs/user-guide/skills/bundled/github/github-github-repo-management)
+
+## Reference: full SKILL.md
+
+info
+
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+
+# Code Wiki Skill
+
+Generate a comprehensive wiki for any codebase — overview, architecture, per-module deep-dives, Mermaid class and sequence diagrams. Inspired by Google CodeWiki, but works on local repos, private repos, and any language. Uses only existing Hermes tools (`terminal`, `read_file`, `search_files`, `write_file`); no Docker, no external services, no extra dependencies.
+
+This skill produces **reference documentation** (what/how). It does not produce strategic narrative (why — that's a different skill).
+
+## When to Use
+
+-   User says "document this codebase", "generate a wiki", "make architecture diagrams"
+-   Onboarding to an unfamiliar repo and wants a structured reference
+-   User points at a GitHub URL and asks for documentation
+-   Need a stable artifact (markdown + Mermaid) that renders on GitHub
+
+Do NOT use this for:
+
+-   Single-file or single-function documentation — just answer directly
+-   API reference for one specific endpoint — use `read_file` and answer inline
+-   Strategic "why does this exist" narrative — different skill, different purpose
+-   Codebases the user is actively developing in this session — just answer questions as they come
+
+## Prerequisites
+
+-   No env vars required.
+-   `git` on PATH for repo SHA tracking and remote clones.
+-   Optional: `pygount` for language-breakdown stats (see the `codebase-inspection` skill).
+
+## How to Run
+
+Invoke through the `terminal` tool from the target repo's root, then use `read_file` / `search_files` / `write_file` to produce the wiki. Default output location is `~/.hermes/wikis/<repo-name>/`. Only write into the repo (`docs/wiki/`) when the user explicitly requests it.
+
+## Quick Reference
+
+Step
+
+Action
+
+1
+
+Resolve target — local cwd, given path, or `git clone --depth 50 <url>` to a temp dir
+
+2
+
+Scan structure — `ls`, `find -maxdepth 3`, manifest files, README
+
+3
+
+Pick 8–10 modules to document
+
+4
+
+Write `README.md` (overview + module map)
+
+5
+
+Write `architecture.md` with Mermaid flowchart
+
+6
+
+Write per-module docs in `modules/`
+
+7
+
+Write `diagrams/class-diagram.md` (Mermaid classDiagram)
+
+8
+
+Write `diagrams/sequences.md` (Mermaid sequenceDiagram, 2–4 workflows)
+
+9
+
+Write `getting-started.md`
+
+10
+
+Write `api.md` if applicable, else skip
+
+11
+
+Write `.codewiki-state.json`
+
+12
+
+Report paths to user
+
+## Procedure
+
+### 1\. Resolve the target
+
+For a GitHub URL:
+
+```
+WIKI_TMP=$(mktemp -d)
+git clone --depth 50 <url> "$WIKI_TMP/repo"
+cd "$WIKI_TMP/repo"
+REPO_SHA=$(git rev-parse HEAD)
+REPO_NAME=$(basename <url> .git)
+```
+
+For a local path (or cwd if none given):
+
+```
+cd <path>
+REPO_SHA=$(git rev-parse HEAD 2>/dev/null || echo "uncommitted")
+REPO_NAME=$(basename "$PWD")
+```
+
+Then set the output dir:
+
+```
+OUTPUT_DIR="$HOME/.hermes/wikis/$REPO_NAME"
+mkdir -p "$OUTPUT_DIR/modules" "$OUTPUT_DIR/diagrams"
+```
+
+### 2\. Scan repo structure
+
+Use the `terminal` tool for the shell work, `read_file` for manifests:
+
+```
+# Shallow tree first
+ls -la
+
+# Deeper tree, noise filtered
+find . -type d \
+  -not -path '*/\.*' \
+  -not -path '*/node_modules*' \
+  -not -path '*/venv*' \
+  -not -path '*/__pycache__*' \
+  -not -path '*/dist*' \
+  -not -path '*/build*' \
+  -not -path '*/target*' \
+  -maxdepth 3 | sort
+
+# Language breakdown (skip if pygount unavailable)
+pygount --format=summary \
+  --folders-to-skip=".git,node_modules,venv,.venv,__pycache__,.cache,dist,build,target" \
+  . 2>/dev/null || true
+```
+
+Then `read_file` the relevant manifests (`package.json`, `pyproject.toml`, `setup.py`, `Cargo.toml`, `go.mod`, `pom.xml`, `build.gradle`) and the project README. Use `search_files target='files'` to find them rather than guessing names.
+
+### 3\. Pick modules to document
+
+Cap initial pass at **8–10 modules**. Heuristics by language:
+
+-   Python: top-level packages (dirs with `__init__.py`), plus subsystem dirs
+-   JS/TS: `src/<subdir>`, top-level workspace dirs
+-   Rust: each crate in a workspace, or top-level `src/<module>` dirs
+-   Go: each top-level package directory
+-   Mixed/unfamiliar: top-level directories that contain source code (not config, not tests)
+
+For very large repos, prioritize by:
+
+1.  Imported-from count (a module imported by many is core)
+2.  LOC (bigger modules usually warrant their own doc)
+3.  Mentions in README / top-level docs
+
+State the module list to the user before generating per-module docs on big repos — gives them a chance to redirect.
+
+### 4\. Write `README.md`
+
+`read_file` the actual project README plus the top 2–3 entry-point files. Then `write_file`:
+
+```
+# <Project Name>
+
+<One paragraph: what it is and what it's for. Self-contained — don't assume the
+reader has the source README.>
+
+## Key Concepts
+
+- **<Concept 1>** — <one line>
+- **<Concept 2>** — <one line>
+
+## Entry Points
+
+- [`path/to/main.py`](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/software-development/code-wiki/<link>) — <what runs when you start it>
+- [`path/to/cli.py`](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/software-development/code-wiki/<link>) — <CLI surface>
+
+## High-Level Architecture
+
+<2-3 sentences. Detail goes in architecture.md.>
+
+See [architecture.md](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/software-development/code-wiki/architecture.md).
+
+## Module Map
+
+| Module | Purpose |
+|---|---|
+| [`<module>`](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/software-development/code-wiki/modules/<module>.md) | <one-line purpose> |
+
+## Getting Started
+
+See [getting-started.md](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/software-development/code-wiki/getting-started.md).
+```
+
+For link targets in local mode use relative paths. For cloned repos use `https://github.com/<owner>/<repo>/blob/<sha>/<path>` so links survive future commits.
+
+### 5\. Write `architecture.md`
+
+```
+# Architecture
+
+<2-3 paragraphs: shape of the system. What talks to what. Where data enters,
+where it exits, where state lives.>
+
+## Components
+
+- **<Component>** — <1-2 sentences>. See [`modules/<module>.md`](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/software-development/code-wiki/modules/<module>.md).
+
+## System Diagram
+
+```mermaid
+flowchart TD
+    User([User]) --> Entry[Entry Point]
+    Entry --> Core[Core Engine]
+    Core --> StorageA[(Database)]
+    Core --> ExternalAPI{{External API}}
+```
+
+## Data Flow
+
+1. **<Step>** — [`<file>`](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/software-development/code-wiki/<link>)
+2. **<Step>** — [`<file>`](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/software-development/code-wiki/<link>)
+
+## Key Design Decisions
+
+- <Anything load-bearing the reader should know>
+```
+
+**Mermaid shape semantics:**
+
+-   `[]` = component
+-   `[()]` = database / storage
+-   `{{}}` = external service
+-   `(())` = entry point or terminal
+-   `-->` = sync call, `-.->` = async/event
+
+Cap at ~20 nodes per diagram. Split into sub-diagrams if larger.
+
+### 6\. Write per-module docs in `modules/`
+
+For each selected module, inspect its layout with `ls`, identify 3–5 most important files (by size, by being named `core.py` / `main.py` / `__init__.py`, by being imported a lot), then `read_file` those files (use `offset` / `limit` to read only what you need; prefer `search_files` for specific symbols).
+
+```
+# Module: `<module>`
+
+<1-2 sentence purpose.>
+
+## Responsibilities
+
+- <bullet>
+- <bullet>
+
+## Key Files
+
+- [`<module>/<file>`](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/software-development/code-wiki/<link>) — <what it does>
+
+## Public API
+
+<Functions/classes/constants other code uses. Group related items. Show
+signatures, not full implementations.>
+
+## Internal Structure
+
+<How the module is organized internally. State management.>
+
+## Dependencies
+
+- **Used by:** <other modules>
+- **Uses:** <other modules + external libs>
+
+## Notable Patterns / Gotchas
+
+- <Anything non-obvious>
+```
+
+### 7\. Write `diagrams/class-diagram.md`
+
+Pick the 5–10 most important classes/types. `read_file` them, then write:
+
+```
+# Class Diagram
+
+## Core Types
+
+```mermaid
+classDiagram
+    class Agent {
+        +string name
+        +list~Tool~ tools
+        +chat(message) string
+    }
+    class Tool {
+        <<interface>>
+        +name string
+        +execute(args) any
+    }
+    Agent --> Tool : uses
+    Tool <|-- TerminalTool
+    Tool <|-- WebTool
+```
+
+## Notes
+
+<Anything the diagram can't express — lifecycle, threading, etc.>
+```
+
+For languages without classes (Go, C, Rust): use the diagram for struct relationships, or skip class-diagram.md and explain it in prose in architecture.md. Don't force-fit.
+
+### 8\. Write `diagrams/sequences.md`
+
+Pick 2–4 of the most important workflows. Trace each call path through the code (read entry point, follow function calls), then:
+
+```
+# Sequence Diagrams
+
+## Workflow: <Name>
+
+<1 sentence describing what this does and when it runs.>
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI
+    participant Agent
+    participant LLM
+    User->>CLI: types message
+    CLI->>Agent: chat(message)
+    Agent->>LLM: API call
+    LLM-->>Agent: response + tool_calls
+    Agent->>Agent: execute tools
+    Agent-->>CLI: final response
+```
+
+### Walkthrough
+
+1. **User input** — [`cli.py:HermesCLI.run_session`](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/software-development/code-wiki/<link>)
+2. **Message dispatch** — [`run_agent.py:AIAgent.chat`](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/software-development/code-wiki/<link>)
+```
+
+Don't invent participants. Every box must correspond to a real component the reader can find in the code.
+
+### 9\. Write `getting-started.md`
+
+```
+# Getting Started
+
+## Prerequisites
+
+<From manifest files + README. Be specific — versions if pinned.>
+
+## Installation
+
+```bash
+<exact commands>
+```
+
+## First Run
+
+```bash
+<minimum command to see the system do something useful>
+```
+
+## Common Workflows
+
+### <Workflow 1>
+<commands>
+
+## Configuration
+
+- `<config-file>` — <what it controls>
+- Env var `<VAR>` — <what it controls>
+
+## Where to Go Next
+
+- Architecture: [architecture.md](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/software-development/code-wiki/architecture.md)
+- Module reference: [README.md#module-map](https://github.com/NousResearch/hermes-agent/blob/main/optional-skills/software-development/code-wiki/README.md#module-map)
+```
+
+### 10\. Write `api.md` (skip if not applicable)
+
+Only write this if the project is a library or API server. If it is:
+
+-   Find the public API surface (`__init__.py` exports, OpenAPI specs, route handlers, exported types)
+-   Document each public entry with signature, parameters, return type, one-line description
+-   Group by category
+
+### 11\. Write the state file
+
+```
+cat > "$OUTPUT_DIR/.codewiki-state.json" <<EOF
+{
+  "repo_name": "$REPO_NAME",
+  "source_path": "$PWD",
+  "source_sha": "$REPO_SHA",
+  "generated_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "generator": "hermes-agent code-wiki skill v0.1.0",
+  "modules_documented": []
+}
+EOF
+```
+
+### 12\. Report to user
+
+State exactly what was generated and where:
+
+```
+Generated wiki at ~/.hermes/wikis/<repo-name>/:
+  README.md                   project overview, module map
+  architecture.md             system architecture + flowchart
+  getting-started.md          setup, first run, workflows
+  modules/<N files>           per-module deep-dives
+  diagrams/architecture.md    Mermaid flowchart
+  diagrams/class-diagram.md   Mermaid class diagram
+  diagrams/sequences.md       Mermaid sequence diagrams
+```
+
+If you cloned to a temp dir, remind the user it can be removed (`rm -rf "$WIKI_TMP"`) after they've reviewed the wiki.
+
+## Scope Control
+
+Generating a full wiki for a 500K-LOC monorepo is wildly token-expensive. Default to bounded scope:
+
+-   Initial scan: max depth 3 directories
+-   Per-module docs: cap at 10 modules unless user expands scope
+-   Per-file reads: prefer `search_files` for symbols + `read_file` with `offset`/`limit` over full reads
+-   Skip vendored code (`vendor/`, `third_party/`, generated code, `_pb2.py`, `.min.js`)
+
+If the user says "do the whole thing exhaustively", believe them — but ballpark the cost first: "this repo has ~340 source files, comprehensive coverage will be expensive — confirm?"
+
+## Re-Run / Update
+
+If `.codewiki-state.json` already exists at the target path:
+
+-   Read it for previous SHA and module list
+-   If source SHA matches: ask user if they want to regenerate or skip
+-   If SHA differs: offer to regenerate only modules with changed files (`git diff --name-only <old-sha> HEAD`)
+
+Full incremental-regeneration is a future enhancement — for now, regenerating the whole thing is acceptable.
+
+## Pitfalls
+
+-   **Fabricating components.** Every diagram node and claimed function call must be in the source. `read_file` before writing. The single biggest failure mode for auto-generated docs is plausible-sounding fabrication.
+-   **Generic AI prose.** "This module is responsible for..." is content-free. Say what the module actually does in domain-specific terms.
+-   **Restating code as prose.** A module doc that says "the `process` function processes things by calling `process_item` on each item" is worse than just linking to the function.
+-   **Mermaid > 50 nodes.** They don't render legibly. Split them.
+-   **Documenting tests, generated code, or vendored deps as if they were product code.** Skip them.
+-   **In-repo output without asking.** Default is `~/.hermes/wikis/`. Only write into the repo when the user explicitly requests it.
+-   **Mermaid special chars need quotes:** `A["Tool / Agent"]` not `A[Tool / Agent]`. `<br>` for line breaks inside a node.
+-   **Nested code fences in SKILL.md.** When writing a markdown example that contains a Mermaid block, use 4-backtick outer fences so the 3-backtick inner ` ```mermaid ` doesn't close the outer. (This SKILL.md does it.)
+-   **classDiagram generics** render as `~T~` (e.g. `List~Tool~`), not `<T>`.
+-   **GitHub Mermaid theme is fixed** — don't include `%%{init: ...}%%` blocks; they're stripped on render.
+
+## Verification
+
+After writing, verify:
+
+1.  **Mermaid blocks balance** — opens equal closes per file:
+    
+    ```
+    for f in "$OUTPUT_DIR"/diagrams/*.md "$OUTPUT_DIR"/architecture.md; do
+      opens=$(grep -c '^```mermaid' "$f")
+      total=$(grep -c '^```' "$f")
+      echo "$f: $opens mermaid blocks, $total total fences (expect total = opens*2)"
+    done
+    ```
+    
+2.  **All expected files exist** —
+    
+    ```
+    ls "$OUTPUT_DIR"/{README.md,architecture.md,getting-started.md,.codewiki-state.json} \
+       "$OUTPUT_DIR"/modules/ "$OUTPUT_DIR"/diagrams/
+    ```
+    
+3.  **Module count matches what you intended** — `ls "$OUTPUT_DIR/modules" | wc -l` should equal the number of modules you committed to in Step 3.
+4.  **No fabricated paths** — sanity-check 2–3 source links resolve to real files.

--- a/research/docs/user-guide/tui.md
+++ b/research/docs/user-guide/tui.md
@@ -98,7 +98,7 @@ Keybindings match the [Classic CLI](/docs/user-guide/cli#keybindings) exactly. T
 -   **`Cmd+V` / `Ctrl+V`** first tries normal text paste, then falls back to OSC52/native clipboard reads, and finally image attach when the clipboard or pasted payload resolves to an image.
 -   **`/terminal-setup`** installs local VS Code / Cursor / Windsurf terminal bindings for better `Cmd+Enter` and undo/redo parity on macOS.
 -   **Slash autocompletion** opens as a floating panel with descriptions, not an inline dropdown.
--   **`Ctrl+X`** — when a queued message is highlighted (sent while the agent was still running), delete it from the queue. **`Esc`** cancels editing and unhighlights without deleting.
+-   **`Ctrl+X`** opens the live session switcher. When a queued message is highlighted (sent while the agent was still running), it still deletes that queued message instead. **`Esc`** cancels editing and unhighlights without deleting.
 -   **`Ctrl+G` / `Ctrl+X Ctrl+E`** — open the current input buffer in `$EDITOR` for multi-line / long-prompt composition; save-and-exit sends the contents back as the prompt.
 
 ## Slash commands
@@ -113,9 +113,9 @@ TUI behavior
 
 Overlay with categorized commands, arrow-key navigable
 
-`/sessions`
+`/sessions` (alias `/switch`)
 
-Modal session picker — preview, title, token totals, resume inline
+Live session switcher — list open TUI sessions, switch between them, close them, or start another one
 
 `/model`
 
@@ -146,6 +146,29 @@ Re-reads `~/.hermes/.env` into the running TUI process so newly added API keys t
 Pick a mouse tracking preset at runtime (also persists to `display.mouse_tracking` in `config.yaml`). `wheel` (1000+1006) keeps scroll-wheel scrolling without the hover events that make tmux spam "No image in clipboard" over the prompt row; `buttons` adds drag-to-select; `all` is the default with hover-driven UI.
 
 Every other slash command (including installed skills, quick commands, and personality toggles) works identically to the classic CLI. See [Slash Commands Reference](/docs/reference/slash-commands).
+
+## Live session switcher
+
+Use the live session switcher when you want one terminal to act as a dispatcher for several TUI sessions. It lists only sessions that are currently live in this TUI process; closed sessions remain saved transcripts and can still be reopened with `/resume` or `hermes --tui --resume <id-or-title>`.
+
+Open it with any of these:
+
+-   `Ctrl+X` from the TUI.
+-   `/sessions` or `/switch`.
+-   `/sessions new` to create a fresh live session immediately.
+-   Click the `N live sessions` count in the status line.
+
+![Hermes TUI Session Orchestrator with one live session and a +new row](/img/docs/tui-session-orchestrator/session-orchestrator.png)
+
+Inside the switcher:
+
+-   `↑` / `↓` move the selection; mouse clicks select rows too.
+-   `Enter` switches to the selected live session.
+-   `Ctrl+D` closes the selected live session.
+-   `Ctrl+N` starts a blank live session.
+-   `Ctrl+R` refreshes the live-session list.
+-   `Esc` closes the switcher.
+-   Select `+new`, type a prompt, and press `Enter` to dispatch a new live session. Press `Tab` first if you want to choose a model just for that new session.
 
 ## LaTeX math rendering
 

--- a/scripts/build-chunks.js
+++ b/scripts/build-chunks.js
@@ -12,6 +12,7 @@
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
+import { enrichChunkMetadata } from "../lib/rag-scoring.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..");
@@ -137,12 +138,12 @@ function pushChunk(chunks, source, heading, text) {
   // Hard-split anything still oversized after paragraph splitting (mega
   // paragraphs with no blank lines, e.g. wall-of-links pages).
   for (const piece of hardSplitByLines(trimmed, MAX_CHUNK_CHARS)) {
-    chunks.push({
+    chunks.push(enrichChunkMetadata({
       id: `${source}:${chunks.length}`,
       text: piece.trim(),
       source,
       section: heading,
-    });
+    }));
   }
 }
 

--- a/scripts/test-rag.js
+++ b/scripts/test-rag.js
@@ -11,6 +11,7 @@
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
+import { combinedRetrievalScore, enrichChunkMetadata } from "../lib/rag-scoring.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..");
@@ -271,7 +272,7 @@ function hybridRetrieve(query, queryEmbedding, chunks, bm25Index, topK = 8) {
   return chunks
     .map((chunk, i) => ({
       ...chunk,
-      score: 0.7 * normCosine[i] + 0.3 * normBM25[i],
+      score: combinedRetrievalScore({ query, chunk, normCosine: normCosine[i], normBM25: normBM25[i] }),
       _cosine: cosineScores[i],
       _bm25: bm25Scores[i],
     }))
@@ -326,7 +327,7 @@ function hybridMmrRetrieve(query, queryEmbedding, chunks, bm25Index, topK = 8) {
   const candidates = chunks
     .map((chunk, i) => ({
       ...chunk,
-      score: 0.7 * normCosine[i] + 0.3 * normBM25[i],
+      score: combinedRetrievalScore({ query, chunk, normCosine: normCosine[i], normBM25: normBM25[i] }),
     }))
     .sort((a, b) => b.score - a.score)
     .slice(0, 20);
@@ -347,7 +348,7 @@ async function runRetrievalTests() {
   }
 
   console.log("Loading chunks...");
-  const chunks = JSON.parse(fs.readFileSync(chunksPath, "utf-8"));
+  const chunks = JSON.parse(fs.readFileSync(chunksPath, "utf-8")).map(enrichChunkMetadata);
   console.log(`  Loaded ${chunks.length} chunks`);
 
   console.log("Building BM25 index...");
@@ -534,7 +535,7 @@ async function runMmrTests() {
   console.log();
 
   const chunksPath = path.join(ROOT, "data", "chunks.json");
-  const chunks = JSON.parse(fs.readFileSync(chunksPath, "utf-8"));
+  const chunks = JSON.parse(fs.readFileSync(chunksPath, "utf-8")).map(enrichChunkMetadata);
   const bm25Index = buildBM25Index(chunks);
 
   // Queries known to retrieve near-duplicate chunks (community sentiment, broad topics)

--- a/tests/rag-scoring.test.js
+++ b/tests/rag-scoring.test.js
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  classifyChunkSource,
+  querySourceAdjustment,
+  combinedRetrievalScore,
+} from "../lib/rag-scoring.js";
+
+test("classifies official docs, generated catalog docs, and curated Atlas sources", () => {
+  assert.equal(classifyChunkSource({ source: "research/docs/user-guide/skills.md" }).authority, "official_docs");
+  assert.equal(classifyChunkSource({ source: "research/docs/skills/index.md" }).contentKind, "catalog");
+  assert.equal(classifyChunkSource({ source: "research/atlas-official-docs-updates.md" }).authority, "curated_atlas");
+  assert.equal(classifyChunkSource({ source: "repos/all-star-counts.md" }).contentKind, "repo_metadata");
+});
+
+test("official feature docs outrank equally relevant community chunks", () => {
+  const official = { source: "research/docs/user-guide/tui.md", text: "TUI session orchestrator lets you switch sessions" };
+  const community = { source: "research/community-note.md", text: "TUI session orchestrator lets you switch sessions" };
+
+  const officialScore = combinedRetrievalScore({ query: "Can Hermes switch TUI sessions?", chunk: official, normCosine: 0.5, normBM25: 0.5 });
+  const communityScore = combinedRetrievalScore({ query: "Can Hermes switch TUI sessions?", chunk: community, normCosine: 0.5, normBM25: 0.5 });
+
+  assert.ok(officialScore > communityScore, `${officialScore} should beat ${communityScore}`);
+});
+
+test("skills catalog pages are penalized for broad questions but boosted for skills catalog questions", () => {
+  const catalog = { source: "research/docs/skills/index.md", text: "Skills Hub source pills include OpenAI, HuggingFace, ClawHub, browse.sh, skills.sh" };
+
+  assert.ok(querySourceAdjustment("What is Hermes Agent?", catalog) < 0);
+  assert.ok(querySourceAdjustment("Which sources are in the Skills Hub catalog?", catalog) > 0);
+});
+
+test("TUI session docs get a query-sensitive feature boost", () => {
+  const tui = { source: "research/docs/user-guide/tui.md", text: "active-session orchestrator list activate close launch sessions" };
+  const unrelated = { source: "research/docs/user-guide/voice.md", text: "voice calls and audio output" };
+
+  const tuiScore = combinedRetrievalScore({ query: "How do I launch and switch TUI sessions?", chunk: tui, normCosine: 0.4, normBM25: 0.4 });
+  const unrelatedScore = combinedRetrievalScore({ query: "How do I launch and switch TUI sessions?", chunk: unrelated, normCosine: 0.4, normBM25: 0.4 });
+
+  assert.ok(tuiScore > unrelatedScore, `${tuiScore} should beat ${unrelatedScore}`);
+});


### PR DESCRIPTION
## Summary
- Refresh official Hermes docs into the Atlas KB and rebuild chunks
- Add source-aware retrieval scoring that prioritizes official docs and curated Atlas summaries
- Penalize catalog/generated Skills Hub docs for broad queries while boosting them for skills/catalog lookups
- Add curated Atlas policy note covering the Skills Hub catalog update and TUI session orchestrator
- Add Node test coverage for authority boosts, catalog noise controls, and TUI query boosts

## Test Plan
- node --test tests/rag-scoring.test.js
- node --check api/chat.js
- node --check scripts/build-chunks.js
- node --check scripts/test-rag.js
- node scripts/scrape-hermes-docs.js
- node scripts/build-chunks.js

Closes #251