### PR TITLE
Triage accepted repo discoveries

### DIFF
--- a/data/repos.json
+++ b/data/repos.json
@@ -500,6 +500,296 @@
     "category": "Multi-Agent & Orchestration"
   },
   {
+    "owner": "Eynzof",
+    "repo": "hermes-agent-cn-desktop",
+    "name": "hermes-agent-cn-desktop",
+    "description": "Windows-first Chinese desktop app for Hermes Agent built with Tauri, TypeScript, and Rust",
+    "stars": 198,
+    "url": "https://github.com/Eynzof/hermes-agent-cn-desktop",
+    "official": false,
+    "category": "Workspaces & GUIs"
+  },
+  {
+    "owner": "Shelpuk-AI-Technology-Consulting",
+    "repo": "kindly-web-search-mcp-server",
+    "name": "kindly-web-search-mcp-server",
+    "description": "Web search and content retrieval MCP server supporting Hermes Agent, OpenClaw, Claude Code, Codex, Cursor, and other AI tools",
+    "stars": 336,
+    "url": "https://github.com/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server",
+    "official": false,
+    "category": "Plugins & Extensions"
+  },
+  {
+    "owner": "Agent-3-7",
+    "repo": "minions",
+    "name": "minions",
+    "description": "Mission Control for Hermes agents: create, supervise, and review autonomous Hermes Agent work from one screen",
+    "stars": 548,
+    "url": "https://github.com/Agent-3-7/minions",
+    "official": false,
+    "category": "Multi-Agent & Orchestration"
+  },
+  {
+    "owner": "CryptoDmitry",
+    "repo": "hermes-agent-control-room",
+    "name": "hermes-agent-control-room",
+    "description": "Control Room-first template for managing Hermes agents from one VPS agent to specialist teams and orchestrated workflows",
+    "stars": 844,
+    "url": "https://github.com/CryptoDmitry/hermes-agent-control-room",
+    "official": false,
+    "category": "Multi-Agent & Orchestration"
+  },
+  {
+    "owner": "colbymchenry",
+    "repo": "codegraph",
+    "name": "codegraph",
+    "description": "Local pre-indexed code knowledge graph for Hermes Agent and other coding agents to reduce token usage and tool calls",
+    "stars": 31072,
+    "url": "https://github.com/colbymchenry/codegraph",
+    "official": false,
+    "category": "Developer Tools"
+  },
+  {
+    "owner": "Felix-Forever",
+    "repo": "hermes-agent-desktop",
+    "name": "hermes-agent-desktop",
+    "description": "Multi-agent Hermes Agent desktop client with specialists, visual skill store, PM orchestrator, and streaming chat",
+    "stars": 34,
+    "url": "https://github.com/Felix-Forever/hermes-agent-desktop",
+    "official": false,
+    "category": "Workspaces & GUIs"
+  },
+  {
+    "owner": "AkoliteZA",
+    "repo": "hermes-agent-idea-workflow",
+    "name": "hermes-agent-idea-workflow",
+    "description": "Pre-build idea-to-spec workflow skills for Hermes Agent that turn rough ideas into design docs and implementation handoffs",
+    "stars": 120,
+    "url": "https://github.com/AkoliteZA/hermes-agent-idea-workflow",
+    "official": false,
+    "category": "Skills & Skill Registries"
+  },
+  {
+    "owner": "shannhk",
+    "repo": "hermes-agent-control-room",
+    "name": "hermes-agent-control-room",
+    "description": "Control Room-first template for scaling Hermes Agent from one VPS agent to specialist teams and automated workflows",
+    "stars": 486,
+    "url": "https://github.com/shannhk/hermes-agent-control-room",
+    "official": false,
+    "category": "Multi-Agent & Orchestration"
+  },
+  {
+    "owner": "Salomondiei08",
+    "repo": "oh-my-hermes",
+    "name": "oh-my-hermes",
+    "description": "Opinionated workflow layer for building, shipping, and operating apps with Hermes Agent",
+    "stars": 417,
+    "url": "https://github.com/Salomondiei08/oh-my-hermes",
+    "official": false,
+    "category": "Developer Tools"
+  },
+  {
+    "owner": "liaohch3",
+    "repo": "claude-tap",
+    "name": "claude-tap",
+    "description": "Local trace viewer for inspecting coding-agent API traffic from Hermes Agent, Claude Code, Codex, Gemini, Cursor, OpenCode, and others",
+    "stars": 951,
+    "url": "https://github.com/liaohch3/claude-tap",
+    "official": false,
+    "category": "Developer Tools"
+  },
+  {
+    "owner": "jazzyalex",
+    "repo": "agent-sessions",
+    "name": "agent-sessions",
+    "description": "Native macOS session browser, agent cockpit, analytics, and limits tracker for Hermes agents and other coding-agent CLIs",
+    "stars": 586,
+    "url": "https://github.com/jazzyalex/agent-sessions",
+    "official": false,
+    "category": "Workspaces & GUIs"
+  },
+  {
+    "owner": "vectrocomputers",
+    "repo": "Hermes-Agent-Action-Plan",
+    "name": "Hermes-Agent-Action-Plan",
+    "description": "Privacy-first practical guidance for configuring and operating Hermes Agent effectively",
+    "stars": 16,
+    "url": "https://github.com/vectrocomputers/Hermes-Agent-Action-Plan",
+    "official": false,
+    "category": "Guides & Docs"
+  },
+  {
+    "owner": "xiaonancs",
+    "repo": "hermes-agent-study",
+    "name": "hermes-agent-study",
+    "description": "Chinese deep research series on Hermes Agent internals, OpenClaw lineage, self-evolution, and source-code architecture",
+    "stars": 20,
+    "url": "https://github.com/xiaonancs/hermes-agent-study",
+    "official": false,
+    "category": "Guides & Docs"
+  },
+  {
+    "owner": "carterwayneskhizeine",
+    "repo": "hermes-agent-windows-R",
+    "name": "hermes-agent-windows-R",
+    "description": "Windows-native adaptation fork of Hermes Agent with runtime, path, process, and terminal backend compatibility improvements",
+    "stars": 19,
+    "url": "https://github.com/carterwayneskhizeine/hermes-agent-windows-R",
+    "official": false,
+    "category": "Forks & Derivatives"
+  },
+  {
+    "owner": "sheawinkler",
+    "repo": "hermes-agent-ultra",
+    "name": "hermes-agent-ultra",
+    "description": "Rust-based Hermes Agent Ultra derivative focused on performance and Hermes Agent feature parity",
+    "stars": 35,
+    "url": "https://github.com/sheawinkler/hermes-agent-ultra",
+    "official": false,
+    "category": "Forks & Derivatives"
+  },
+  {
+    "owner": "AbuZar-Ansarii",
+    "repo": "Hermes-Agent-On-Android",
+    "name": "Hermes-Agent-On-Android",
+    "description": "Termux-based installer and guide for running Hermes Agent on Android devices",
+    "stars": 75,
+    "url": "https://github.com/AbuZar-Ansarii/Hermes-Agent-On-Android",
+    "official": false,
+    "category": "Deployment & Infra"
+  },
+  {
+    "owner": "jefferyjob",
+    "repo": "awesome-hermes-agent-zh",
+    "name": "awesome-hermes-agent-zh",
+    "description": "Chinese awesome list of practical Hermes Agent skills, tools, integrations, and resources",
+    "stars": 50,
+    "url": "https://github.com/jefferyjob/awesome-hermes-agent-zh",
+    "official": false,
+    "category": "Guides & Docs"
+  },
+  {
+    "owner": "anneheartrecord",
+    "repo": "hermes-agent-anatomy",
+    "name": "hermes-agent-anatomy",
+    "description": "Chinese Hermes Agent source-code anatomy and architecture analysis",
+    "stars": 48,
+    "url": "https://github.com/anneheartrecord/hermes-agent-anatomy",
+    "official": false,
+    "category": "Guides & Docs"
+  },
+  {
+    "owner": "nickvasilescu",
+    "repo": "hermes-desktop-os1",
+    "name": "hermes-desktop-os1",
+    "description": "Native macOS workspace for Hermes Agent running on Orgo cloud computers and SSH hosts",
+    "stars": 446,
+    "url": "https://github.com/nickvasilescu/hermes-desktop-os1",
+    "official": false,
+    "category": "Workspaces & GUIs"
+  },
+  {
+    "owner": "adityahimaone",
+    "repo": "hermes-agent-rtk-caveman",
+    "name": "hermes-agent-rtk-caveman",
+    "description": "Hermes Agent RTK and Caveman setup with preconfigured skills and token-saving CLI workflows",
+    "stars": 53,
+    "url": "https://github.com/adityahimaone/hermes-agent-rtk-caveman",
+    "official": false,
+    "category": "Developer Tools"
+  },
+  {
+    "owner": "pengchengxia75-arch",
+    "repo": "hermes-agent-windows",
+    "name": "hermes-agent-windows",
+    "description": "Windows-native Hermes Agent adaptation with one-line PowerShell installer and no WSL requirement",
+    "stars": 40,
+    "url": "https://github.com/pengchengxia75-arch/hermes-agent-windows",
+    "official": false,
+    "category": "Forks & Derivatives"
+  },
+  {
+    "owner": "ultraworkers",
+    "repo": "hermes-agent-helm-chart",
+    "name": "hermes-agent-helm-chart",
+    "description": "Unofficial community Helm chart for deploying Hermes Agent on Kubernetes with cloud-native state-safety guardrails",
+    "stars": 77,
+    "url": "https://github.com/ultraworkers/hermes-agent-helm-chart",
+    "official": false,
+    "category": "Deployment & Infra"
+  },
+  {
+    "owner": "ZeroPointRepo",
+    "repo": "youtube-skills",
+    "name": "youtube-skills",
+    "description": "YouTube transcript, search, channel, and playlist skills for Hermes Agent, OpenClaw, Claude Code, Cursor, and Windsurf",
+    "stars": 231,
+    "url": "https://github.com/ZeroPointRepo/youtube-skills",
+    "official": false,
+    "category": "Skills & Skill Registries"
+  },
+  {
+    "owner": "stainlu",
+    "repo": "hermes-labyrinth",
+    "name": "hermes-labyrinth",
+    "description": "Read-only observability plugin for Hermes Agent with journeys, crossings, guideposts, and reports",
+    "stars": 277,
+    "url": "https://github.com/stainlu/hermes-labyrinth",
+    "official": false,
+    "category": "Plugins & Extensions"
+  },
+  {
+    "owner": "marshallrichards",
+    "repo": "ClawPhone",
+    "name": "ClawPhone",
+    "description": "Scripts and notes for running agent CLIs including Hermes Agent on Android smartphones through Termux",
+    "stars": 528,
+    "url": "https://github.com/marshallrichards/ClawPhone",
+    "official": false,
+    "category": "Deployment & Infra"
+  },
+  {
+    "owner": "agent-of-empires",
+    "repo": "agent-of-empires",
+    "name": "agent-of-empires",
+    "description": "TUI and web control surface for managing multiple coding agents including Hermes Agent, Claude Code, OpenCode, Codex, Gemini, and others",
+    "stars": 2438,
+    "url": "https://github.com/agent-of-empires/agent-of-empires",
+    "official": false,
+    "category": "Multi-Agent & Orchestration"
+  },
+  {
+    "owner": "nexu-io",
+    "repo": "open-design",
+    "name": "open-design",
+    "description": "Local-first open-source design/prototyping system with coding-agent CLI support including Hermes Agent",
+    "stars": 54487,
+    "url": "https://github.com/nexu-io/open-design",
+    "official": false,
+    "category": "Skills & Skill Registries"
+  },
+  {
+    "owner": "farion1231",
+    "repo": "cc-switch",
+    "name": "cc-switch",
+    "description": "Cross-platform all-in-one manager for Claude Code, Codex, OpenCode, OpenClaw, Gemini CLI, and Hermes Agent",
+    "stars": 83424,
+    "url": "https://github.com/farion1231/cc-switch",
+    "official": false,
+    "category": "Workspaces & GUIs"
+  },
+  {
+    "owner": "iOfficeAI",
+    "repo": "AionUi",
+    "name": "AionUi",
+    "description": "Local open-source cowork app for OpenClaw, Hermes Agent, Claude Code, Codex, OpenCode, Gemini CLI, and other agent CLIs",
+    "stars": 26976,
+    "url": "https://github.com/iOfficeAI/AionUi",
+    "official": false,
+    "category": "Workspaces & GUIs"
+  },
+  {
     "owner": "numtide",
     "repo": "llm-agents.nix",
     "name": "llm-agents.nix",


### PR DESCRIPTION
## Summary
- accept reviewed repo-discovery issues that have explicit Hermes Agent support, first-class integrations, or Hermes-specific docs/forks/tools
- add 29 community entries to data/repos.json across Workspaces & GUIs, Developer Tools, Multi-Agent & Orchestration, Skills, Guides, Forks, Deployment, and Plugins
- keep all entries marked non-official so Ask the Atlas can surface them as ecosystem catalog data without treating them as authoritative official docs

## Noise-control decision
These are catalog entries, not official documentation. They improve ecosystem coverage, but the source-aware RAG scoring keeps official Hermes docs and curated Atlas policy content above community project pages for general Ask the Atlas answers.

## Test Plan
- repo JSON validation script passed
- `git diff --check`

Closes #243
Closes #242
Closes #241
Closes #240
Closes #239
Closes #224
Closes #223
Closes #222
Closes #221
Closes #220
Closes #219
Closes #187
Closes #186
Closes #185
Closes #184
Closes #183
Closes #182
Closes #181
Closes #180
Closes #166
Closes #165
Closes #164
Closes #163
Closes #162
Closes #161
Closes #160
Closes #159
Closes #158
Closes #157