### PR TITLE
Add hermes-agent-team to Atlas ecosystem

### DIFF
--- a/data/repos.json
+++ b/data/repos.json
@@ -490,6 +490,16 @@
     "category": "Multi-Agent & Orchestration"
   },
   {
+    "owner": "linke-ai",
+    "repo": "hermes-agent-team",
+    "name": "hermes-agent-team",
+    "description": "Local multi-agent team collaboration web system built on Hermes Agent profiles, MCP, ACP, and Hermes Kanban",
+    "stars": 114,
+    "url": "https://github.com/linke-ai/hermes-agent-team",
+    "official": false,
+    "category": "Multi-Agent & Orchestration"
+  },
+  {
     "owner": "numtide",
     "repo": "llm-agents.nix",
     "name": "llm-agents.nix",


### PR DESCRIPTION
## Summary
- accept #244 as relevant to Atlas under Multi-Agent & Orchestration
- add linke-ai/hermes-agent-team to data/repos.json

## Triage decision
This is a real Hermes-specific community project: the README says it is built on Hermes Agent profiles, MCP, ACP, and Hermes Kanban, and it exposes a local multi-agent team UI. It is community/non-official catalog data, so it should be discoverable in the ecosystem map without being treated as high-authority official docs.

## Test Plan
- repo JSON validation script passed
- `git diff --check`

Closes #244