### PR TITLE
Add Hermes memory guidebook

### DIFF
--- a/drafts/guide-memory.md
+++ b/drafts/guide-memory.md
@@ -1,0 +1,231 @@
+# The Hermes Agent Memory Guidebook
+
+By [Kevin Simback](https://x.com/KSimback) · Published on X, May 23, 2026
+
+Source: https://x.com/KSimback/status/2058262328496554021
+
+TLDR: this is your definitive guide to all things related to memory systems for Hermes Agent. Why create this? Because every week I see new posts or articles describing some new memory tool for Hermes agents and these make me question if my memory setup is the best. So I dug into all of them and broke it down for you.
+
+Over the past few months my Hermes agent has been mapping the Hermes ecosystem over at hermesatlas.com. One of the key areas it has covered is memory and it even has a dedicated section for it.
+
+And let's be honest, there are a LOT of memory related tools available and there are a LOT of write-ups about them. I see new articles on X every week about some new memory setup. It's hard to keep up, and even harder to know if you're doing it all wrong because they all make claims about how certain memory systems are better than others.
+
+But many of these write-ups skip the architecture (how memory works in Hermes) or conflate different elements of the memory stack. This article is the culmination of everything I've learned about Hermes agent memory and a guide to help you navigate what makes most sense for your setup.
+
+## Memory is arguably the most important element of an agent setup
+
+Without memory, an agent is just a stateless function and no different than a blank ChatGPT window. Every prompt looks like the first prompt. That works for one-shot questions but breaks down the moment you have a use case that needs to know what happened yesterday, remember your preferences, accumulate skills from prior tasks, or coordinate with another agent.
+
+A coding session that doesn't remember the conventions you established last Tuesday will reinvent them this Tuesday. A personal assistant agent that doesn't remember your preferences has to ask you the same repeated questions. Without memory, an agent really isn't an agent at all.
+
+Memory is what turns an chatbot into something that compounds. Which is why every serious agent harness - OpenClaw, Claude Code, Codex, and our beloved Hermes - has memory primitives built in, and why a real product category has emerged around dedicated memory infrastructure or agents (Mem0 raised $24M, Letta $10M, plus Zep, Cipher, Supermemory, Hindsight, etc.).
+
+The Hermes Agent take is interesting because Nous Research treats memory as first-class plug-in infrastructure, not a feature. There's a base layer that always runs, a pluggable provider system that lets you choose from 8 architectures (or write your own), and a healthy community plug-in layer on top.
+
+That 3-layer stack is what I will explore in depth in this article.
+
+## Hermes Agent memory architecture at a glance
+
+Here's what each layer means for you as a Hermes user.
+
+Layer 1 - what ships in the box. You get this whether you do anything or not. Two small markdown files the agent uses as its always-visible notebook, plus a local database that archives every session you've ever had. No setup, no config. For many use cases, this is often all you need.
+
+Layer 2 - the optional plug-in slot. When you outgrow the native layer (you want semantic recall across sessions, or a system that models your preferences, or token-efficient retrieval at scale) you pick one of 8 official providers. They each take a different architectural bet about what memory should do, and you can run exactly one at a time. Switching providers is a clean start - the new provider doesn't inherit the old one's data, but the Layer 1 native files keep running underneath either way.
+
+Layer 3 - what the community builds beyond the official 8. Two flavors. Some community projects are MemoryProvider plug-ins that compete head-to-head with the Layer 2 picks (Mnemosyne is the standout - fully local, sub-millisecond, with a real tiered cognitive architecture). Others sit alongside the official providers in a different slot entirely (GBrain is the standout here - it stores world facts like people, companies, and projects in a markdown vault, while your Layer 2 provider handles operational memory). Layer 3 usually means more setup and less polish than the official 8, but it's where you go when you need a capability the eight providers don't offer.
+
+The layers stack rather than replace each other. Switching the Layer 2 provider does not wipe Layer 1. Each provider has its own store, but the native session database and the two markdown files keep running underneath. Layer 3 plug-ins are additive on top of both.
+
+## Layer 1: Native - what you get out of the box
+
+The native layer is three things that ship with every Hermes install: two small markdown files and one database. They play different roles, and it's worth understanding each before we get to the plug-in providers.
+
+Note: if you already understand the out of box setup or want to skip to the optional stuff you can install on top, go to Layer 2.
+
+## The two markdown files
+
+When you install Hermes, it creates two text files in your home directory at ~/.hermes/:
+
+MEMORY.md - the agent's general knowledge notebook. Project context, technical decisions, things worth remembering across sessions. Capped at about 2,200 characters, roughly a paragraph and a half.
+
+USER.md - what the agent knows about you specifically. Your preferences, your working style, your role. Capped at about 1,375 characters, roughly one paragraph.
+
+You can open both files in any text editor. They're plain markdown. You can even edit them by hand if you want, and the agent will read your edits next session.
+
+The reason they're so small is that they aren't the agent's filing cabinet - they're the agent's sticky notes. At the start of every session, Hermes pastes the entire contents of both files into the prompt sent to the model. So everything in these files is always "in front of" the agent. No retrieval needed, it just sees them.
+
+The agent itself decides what goes into these files. When something important comes up in a session - you say "I prefer bullet points instead of paragraphs" or the agent figures out that you use Vercel for deployments - the agent calls a tool called memory with one of three actions: add, replace, or remove. There's no read action because the files are already pasted into the prompt; the agent reads them by virtue of looking at its own context.
+
+## What happens when the files fill up?
+
+This is where most third-party write-ups get things wrong. They claim Hermes automatically consolidates the files when they hit 80% of the cap. I went into the code at agent/memory_manager.py to verify, and the actual behavior is more interesting:
+
+There is no automatic consolidation - the 80% rule is a prompt instruction, not code. The system prompt header shows the agent a real-time fill gauge - something like "MEMORY: 1,847/2,200 chars (84 percent)" - along with the instruction "when memory is above 80% capacity, consolidate entries before adding new ones." The agent reads that, and the agent decides whether to act on it. If the file is already at the cap and the agent tries to add anything anyway, the memory tool returns an error listing the current entries and forces the agent to free space via replace or remove first.
+
+This is a deliberate design choice. Nous trusts the model to manage its own notebook. The upside is full agent control, but the downside is also full agent control. A poorly-prompted agent can sit at the cap indefinitely, refusing every new add call and quietly losing information that should have replaced something older, but I'm confident this gets resolved soon as there's some PRs around this.
+
+A related point of confusion worth clearing up before we go on: v0.12 introduced something called the "Autonomous Curator" and many write-ups describe it as automatic memory management. It is not. The Curator operates only on the agent's skill library at ~/.hermes/skills/ - moving skills from active to stale to archived based on usage. It never touches MEMORY.md or USER.md.
+
+## The database (and how it relates to the markdown files)
+
+The two markdown files are the agent's always-visible notes. The database is the agent's full archive of everything that has ever happened.
+
+Hermes stores every session in a SQLite database file at ~/.hermes/hermes_state.db. Every user message, every agent response, every tool call, every reasoning step, plus economic data like token counts and dollar cost per session - all of it lands here. Default retention is 90 days; older sessions get pruned automatically every 24 hours unless you change the setting.
+
+This database is not auto-injected into prompts. It would be enormous - imagine pasting your entire chat history into every new conversation. Instead, the agent searches it on demand when it needs to find something specific.
+
+The search uses SQLite's built-in full-text search (FTS5), and Hermes maintains two parallel indexes: one for normal word-level search ("did we discuss the content strategy?") and one for trigram search that handles substrings and code tokens ("find every session where I mentioned github").
+
+So the mental model is:
+
+The two markdown files = what the agent always has in its head. Small, curated, always present in every prompt.
+
+The session database = what the agent can look up if it knows what to look for. Huge, raw, searchable on demand.
+
+These are complementary, not redundant. When something matters across all future sessions, the agent should write it to MEMORY.md so it's always present. When something might matter again but doesn't need to be top-of-mind, it lives in the session database and gets pulled up only when the agent searches for it.
+
+A nice side-effect of the database design: because Hermes captures every reasoning step and every tool call with full economic data, the database is also a complete training trajectory if you ever want to export it. This is beyond the scope of this article but something that aligns with my thesis on where the moats are in agents.
+
+## Layer 2: The pluggable "MemoryProvider" system
+
+This is the layer that lets you graduate from "small notebook plus searchable archive" to a real memory system - one that extracts facts from your conversations automatically, builds a profile of you, supports semantic recall across sessions, or handles a large knowledge graph.
+
+Setting this up is quite simple - you run "hermes memory setup", pick a provider from the menu, and from then on the agent has a richer memory layer to draw from on top of the native files. Note: some providers require API keys and paid plans.
+
+The important note is you can only run one provider at a time. Hermes treats this as a single deliberate choice, not a stack of bolt-ons.
+
+That keeps your tool surface clean - each provider exposes its own set of agent tools, and the agent would get confused if there were three competing "search memory" tools sitting in front of it - and it makes the configuration easy to reason about. The Layer 1 native files keep running underneath whether you have a provider active or not.
+
+Picking the right provider matters because they make very different architectural bets. Some are aggressive at extracting facts. Some build a model of how you think rather than what you said. Some are obsessed with token efficiency. Some are graph-first. The full decision tree is later in this article; the technical mechanics below are for readers who want to know what providers actually plug into.
+
+Let's dive in.
+
+## The 8 Official Providers
+
+## Honcho (Plastic Labs) - AI-native dialectic user modeling
+
+The only provider in the lineup that tries to model how you think, not just what you said. Instead of storing flat facts like "Kevin uses 4-space indents," Honcho runs a multi-step reasoning pass after your conversations to build a profile of your reasoning patterns, preferences, and goals.
+
+That profile evolves over time, so the agent gets better at anticipating what you'd want even on topics you've never discussed. It also lets multiple "AI identities" share the same view of you - useful if you run different specialist agents for coding, writing, and strategy and want all of them to know your style. Most-cited favorite in the Hermes Discord (@offendingcommit: "I've tried them all... I freakin' love Honcho.").
+
+## Mem0 - fastest 30-second setup, broadest ecosystem
+
+The "just give me memory and stop asking questions" pick. You sign up for Mem0 cloud, paste an API key, and you're done - the provider extracts facts from conversations, deduplicates them, and serves up semantic search automatically in the background.
+
+It's also the exclusive memory provider for AWS's Strands Agents SDK, which gives it the widest ecosystem reach in the lineup. In April 2026 Mem0 shipped a "v3" algorithm claiming to leapfrog Hindsight on benchmarks (94.8 on LongMemEval, 91.6 on LoCoMo).
+
+## Hindsight (Vectorize.io) - the benchmark king
+
+The first memory system of any kind to publicly cross 90 on LongMemEval (91.4, December 2025). Hindsight thinks about memory as four separate networks - things about the world, things that happened, opinions, and raw observations - and pulls only a handful of high-value facts from each conversation (2 to 5, not one per sentence).
+
+When you ask it something, it runs four different retrieval strategies in parallel - keyword search, vector similarity, graph traversal across related entities, and a recency pass - then fuses the results. That's how it gets the best recall accuracy in the published lineup.
+
+It's also the only provider with a reflect tool that lets the agent run a reasoning pass over its own memory. That's uniquely valuable if you're running multiple agents on a shared memory bank and you need an orchestrator to synthesize what all of them know.
+
+## Holographic - zero-dependency, fully local, air-gapped
+
+The only provider in the lineup that needs no internet, no API key, and no LLM to function. Everything lives in a local SQLite file. It uses a 1991-era technique called Holographic Reduced Representations to do compositional reasoning over facts - you can bind concepts together algebraically and probe for related ones later. Retrieval is sub-millisecond because it's pure local SQL.
+
+## OpenViking - tiered filesystem context DB
+
+Your memory lives as files in a directory tree on your disk. You can cat them, grep them, edit them by hand. Each piece of stored knowledge has three loading tiers: a one-sentence summary, a paragraph-level overview, and the full content.
+
+When the agent recalls something, it starts cheap (summaries only) and only loads the deeper tiers if the summary looks relevant. That structure is important if you're cost-sensitive at scale or you want memory you can read and edit like normal files.
+
+## RetainDB - cheapest paid tier, lowest friction
+
+$20/month for 100,000 queries, with a free tier of 10,000 operations to test. The only provider in the lineup that's cloud-only at every price point (no self-host even on enterprise). The hook is convenience: you operate no infrastructure, RetainDB handles everything, and there's a "Memory Router" mode that intercepts your LLM calls and adds memory transparently with one config line.
+
+Pick this option if you want shared memory across team members or agents and you don't want to operate a database.
+
+## ByteRover - memory as a git repo
+
+Your memory is plain markdown files in a .brv/context-tree/ directory - grep-able, version-controllable, no database to run. ByteRover layers a 5-tier retrieval system on top, and four of those tiers don't need an LLM call, so most lookups finish in under 100ms with zero token spend.
+
+The key selling point: you can branch, merge, and roll back memory like code with CLI commands. It also uses a special hook to extract high-value insights before Hermes compresses context, which is the cleanest fix in the lineup for the "agent loses memory after restart" failure mode (noted in issue #17251).
+
+## Supermemory - latency + scale leader
+
+Sub-300ms recall sustained at over 100 billion tokens per month. Supermemory built a custom vector graph engine for this rather than stapling a vector DB and a graph DB together.
+
+Its standout feature is context fencing: it automatically strips already-recalled memories out of conversations before storing them, which kills the "memory feedback loop" where auto-capture systems start re-ingesting their own outputs into the next round of memory.
+
+Good choice if you want to operate at real scale (consumer app, multi-tenant SaaS, agent platform) and latency matters, but likely overkill for normal consumer use.
+
+Here's a comparative look across all 8
+
+## Layer 3: Community plug-ins worth knowing
+
+If none of the official 8 fits your use case, or if you want even more on top, the community has built another layer of memory tooling for Hermes. About five of these are production-quality enough to consider seriously, plus a longer tail of experiments to keep eyes on.
+
+Two things to know up front about Layer 3:
+
+Not every Layer 3 project competes with Layer 2. Some are alternative MemoryProvider plug-ins you'd pick instead of one of the official 8 (Mnemosyne is the clearest example). Others occupy a different role entirely - they store a different type of memory and run alongside your Layer 2 provider, not in place of it (GBrain is the clearest example, storing world facts about people, companies, and projects in a separate brain layer while your Layer 2 provider handles operational memory).
+
+You give up polish to get capability. The official 8 ship with Nous's review and tend to "just work." Community plug-ins are typically a bit rougher on the install, have fewer docs, and more chance of hitting a bug. But they unlock things the official set doesn't offer like fully-local sub-millisecond retrieval (Mnemosyne), a markdown-and-Postgres knowledge graph that builds itself with zero LLM calls (GBrain), explainable retrieval rankings (yantrikdb), and cross-agent memory portability (PLUR).
+
+The safe path if you're committing to a memory stack for real work: start with one of the official 8 and only reach for Layer 3 when you've identified a specific capability gap a community project fills. The standouts below are GBrain and Mnemosyne.
+
+## GBrain (by garrytan) - this is what I personally use
+
+Open-sourced in April, MIT licensed, ~18k+ stars. TypeScript. Built by Garry Tan to run his own production agents. GBrain is structurally different from the official 8. GBrain does not subclass MemoryProvider, it plugs in as skillpack + MCP server (~30 MCP tools), and occupys a different ontological slot. The explicit doctrine in docs/guides/brain-vs-memory.md:
+
+What makes it special:
+
+Not just RAG: a full 8-layer knowledge engine for dramatically better memory and recall
+
+Epistemology layer: tracks “who said what, when, and with what confidence” so no more hallucinated facts or lost context
+
+Self-wiring knowledge graph: automatically extracts entities and creates real relationships (e.g., “attended,” “works_at,” “invested_in,” “founded”) with zero extra LLM calls
+
+Dream cycles for autonomous synthesis: runs overnight (or on-demand) so your brain literally gets smarter while you sleep
+
+Hybrid search done right: combines vector, keyword, RRF fusion, multi-query expansion, cosine reranking, compiled-truth boost, and backlink boost for far more accurate results than plain vector search
+
+Specialized + versioned chunking: recursive markdown chunker (v4) that intelligently handles code blocks, frontmatter, transcripts, etc. so edits don’t break memory
+
+Autonomous enrichment + persistent personal memory: tiered enrichment based on how often something is mentioned turning Hermes agent into a “clairvoyant” personal AI that actually knows you
+
+Why pick GBrain over the official 8? If you want a graph cheap, git as system of record, overnight maintenance, you already have a markdown vault (migration covers Obsidian / Logseq / Notion / Roam), or you're building a "company of agents."
+
+## Mnemosyne (AxDSan/mnemosyne)
+
+The strongest community alternative when you want a real MemoryProvider plug-in (rather than GBrain, which plays a different role). Runs entirely on your machine - no cloud, no API key, no internet - and recall is fast enough to feel instant (under 2 milliseconds in published tests).
+
+What makes Mnemosyne interesting is its tiered memory architecture, modeled loosely on how humans handle short-term vs long-term memory. There's a "working" tier for what's actively relevant right now, an "episodic" tier for time-stamped events you might want to look up later, and a "scratchpad" for things still being considered for promotion. A consolidation pass runs periodically in the background to move useful items into long-term memory and prune the noise.
+
+The standout feature for serious users: memory has a sense of time. You can ask "what did I believe about X last Tuesday?" and get back the agent's understanding as it was at that point, not as it is today. No other Hermes plug-in does this as cleanly. One soft adoption signal worth noticing: Mnemosyne is the only community memory plug-in that someone has bothered to write a dedicated Hermes skill wrapper for (a small file that teaches the agent how to use it intelligently). Nobody's done that for the others.
+
+## Others worth knowing about
+
+Ladybug Memory - the local-only option with built-in importance ranking. Every memory gets a score from 1 to 10 so the system surfaces the things that matter first instead of treating everything equally. Pick it if you want fully-local memory and the built-in MEMORY.md cap is too small for your knowledge.
+
+yantrikdb - he one to pick when you need to know why the agent recalled what it did. Every retrieval comes back with a "why retrieved" explanation, which is useful for debugging when the agent surfaces the wrong thing or for high-trust contexts where you need to audit what's shaping the agent's responses. Runs embedded out of the box, no separate database to manage.
+
+hermes-agentmemory - a community fix for a real Hermes problem: when you tell the agent to forget something, it doesn't actually forget - it keeps an internal summary that quietly influences future recall. This provider does real deletion (gone is gone) and logs every memory operation so you can audit what happened. Pick it if compliance, privacy, or user-controlled forgetting matters.
+
+PLUR - the cross-agent memory bridge. Hermes memory normally doesn't reach Cursor, and Cursor's doesn't reach Claude Code. PLUR stores everything in a shared .plur/ folder that all of them can read, so a fact you teach one agent automatically shows up in the others. Pick it if you work across multiple agents on the same project and don't want to teach each one separately.
+
+FlowState-QMD - The "guess what you'll need next" provider. It tries to predict the agent's next likely query and warms up that memory in advance, so by the time the agent actually searches, the result is already cached and responses come back faster. Pick it if your agent does repetitive long-horizon work where the next step is usually guessable from context.
+
+One thing I expected to find that doesn't exist: memory-as-skill is effectively a non-pattern. The agentskills.io standard means a "skill" could in principle implement memory. In practice all credible persistent memory flows through the MemoryProvider ABC. Even skills that "do memory" (the Mnemosyne SKILL.md, for instance) are wrappers around plug-ins, telling the agent how to use them.
+
+## How to actually pick?
+
+Step 1: pick your layer strategy
+
+Step 2: pick your layer 2 system
+
+## Warning signs you went too heavy:
+
+The agent feels noticeably slower. Responses that used to come back in about a second now take 3+ seconds. A heavy memory layer adds work on every turn, and once latency creeps past a few seconds the agent stops feeling responsive.
+
+Your API bill is creeping up for the same usage. Memory operations consume tokens, and some providers fire extra background LLM calls every time you save something. If your usage patterns haven't changed but your spend has, suspect the memory layer.
+
+The agent starts contradicting itself. It recalls one version of a fact in one session and the opposite in the next, and can't tell you which is right. This usually means memory is accumulating without ever being consolidated - the agent is now drawing from a polluted well.
+
+The agent runs out of context mid-conversation. A greedy memory layer eats into the same context budget your actual conversation needs. If you start seeing "context too long" errors, or the agent forgets what you told it five minutes ago, the memory layer is overspending its share.
+
+Your work isn't actually getting better. This is the one that matters most. You added memory expecting more accurate, more personalized output. After a couple of weeks, can you point at a specific way the agent is genuinely better than before? If you can't, the memory layer isn't earning its complexity. Pull it.
+
+I hope you enjoyed this Hermes Agent deep dive on all things memory. If you want to explore more within the Hermes ecosystem, check out hermesatlas.com and sign up for the Hermes Atlas newsletter to stay up to date on everything.

--- a/guide/index.html
+++ b/guide/index.html
@@ -621,6 +621,8 @@ hermes skills info &lt;name&gt;      # inspect before installing</code></pre>
 
 <p>And if you want the broader picture of where Hermes is right now — stars, PRs, key launches, what's next — read the quarterly report: <strong><a href="/reports/state-of-hermes-april-2026">The State of Hermes Agent — April 2026 →</a></strong>.</p>
 
+<p>If you want the deeper architecture behind Hermes memory — native markdown files, the session database, official MemoryProviders, and community plug-ins — read <strong><a href="/guide/memory/">The Hermes Agent Memory Guidebook →</a></strong>.</p>
+
 <hr>
 
 <h2 id="10-faq">10. FAQ</h2>

--- a/guide/memory/index.html
+++ b/guide/memory/index.html
@@ -1,0 +1,340 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>The Hermes Agent Memory Guidebook | Hermes Atlas</title>
+<meta name="description" content="Kevin Simback's Hermes Agent Memory Guidebook: the three-layer Hermes memory stack, native memory, official MemoryProviders, and community memory plug-ins.">
+<link rel="canonical" href="https://hermesatlas.com/guide/memory/">
+<meta property="og:title" content="The Hermes Agent Memory Guidebook">
+<meta property="og:description" content="A definitive guide to Hermes Agent memory systems: native memory, official MemoryProviders, and community plug-ins.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://hermesatlas.com/guide/memory/">
+<meta property="og:site_name" content="Hermes Atlas">
+<meta property="article:published_time" content="2026-05-23T00:00:00Z">
+<meta property="article:author" content="https://x.com/KSimback">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=The+Hermes+Agent+Memory+Guidebook&amp;subtitle=Native+memory%2C+MemoryProviders%2C+and+community+memory+plug-ins&amp;kind=guide">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="The Hermes Agent Memory Guidebook">
+<meta name="twitter:description" content="Native memory, MemoryProviders, and community memory plug-ins for Hermes Agent.">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=The+Hermes+Agent+Memory+Guidebook&amp;subtitle=Native+memory%2C+MemoryProviders%2C+and+community+memory+plug-ins&amp;kind=guide">
+<meta name="twitter:creator" content="@KSimback">
+<meta name="author" content="Kevin Simback">
+<link rel="alternate" type="application/rss+xml" title="Hermes Atlas — new projects" href="/rss.xml">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+<link rel="apple-touch-icon" href="/apple-touch-icon.png">
+<link rel="manifest" href="/site.webmanifest">
+<script>(function(){try{var s=localStorage.getItem('theme');var o=window.matchMedia&&window.matchMedia('(prefers-color-scheme: light)').matches;var t=s||(o?'light':'dark');document.documentElement.setAttribute('data-theme',t)}catch(e){document.documentElement.setAttribute('data-theme','dark')}})();</script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap">
+<link rel="stylesheet" href="/assets/css/tokens.css">
+<link rel="stylesheet" href="/assets/css/base.css">
+<link rel="stylesheet" href="/assets/css/page.css">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "The Hermes Agent Memory Guidebook",
+  "description": "A guide to Hermes Agent memory systems: native memory, official MemoryProviders, and community memory plug-ins.",
+  "datePublished": "2026-05-23T00:00:00Z",
+  "author": {"@type": "Person", "name": "Kevin Simback", "url": "https://x.com/KSimback"},
+  "publisher": {"@type": "Organization", "name": "Hermes Atlas", "url": "https://hermesatlas.com"},
+  "mainEntityOfPage": {"@type": "WebPage", "@id": "https://hermesatlas.com/guide/memory/"}
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {"@type": "ListItem", "position": 1, "name": "map", "item": "https://hermesatlas.com/"},
+    {"@type": "ListItem", "position": 2, "name": "handbook", "item": "https://hermesatlas.com/guide/"},
+    {"@type": "ListItem", "position": 3, "name": "memory"}
+  ]
+}
+</script>
+</head>
+<body>
+<a class="skip-link" href="#main">Skip to content</a>
+<header class="masthead">
+  <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
+  <div class="mast-meta" aria-label="Site metadata">
+    <span>may·2026</span>
+    <span id="meta-count">repos</span>
+    <span id="meta-version">hermes</span>
+    <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
+  </div>
+  <nav class="mast-nav" aria-label="Primary">
+    <a href="/">map</a>
+    <a href="/#curated-lists">lists</a>
+    <a href="/guide/" class="active">handbook</a>
+    <a href="/reports/">reports</a>
+    <a href="/#newsletter">newsletter</a>
+    <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
+  </nav>
+  <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
+    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+  </button>
+</header>
+<div class="breadcrumb" aria-label="Breadcrumb">
+  <a href="/">map</a><span class="sep">/</span><a href="/guide/">handbook</a><span class="sep">/</span>memory
+</div>
+<main class="article" id="main">
+<header class="article-header">
+  <div class="article-badge">guide · memory</div>
+  <h1>The Hermes Agent Memory Guidebook</h1>
+  <p class="subtitle">Native memory, MemoryProviders, and community memory plug-ins for Hermes Agent.</p>
+  <p class="meta">By <a href="https://x.com/KSimback">Kevin Simback</a> · Published 2026-05-23 · Source: <a href="https://x.com/KSimback/status/2058262328496554021">X article</a></p>
+</header>
+<p>By <a href="https://x.com/KSimback">Kevin Simback</a> · Published on X, May 23, 2026</p>
+
+<p>Source: <a href="https://x.com/KSimback/status/2058262328496554021">https://x.com/KSimback/status/2058262328496554021</a></p>
+
+<p>TLDR: this is your definitive guide to all things related to memory systems for Hermes Agent. Why create this? Because every week I see new posts or articles describing some new memory tool for Hermes agents and these make me question if my memory setup is the best. So I dug into all of them and broke it down for you.</p>
+
+<p>Over the past few months my Hermes agent has been mapping the Hermes ecosystem over at <a href="https://hermesatlas.com">hermesatlas.com</a>. One of the key areas it has covered is memory and it even has a dedicated section for it.</p>
+
+<p>And let&#x27;s be honest, there are a LOT of memory related tools available and there are a LOT of write-ups about them. I see new articles on X every week about some new memory setup. It&#x27;s hard to keep up, and even harder to know if you&#x27;re doing it all wrong because they all make claims about how certain memory systems are better than others.</p>
+
+<p>But many of these write-ups skip the architecture (how memory works in Hermes) or conflate different elements of the memory stack. This article is the culmination of everything I&#x27;ve learned about Hermes agent memory and a guide to help you navigate what makes most sense for your setup.</p>
+
+<h2 id="memory-is-arguably-the-most-important-element-of-an-agent-setup">Memory is arguably the most important element of an agent setup</h2>
+
+<p>Without memory, an agent is just a stateless function and no different than a blank ChatGPT window. Every prompt looks like the first prompt. That works for one-shot questions but breaks down the moment you have a use case that needs to know what happened yesterday, remember your preferences, accumulate skills from prior tasks, or coordinate with another agent.</p>
+
+<p>A coding session that doesn&#x27;t remember the conventions you established last Tuesday will reinvent them this Tuesday. A personal assistant agent that doesn&#x27;t remember your preferences has to ask you the same repeated questions. Without memory, an agent really isn&#x27;t an agent at all.</p>
+
+<p>Memory is what turns an chatbot into something that compounds. Which is why every serious agent harness - OpenClaw, Claude Code, Codex, and our beloved Hermes - has memory primitives built in, and why a real product category has emerged around dedicated memory infrastructure or agents (Mem0 raised $24M, Letta $10M, plus Zep, Cipher, Supermemory, Hindsight, etc.).</p>
+
+<p>The Hermes Agent take is interesting because Nous Research treats memory as first-class plug-in infrastructure, not a feature. There&#x27;s a base layer that always runs, a pluggable provider system that lets you choose from 8 architectures (or write your own), and a healthy community plug-in layer on top.</p>
+
+<p>That 3-layer stack is what I will explore in depth in this article.</p>
+
+<h2 id="hermes-agent-memory-architecture-at-a-glance">Hermes Agent memory architecture at a glance</h2>
+
+<p>Here&#x27;s what each layer means for you as a Hermes user.</p>
+
+<p>Layer 1 - what ships in the box. You get this whether you do anything or not. Two small markdown files the agent uses as its always-visible notebook, plus a local database that archives every session you&#x27;ve ever had. No setup, no config. For many use cases, this is often all you need.</p>
+
+<p>Layer 2 - the optional plug-in slot. When you outgrow the native layer (you want semantic recall across sessions, or a system that models your preferences, or token-efficient retrieval at scale) you pick one of 8 official providers. They each take a different architectural bet about what memory should do, and you can run exactly one at a time. Switching providers is a clean start - the new provider doesn&#x27;t inherit the old one&#x27;s data, but the Layer 1 native files keep running underneath either way.</p>
+
+<p>Layer 3 - what the community builds beyond the official 8. Two flavors. Some community projects are MemoryProvider plug-ins that compete head-to-head with the Layer 2 picks (Mnemosyne is the standout - fully local, sub-millisecond, with a real tiered cognitive architecture). Others sit alongside the official providers in a different slot entirely (GBrain is the standout here - it stores world facts like people, companies, and projects in a markdown vault, while your Layer 2 provider handles operational memory). Layer 3 usually means more setup and less polish than the official 8, but it&#x27;s where you go when you need a capability the eight providers don&#x27;t offer.</p>
+
+<p>The layers stack rather than replace each other. Switching the Layer 2 provider does not wipe Layer 1. Each provider has its own store, but the native session database and the two markdown files keep running underneath. Layer 3 plug-ins are additive on top of both.</p>
+
+<h2 id="layer-1-native-what-you-get-out-of-the-box">Layer 1: Native - what you get out of the box</h2>
+
+<p>The native layer is three things that ship with every Hermes install: two small markdown files and one database. They play different roles, and it&#x27;s worth understanding each before we get to the plug-in providers.</p>
+
+<p>Note: if you already understand the out of box setup or want to skip to the optional stuff you can install on top, go to Layer 2.</p>
+
+<h2 id="the-two-markdown-files">The two markdown files</h2>
+
+<p>When you install Hermes, it creates two text files in your home directory at ~/.hermes/:</p>
+
+<p>MEMORY.md - the agent&#x27;s general knowledge notebook. Project context, technical decisions, things worth remembering across sessions. Capped at about 2,200 characters, roughly a paragraph and a half.</p>
+
+<p>USER.md - what the agent knows about you specifically. Your preferences, your working style, your role. Capped at about 1,375 characters, roughly one paragraph.</p>
+
+<p>You can open both files in any text editor. They&#x27;re plain markdown. You can even edit them by hand if you want, and the agent will read your edits next session.</p>
+
+<p>The reason they&#x27;re so small is that they aren&#x27;t the agent&#x27;s filing cabinet - they&#x27;re the agent&#x27;s sticky notes. At the start of every session, Hermes pastes the entire contents of both files into the prompt sent to the model. So everything in these files is always &quot;in front of&quot; the agent. No retrieval needed, it just sees them.</p>
+
+<p>The agent itself decides what goes into these files. When something important comes up in a session - you say &quot;I prefer bullet points instead of paragraphs&quot; or the agent figures out that you use Vercel for deployments - the agent calls a tool called memory with one of three actions: add, replace, or remove. There&#x27;s no read action because the files are already pasted into the prompt; the agent reads them by virtue of looking at its own context.</p>
+
+<h2 id="what-happens-when-the-files-fill-up">What happens when the files fill up?</h2>
+
+<p>This is where most third-party write-ups get things wrong. They claim Hermes automatically consolidates the files when they hit 80% of the cap. I went into the code at agent/memory_manager.py to verify, and the actual behavior is more interesting:</p>
+
+<p>There is no automatic consolidation - the 80% rule is a prompt instruction, not code. The system prompt header shows the agent a real-time fill gauge - something like &quot;MEMORY: 1,847/2,200 chars (84 percent)&quot; - along with the instruction &quot;when memory is above 80% capacity, consolidate entries before adding new ones.&quot; The agent reads that, and the agent decides whether to act on it. If the file is already at the cap and the agent tries to add anything anyway, the memory tool returns an error listing the current entries and forces the agent to free space via replace or remove first.</p>
+
+<p>This is a deliberate design choice. Nous trusts the model to manage its own notebook. The upside is full agent control, but the downside is also full agent control. A poorly-prompted agent can sit at the cap indefinitely, refusing every new add call and quietly losing information that should have replaced something older, but I&#x27;m confident this gets resolved soon as there&#x27;s some PRs around this.</p>
+
+<p>A related point of confusion worth clearing up before we go on: v0.12 introduced something called the &quot;Autonomous Curator&quot; and many write-ups describe it as automatic memory management. It is not. The Curator operates only on the agent&#x27;s skill library at ~/.hermes/skills/ - moving skills from active to stale to archived based on usage. It never touches MEMORY.md or USER.md.</p>
+
+<h2 id="the-database-and-how-it-relates-to-the-markdown-files">The database (and how it relates to the markdown files)</h2>
+
+<p>The two markdown files are the agent&#x27;s always-visible notes. The database is the agent&#x27;s full archive of everything that has ever happened.</p>
+
+<p>Hermes stores every session in a SQLite database file at ~/.hermes/hermes_state.db. Every user message, every agent response, every tool call, every reasoning step, plus economic data like token counts and dollar cost per session - all of it lands here. Default retention is 90 days; older sessions get pruned automatically every 24 hours unless you change the setting.</p>
+
+<p>This database is not auto-injected into prompts. It would be enormous - imagine pasting your entire chat history into every new conversation. Instead, the agent searches it on demand when it needs to find something specific.</p>
+
+<p>The search uses SQLite&#x27;s built-in full-text search (FTS5), and Hermes maintains two parallel indexes: one for normal word-level search (&quot;did we discuss the content strategy?&quot;) and one for trigram search that handles substrings and code tokens (&quot;find every session where I mentioned github&quot;).</p>
+
+<p>So the mental model is:</p>
+
+<p>The two markdown files = what the agent always has in its head. Small, curated, always present in every prompt.</p>
+
+<p>The session database = what the agent can look up if it knows what to look for. Huge, raw, searchable on demand.</p>
+
+<p>These are complementary, not redundant. When something matters across all future sessions, the agent should write it to MEMORY.md so it&#x27;s always present. When something might matter again but doesn&#x27;t need to be top-of-mind, it lives in the session database and gets pulled up only when the agent searches for it.</p>
+
+<p>A nice side-effect of the database design: because Hermes captures every reasoning step and every tool call with full economic data, the database is also a complete training trajectory if you ever want to export it. This is beyond the scope of this article but something that aligns with my thesis on where the moats are in agents.</p>
+
+<h2 id="layer-2-the-pluggable-memoryprovider-system">Layer 2: The pluggable &quot;MemoryProvider&quot; system</h2>
+
+<p>This is the layer that lets you graduate from &quot;small notebook plus searchable archive&quot; to a real memory system - one that extracts facts from your conversations automatically, builds a profile of you, supports semantic recall across sessions, or handles a large knowledge graph.</p>
+
+<p>Setting this up is quite simple - you run &quot;hermes memory setup&quot;, pick a provider from the menu, and from then on the agent has a richer memory layer to draw from on top of the native files. Note: some providers require API keys and paid plans.</p>
+
+<p>The important note is you can only run one provider at a time. Hermes treats this as a single deliberate choice, not a stack of bolt-ons.</p>
+
+<p>That keeps your tool surface clean - each provider exposes its own set of agent tools, and the agent would get confused if there were three competing &quot;search memory&quot; tools sitting in front of it - and it makes the configuration easy to reason about. The Layer 1 native files keep running underneath whether you have a provider active or not.</p>
+
+<p>Picking the right provider matters because they make very different architectural bets. Some are aggressive at extracting facts. Some build a model of how you think rather than what you said. Some are obsessed with token efficiency. Some are graph-first. The full decision tree is later in this article; the technical mechanics below are for readers who want to know what providers actually plug into.</p>
+
+<p>Let&#x27;s dive in.</p>
+
+<h2 id="the-8-official-providers">The 8 Official Providers</h2>
+
+<h2 id="honcho-plastic-labs-ai-native-dialectic-user-modeling">Honcho (Plastic Labs) - AI-native dialectic user modeling</h2>
+
+<p>The only provider in the lineup that tries to model how you think, not just what you said. Instead of storing flat facts like &quot;Kevin uses 4-space indents,&quot; Honcho runs a multi-step reasoning pass after your conversations to build a profile of your reasoning patterns, preferences, and goals.</p>
+
+<p>That profile evolves over time, so the agent gets better at anticipating what you&#x27;d want even on topics you&#x27;ve never discussed. It also lets multiple &quot;AI identities&quot; share the same view of you - useful if you run different specialist agents for coding, writing, and strategy and want all of them to know your style. Most-cited favorite in the Hermes Discord (@offendingcommit: &quot;I&#x27;ve tried them all... I freakin&#x27; love Honcho.&quot;).</p>
+
+<h2 id="mem0-fastest-30-second-setup-broadest-ecosystem">Mem0 - fastest 30-second setup, broadest ecosystem</h2>
+
+<p>The &quot;just give me memory and stop asking questions&quot; pick. You sign up for Mem0 cloud, paste an API key, and you&#x27;re done - the provider extracts facts from conversations, deduplicates them, and serves up semantic search automatically in the background.</p>
+
+<p>It&#x27;s also the exclusive memory provider for AWS&#x27;s Strands Agents SDK, which gives it the widest ecosystem reach in the lineup. In April 2026 Mem0 shipped a &quot;v3&quot; algorithm claiming to leapfrog Hindsight on benchmarks (94.8 on LongMemEval, 91.6 on LoCoMo).</p>
+
+<h2 id="hindsight-vectorize-io-the-benchmark-king">Hindsight (Vectorize.io) - the benchmark king</h2>
+
+<p>The first memory system of any kind to publicly cross 90 on LongMemEval (91.4, December 2025). Hindsight thinks about memory as four separate networks - things about the world, things that happened, opinions, and raw observations - and pulls only a handful of high-value facts from each conversation (2 to 5, not one per sentence).</p>
+
+<p>When you ask it something, it runs four different retrieval strategies in parallel - keyword search, vector similarity, graph traversal across related entities, and a recency pass - then fuses the results. That&#x27;s how it gets the best recall accuracy in the published lineup.</p>
+
+<p>It&#x27;s also the only provider with a reflect tool that lets the agent run a reasoning pass over its own memory. That&#x27;s uniquely valuable if you&#x27;re running multiple agents on a shared memory bank and you need an orchestrator to synthesize what all of them know.</p>
+
+<h2 id="holographic-zero-dependency-fully-local-air-gapped">Holographic - zero-dependency, fully local, air-gapped</h2>
+
+<p>The only provider in the lineup that needs no internet, no API key, and no LLM to function. Everything lives in a local SQLite file. It uses a 1991-era technique called Holographic Reduced Representations to do compositional reasoning over facts - you can bind concepts together algebraically and probe for related ones later. Retrieval is sub-millisecond because it&#x27;s pure local SQL.</p>
+
+<h2 id="openviking-tiered-filesystem-context-db">OpenViking - tiered filesystem context DB</h2>
+
+<p>Your memory lives as files in a directory tree on your disk. You can cat them, grep them, edit them by hand. Each piece of stored knowledge has three loading tiers: a one-sentence summary, a paragraph-level overview, and the full content.</p>
+
+<p>When the agent recalls something, it starts cheap (summaries only) and only loads the deeper tiers if the summary looks relevant. That structure is important if you&#x27;re cost-sensitive at scale or you want memory you can read and edit like normal files.</p>
+
+<h2 id="retaindb-cheapest-paid-tier-lowest-friction">RetainDB - cheapest paid tier, lowest friction</h2>
+
+<p>$20/month for 100,000 queries, with a free tier of 10,000 operations to test. The only provider in the lineup that&#x27;s cloud-only at every price point (no self-host even on enterprise). The hook is convenience: you operate no infrastructure, RetainDB handles everything, and there&#x27;s a &quot;Memory Router&quot; mode that intercepts your LLM calls and adds memory transparently with one config line.</p>
+
+<p>Pick this option if you want shared memory across team members or agents and you don&#x27;t want to operate a database.</p>
+
+<h2 id="byterover-memory-as-a-git-repo">ByteRover - memory as a git repo</h2>
+
+<p>Your memory is plain markdown files in a .brv/context-tree/ directory - grep-able, version-controllable, no database to run. ByteRover layers a 5-tier retrieval system on top, and four of those tiers don&#x27;t need an LLM call, so most lookups finish in under 100ms with zero token spend.</p>
+
+<p>The key selling point: you can branch, merge, and roll back memory like code with CLI commands. It also uses a special hook to extract high-value insights before Hermes compresses context, which is the cleanest fix in the lineup for the &quot;agent loses memory after restart&quot; failure mode (noted in issue #17251).</p>
+
+<h2 id="supermemory-latency-scale-leader">Supermemory - latency + scale leader</h2>
+
+<p>Sub-300ms recall sustained at over 100 billion tokens per month. Supermemory built a custom vector graph engine for this rather than stapling a vector DB and a graph DB together.</p>
+
+<p>Its standout feature is context fencing: it automatically strips already-recalled memories out of conversations before storing them, which kills the &quot;memory feedback loop&quot; where auto-capture systems start re-ingesting their own outputs into the next round of memory.</p>
+
+<p>Good choice if you want to operate at real scale (consumer app, multi-tenant SaaS, agent platform) and latency matters, but likely overkill for normal consumer use.</p>
+
+<p>Here&#x27;s a comparative look across all 8</p>
+
+<h2 id="layer-3-community-plug-ins-worth-knowing">Layer 3: Community plug-ins worth knowing</h2>
+
+<p>If none of the official 8 fits your use case, or if you want even more on top, the community has built another layer of memory tooling for Hermes. About five of these are production-quality enough to consider seriously, plus a longer tail of experiments to keep eyes on.</p>
+
+<p>Two things to know up front about Layer 3:</p>
+
+<p>Not every Layer 3 project competes with Layer 2. Some are alternative MemoryProvider plug-ins you&#x27;d pick instead of one of the official 8 (Mnemosyne is the clearest example). Others occupy a different role entirely - they store a different type of memory and run alongside your Layer 2 provider, not in place of it (GBrain is the clearest example, storing world facts about people, companies, and projects in a separate brain layer while your Layer 2 provider handles operational memory).</p>
+
+<p>You give up polish to get capability. The official 8 ship with Nous&#x27;s review and tend to &quot;just work.&quot; Community plug-ins are typically a bit rougher on the install, have fewer docs, and more chance of hitting a bug. But they unlock things the official set doesn&#x27;t offer like fully-local sub-millisecond retrieval (Mnemosyne), a markdown-and-Postgres knowledge graph that builds itself with zero LLM calls (GBrain), explainable retrieval rankings (yantrikdb), and cross-agent memory portability (PLUR).</p>
+
+<p>The safe path if you&#x27;re committing to a memory stack for real work: start with one of the official 8 and only reach for Layer 3 when you&#x27;ve identified a specific capability gap a community project fills. The standouts below are GBrain and Mnemosyne.</p>
+
+<h2 id="gbrain-by-garrytan-this-is-what-i-personally-use">GBrain (by garrytan) - this is what I personally use</h2>
+
+<p>Open-sourced in April, MIT licensed, ~18k+ stars. TypeScript. Built by Garry Tan to run his own production agents. GBrain is structurally different from the official 8. GBrain does not subclass MemoryProvider, it plugs in as skillpack + MCP server (~30 MCP tools), and occupys a different ontological slot. The explicit doctrine in docs/guides/brain-vs-memory.md:</p>
+
+<p>What makes it special:</p>
+
+<p>Not just RAG: a full 8-layer knowledge engine for dramatically better memory and recall</p>
+
+<p>Epistemology layer: tracks “who said what, when, and with what confidence” so no more hallucinated facts or lost context</p>
+
+<p>Self-wiring knowledge graph: automatically extracts entities and creates real relationships (e.g., “attended,” “works_at,” “invested_in,” “founded”) with zero extra LLM calls</p>
+
+<p>Dream cycles for autonomous synthesis: runs overnight (or on-demand) so your brain literally gets smarter while you sleep</p>
+
+<p>Hybrid search done right: combines vector, keyword, RRF fusion, multi-query expansion, cosine reranking, compiled-truth boost, and backlink boost for far more accurate results than plain vector search</p>
+
+<p>Specialized + versioned chunking: recursive markdown chunker (v4) that intelligently handles code blocks, frontmatter, transcripts, etc. so edits don’t break memory</p>
+
+<p>Autonomous enrichment + persistent personal memory: tiered enrichment based on how often something is mentioned turning Hermes agent into a “clairvoyant” personal AI that actually knows you</p>
+
+<p>Why pick GBrain over the official 8? If you want a graph cheap, git as system of record, overnight maintenance, you already have a markdown vault (migration covers Obsidian / Logseq / Notion / Roam), or you&#x27;re building a &quot;company of agents.&quot;</p>
+
+<h2 id="mnemosyne-axdsan-mnemosyne">Mnemosyne (AxDSan/mnemosyne)</h2>
+
+<p>The strongest community alternative when you want a real MemoryProvider plug-in (rather than GBrain, which plays a different role). Runs entirely on your machine - no cloud, no API key, no internet - and recall is fast enough to feel instant (under 2 milliseconds in published tests).</p>
+
+<p>What makes Mnemosyne interesting is its tiered memory architecture, modeled loosely on how humans handle short-term vs long-term memory. There&#x27;s a &quot;working&quot; tier for what&#x27;s actively relevant right now, an &quot;episodic&quot; tier for time-stamped events you might want to look up later, and a &quot;scratchpad&quot; for things still being considered for promotion. A consolidation pass runs periodically in the background to move useful items into long-term memory and prune the noise.</p>
+
+<p>The standout feature for serious users: memory has a sense of time. You can ask &quot;what did I believe about X last Tuesday?&quot; and get back the agent&#x27;s understanding as it was at that point, not as it is today. No other Hermes plug-in does this as cleanly. One soft adoption signal worth noticing: Mnemosyne is the only community memory plug-in that someone has bothered to write a dedicated Hermes skill wrapper for (a small file that teaches the agent how to use it intelligently). Nobody&#x27;s done that for the others.</p>
+
+<h2 id="others-worth-knowing-about">Others worth knowing about</h2>
+
+<p>Ladybug Memory - the local-only option with built-in importance ranking. Every memory gets a score from 1 to 10 so the system surfaces the things that matter first instead of treating everything equally. Pick it if you want fully-local memory and the built-in MEMORY.md cap is too small for your knowledge.</p>
+
+<p>yantrikdb - he one to pick when you need to know why the agent recalled what it did. Every retrieval comes back with a &quot;why retrieved&quot; explanation, which is useful for debugging when the agent surfaces the wrong thing or for high-trust contexts where you need to audit what&#x27;s shaping the agent&#x27;s responses. Runs embedded out of the box, no separate database to manage.</p>
+
+<p>hermes-agentmemory - a community fix for a real Hermes problem: when you tell the agent to forget something, it doesn&#x27;t actually forget - it keeps an internal summary that quietly influences future recall. This provider does real deletion (gone is gone) and logs every memory operation so you can audit what happened. Pick it if compliance, privacy, or user-controlled forgetting matters.</p>
+
+<p>PLUR - the cross-agent memory bridge. Hermes memory normally doesn&#x27;t reach Cursor, and Cursor&#x27;s doesn&#x27;t reach Claude Code. PLUR stores everything in a shared .plur/ folder that all of them can read, so a fact you teach one agent automatically shows up in the others. Pick it if you work across multiple agents on the same project and don&#x27;t want to teach each one separately.</p>
+
+<p>FlowState-QMD - The &quot;guess what you&#x27;ll need next&quot; provider. It tries to predict the agent&#x27;s next likely query and warms up that memory in advance, so by the time the agent actually searches, the result is already cached and responses come back faster. Pick it if your agent does repetitive long-horizon work where the next step is usually guessable from context.</p>
+
+<p>One thing I expected to find that doesn&#x27;t exist: memory-as-skill is effectively a non-pattern. The agentskills.io standard means a &quot;skill&quot; could in principle implement memory. In practice all credible persistent memory flows through the MemoryProvider ABC. Even skills that &quot;do memory&quot; (the Mnemosyne SKILL.md, for instance) are wrappers around plug-ins, telling the agent how to use them.</p>
+
+<h2 id="how-to-actually-pick">How to actually pick?</h2>
+
+<p>Step 1: pick your layer strategy</p>
+
+<p>Step 2: pick your layer 2 system</p>
+
+<h2 id="warning-signs-you-went-too-heavy">Warning signs you went too heavy:</h2>
+
+<p>The agent feels noticeably slower. Responses that used to come back in about a second now take 3+ seconds. A heavy memory layer adds work on every turn, and once latency creeps past a few seconds the agent stops feeling responsive.</p>
+
+<p>Your API bill is creeping up for the same usage. Memory operations consume tokens, and some providers fire extra background LLM calls every time you save something. If your usage patterns haven&#x27;t changed but your spend has, suspect the memory layer.</p>
+
+<p>The agent starts contradicting itself. It recalls one version of a fact in one session and the opposite in the next, and can&#x27;t tell you which is right. This usually means memory is accumulating without ever being consolidated - the agent is now drawing from a polluted well.</p>
+
+<p>The agent runs out of context mid-conversation. A greedy memory layer eats into the same context budget your actual conversation needs. If you start seeing &quot;context too long&quot; errors, or the agent forgets what you told it five minutes ago, the memory layer is overspending its share.</p>
+
+<p>Your work isn&#x27;t actually getting better. This is the one that matters most. You added memory expecting more accurate, more personalized output. After a couple of weeks, can you point at a specific way the agent is genuinely better than before? If you can&#x27;t, the memory layer isn&#x27;t earning its complexity. Pull it.</p>
+
+<p>I hope you enjoyed this Hermes Agent deep dive on all things memory. If you want to explore more within the Hermes ecosystem, check out <a href="https://hermesatlas.com">hermesatlas.com</a> and sign up for the Hermes Atlas newsletter to stay up to date on everything.</p>
+<div class="article-footer">
+  <p><strong>Written by <a href="https://x.com/KSimback">Kevin Simback</a></strong> · originally published on X</p>
+  <p><strong>Source:</strong> <a href="https://x.com/KSimback/status/2058262328496554021">The Hermes Agent Memory Guidebook</a></p>
+  <a class="cta" href="/lists/best-memory-providers">explore Hermes memory providers →</a>
+</div>
+</main>
+<footer class="page-footer">
+  <div class="fn-left">hermes atlas · curated by <a href="https://github.com/ksimback">ksimback</a> · <a href="https://github.com/ksimback/hermes-ecosystem/issues">suggest a repo</a> · <a href="/privacy">privacy</a></div>
+  <div>v2 · 2026.04</div>
+</footer>
+<script>(function(){var t=document.getElementById('theme-toggle');if(!t)return;function render(){var c=document.documentElement.getAttribute('data-theme');t.querySelector('.tt-light').classList.toggle('tt-active',c==='light');t.querySelector('.tt-dark').classList.toggle('tt-active',c!=='light');}render();t.addEventListener('click',function(){var c=document.documentElement.getAttribute('data-theme');var n=c==='light'?'dark':'light';document.documentElement.setAttribute('data-theme',n);try{localStorage.setItem('theme',n)}catch(e){}render();});})();</script>
+<script src="/assets/js/masthead-fetch.js" defer></script>
+<!-- Cloudflare Web Analytics -->
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js"
+        data-cf-beacon='{"token": "fe0d4d79280b4386b6b0cd99b2d94dbc"}'></script>
+<!-- End Cloudflare Web Analytics -->
+</body>
+</html>

--- a/lists/best-memory-providers.html
+++ b/lists/best-memory-providers.html
@@ -234,6 +234,7 @@
 <section class="list-page">
   <h1 class="list-title">Best Memory Providers for Hermes Agent</h1>
   <p class="list-intro">The top community-built memory and context management tools for Hermes Agent, ranked by GitHub stars. Memory is what makes Hermes self-improving — these tools extend its built-in recall with long-term semantic memory, graph-based retrieval, and cross-session persistence.</p>
+  <p class="list-intro">For the architecture behind these tools, read <a href="/guide/memory/">The Hermes Agent Memory Guidebook</a>.</p>
 </section>
 
 <div class="list-table" aria-label="Ranked list">

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1348,6 +1348,245 @@ curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scri
 
 ---
 
+# The Hermes Agent Memory Guidebook (/guide/memory/)
+
+Canonical URL: https://hermesatlas.com/guide/memory/
+
+# The Hermes Agent Memory Guidebook
+
+By [Kevin Simback](https://x.com/KSimback) · Published on X, May 23, 2026
+
+Source: https://x.com/KSimback/status/2058262328496554021
+
+TLDR: this is your definitive guide to all things related to memory systems for Hermes Agent. Why create this? Because every week I see new posts or articles describing some new memory tool for Hermes agents and these make me question if my memory setup is the best. So I dug into all of them and broke it down for you.
+
+Over the past few months my Hermes agent has been mapping the Hermes ecosystem over at hermesatlas.com. One of the key areas it has covered is memory and it even has a dedicated section for it.
+
+And let's be honest, there are a LOT of memory related tools available and there are a LOT of write-ups about them. I see new articles on X every week about some new memory setup. It's hard to keep up, and even harder to know if you're doing it all wrong because they all make claims about how certain memory systems are better than others.
+
+But many of these write-ups skip the architecture (how memory works in Hermes) or conflate different elements of the memory stack. This article is the culmination of everything I've learned about Hermes agent memory and a guide to help you navigate what makes most sense for your setup.
+
+## Memory is arguably the most important element of an agent setup
+
+Without memory, an agent is just a stateless function and no different than a blank ChatGPT window. Every prompt looks like the first prompt. That works for one-shot questions but breaks down the moment you have a use case that needs to know what happened yesterday, remember your preferences, accumulate skills from prior tasks, or coordinate with another agent.
+
+A coding session that doesn't remember the conventions you established last Tuesday will reinvent them this Tuesday. A personal assistant agent that doesn't remember your preferences has to ask you the same repeated questions. Without memory, an agent really isn't an agent at all.
+
+Memory is what turns an chatbot into something that compounds. Which is why every serious agent harness - OpenClaw, Claude Code, Codex, and our beloved Hermes - has memory primitives built in, and why a real product category has emerged around dedicated memory infrastructure or agents (Mem0 raised $24M, Letta $10M, plus Zep, Cipher, Supermemory, Hindsight, etc.).
+
+The Hermes Agent take is interesting because Nous Research treats memory as first-class plug-in infrastructure, not a feature. There's a base layer that always runs, a pluggable provider system that lets you choose from 8 architectures (or write your own), and a healthy community plug-in layer on top.
+
+That 3-layer stack is what I will explore in depth in this article.
+
+## Hermes Agent memory architecture at a glance
+
+Here's what each layer means for you as a Hermes user.
+
+Layer 1 - what ships in the box. You get this whether you do anything or not. Two small markdown files the agent uses as its always-visible notebook, plus a local database that archives every session you've ever had. No setup, no config. For many use cases, this is often all you need.
+
+Layer 2 - the optional plug-in slot. When you outgrow the native layer (you want semantic recall across sessions, or a system that models your preferences, or token-efficient retrieval at scale) you pick one of 8 official providers. They each take a different architectural bet about what memory should do, and you can run exactly one at a time. Switching providers is a clean start - the new provider doesn't inherit the old one's data, but the Layer 1 native files keep running underneath either way.
+
+Layer 3 - what the community builds beyond the official 8. Two flavors. Some community projects are MemoryProvider plug-ins that compete head-to-head with the Layer 2 picks (Mnemosyne is the standout - fully local, sub-millisecond, with a real tiered cognitive architecture). Others sit alongside the official providers in a different slot entirely (GBrain is the standout here - it stores world facts like people, companies, and projects in a markdown vault, while your Layer 2 provider handles operational memory). Layer 3 usually means more setup and less polish than the official 8, but it's where you go when you need a capability the eight providers don't offer.
+
+The layers stack rather than replace each other. Switching the Layer 2 provider does not wipe Layer 1. Each provider has its own store, but the native session database and the two markdown files keep running underneath. Layer 3 plug-ins are additive on top of both.
+
+## Layer 1: Native - what you get out of the box
+
+The native layer is three things that ship with every Hermes install: two small markdown files and one database. They play different roles, and it's worth understanding each before we get to the plug-in providers.
+
+Note: if you already understand the out of box setup or want to skip to the optional stuff you can install on top, go to Layer 2.
+
+## The two markdown files
+
+When you install Hermes, it creates two text files in your home directory at ~/.hermes/:
+
+MEMORY.md - the agent's general knowledge notebook. Project context, technical decisions, things worth remembering across sessions. Capped at about 2,200 characters, roughly a paragraph and a half.
+
+USER.md - what the agent knows about you specifically. Your preferences, your working style, your role. Capped at about 1,375 characters, roughly one paragraph.
+
+You can open both files in any text editor. They're plain markdown. You can even edit them by hand if you want, and the agent will read your edits next session.
+
+The reason they're so small is that they aren't the agent's filing cabinet - they're the agent's sticky notes. At the start of every session, Hermes pastes the entire contents of both files into the prompt sent to the model. So everything in these files is always "in front of" the agent. No retrieval needed, it just sees them.
+
+The agent itself decides what goes into these files. When something important comes up in a session - you say "I prefer bullet points instead of paragraphs" or the agent figures out that you use Vercel for deployments - the agent calls a tool called memory with one of three actions: add, replace, or remove. There's no read action because the files are already pasted into the prompt; the agent reads them by virtue of looking at its own context.
+
+## What happens when the files fill up?
+
+This is where most third-party write-ups get things wrong. They claim Hermes automatically consolidates the files when they hit 80% of the cap. I went into the code at agent/memory_manager.py to verify, and the actual behavior is more interesting:
+
+There is no automatic consolidation - the 80% rule is a prompt instruction, not code. The system prompt header shows the agent a real-time fill gauge - something like "MEMORY: 1,847/2,200 chars (84 percent)" - along with the instruction "when memory is above 80% capacity, consolidate entries before adding new ones." The agent reads that, and the agent decides whether to act on it. If the file is already at the cap and the agent tries to add anything anyway, the memory tool returns an error listing the current entries and forces the agent to free space via replace or remove first.
+
+This is a deliberate design choice. Nous trusts the model to manage its own notebook. The upside is full agent control, but the downside is also full agent control. A poorly-prompted agent can sit at the cap indefinitely, refusing every new add call and quietly losing information that should have replaced something older, but I'm confident this gets resolved soon as there's some PRs around this.
+
+A related point of confusion worth clearing up before we go on: v0.12 introduced something called the "Autonomous Curator" and many write-ups describe it as automatic memory management. It is not. The Curator operates only on the agent's skill library at ~/.hermes/skills/ - moving skills from active to stale to archived based on usage. It never touches MEMORY.md or USER.md.
+
+## The database (and how it relates to the markdown files)
+
+The two markdown files are the agent's always-visible notes. The database is the agent's full archive of everything that has ever happened.
+
+Hermes stores every session in a SQLite database file at ~/.hermes/hermes_state.db. Every user message, every agent response, every tool call, every reasoning step, plus economic data like token counts and dollar cost per session - all of it lands here. Default retention is 90 days; older sessions get pruned automatically every 24 hours unless you change the setting.
+
+This database is not auto-injected into prompts. It would be enormous - imagine pasting your entire chat history into every new conversation. Instead, the agent searches it on demand when it needs to find something specific.
+
+The search uses SQLite's built-in full-text search (FTS5), and Hermes maintains two parallel indexes: one for normal word-level search ("did we discuss the content strategy?") and one for trigram search that handles substrings and code tokens ("find every session where I mentioned github").
+
+So the mental model is:
+
+The two markdown files = what the agent always has in its head. Small, curated, always present in every prompt.
+
+The session database = what the agent can look up if it knows what to look for. Huge, raw, searchable on demand.
+
+These are complementary, not redundant. When something matters across all future sessions, the agent should write it to MEMORY.md so it's always present. When something might matter again but doesn't need to be top-of-mind, it lives in the session database and gets pulled up only when the agent searches for it.
+
+A nice side-effect of the database design: because Hermes captures every reasoning step and every tool call with full economic data, the database is also a complete training trajectory if you ever want to export it. This is beyond the scope of this article but something that aligns with my thesis on where the moats are in agents.
+
+## Layer 2: The pluggable "MemoryProvider" system
+
+This is the layer that lets you graduate from "small notebook plus searchable archive" to a real memory system - one that extracts facts from your conversations automatically, builds a profile of you, supports semantic recall across sessions, or handles a large knowledge graph.
+
+Setting this up is quite simple - you run "hermes memory setup", pick a provider from the menu, and from then on the agent has a richer memory layer to draw from on top of the native files. Note: some providers require API keys and paid plans.
+
+The important note is you can only run one provider at a time. Hermes treats this as a single deliberate choice, not a stack of bolt-ons.
+
+That keeps your tool surface clean - each provider exposes its own set of agent tools, and the agent would get confused if there were three competing "search memory" tools sitting in front of it - and it makes the configuration easy to reason about. The Layer 1 native files keep running underneath whether you have a provider active or not.
+
+Picking the right provider matters because they make very different architectural bets. Some are aggressive at extracting facts. Some build a model of how you think rather than what you said. Some are obsessed with token efficiency. Some are graph-first. The full decision tree is later in this article; the technical mechanics below are for readers who want to know what providers actually plug into.
+
+Let's dive in.
+
+## The 8 Official Providers
+
+## Honcho (Plastic Labs) - AI-native dialectic user modeling
+
+The only provider in the lineup that tries to model how you think, not just what you said. Instead of storing flat facts like "Kevin uses 4-space indents," Honcho runs a multi-step reasoning pass after your conversations to build a profile of your reasoning patterns, preferences, and goals.
+
+That profile evolves over time, so the agent gets better at anticipating what you'd want even on topics you've never discussed. It also lets multiple "AI identities" share the same view of you - useful if you run different specialist agents for coding, writing, and strategy and want all of them to know your style. Most-cited favorite in the Hermes Discord (@offendingcommit: "I've tried them all... I freakin' love Honcho.").
+
+## Mem0 - fastest 30-second setup, broadest ecosystem
+
+The "just give me memory and stop asking questions" pick. You sign up for Mem0 cloud, paste an API key, and you're done - the provider extracts facts from conversations, deduplicates them, and serves up semantic search automatically in the background.
+
+It's also the exclusive memory provider for AWS's Strands Agents SDK, which gives it the widest ecosystem reach in the lineup. In April 2026 Mem0 shipped a "v3" algorithm claiming to leapfrog Hindsight on benchmarks (94.8 on LongMemEval, 91.6 on LoCoMo).
+
+## Hindsight (Vectorize.io) - the benchmark king
+
+The first memory system of any kind to publicly cross 90 on LongMemEval (91.4, December 2025). Hindsight thinks about memory as four separate networks - things about the world, things that happened, opinions, and raw observations - and pulls only a handful of high-value facts from each conversation (2 to 5, not one per sentence).
+
+When you ask it something, it runs four different retrieval strategies in parallel - keyword search, vector similarity, graph traversal across related entities, and a recency pass - then fuses the results. That's how it gets the best recall accuracy in the published lineup.
+
+It's also the only provider with a reflect tool that lets the agent run a reasoning pass over its own memory. That's uniquely valuable if you're running multiple agents on a shared memory bank and you need an orchestrator to synthesize what all of them know.
+
+## Holographic - zero-dependency, fully local, air-gapped
+
+The only provider in the lineup that needs no internet, no API key, and no LLM to function. Everything lives in a local SQLite file. It uses a 1991-era technique called Holographic Reduced Representations to do compositional reasoning over facts - you can bind concepts together algebraically and probe for related ones later. Retrieval is sub-millisecond because it's pure local SQL.
+
+## OpenViking - tiered filesystem context DB
+
+Your memory lives as files in a directory tree on your disk. You can cat them, grep them, edit them by hand. Each piece of stored knowledge has three loading tiers: a one-sentence summary, a paragraph-level overview, and the full content.
+
+When the agent recalls something, it starts cheap (summaries only) and only loads the deeper tiers if the summary looks relevant. That structure is important if you're cost-sensitive at scale or you want memory you can read and edit like normal files.
+
+## RetainDB - cheapest paid tier, lowest friction
+
+$20/month for 100,000 queries, with a free tier of 10,000 operations to test. The only provider in the lineup that's cloud-only at every price point (no self-host even on enterprise). The hook is convenience: you operate no infrastructure, RetainDB handles everything, and there's a "Memory Router" mode that intercepts your LLM calls and adds memory transparently with one config line.
+
+Pick this option if you want shared memory across team members or agents and you don't want to operate a database.
+
+## ByteRover - memory as a git repo
+
+Your memory is plain markdown files in a .brv/context-tree/ directory - grep-able, version-controllable, no database to run. ByteRover layers a 5-tier retrieval system on top, and four of those tiers don't need an LLM call, so most lookups finish in under 100ms with zero token spend.
+
+The key selling point: you can branch, merge, and roll back memory like code with CLI commands. It also uses a special hook to extract high-value insights before Hermes compresses context, which is the cleanest fix in the lineup for the "agent loses memory after restart" failure mode (noted in issue #17251).
+
+## Supermemory - latency + scale leader
+
+Sub-300ms recall sustained at over 100 billion tokens per month. Supermemory built a custom vector graph engine for this rather than stapling a vector DB and a graph DB together.
+
+Its standout feature is context fencing: it automatically strips already-recalled memories out of conversations before storing them, which kills the "memory feedback loop" where auto-capture systems start re-ingesting their own outputs into the next round of memory.
+
+Good choice if you want to operate at real scale (consumer app, multi-tenant SaaS, agent platform) and latency matters, but likely overkill for normal consumer use.
+
+Here's a comparative look across all 8
+
+## Layer 3: Community plug-ins worth knowing
+
+If none of the official 8 fits your use case, or if you want even more on top, the community has built another layer of memory tooling for Hermes. About five of these are production-quality enough to consider seriously, plus a longer tail of experiments to keep eyes on.
+
+Two things to know up front about Layer 3:
+
+Not every Layer 3 project competes with Layer 2. Some are alternative MemoryProvider plug-ins you'd pick instead of one of the official 8 (Mnemosyne is the clearest example). Others occupy a different role entirely - they store a different type of memory and run alongside your Layer 2 provider, not in place of it (GBrain is the clearest example, storing world facts about people, companies, and projects in a separate brain layer while your Layer 2 provider handles operational memory).
+
+You give up polish to get capability. The official 8 ship with Nous's review and tend to "just work." Community plug-ins are typically a bit rougher on the install, have fewer docs, and more chance of hitting a bug. But they unlock things the official set doesn't offer like fully-local sub-millisecond retrieval (Mnemosyne), a markdown-and-Postgres knowledge graph that builds itself with zero LLM calls (GBrain), explainable retrieval rankings (yantrikdb), and cross-agent memory portability (PLUR).
+
+The safe path if you're committing to a memory stack for real work: start with one of the official 8 and only reach for Layer 3 when you've identified a specific capability gap a community project fills. The standouts below are GBrain and Mnemosyne.
+
+## GBrain (by garrytan) - this is what I personally use
+
+Open-sourced in April, MIT licensed, ~18k+ stars. TypeScript. Built by Garry Tan to run his own production agents. GBrain is structurally different from the official 8. GBrain does not subclass MemoryProvider, it plugs in as skillpack + MCP server (~30 MCP tools), and occupys a different ontological slot. The explicit doctrine in docs/guides/brain-vs-memory.md:
+
+What makes it special:
+
+Not just RAG: a full 8-layer knowledge engine for dramatically better memory and recall
+
+Epistemology layer: tracks “who said what, when, and with what confidence” so no more hallucinated facts or lost context
+
+Self-wiring knowledge graph: automatically extracts entities and creates real relationships (e.g., “attended,” “works_at,” “invested_in,” “founded”) with zero extra LLM calls
+
+Dream cycles for autonomous synthesis: runs overnight (or on-demand) so your brain literally gets smarter while you sleep
+
+Hybrid search done right: combines vector, keyword, RRF fusion, multi-query expansion, cosine reranking, compiled-truth boost, and backlink boost for far more accurate results than plain vector search
+
+Specialized + versioned chunking: recursive markdown chunker (v4) that intelligently handles code blocks, frontmatter, transcripts, etc. so edits don’t break memory
+
+Autonomous enrichment + persistent personal memory: tiered enrichment based on how often something is mentioned turning Hermes agent into a “clairvoyant” personal AI that actually knows you
+
+Why pick GBrain over the official 8? If you want a graph cheap, git as system of record, overnight maintenance, you already have a markdown vault (migration covers Obsidian / Logseq / Notion / Roam), or you're building a "company of agents."
+
+## Mnemosyne (AxDSan/mnemosyne)
+
+The strongest community alternative when you want a real MemoryProvider plug-in (rather than GBrain, which plays a different role). Runs entirely on your machine - no cloud, no API key, no internet - and recall is fast enough to feel instant (under 2 milliseconds in published tests).
+
+What makes Mnemosyne interesting is its tiered memory architecture, modeled loosely on how humans handle short-term vs long-term memory. There's a "working" tier for what's actively relevant right now, an "episodic" tier for time-stamped events you might want to look up later, and a "scratchpad" for things still being considered for promotion. A consolidation pass runs periodically in the background to move useful items into long-term memory and prune the noise.
+
+The standout feature for serious users: memory has a sense of time. You can ask "what did I believe about X last Tuesday?" and get back the agent's understanding as it was at that point, not as it is today. No other Hermes plug-in does this as cleanly. One soft adoption signal worth noticing: Mnemosyne is the only community memory plug-in that someone has bothered to write a dedicated Hermes skill wrapper for (a small file that teaches the agent how to use it intelligently). Nobody's done that for the others.
+
+## Others worth knowing about
+
+Ladybug Memory - the local-only option with built-in importance ranking. Every memory gets a score from 1 to 10 so the system surfaces the things that matter first instead of treating everything equally. Pick it if you want fully-local memory and the built-in MEMORY.md cap is too small for your knowledge.
+
+yantrikdb - he one to pick when you need to know why the agent recalled what it did. Every retrieval comes back with a "why retrieved" explanation, which is useful for debugging when the agent surfaces the wrong thing or for high-trust contexts where you need to audit what's shaping the agent's responses. Runs embedded out of the box, no separate database to manage.
+
+hermes-agentmemory - a community fix for a real Hermes problem: when you tell the agent to forget something, it doesn't actually forget - it keeps an internal summary that quietly influences future recall. This provider does real deletion (gone is gone) and logs every memory operation so you can audit what happened. Pick it if compliance, privacy, or user-controlled forgetting matters.
+
+PLUR - the cross-agent memory bridge. Hermes memory normally doesn't reach Cursor, and Cursor's doesn't reach Claude Code. PLUR stores everything in a shared .plur/ folder that all of them can read, so a fact you teach one agent automatically shows up in the others. Pick it if you work across multiple agents on the same project and don't want to teach each one separately.
+
+FlowState-QMD - The "guess what you'll need next" provider. It tries to predict the agent's next likely query and warms up that memory in advance, so by the time the agent actually searches, the result is already cached and responses come back faster. Pick it if your agent does repetitive long-horizon work where the next step is usually guessable from context.
+
+One thing I expected to find that doesn't exist: memory-as-skill is effectively a non-pattern. The agentskills.io standard means a "skill" could in principle implement memory. In practice all credible persistent memory flows through the MemoryProvider ABC. Even skills that "do memory" (the Mnemosyne SKILL.md, for instance) are wrappers around plug-ins, telling the agent how to use them.
+
+## How to actually pick?
+
+Step 1: pick your layer strategy
+
+Step 2: pick your layer 2 system
+
+## Warning signs you went too heavy:
+
+The agent feels noticeably slower. Responses that used to come back in about a second now take 3+ seconds. A heavy memory layer adds work on every turn, and once latency creeps past a few seconds the agent stops feeling responsive.
+
+Your API bill is creeping up for the same usage. Memory operations consume tokens, and some providers fire extra background LLM calls every time you save something. If your usage patterns haven't changed but your spend has, suspect the memory layer.
+
+The agent starts contradicting itself. It recalls one version of a fact in one session and the opposite in the next, and can't tell you which is right. This usually means memory is accumulating without ever being consolidated - the agent is now drawing from a polluted well.
+
+The agent runs out of context mid-conversation. A greedy memory layer eats into the same context budget your actual conversation needs. If you start seeing "context too long" errors, or the agent forgets what you told it five minutes ago, the memory layer is overspending its share.
+
+Your work isn't actually getting better. This is the one that matters most. You added memory expecting more accurate, more personalized output. After a couple of weeks, can you point at a specific way the agent is genuinely better than before? If you can't, the memory layer isn't earning its complexity. Pull it.
+
+I hope you enjoyed this Hermes Agent deep dive on all things memory. If you want to explore more within the Hermes ecosystem, check out hermesatlas.com and sign up for the Hermes Atlas newsletter to stay up to date on everything.
+
+
+---
+
 # State of Hermes — April 2026
 
 Canonical URL: https://hermesatlas.com/reports/state-of-hermes-april-2026

--- a/llms.txt
+++ b/llms.txt
@@ -7,6 +7,7 @@ Hermes Atlas tracks every open-source project in the Hermes Agent ecosystem acro
 ## Guide
 - [Beginner's Guide to Hermes Agent](https://hermesatlas.com/guide/): Install, pick a model, ship your first workflow, with the best community tool for every step.
 - [Install Hermes Agent](https://hermesatlas.com/guide/install/): Step-by-step install for macOS, Linux, Windows, and WSL, with troubleshooting.
+- [The Hermes Agent Memory Guidebook](https://hermesatlas.com/guide/memory/): Kevin Simback's guide to native memory, MemoryProviders, and community memory plug-ins.
 - [Hermes Agent vs. Claude Code](https://hermesatlas.com/guide/vs-claude-code/): Feature-by-feature comparison for choosing between the two.
 
 ## Top Projects

--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -488,6 +488,7 @@ Hermes Atlas tracks every open-source project in the Hermes Agent ecosystem acro
 ## Guide
 - [Beginner's Guide to Hermes Agent](${SITE_URL}/guide/): Install, pick a model, ship your first workflow, with the best community tool for every step.
 - [Install Hermes Agent](${SITE_URL}/guide/install/): Step-by-step install for macOS, Linux, Windows, and WSL, with troubleshooting.
+- [The Hermes Agent Memory Guidebook](${SITE_URL}/guide/memory/): Kevin Simback's guide to native memory, MemoryProviders, and community memory plug-ins.
 - [Hermes Agent vs. Claude Code](${SITE_URL}/guide/vs-claude-code/): Feature-by-feature comparison for choosing between the two.
 
 ## Top Projects
@@ -543,6 +544,11 @@ This file is the companion to ${SITE_URL}/llms.txt (the concise index).`);
     const installHtml = fs.readFileSync(path.join(ROOT, "guide", "install", "index.html"), "utf-8");
     const stripped = stripHtmlToText(installHtml);
     if (stripped) sections.push(`# Install Hermes Agent (/guide/install/)\n\nCanonical URL: ${SITE_URL}/guide/install/\n\n${stripped}`);
+  } catch {}
+
+  try {
+    const memoryDraft = fs.readFileSync(path.join(ROOT, "drafts", "guide-memory.md"), "utf-8");
+    sections.push(`# The Hermes Agent Memory Guidebook (/guide/memory/)\n\nCanonical URL: ${SITE_URL}/guide/memory/\n\n${memoryDraft}`);
   } catch {}
 
   try {
@@ -836,6 +842,7 @@ ${renderMasthead("lists")}
 <section class="list-page">
   <h1 class="list-title">${escapeHtml(list.title)}</h1>
   <p class="list-intro">${escapeHtml(list.description)}</p>
+  ${list.slug === "best-memory-providers" ? '<p class="list-intro">For the architecture behind these tools, read <a href="/guide/memory/">The Hermes Agent Memory Guidebook</a>.</p>' : ""}
 </section>
 
 <div class="list-table" aria-label="Ranked list">
@@ -1011,6 +1018,7 @@ function generateSitemap(projectPages, listPages, reportPages = []) {
   urls += `  <url><loc>${SITE_URL}/guide/</loc><changefreq>monthly</changefreq><priority>0.9</priority><lastmod>${today}</lastmod></url>\n`;
   urls += `  <url><loc>${SITE_URL}/guide/vs-claude-code/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>${today}</lastmod></url>\n`;
   urls += `  <url><loc>${SITE_URL}/guide/install/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>${today}</lastmod></url>\n`;
+  urls += `  <url><loc>${SITE_URL}/guide/memory/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>${today}</lastmod></url>\n`;
   urls += `  <url><loc>${SITE_URL}/reports/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>${today}</lastmod></url>\n`;
   for (const r of reportPages) {
     urls += `  <url><loc>${SITE_URL}/reports/${r.slug}</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>\n`;

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -4,6 +4,7 @@
   <url><loc>https://hermesatlas.com/guide/</loc><changefreq>monthly</changefreq><priority>0.9</priority><lastmod>2026-06-05</lastmod></url>
   <url><loc>https://hermesatlas.com/guide/vs-claude-code/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>2026-06-05</lastmod></url>
   <url><loc>https://hermesatlas.com/guide/install/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>2026-06-05</lastmod></url>
+  <url><loc>https://hermesatlas.com/guide/memory/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>2026-06-05</lastmod></url>
   <url><loc>https://hermesatlas.com/reports/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>2026-06-05</lastmod></url>
   <url><loc>https://hermesatlas.com/reports/state-of-hermes-may-2026</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://hermesatlas.com/reports/state-of-hermes-april-2026</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>


### PR DESCRIPTION
## Summary
- add Kevin's X article as the new /guide/memory/ evergreen Atlas guide
- link it from the handbook and the best memory providers list
- add it to sitemap plus llms.txt / llms-full.txt artifacts

## Validation
- node scripts/build-pages.js
- local checks confirm /guide/memory/, /guide/, /lists/best-memory-providers.html, sitemap, llms.txt, and llms-full.txt include the new guide
- browser-verified /guide/memory/ and the memory providers list locally