### PR TITLE
Add Cordn8 to Atlas ecosystem

### DIFF
--- a/data/repos.json
+++ b/data/repos.json
@@ -480,6 +480,16 @@
     "category": "Multi-Agent & Orchestration"
   },
   {
+    "owner": "MorvaniLabs",
+    "repo": "cordn8",
+    "name": "cordn8",
+    "description": "Local-first coordination layer for multiple AI agents using an append-only markdown channel, Hermes adapter, approval modes, and audit trail",
+    "stars": 1,
+    "url": "https://github.com/MorvaniLabs/cordn8",
+    "official": false,
+    "category": "Multi-Agent & Orchestration"
+  },
+  {
     "owner": "numtide",
     "repo": "llm-agents.nix",
     "name": "llm-agents.nix",


### PR DESCRIPTION
## Summary
- accept #252 as relevant to Atlas under Multi-Agent & Orchestration
- add MorvaniLabs/cordn8 to data/repos.json with current metadata

## Triage decision
Cordn8 is relevant enough to include despite being early: it now explicitly documents Hermes support in the README/topics, has an append-only local coordination model that fits the Hermes ecosystem, and will remain community/non-official catalog data rather than high-authority Ask the Atlas docs.

## Test Plan
- `node -e "const fs=require('fs'); const repos=JSON.parse(fs.readFileSync('data/repos.json','utf8')); const keys=new Set(); for (const r of repos){ for (const f of ['owner','repo','name','description','stars','url','official','category']) if(!(f in r)) throw new Error('missing '+f+' in '+r.owner+'/'+r.repo); const k=(r.owner+'/'+r.repo).toLowerCase(); if(keys.has(k)) throw new Error('duplicate '+k); keys.add(k); } console.log('repos validation ok', repos.length);"`
- `git diff --check`

Closes #252