### PR TITLE
fix: make latest release answers deterministic

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -1,5 +1,6 @@
 import { kvIncr, kvExpireNx } from "../lib/redis.js";
 import { combinedRetrievalScore, enrichChunkMetadata } from "../lib/rag-scoring.js";
+import { buildLatestReleaseBlock, detectLatestReleaseQuery } from "../lib/latest-release.js";
 import { readFileSync } from "fs";
 import { join } from "path";
 
@@ -7,6 +8,7 @@ import { join } from "path";
 let chunks = null;
 let bm25Index = null;
 let reposData = null;
+let latestReleaseData = null;
 
 function loadChunks() {
   if (chunks) return chunks;
@@ -30,6 +32,18 @@ function loadRepos() {
   } catch (e) {
     console.error("Failed to load repos.json:", e.message);
     return [];
+  }
+}
+
+function loadLatestRelease() {
+  if (latestReleaseData) return latestReleaseData;
+  try {
+    const raw = readFileSync(join(process.cwd(), "data", "latest-release.json"), "utf-8");
+    latestReleaseData = JSON.parse(raw);
+    return latestReleaseData;
+  } catch (e) {
+    console.error("Failed to load latest-release.json:", e.message);
+    return null;
   }
 }
 
@@ -371,11 +385,18 @@ export default async function handler(req, res) {
       }
     }
 
