### PR TITLE
Run smoke tests against PR previews

### DIFF
--- a/.github/workflows/smoke-test-pr.yml
+++ b/.github/workflows/smoke-test-pr.yml
@@ -1,0 +1,137 @@
+name: PR Preview Smoke Test
+
+# Runs the existing Atlas smoke test against the Vercel preview URL before merge.
+# This keeps Ask the Atlas/project-page regressions out of main: malformed data,
+# missing generated pages, sitemap drift, broken critical pages, and stale links
+# should fail the PR instead of becoming a production revert.
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'data/**'
+      - 'index.html'
+      - 'lib/**'
+      - 'api/**'
+      - 'scripts/build-pages.js'
+      - 'scripts/build-chunks.js'
+      - 'scripts/smoke-test-prod.js'
+      - '.github/workflows/smoke-test-pr.yml'
+
+concurrency:
+  group: pr-preview-smoke-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+      statuses: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+
+      - name: Wait for Vercel preview URL
+        id: vercel
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = context.payload.pull_request.head.sha;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const MAX_WAIT_MS = 10 * 60 * 1000;
+            const INTERVAL_MS = 15 * 1000;
+            const start = Date.now();
+            let lastState = null;
+
+            core.info(`Polling Vercel preview status for PR #${context.payload.pull_request.number} @ ${sha}`);
+
+            while (Date.now() - start < MAX_WAIT_MS) {
+              const { data } = await github.rest.repos.getCombinedStatusForRef({
+                owner,
+                repo,
+                ref: sha,
+              });
+              const vercel = data.statuses.find((status) => status.context === 'Vercel');
+              const state = vercel ? vercel.state : 'no-status-yet';
+              if (state !== lastState) {
+                core.info(`Vercel status: ${state}`);
+                lastState = state;
+              }
+
+              if (state === 'success') {
+                if (!vercel.target_url) {
+                  core.setFailed('Vercel status succeeded but did not expose a preview URL');
+                  return;
+                }
+                core.setOutput('base_url', vercel.target_url);
+                core.info(`Vercel preview ready: ${vercel.target_url}`);
+                return;
+              }
+
+              if (state === 'failure' || state === 'error') {
+                core.setFailed(`Vercel preview failed for ${sha}; smoke test skipped`);
+                return;
+              }
+
+              await new Promise((resolve) => setTimeout(resolve, INTERVAL_MS));
+            }
+
+            core.setFailed('Timed out waiting for Vercel preview deploy (10min)');
+
+      - name: Run smoke test against preview
+        id: smoke
+        env:
+          SMOKE_ALLOW_FAILURES: '/lists/,Core & Official count'
+        run: |
+          node scripts/smoke-test-prod.js \
+            --base "${{ steps.vercel.outputs.base_url }}" \
+            --sample "25" \
+            --continue \
+            | tee smoke-output.txt
+
+      - name: Comment with failure summary
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let smokeOutput = '';
+            try {
+              smokeOutput = fs.readFileSync('smoke-output.txt', 'utf8');
+            } catch (error) {
+              smokeOutput = '(smoke-output.txt not produced — check the workflow log)';
+            }
+
+            const body = [
+              'PR preview smoke test failed.',
+              '',
+              `**Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              '',
+              '```',
+              smokeOutput.slice(-3500),
+              '```',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body,
+            });


### PR DESCRIPTION
## Summary
- Add a dedicated PR Preview Smoke Test workflow
- Poll the PR head SHA for the Vercel status and extract the preview URL
- Run the existing smoke-test-prod.js suite against that preview with the current acknowledged-failure allow-list
- Comment a compact failure summary back on the PR when preview smoke fails

## Test Plan
- python YAML parse for .github/workflows/smoke-test-pr.yml
- node --test tests/validate-repos-json.test.js tests/build-artifacts.test.js
- node scripts/validate-repos-json.js
- git diff --check
- SMOKE_ALLOW_FAILURES='/lists/,Core & Official count' node scripts/smoke-test-prod.js --base https://hermesatlas.com --sample 3 --continue

Closes #235