### PR TITLE
Fix build-pages artifact staging drift

### DIFF
--- a/.github/workflows/build-pages.yml
+++ b/.github/workflows/build-pages.yml
@@ -50,15 +50,11 @@ jobs:
       - name: Check for changes
         id: diff
         run: |
-          # index.html is mutated by syncHomepageRepos() in build-pages.js
-          # — must be staged or homepage drifts silently (bug pre-2026-05-17).
-          # data/repos.json is mutated by the GraphQL stars-refresh step in
-          # build-pages.js — must be staged or per-repo stars in the public
-          # dataset stay frozen at submitter time (bug pre-2026-05-24).
-          # reports/index.html is rendered from data/reports.json on every
-          # build but was never staged — meant /reports/ silently missed
-          # new entries until the workflow was edited (bug pre-2026-05-25).
-          git add index.html projects/ lists/ reports/ sitemap.xml robots.txt llms.txt llms-full.txt rss.xml data/repos.json data/summaries.json data/list-summaries.json
+          # Stage generated artifacts through a repo-owned manifest instead of
+          # hand-maintaining pathspecs in this workflow. If a generator emits a
+          # new path that is not in the manifest, the script fails loudly so the
+          # artifact cannot be silently dropped from the bot commit.
+          node scripts/stage-build-artifacts.js
           if git diff --cached --quiet; then
             echo "changed=false" >> $GITHUB_OUTPUT
           else

--- a/lib/build-artifacts.js
+++ b/lib/build-artifacts.js
@@ -1,0 +1,60 @@
+import { execFileSync } from "child_process";
+
+export const GENERATED_ARTIFACT_PATHS = [
+  "index.html",
+  "projects/",
+  "lists/",
+  "reports/",
+  "sitemap.xml",
+  "robots.txt",
+  "llms.txt",
+  "llms-full.txt",
+  "rss.xml",
+  "data/repos.json",
+  "data/summaries.json",
+  "data/list-summaries.json",
+];
+
+export function git(args, options = {}) {
+  return execFileSync("git", args, {
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+    ...options,
+  });
+}
+
+export function parsePorcelainStatus(output) {
+  return String(output || "")
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => ({
+      raw: line,
+      index: line.slice(0, 1),
+      worktree: line.slice(1, 2),
+      path: line.slice(3),
+    }));
+}
+
+export function isUnstaged(entry) {
+  return entry.index === "?" || entry.worktree !== " ";
+}
+
+export function assertNoUnstagedChanges({ cwd = process.cwd(), statusOutput } = {}) {
+  const output = statusOutput ?? git(["status", "--porcelain"], { cwd });
+  const leftovers = parsePorcelainStatus(output).filter(isUnstaged);
+
+  if (leftovers.length > 0) {
+    const details = leftovers.map((entry) => `  ${entry.raw}`).join("\n");
+    throw new Error(
+      "Unstaged files remain after staging generated artifacts. " +
+      "If build-pages or generate-summaries emits a new artifact, add it to " +
+      "GENERATED_ARTIFACT_PATHS in lib/build-artifacts.js so CI commits it intentionally.\n" +
+      details
+    );
+  }
+}
+
+export function stageGeneratedArtifacts({ cwd = process.cwd(), paths = GENERATED_ARTIFACT_PATHS } = {}) {
+  git(["add", "--", ...paths], { cwd });
+  assertNoUnstagedChanges({ cwd });
+}

--- a/scripts/stage-build-artifacts.js
+++ b/scripts/stage-build-artifacts.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+/**
+ * Stage every generated artifact emitted by generate-summaries.js and
+ * build-pages.js, then fail loudly if the build produced any unstaged files.
+ *
+ * This keeps .github/workflows/build-pages.yml from hand-maintaining a fragile
+ * `git add ...` list. When a future generator emits a new artifact, CI will
+ * fail with the exact path instead of silently dropping it from the bot commit.
+ */
+import { GENERATED_ARTIFACT_PATHS, stageGeneratedArtifacts } from "../lib/build-artifacts.js";
+
+try {
+  stageGeneratedArtifacts();
+  console.log(`Staged generated artifacts: ${GENERATED_ARTIFACT_PATHS.join(", ")}`);
+} catch (err) {
+  console.error(err.message || err);
+  process.exit(1);
+}

--- a/tests/build-artifacts.test.js
+++ b/tests/build-artifacts.test.js
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  GENERATED_ARTIFACT_PATHS,
+  assertNoUnstagedChanges,
+  parsePorcelainStatus,
+} from "../lib/build-artifacts.js";
+
+test("generated artifact manifest covers current build outputs", () => {
+  assert.deepEqual(GENERATED_ARTIFACT_PATHS, [
+    "index.html",
+    "projects/",
+    "lists/",
+    "reports/",
+    "sitemap.xml",
+    "robots.txt",
+    "llms.txt",
+    "llms-full.txt",
+    "rss.xml",
+    "data/repos.json",
+    "data/summaries.json",
+    "data/list-summaries.json",
+  ]);
+});
+
+test("porcelain parser identifies unstaged modified and untracked files", () => {
+  const entries = parsePorcelainStatus([
+    "M  index.html",
+    " M scripts/build-pages.js",
+    "?? new-artifact.json",
+    "D  projects/old.html",
+  ].join("\n"));
+
+  assert.equal(entries.length, 4);
+  assert.deepEqual(entries.map((e) => e.path), [
+    "index.html",
+    "scripts/build-pages.js",
+    "new-artifact.json",
+    "projects/old.html",
+  ]);
+  assert.deepEqual(entries.map((e) => `${e.index}${e.worktree}`), ["M ", " M", "??", "D "]);
+});
+
+test("assertNoUnstagedChanges allows fully staged generated changes", () => {
+  assert.doesNotThrow(() => assertNoUnstagedChanges({
+    statusOutput: [
+      "M  index.html",
+      "A  reports/new.html",
+      "D  projects/old.html",
+    ].join("\n"),
+  }));
+});
+
+test("assertNoUnstagedChanges fails loudly on silently dropped artifacts", () => {
+  assert.throws(
+    () => assertNoUnstagedChanges({
+      statusOutput: [
+        "M  index.html",
+        "?? data/new-generated-file.json",
+      ].join("\n"),
+    }),
+    /data\/new-generated-file\.json/
+  );
+});


### PR DESCRIPTION
## Summary
- replace the build-pages workflow's hand-maintained generated-artifact `git add` list with a repo-owned manifest and staging helper
- fail loudly when generators create unmanifested artifacts so bot commits cannot silently drop new files
- add tests for the manifest, git status parsing, and unstaged-artifact guardrail

## Test Plan
- `node --check lib/build-artifacts.js`
- `node --check scripts/stage-build-artifacts.js`
- `node --test tests/build-artifacts.test.js tests/rag-scoring.test.js`
- `git diff --check`

Closes #247