+    const needsLatestRelease = detectLatestReleaseQuery(`${message}\n${searchQuery}`);
+    const latestRelease = needsLatestRelease ? loadLatestRelease() : null;
+    const latestReleaseBlock = latestRelease ? `\n\n${buildLatestReleaseBlock(latestRelease)}\n` : "";
+    if (latestReleaseBlock) {
+      console.log(`[RAG] Injected latest release metadata (${latestRelease.version}/${latestRelease.tag || "no tag"})`);
+    }
+
     // 4. Build context: ALWAYS include baseline + retrieved chunks
     // This prevents vague queries from getting weak answers due to bad retrieval
     const baselineContext = `## CORE FACTS (always true)
 
-Hermes Agent is an open-source autonomous AI agent developed by Nous Research, released in February 2026 under MIT license. It currently has 83,000+ stars on GitHub (v0.9.0 released April 13, 2026).
+Hermes Agent is an open-source autonomous AI agent developed by Nous Research, released in February 2026 under MIT license.
 
 **What makes it unique:** Unlike stateless chatbots, Hermes has a built-in learning loop — it creates reusable skills from experience, remembers what it learns across sessions via persistent memory (MEMORY.md + USER.md + SQLite FTS5), and gets more capable the longer you use it. It's "the agent that grows with you."
 
@@ -386,8 +407,6 @@ Hermes Agent is an open-source autonomous AI agent developed by Nous Research, r
 - 6 execution backends (local, Docker, SSH, Singularity, Modal, Daytona)
 - Autonomous skill creation following agentskills.io standard
 - Persistent cross-session memory with 8 pluggable memory providers
-
-**Latest release (v0.9.0, April 13 2026):** Local web dashboard, Fast Mode (/fast) for GPT-5.4/Codex/Claude, iMessage via BlueBubbles, WeChat + WeCom native support, Termux/Android native, background process monitoring (watch_patterns), pluggable context engine, xAI (Grok) + Xiaomi MiMo + Qwen native providers, unified proxy support, 16 security fixes. 487 commits, 269 PRs, 24 contributors.
 
 **Installation:** One-line install on Linux/macOS/WSL2:
 \`curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash\`
@@ -405,7 +424,8 @@ Then run \`hermes\` to start. Only Git is required as a prerequisite — the ins
 ANSWER RULES:
 - Start with a direct, complete answer. NEVER say "I don't have details" or "specific details are not in the context" when the CORE FACTS or RETRIEVED CONTEXT sections contain relevant information. Always synthesize what you DO have.
 - Don't hedge with "based on the context" or "based on the available records."
-- Use the CORE FACTS section as your baseline — those are always true. The "Latest release" line in CORE FACTS contains headline features that you MUST use when asked about the latest or newest release.
+- Use the CORE FACTS section as your baseline — those are always true.
+- If a LATEST RELEASE section is present, treat it as authoritative for latest/newest/current release questions and prefer it over older retrieved release notes.
 - Use the RETRIEVED CONTEXT section for specific details, recent updates, and tool recommendations.
 - Prefer official_docs and curated_atlas sources when context conflicts. Treat catalog/generated pages as lookup sources, not broad product overviews, unless the user is asking about skills/catalogs.
 - For ranking/comparison/recommendation questions, use the REPO METADATA section for accurate star counts.
@@ -417,7 +437,7 @@ ANSWER RULES:
 - ALWAYS mention exact star counts from REPO METADATA when comparing or recommending repos.
 - If a question truly isn't covered by any of your sources, say so — but ONLY after checking CORE FACTS, RETRIEVED CONTEXT, and REPO METADATA. Do not give up prematurely.
 
-${baselineContext}
+${baselineContext}${latestReleaseBlock}
 
 ## RETRIEVED CONTEXT (relevant to this specific question)
 

--- a/data/latest-release.json
+++ b/data/latest-release.json
@@ -1,0 +1,9 @@
+{
+  "version": "v0.15.1",
+  "tag": "v2026.5.29",
+  "name": "Hermes Agent v0.15.1 (v2026.5.29)",
+  "publishedAt": "2026-05-29T01:12:15Z",
+  "source": "research/46-release-2026-5-29.md",
+  "sourceUrl": "https://github.com/NousResearch/hermes-agent/releases/tag/v2026.5.29",
+  "summary": "The Patch Release. A same-day hotfix for v0.15.0. Headline fix: the dashboard infinite-reload loop that hit anyone running v0.15.0 in loopback mode (Docker, hosted Hermes, fresh installs). A handful of other v0.15.0 follow-ups go along for the ride — kanban worker SIGTERM, /model picker unification, /yolo session bypass, the full 19,932-entry skills.sh catalog, .md media delivery restoration, gateway probe-stepdown safety, web-URL redaction passthrough, kanban worker vision on referenced images, hindsight observation-default. Docker users get an explicit --insecure opt-in env var (no more bind-host inference), MCP server bare-command PATH resolution, and arm64 PR-build cache fixes."
+}

--- a/lib/build-artifacts.js
+++ b/lib/build-artifacts.js
@@ -13,6 +13,7 @@ export const GENERATED_ARTIFACT_PATHS = [
   "data/repos.json",
   "data/summaries.json",
   "data/list-summaries.json",
+  "data/latest-release.json",
 ];
 
 export function git(args, options = {}) {

--- a/lib/latest-release.js
+++ b/lib/latest-release.js
@@ -1,0 +1,84 @@
+const LATEST_RELEASE_QUERY_RE = /\b(latest|newest|current|recent)\b[\s\S]{0,80}\b(release|version|update|what'?s new|changed|changelog)\b|\bwhat'?s new\b[\s\S]{0,80}\b(release|version|hermes)\b/i;
+
+export function detectLatestReleaseQuery(query) {
+  return LATEST_RELEASE_QUERY_RE.test(String(query || ""));
+}
+
+export function parseReleaseMarkdown({ source, content }) {
+  const text = String(content || "");
+  const tag = firstMatch(text, /\*\*Version:\*\*\s*([^\n]+)/i) || firstMatch(source, /release-([0-9-]+)\.md$/i)?.replace(/-/g, ".");
+  const publishedAt = firstMatch(text, /\*\*Published:\*\*\s*([^\n]+)/i);
+  const sourceUrl = firstMatch(text, /\*\*Source:\*\*\s*([^\n]+)/i);
+
+  const releaseHeading = findPublicVersionHeading(text);
+  const version = firstMatch(releaseHeading, /(v\d+\.\d+\.\d+)/i) || normalizeReleaseTag(tag);
+  const name = releaseHeading ? `Hermes Agent ${releaseHeading}` : `Hermes Agent ${version || tag}`;
+
+  if (!version || !publishedAt) return null;
+
+  return {
+    version,
+    tag: tag?.trim(),
+    name,
+    publishedAt: publishedAt.trim(),
+    source,
+    sourceUrl: sourceUrl?.trim(),
+    summary: extractReleaseSummary(text),
+  };
+}
+
+export function findLatestReleaseFromMarkdownFiles(files) {
+  return files
+    .map(parseReleaseMarkdown)
+    .filter(Boolean)
+    .sort((a, b) => Date.parse(b.publishedAt) - Date.parse(a.publishedAt))[0] || null;
+}
+
+export function buildLatestReleaseBlock(latestRelease) {
+  if (!latestRelease?.version) return "";
+
+  const parts = [
+    "## LATEST RELEASE (authoritative)",
+    `${latestRelease.name || `Hermes Agent ${latestRelease.version}`} is the latest known Hermes Agent release${latestRelease.tag ? ` (${latestRelease.tag})` : ""}.`,
+    latestRelease.publishedAt ? `Published: ${latestRelease.publishedAt}.` : null,
+    latestRelease.source ? `Source: ${latestRelease.source}.` : null,
+    "When the user asks about the latest/newest/current Hermes release, use this release as the answer anchor even if older release notes also appear in retrieved context.",
+    latestRelease.summary ? `Headline: ${latestRelease.summary}` : null,
+  ].filter(Boolean);
+
+  return parts.join("\n");
+}
+
+function firstMatch(text, regex) {
+  return String(text || "").match(regex)?.[1]?.trim() || null;
+}
+
+function findPublicVersionHeading(text) {
+  const headings = [...String(text || "").matchAll(/^#\s+Hermes Agent\s+(v\d+\.\d+\.\d+[^\n]*)/gmi)]
+    .map((m) => m[1].trim());
+
+  return headings.find((heading) => !/^v20\d{2}\.\d{1,2}\.\d{1,2}\b/.test(heading)) || headings[0] || null;
+}
+
+function normalizeReleaseTag(tag) {
+  const cleaned = String(tag || "").trim();
+  return /^v\d+\.\d+\.\d+$/i.test(cleaned) ? cleaned : null;
+}
+
+function extractReleaseSummary(text) {
+  const blockquote = firstMatch(text, /^>\s+(.+)$/mi);
+  if (blockquote) return stripMarkdown(blockquote);
+
+  const firstBullet = firstMatch(text, /^-\s+(.+)$/mi);
+  if (firstBullet) return stripMarkdown(firstBullet);
+
+  return "";
+}
+
+function stripMarkdown(text) {
+  return String(text || "")
+    .replace(/\[([^\]]+)\]\([^\)]+\)/g, "$1")
+    .replace(/[*_`#>]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}

