### PR TITLE
Add repos.json validation gate

### DIFF
--- a/.github/workflows/validate-repos-json.yml
+++ b/.github/workflows/validate-repos-json.yml
@@ -1,0 +1,36 @@
+name: Validate repos.json
+
+on:
+  pull_request:
+    paths:
+      - 'data/repos.json'
+      - 'scripts/validate-repos-json.js'
+      - 'tests/validate-repos-json.test.js'
+      - '.github/workflows/validate-repos-json.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'data/repos.json'
+      - 'scripts/validate-repos-json.js'
+      - 'tests/validate-repos-json.test.js'
+      - '.github/workflows/validate-repos-json.yml'
+  workflow_dispatch: {}
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Run validation tests
+        run: node --test tests/validate-repos-json.test.js
+
+      - name: Validate data/repos.json
+        run: node scripts/validate-repos-json.js

--- a/scripts/validate-repos-json.js
+++ b/scripts/validate-repos-json.js
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const CANONICAL_CATEGORIES = [
+  "Core & Official",
+  "Deployment & Infra",
+  "Developer Tools",
+  "Domain Applications",
+  "Forks & Derivatives",
+  "Guides & Docs",
+  "Integrations & Bridges",
+  "Memory & Context",
+  "Multi-Agent & Orchestration",
+  "Plugins & Extensions",
+  "Skills & Skill Registries",
+  "Workspaces & GUIs",
+];
+
+const REQUIRED_FIELDS = [
+  "owner",
+  "repo",
+  "name",
+  "description",
+  "stars",
+  "url",
+  "official",
+  "category",
+];
+
+function labelFor(index) {
+  return `[${index}]`;
+}
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export function validateRepos(repos) {
+  const errors = [];
+
+  if (!Array.isArray(repos)) {
+    return ["repos.json must contain a top-level array"];
+  }
+
+  const seen = new Set();
+
+  repos.forEach((entry, index) => {
+    const label = labelFor(index);
+
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      errors.push(`${label} entry must be an object`);
+      return;
+    }
+
+    for (const field of REQUIRED_FIELDS) {
+      if (!(field in entry)) {
+        errors.push(`${label} missing required field: ${field}`);
+      }
+    }
+
+    if ("owner" in entry && !isNonEmptyString(entry.owner)) {
+      errors.push(`${label} owner must be a non-empty string`);
+    }
+
+    if ("repo" in entry && !isNonEmptyString(entry.repo)) {
+      errors.push(`${label} repo must be a non-empty string`);
+    }
+
+    if ("name" in entry && !isNonEmptyString(entry.name)) {
+      errors.push(`${label} name must be a non-empty string`);
+    }
+
+    if ("description" in entry && !isNonEmptyString(entry.description)) {
+      errors.push(`${label} description must be a non-empty string`);
+    }
+
+    let duplicateOwnerRepo = false;
+    if (isNonEmptyString(entry.owner) && isNonEmptyString(entry.repo)) {
+      const key = `${entry.owner.toLowerCase()}/${entry.repo.toLowerCase()}`;
+      if (seen.has(key)) {
+        errors.push(`${label} duplicate owner/repo: ${key}`);
+        duplicateOwnerRepo = true;
+      } else {
+        seen.add(key);
+      }
+    }
+
+    if (
+      "category" in entry &&
+      !CANONICAL_CATEGORIES.includes(entry.category)
+    ) {
+      errors.push(
+        `${label} category must be one of: ${CANONICAL_CATEGORIES.join(", ")}`,
+      );
+    }
+
+    if ("url" in entry && !isNonEmptyString(entry.url)) {
+      errors.push(`${label} url must be a non-empty string`);
+    }
+
+    if (
+      !duplicateOwnerRepo &&
+      isNonEmptyString(entry.owner) &&
+      isNonEmptyString(entry.repo) &&
+      isNonEmptyString(entry.url)
+    ) {
+      const expectedUrl = `https://github.com/${entry.owner}/${entry.repo}`;
+      if (entry.url.toLowerCase() !== expectedUrl.toLowerCase()) {
+        errors.push(`${label} url must match ${expectedUrl}`);
+      }
+    }
+
+    if ("official" in entry && typeof entry.official !== "boolean") {
+      errors.push(`${label} official must be boolean`);
+    }
+
+    if (
+      "stars" in entry &&
+      (!Number.isInteger(entry.stars) || entry.stars < 0)
+    ) {
+      errors.push(`${label} stars must be a non-negative integer`);
+    }
+  });
+
+  return errors;
+}
+
+function readReposJson(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch (error) {
+    return { parseError: error };
+  }
+}
+
+function main() {
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = path.dirname(__filename);
+  const repoRoot = path.resolve(__dirname, "..");
+  const reposPath = path.join(repoRoot, "data", "repos.json");
+  const parsed = readReposJson(reposPath);
+
+  if (parsed.parseError) {
+    console.error(`data/repos.json is not valid JSON: ${parsed.parseError.message}`);
+    process.exit(1);
+  }
+
+  const errors = validateRepos(parsed);
+  if (errors.length > 0) {
+    console.error("data/repos.json validation failed:");
+    for (const error of errors) {
+      console.error(`- ${error}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(`data/repos.json validation passed (${parsed.length} repos)`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/tests/validate-repos-json.test.js
+++ b/tests/validate-repos-json.test.js
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  validateRepos,
+  CANONICAL_CATEGORIES,
+} from "../scripts/validate-repos-json.js";
+
+const validRepo = {
+  owner: "example",
+  repo: "hermes-example",
+  name: "hermes-example",
+  description: "Example Hermes integration",
+  stars: 1,
+  url: "https://github.com/example/hermes-example",
+  official: false,
+  category: "Developer Tools",
+};
+
+test("validates a well-formed repos.json entry", () => {
+  assert.deepEqual(validateRepos([validRepo]), []);
+});
+
+test("reports missing required fields", () => {
+  const { owner, ...missingOwner } = validRepo;
+
+  assert.deepEqual(validateRepos([missingOwner]), [
+    "[0] missing required field: owner",
+  ]);
+});
+
+test("rejects duplicate owner/repo pairs case-insensitively", () => {
+  const duplicate = { ...validRepo, owner: "Example", repo: "Hermes-Example" };
+
+  assert.deepEqual(validateRepos([validRepo, duplicate]), [
+    "[1] duplicate owner/repo: example/hermes-example",
+  ]);
+});
+
+test("rejects invalid category, URL, official, and stars values", () => {
+  const badRepo = {
+    ...validRepo,
+    category: "Random Stuff",
+    url: "https://example.com/example/hermes-example",
+    official: "false",
+    stars: -1,
+  };
+
+  assert.deepEqual(validateRepos([badRepo]), [
+    `[0] category must be one of: ${CANONICAL_CATEGORIES.join(", ")}`,
+    "[0] url must match https://github.com/example/hermes-example",
+    "[0] official must be boolean",
+    "[0] stars must be a non-negative integer",
+  ]);
+});


### PR DESCRIPTION
## Summary
- Add a Node validator for data/repos.json required fields, canonical categories, duplicate owner/repo pairs, GitHub URL shape, official boolean values, and non-negative integer stars
- Add focused node:test coverage for the validator
- Add a PR/push workflow so catalog metadata changes are blocked before they can affect Ask the Atlas retrieval or project pages

## Test Plan
- node --test tests/validate-repos-json.test.js tests/build-artifacts.test.js
- node scripts/validate-repos-json.js
- git diff --check

Closes #234