--- a/scripts/build-chunks.js
+++ b/scripts/build-chunks.js
@@ -13,6 +13,7 @@ import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 import { enrichChunkMetadata } from "../lib/rag-scoring.js";
+import { findLatestReleaseFromMarkdownFiles } from "../lib/latest-release.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..");
@@ -83,11 +84,16 @@ async function main() {
 
   console.log(`Found ${files.length} files to process`);
 
+  const markdownFiles = files.map((file) => ({
+    source: file.source,
+    content: fs.readFileSync(file.path, "utf-8"),
+  }));
+  writeLatestReleaseMetadata(markdownFiles);
+
   // Chunk all files
   const chunks = [];
-  for (const file of files) {
-    const content = fs.readFileSync(file.path, "utf-8");
-    const fileChunks = chunkText(content, file.source);
+  for (const file of markdownFiles) {
+    const fileChunks = chunkText(file.content, file.source);
     chunks.push(...fileChunks);
   }
 
@@ -119,6 +125,19 @@ async function main() {
 
   const sizeMB = (fs.statSync(outputPath).size / 1024 / 1024).toFixed(1);
   console.log(`\nWrote ${outputPath} (${sizeMB} MB)`);
+}
+
+function writeLatestReleaseMetadata(markdownFiles) {
+  const latestRelease = findLatestReleaseFromMarkdownFiles(markdownFiles);
+  if (!latestRelease) {
+    console.warn("No release markdown found; skipping data/latest-release.json");
+    return;
+  }
+
+  const outputPath = path.join(ROOT, "data", "latest-release.json");
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, `${JSON.stringify(latestRelease, null, 2)}\n`);
+  console.log(`Latest release metadata: ${latestRelease.version} (${latestRelease.tag || "no tag"})`);
 }
 
 function* walkMarkdown(dir) {

--- a/tests/build-artifacts.test.js
+++ b/tests/build-artifacts.test.js
@@ -21,6 +21,7 @@ test("generated artifact manifest covers current build outputs", () => {
     "data/repos.json",
     "data/summaries.json",
     "data/list-summaries.json",
+    "data/latest-release.json",
   ]);
 });
 

--- a/tests/latest-release.test.js
+++ b/tests/latest-release.test.js
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  buildLatestReleaseBlock,
+  detectLatestReleaseQuery,
+  findLatestReleaseFromMarkdownFiles,
+  parseReleaseMarkdown,
+} from "../lib/latest-release.js";
+
+test("parseReleaseMarkdown extracts public version, release tag, and publish date", () => {
+  const release = parseReleaseMarkdown({
+    source: "research/46-release-2026-5-29.md",
+    content: [
+      "# Hermes Agent v2026.5.29 Release Notes",
+      "",
+      "**Version:** v2026.5.29",
+      "**Published:** 2026-05-29T01:12:15Z",
+      "**Source:** https://github.com/NousResearch/hermes-agent/releases/tag/v2026.5.29",
+      "",
+      "# Hermes Agent v0.15.1 (v2026.5.29)",
+      "",
+      "> **The Patch Release.** A same-day hotfix for v0.15.0.",
+    ].join("\n"),
+  });
+
+  assert.equal(release.version, "v0.15.1");
+  assert.equal(release.tag, "v2026.5.29");
+  assert.equal(release.publishedAt, "2026-05-29T01:12:15Z");
+  assert.equal(release.source, "research/46-release-2026-5-29.md");
+  assert.match(release.summary, /same-day hotfix/);
+});
+
+test("findLatestReleaseFromMarkdownFiles chooses newest Published date", () => {
+  const latest = findLatestReleaseFromMarkdownFiles([
+    {
+      source: "research/34-release-2026-4-23.md",
+      content: "**Version:** v2026.4.23\n**Published:** 2026-04-23T22:32:13Z\n# Hermes Agent v0.11.0 (v2026.4.23)",
+    },
+    {
+      source: "research/46-release-2026-5-29.md",
+      content: "**Version:** v2026.5.29\n**Published:** 2026-05-29T01:12:15Z\n# Hermes Agent v0.15.1 (v2026.5.29)",
+    },
+  ]);
+
+  assert.equal(latest.version, "v0.15.1");
+  assert.equal(latest.tag, "v2026.5.29");
+});
+
+test("detectLatestReleaseQuery catches newest/latest what's-new questions", () => {
+  assert.equal(detectLatestReleaseQuery("what's new in the latest hermes release?"), true);
+  assert.equal(detectLatestReleaseQuery("what changed in the newest release"), true);
+  assert.equal(detectLatestReleaseQuery("how do I install Hermes?"), false);
+});
+
+test("buildLatestReleaseBlock tells the model to use v0.15.1 as latest", () => {
+  const block = buildLatestReleaseBlock({
+    version: "v0.15.1",
+    tag: "v2026.5.29",
+    name: "Hermes Agent v0.15.1 (2026.5.29) — The Patch Release",
+    publishedAt: "2026-05-29T01:12:15Z",
+    source: "research/46-release-2026-5-29.md",
+    summary: "A same-day hotfix for v0.15.0.",
+  });
+
+  assert.match(block, /Hermes Agent v0\.15\.1/);
+  assert.match(block, /v2026\.5\.29/);
+  assert.match(block, /latest known Hermes Agent release/i);
+  assert.doesNotMatch(block, /v0\.11\.0/);
+});


### PR DESCRIPTION
## Summary
- add data/latest-release.json generated from release markdown by newest Published timestamp
- inject an authoritative LATEST RELEASE block for latest/newest/current release queries
- remove stale hard-coded v0.9.0 latest-release prompt text
- add regression coverage for v0.15.1/latest-release detection and artifact staging

## Test Plan
- node --test tests/*.test.js

## Verification
- Current production still answers the latest-release prompt with v0.11.0 before this fix deploys, confirming the bug path.