### PR TITLE
Improve memory guide links and discovery

### DIFF
--- a/drafts/guide-memory.md
+++ b/drafts/guide-memory.md
@@ -8,7 +8,7 @@ Source: https://x.com/KSimback/status/2058262328496554021
 
 TLDR: this is your definitive guide to all things related to memory systems for Hermes Agent. Why create this? Because every week I see new posts or articles describing some new memory tool for Hermes agents and these make me question if my memory setup is the best. So I dug into all of them and broke it down for you.
 
-Over the past few months my Hermes agent has been mapping the Hermes ecosystem over at hermesatlas.com. One of the key areas it has covered is memory and it even has a dedicated section for it.
+Over the past few months my Hermes agent has been mapping the Hermes ecosystem over at [hermesatlas.com](https://hermesatlas.com). One of the key areas it has covered is memory and it even has a dedicated [memory providers section](/lists/best-memory-providers) for it.
 
 ![Best Memory Providers for Hermes Agent](/guide/memory/assets/best-memory-providers-for-hermes-agent.jpg)
 
@@ -22,7 +22,7 @@ Without memory, an agent is just a stateless function and no different than a bl
 
 A coding session that doesn't remember the conventions you established last Tuesday will reinvent them this Tuesday. A personal assistant agent that doesn't remember your preferences has to ask you the same repeated questions. Without memory, an agent really isn't an agent at all.
 
-Memory is what turns an chatbot into something that compounds. Which is why every serious agent harness - OpenClaw, Claude Code, Codex, and our beloved Hermes - has memory primitives built in, and why a real product category has emerged around dedicated memory infrastructure or agents (Mem0 raised $24M, Letta $10M, plus Zep, Cipher, Supermemory, Hindsight, etc.).
+Memory is what turns an chatbot into something that compounds. Which is why every serious agent harness - OpenClaw, Claude Code, Codex, and our beloved [Hermes Agent](/projects/NousResearch/hermes-agent) - has memory primitives built in, and why a real product category has emerged around dedicated memory infrastructure or agents ([Mem0](/projects/mem0ai/mem0) raised $24M, [Letta](https://www.letta.com/) $10M, plus [Zep](https://www.getzep.com/), Cipher, [Supermemory](/projects/supermemoryai/supermemory), [Hindsight](/projects/vectorize-io/hindsight), etc.).
 
 The Hermes Agent take is interesting because Nous Research treats memory as first-class plug-in infrastructure, not a feature. There's a base layer that always runs, a pluggable provider system that lets you choose from 8 architectures (or write your own), and a healthy community plug-in layer on top.
 
@@ -108,19 +108,19 @@ Let's dive in.
 
 ## The 8 Official Providers
 
-## Honcho (Plastic Labs) - AI-native dialectic user modeling
+## [Honcho](/projects/plastic-labs/honcho) (Plastic Labs) - AI-native dialectic user modeling
 
 The only provider in the lineup that tries to model how you think, not just what you said. Instead of storing flat facts like "Kevin uses 4-space indents," Honcho runs a multi-step reasoning pass after your conversations to build a profile of your reasoning patterns, preferences, and goals.
 
 That profile evolves over time, so the agent gets better at anticipating what you'd want even on topics you've never discussed. It also lets multiple "AI identities" share the same view of you - useful if you run different specialist agents for coding, writing, and strategy and want all of them to know your style. Most-cited favorite in the Hermes Discord (@offendingcommit: "I've tried them all... I freakin' love Honcho.").
 
-## Mem0 - fastest 30-second setup, broadest ecosystem
+## [Mem0](/projects/mem0ai/mem0) - fastest 30-second setup, broadest ecosystem
 
 The "just give me memory and stop asking questions" pick. You sign up for Mem0 cloud, paste an API key, and you're done - the provider extracts facts from conversations, deduplicates them, and serves up semantic search automatically in the background.
 
 It's also the exclusive memory provider for AWS's Strands Agents SDK, which gives it the widest ecosystem reach in the lineup. In April 2026 Mem0 shipped a "v3" algorithm claiming to leapfrog Hindsight on benchmarks (94.8 on LongMemEval, 91.6 on LoCoMo).
 
-## Hindsight (Vectorize.io) - the benchmark king
+## [Hindsight](/projects/vectorize-io/hindsight) (Vectorize.io) - the benchmark king
 
 The first memory system of any kind to publicly cross 90 on LongMemEval (91.4, December 2025). Hindsight thinks about memory as four separate networks - things about the world, things that happened, opinions, and raw observations - and pulls only a handful of high-value facts from each conversation (2 to 5, not one per sentence).
 
@@ -132,7 +132,7 @@ It's also the only provider with a reflect tool that lets the agent run a reason
 
 The only provider in the lineup that needs no internet, no API key, and no LLM to function. Everything lives in a local SQLite file. It uses a 1991-era technique called Holographic Reduced Representations to do compositional reasoning over facts - you can bind concepts together algebraically and probe for related ones later. Retrieval is sub-millisecond because it's pure local SQL.
 
-## OpenViking - tiered filesystem context DB
+## [OpenViking](/projects/volcengine/OpenViking) - tiered filesystem context DB
 
 Your memory lives as files in a directory tree on your disk. You can cat them, grep them, edit them by hand. Each piece of stored knowledge has three loading tiers: a one-sentence summary, a paragraph-level overview, and the full content.
 
@@ -144,13 +144,13 @@ $20/month for 100,000 queries, with a free tier of 10,000 operations to test. Th
 
 Pick this option if you want shared memory across team members or agents and you don't want to operate a database.
 
-## ByteRover - memory as a git repo
+## [ByteRover](/projects/campfirein/byterover-cli) - memory as a git repo
 
 Your memory is plain markdown files in a .brv/context-tree/ directory - grep-able, version-controllable, no database to run. ByteRover layers a 5-tier retrieval system on top, and four of those tiers don't need an LLM call, so most lookups finish in under 100ms with zero token spend.
 
 The key selling point: you can branch, merge, and roll back memory like code with CLI commands. It also uses a special hook to extract high-value insights before Hermes compresses context, which is the cleanest fix in the lineup for the "agent loses memory after restart" failure mode (noted in issue #17251).
 
-## Supermemory - latency + scale leader
+## [Supermemory](/projects/supermemoryai/supermemory) - latency + scale leader
 
 Sub-300ms recall sustained at over 100 billion tokens per month. Supermemory built a custom vector graph engine for this rather than stapling a vector DB and a graph DB together.
 
@@ -168,13 +168,13 @@ If none of the official 8 fits your use case, or if you want even more on top, t
 
 Two things to know up front about Layer 3:
 
-Not every Layer 3 project competes with Layer 2. Some are alternative MemoryProvider plug-ins you'd pick instead of one of the official 8 (Mnemosyne is the clearest example). Others occupy a different role entirely - they store a different type of memory and run alongside your Layer 2 provider, not in place of it (GBrain is the clearest example, storing world facts about people, companies, and projects in a separate brain layer while your Layer 2 provider handles operational memory).
+Not every Layer 3 project competes with Layer 2. Some are alternative MemoryProvider plug-ins you'd pick instead of one of the official 8 ([Mnemosyne](/projects/AxDSan/mnemosyne) is the clearest example). Others occupy a different role entirely - they store a different type of memory and run alongside your Layer 2 provider, not in place of it ([GBrain](/projects/garrytan/gbrain) is the clearest example, storing world facts about people, companies, and projects in a separate brain layer while your Layer 2 provider handles operational memory).
 
 You give up polish to get capability. The official 8 ship with Nous's review and tend to "just work." Community plug-ins are typically a bit rougher on the install, have fewer docs, and more chance of hitting a bug. But they unlock things the official set doesn't offer like fully-local sub-millisecond retrieval (Mnemosyne), a markdown-and-Postgres knowledge graph that builds itself with zero LLM calls (GBrain), explainable retrieval rankings (yantrikdb), and cross-agent memory portability (PLUR).
 
-The safe path if you're committing to a memory stack for real work: start with one of the official 8 and only reach for Layer 3 when you've identified a specific capability gap a community project fills. The standouts below are GBrain and Mnemosyne.
+The safe path if you're committing to a memory stack for real work: start with one of the official 8 and only reach for Layer 3 when you've identified a specific capability gap a community project fills. The standouts below are [GBrain](/projects/garrytan/gbrain) and [Mnemosyne](/projects/AxDSan/mnemosyne).
 
-## GBrain (by garrytan) - this is what I personally use
+## [GBrain](/projects/garrytan/gbrain) (by garrytan) - this is what I personally use
 
 Open-sourced in April, MIT licensed, ~18k+ stars. TypeScript. Built by Garry Tan to run his own production agents. GBrain is structurally different from the official 8. GBrain does not subclass MemoryProvider, it plugs in as skillpack + MCP server (~30 MCP tools), and occupys a different ontological slot. The explicit doctrine in docs/guides/brain-vs-memory.md:
 
@@ -196,7 +196,7 @@ Autonomous enrichment + persistent personal memory: tiered enrichment based on h
 
 Why pick GBrain over the official 8? If you want a graph cheap, git as system of record, overnight maintenance, you already have a markdown vault (migration covers Obsidian / Logseq / Notion / Roam), or you're building a "company of agents."
 
-## Mnemosyne (AxDSan/mnemosyne)
+## [Mnemosyne](/projects/AxDSan/mnemosyne) (AxDSan/mnemosyne)
 
 The strongest community alternative when you want a real MemoryProvider plug-in (rather than GBrain, which plays a different role). Runs entirely on your machine - no cloud, no API key, no internet - and recall is fast enough to feel instant (under 2 milliseconds in published tests).
 
@@ -206,15 +206,15 @@ The standout feature for serious users: memory has a sense of time. You can ask 
 
 ## Others worth knowing about
 
-Ladybug Memory - the local-only option with built-in importance ranking. Every memory gets a score from 1 to 10 so the system surfaces the things that matter first instead of treating everything equally. Pick it if you want fully-local memory and the built-in MEMORY.md cap is too small for your knowledge.
+[Ladybug Memory](/projects/Ladybug-Memory/hermes-memory-plugin) - the local-only option with built-in importance ranking. Every memory gets a score from 1 to 10 so the system surfaces the things that matter first instead of treating everything equally. Pick it if you want fully-local memory and the built-in MEMORY.md cap is too small for your knowledge.
 
-yantrikdb - he one to pick when you need to know why the agent recalled what it did. Every retrieval comes back with a "why retrieved" explanation, which is useful for debugging when the agent surfaces the wrong thing or for high-trust contexts where you need to audit what's shaping the agent's responses. Runs embedded out of the box, no separate database to manage.
+[yantrikdb](/projects/yantrikos/yantrikdb-hermes-plugin) - the one to pick when you need to know why the agent recalled what it did. Every retrieval comes back with a "why retrieved" explanation, which is useful for debugging when the agent surfaces the wrong thing or for high-trust contexts where you need to audit what's shaping the agent's responses. Runs embedded out of the box, no separate database to manage.
 
-hermes-agentmemory - a community fix for a real Hermes problem: when you tell the agent to forget something, it doesn't actually forget - it keeps an internal summary that quietly influences future recall. This provider does real deletion (gone is gone) and logs every memory operation so you can audit what happened. Pick it if compliance, privacy, or user-controlled forgetting matters.
+[hermes-agentmemory](/projects/MukundaKatta/hermes-agentmemory) - a community fix for a real Hermes problem: when you tell the agent to forget something, it doesn't actually forget - it keeps an internal summary that quietly influences future recall. This provider does real deletion (gone is gone) and logs every memory operation so you can audit what happened. Pick it if compliance, privacy, or user-controlled forgetting matters.
 
-PLUR - the cross-agent memory bridge. Hermes memory normally doesn't reach Cursor, and Cursor's doesn't reach Claude Code. PLUR stores everything in a shared .plur/ folder that all of them can read, so a fact you teach one agent automatically shows up in the others. Pick it if you work across multiple agents on the same project and don't want to teach each one separately.
+[PLUR](/projects/plur-ai/plur) - the cross-agent memory bridge. Hermes memory normally doesn't reach Cursor, and Cursor's doesn't reach Claude Code. PLUR stores everything in a shared .plur/ folder that all of them can read, so a fact you teach one agent automatically shows up in the others. Pick it if you work across multiple agents on the same project and don't want to teach each one separately.
 
-FlowState-QMD - The "guess what you'll need next" provider. It tries to predict the agent's next likely query and warms up that memory in advance, so by the time the agent actually searches, the result is already cached and responses come back faster. Pick it if your agent does repetitive long-horizon work where the next step is usually guessable from context.
+[FlowState-QMD](/projects/amanning3390/flowstate-qmd) - The "guess what you'll need next" provider. It tries to predict the agent's next likely query and warms up that memory in advance, so by the time the agent actually searches, the result is already cached and responses come back faster. Pick it if your agent does repetitive long-horizon work where the next step is usually guessable from context.
 
 One thing I expected to find that doesn't exist: memory-as-skill is effectively a non-pattern. The agentskills.io standard means a "skill" could in principle implement memory. In practice all credible persistent memory flows through the MemoryProvider ABC. Even skills that "do memory" (the Mnemosyne SKILL.md, for instance) are wrappers around plug-ins, telling the agent how to use them.
 
@@ -240,4 +240,18 @@ The agent runs out of context mid-conversation. A greedy memory layer eats into 
 
 Your work isn't actually getting better. This is the one that matters most. You added memory expecting more accurate, more personalized output. After a couple of weeks, can you point at a specific way the agent is genuinely better than before? If you can't, the memory layer isn't earning its complexity. Pull it.
 
-I hope you enjoyed this Hermes Agent deep dive on all things memory. If you want to explore more within the Hermes ecosystem, check out hermesatlas.com and sign up for the Hermes Atlas newsletter to stay up to date on everything.
+## Frequently asked questions
+
+## What are the layers of Hermes Agent memory?
+
+Hermes Agent memory has three practical layers: native memory that ships with Hermes, one optional official MemoryProvider, and community plug-ins such as [GBrain](/projects/garrytan/gbrain) or [Mnemosyne](/projects/AxDSan/mnemosyne) for specialized needs.
+
+## Which Hermes memory provider should I choose?
+
+Start with native memory unless you need semantic recall, shared team memory, graph memory, or compliance-grade deletion. Then choose the provider that matches that specific gap rather than installing memory infrastructure by default.
+
+## Can Hermes Agent use GBrain with another MemoryProvider?
+
+Yes. [GBrain](/projects/garrytan/gbrain) occupies a different knowledge-graph slot than the official MemoryProvider layer, so it can complement a Layer 2 provider that handles operational conversation memory.
+
+I hope you enjoyed this Hermes Agent deep dive on all things memory. If you want to explore more within the Hermes ecosystem, check out [hermesatlas.com](https://hermesatlas.com) and sign up for the [Hermes Atlas newsletter](/#newsletter) to stay up to date on everything.

--- a/guide/index.html
+++ b/guide/index.html
@@ -247,6 +247,8 @@
   <p class="meta">By <a href="https://x.com/ksimback">Kevin Simback</a> · Hermes Atlas maintainer · Updated 2026-04-20 · ~18 min read</p>
 </header>
 
+<blockquote><strong>More handbook guides:</strong> if you are here for memory architecture, provider comparisons, or how to choose between GBrain, Mnemosyne, Mem0, Hindsight, Honcho, and Supermemory, read <a href="/guide/memory/"><strong>The Hermes Agent Memory Guidebook →</strong></a></blockquote>
+
 <blockquote><strong>TL;DR</strong> — Hermes Agent is Nous Research's open-source autonomous AI agent. It runs on your laptop or a VPS, remembers everything across sessions, writes its own reusable skills as it works, and reaches you through 14+ messaging platforms (CLI, Telegram, Discord, Slack, email, and more). You install it with one command, pick any model from 20+ LLM providers, and it compounds in capability over the following thirty days. As of April 2026. Based on 100+ ecosystem projects reviewed, 33 research sources, and the live GitHub repo.</blockquote>
 
 <h2>Table of contents</h2>

--- a/guide/memory/index.html
+++ b/guide/memory/index.html
@@ -4,7 +4,8 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>The Hermes Agent Memory Guidebook | Hermes Atlas</title>
-<meta name="description" content="Kevin Simback's Hermes Agent Memory Guidebook: the three-layer Hermes memory stack, native memory, official MemoryProviders, and community memory plug-ins.">
+<meta name="description" content="Kevin Simback's Hermes Agent memory guide: compare native memory, official MemoryProviders, and community plug-ins like GBrain, Mnemosyne, Mem0, Hindsight, Honcho, and Supermemory.">
+<meta name="keywords" content="Hermes Agent memory, Hermes MemoryProvider, AI agent memory, GBrain, Mnemosyne, Mem0, Hindsight, Honcho, Supermemory, Hermes Atlas">
 <link rel="canonical" href="https://hermesatlas.com/guide/memory/">
 <meta property="og:title" content="The Hermes Agent Memory Guidebook">
 <meta property="og:description" content="A definitive guide to Hermes Agent memory systems: native memory, official MemoryProviders, and community plug-ins.">
@@ -12,6 +13,7 @@
 <meta property="og:url" content="https://hermesatlas.com/guide/memory/">
 <meta property="og:site_name" content="Hermes Atlas">
 <meta property="article:published_time" content="2026-05-23T00:00:00Z">
+<meta property="article:modified_time" content="2026-06-07T00:00:00-04:00">
 <meta property="article:author" content="https://x.com/KSimback">
 <meta property="og:image" content="https://hermesatlas.com/api/og?title=The+Hermes+Agent+Memory+Guidebook&amp;subtitle=Native+memory%2C+MemoryProviders%2C+and+community+memory+plug-ins&amp;kind=guide">
 <meta property="og:image:width" content="1200">
@@ -41,10 +43,36 @@
   "@type": "Article",
   "headline": "The Hermes Agent Memory Guidebook",
   "description": "A guide to Hermes Agent memory systems: native memory, official MemoryProviders, and community memory plug-ins.",
+  "image": "https://hermesatlas.com/guide/memory/assets/complete-guide-to-hermes-agent-memory.jpg",
+  "keywords": ["Hermes Agent memory", "Hermes MemoryProvider", "AI agent memory", "GBrain", "Mnemosyne", "Mem0", "Hindsight", "Honcho", "Supermemory"],
   "datePublished": "2026-05-23T00:00:00Z",
+  "dateModified": "2026-06-07T00:00:00-04:00",
   "author": {"@type": "Person", "name": "Kevin Simback", "url": "https://x.com/KSimback"},
   "publisher": {"@type": "Organization", "name": "Hermes Atlas", "url": "https://hermesatlas.com"},
   "mainEntityOfPage": {"@type": "WebPage", "@id": "https://hermesatlas.com/guide/memory/"}
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What are the layers of Hermes Agent memory?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Hermes Agent memory has three practical layers: native memory that ships with Hermes, one optional official MemoryProvider, and community plug-ins such as GBrain or Mnemosyne for specialized needs."}
+    },
+    {
+      "@type": "Question",
+      "name": "Which Hermes memory provider should I choose?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Start with native memory unless you need semantic recall, shared team memory, graph memory, or compliance-grade deletion. Then choose the provider that matches that specific gap rather than installing memory infrastructure by default."}
+    },
+    {
+      "@type": "Question",
+      "name": "Can Hermes Agent use GBrain with another MemoryProvider?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Yes. GBrain occupies a different knowledge-graph slot than the official MemoryProvider layer, so it can complement a Layer 2 provider that handles operational conversation memory."}
+    }
+  ]
 }
 </script>
 <script type="application/ld+json">
@@ -102,7 +130,7 @@
 
 <p>TLDR: this is your definitive guide to all things related to memory systems for Hermes Agent. Why create this? Because every week I see new posts or articles describing some new memory tool for Hermes agents and these make me question if my memory setup is the best. So I dug into all of them and broke it down for you.</p>
 
-<p>Over the past few months my Hermes agent has been mapping the Hermes ecosystem over at <a href="https://hermesatlas.com">hermesatlas.com</a>. One of the key areas it has covered is memory and it even has a dedicated section for it.</p>
+<p>Over the past few months my Hermes agent has been mapping the Hermes ecosystem over at <a href="https://hermesatlas.com">hermesatlas.com</a>. One of the key areas it has covered is memory and it even has a dedicated <a href="/lists/best-memory-providers">memory providers section</a> for it.</p>
 
 <figure>
   <img src="/guide/memory/assets/best-memory-providers-for-hermes-agent.jpg" alt="Best Memory Providers for Hermes Agent">
@@ -119,7 +147,7 @@
 
 <p>A coding session that doesn&#x27;t remember the conventions you established last Tuesday will reinvent them this Tuesday. A personal assistant agent that doesn&#x27;t remember your preferences has to ask you the same repeated questions. Without memory, an agent really isn&#x27;t an agent at all.</p>
 
-<p>Memory is what turns an chatbot into something that compounds. Which is why every serious agent harness - OpenClaw, Claude Code, Codex, and our beloved Hermes - has memory primitives built in, and why a real product category has emerged around dedicated memory infrastructure or agents (Mem0 raised $24M, Letta $10M, plus Zep, Cipher, Supermemory, Hindsight, etc.).</p>
+<p>Memory is what turns an chatbot into something that compounds. Which is why every serious agent harness - OpenClaw, Claude Code, Codex, and our beloved <a href="/projects/NousResearch/hermes-agent">Hermes Agent</a> - has memory primitives built in, and why a real product category has emerged around dedicated memory infrastructure or agents (<a href="/projects/mem0ai/mem0">Mem0</a> raised $24M, <a href="https://www.letta.com/" target="_blank" rel="noopener">Letta</a> $10M, plus <a href="https://www.getzep.com/" target="_blank" rel="noopener">Zep</a>, Cipher, <a href="/projects/supermemoryai/supermemory">Supermemory</a>, <a href="/projects/vectorize-io/hindsight">Hindsight</a>, etc.).</p>
 
 <p>The Hermes Agent take is interesting because Nous Research treats memory as first-class plug-in infrastructure, not a feature. There&#x27;s a base layer that always runs, a pluggable provider system that lets you choose from 8 architectures (or write your own), and a healthy community plug-in layer on top.</p>
 
@@ -133,7 +161,7 @@
 
 <p>Layer 2 - the optional plug-in slot. When you outgrow the native layer (you want semantic recall across sessions, or a system that models your preferences, or token-efficient retrieval at scale) you pick one of 8 official providers. They each take a different architectural bet about what memory should do, and you can run exactly one at a time. Switching providers is a clean start - the new provider doesn&#x27;t inherit the old one&#x27;s data, but the Layer 1 native files keep running underneath either way.</p>
 
-<p>Layer 3 - what the community builds beyond the official 8. Two flavors. Some community projects are MemoryProvider plug-ins that compete head-to-head with the Layer 2 picks (Mnemosyne is the standout - fully local, sub-millisecond, with a real tiered cognitive architecture). Others sit alongside the official providers in a different slot entirely (GBrain is the standout here - it stores world facts like people, companies, and projects in a markdown vault, while your Layer 2 provider handles operational memory). Layer 3 usually means more setup and less polish than the official 8, but it&#x27;s where you go when you need a capability the eight providers don&#x27;t offer.</p>
+<p>Layer 3 - what the community builds beyond the official 8. Two flavors. Some community projects are MemoryProvider plug-ins that compete head-to-head with the Layer 2 picks (<a href="/projects/AxDSan/mnemosyne">Mnemosyne</a> is the standout - fully local, sub-millisecond, with a real tiered cognitive architecture). Others sit alongside the official providers in a different slot entirely (<a href="/projects/garrytan/gbrain">GBrain</a> is the standout here - it stores world facts like people, companies, and projects in a markdown vault, while your Layer 2 provider handles operational memory). Layer 3 usually means more setup and less polish than the official 8, but it&#x27;s where you go when you need a capability the eight providers don&#x27;t offer.</p>
 
 <p>The layers stack rather than replace each other. Switching the Layer 2 provider does not wipe Layer 1. Each provider has its own store, but the native session database and the two markdown files keep running underneath. Layer 3 plug-ins are additive on top of both.</p>
 
@@ -208,19 +236,19 @@
 
 <h2 id="the-8-official-providers">The 8 Official Providers</h2>
 
-<h2 id="honcho-plastic-labs-ai-native-dialectic-user-modeling">Honcho (Plastic Labs) - AI-native dialectic user modeling</h2>
+<h2 id="honcho-plastic-labs-ai-native-dialectic-user-modeling"><a href="/projects/plastic-labs/honcho">Honcho</a> (Plastic Labs) - AI-native dialectic user modeling</h2>
 
 <p>The only provider in the lineup that tries to model how you think, not just what you said. Instead of storing flat facts like &quot;Kevin uses 4-space indents,&quot; Honcho runs a multi-step reasoning pass after your conversations to build a profile of your reasoning patterns, preferences, and goals.</p>
 
 <p>That profile evolves over time, so the agent gets better at anticipating what you&#x27;d want even on topics you&#x27;ve never discussed. It also lets multiple &quot;AI identities&quot; share the same view of you - useful if you run different specialist agents for coding, writing, and strategy and want all of them to know your style. Most-cited favorite in the Hermes Discord (@offendingcommit: &quot;I&#x27;ve tried them all... I freakin&#x27; love Honcho.&quot;).</p>
 
-<h2 id="mem0-fastest-30-second-setup-broadest-ecosystem">Mem0 - fastest 30-second setup, broadest ecosystem</h2>
+<h2 id="mem0-fastest-30-second-setup-broadest-ecosystem"><a href="/projects/mem0ai/mem0">Mem0</a> - fastest 30-second setup, broadest ecosystem</h2>
 
 <p>The &quot;just give me memory and stop asking questions&quot; pick. You sign up for Mem0 cloud, paste an API key, and you&#x27;re done - the provider extracts facts from conversations, deduplicates them, and serves up semantic search automatically in the background.</p>
 
 <p>It&#x27;s also the exclusive memory provider for AWS&#x27;s Strands Agents SDK, which gives it the widest ecosystem reach in the lineup. In April 2026 Mem0 shipped a &quot;v3&quot; algorithm claiming to leapfrog Hindsight on benchmarks (94.8 on LongMemEval, 91.6 on LoCoMo).</p>
 
-<h2 id="hindsight-vectorize-io-the-benchmark-king">Hindsight (Vectorize.io) - the benchmark king</h2>
+<h2 id="hindsight-vectorize-io-the-benchmark-king"><a href="/projects/vectorize-io/hindsight">Hindsight</a> (Vectorize.io) - the benchmark king</h2>
 
 <p>The first memory system of any kind to publicly cross 90 on LongMemEval (91.4, December 2025). Hindsight thinks about memory as four separate networks - things about the world, things that happened, opinions, and raw observations - and pulls only a handful of high-value facts from each conversation (2 to 5, not one per sentence).</p>
 
@@ -232,7 +260,7 @@
 
 <p>The only provider in the lineup that needs no internet, no API key, and no LLM to function. Everything lives in a local SQLite file. It uses a 1991-era technique called Holographic Reduced Representations to do compositional reasoning over facts - you can bind concepts together algebraically and probe for related ones later. Retrieval is sub-millisecond because it&#x27;s pure local SQL.</p>
 
-<h2 id="openviking-tiered-filesystem-context-db">OpenViking - tiered filesystem context DB</h2>
+<h2 id="openviking-tiered-filesystem-context-db"><a href="/projects/volcengine/OpenViking">OpenViking</a> - tiered filesystem context DB</h2>
 
 <p>Your memory lives as files in a directory tree on your disk. You can cat them, grep them, edit them by hand. Each piece of stored knowledge has three loading tiers: a one-sentence summary, a paragraph-level overview, and the full content.</p>
 
@@ -244,13 +272,13 @@
 
 <p>Pick this option if you want shared memory across team members or agents and you don&#x27;t want to operate a database.</p>
 
-<h2 id="byterover-memory-as-a-git-repo">ByteRover - memory as a git repo</h2>
+<h2 id="byterover-memory-as-a-git-repo"><a href="/projects/campfirein/byterover-cli">ByteRover</a> - memory as a git repo</h2>
 
 <p>Your memory is plain markdown files in a .brv/context-tree/ directory - grep-able, version-controllable, no database to run. ByteRover layers a 5-tier retrieval system on top, and four of those tiers don&#x27;t need an LLM call, so most lookups finish in under 100ms with zero token spend.</p>
 
 <p>The key selling point: you can branch, merge, and roll back memory like code with CLI commands. It also uses a special hook to extract high-value insights before Hermes compresses context, which is the cleanest fix in the lineup for the &quot;agent loses memory after restart&quot; failure mode (noted in issue #17251).</p>
 
-<h2 id="supermemory-latency-scale-leader">Supermemory - latency + scale leader</h2>
+<h2 id="supermemory-latency-scale-leader"><a href="/projects/supermemoryai/supermemory">Supermemory</a> - latency + scale leader</h2>
 
 <p>Sub-300ms recall sustained at over 100 billion tokens per month. Supermemory built a custom vector graph engine for this rather than stapling a vector DB and a graph DB together.</p>
 
@@ -271,13 +299,13 @@
 
 <p>Two things to know up front about Layer 3:</p>
 
-<p>Not every Layer 3 project competes with Layer 2. Some are alternative MemoryProvider plug-ins you&#x27;d pick instead of one of the official 8 (Mnemosyne is the clearest example). Others occupy a different role entirely - they store a different type of memory and run alongside your Layer 2 provider, not in place of it (GBrain is the clearest example, storing world facts about people, companies, and projects in a separate brain layer while your Layer 2 provider handles operational memory).</p>
+<p>Not every Layer 3 project competes with Layer 2. Some are alternative MemoryProvider plug-ins you&#x27;d pick instead of one of the official 8 (<a href="/projects/AxDSan/mnemosyne">Mnemosyne</a> is the clearest example). Others occupy a different role entirely - they store a different type of memory and run alongside your Layer 2 provider, not in place of it (<a href="/projects/garrytan/gbrain">GBrain</a> is the clearest example, storing world facts about people, companies, and projects in a separate brain layer while your Layer 2 provider handles operational memory).</p>
 
-<p>You give up polish to get capability. The official 8 ship with Nous&#x27;s review and tend to &quot;just work.&quot; Community plug-ins are typically a bit rougher on the install, have fewer docs, and more chance of hitting a bug. But they unlock things the official set doesn&#x27;t offer like fully-local sub-millisecond retrieval (Mnemosyne), a markdown-and-Postgres knowledge graph that builds itself with zero LLM calls (GBrain), explainable retrieval rankings (yantrikdb), and cross-agent memory portability (PLUR).</p>
+<p>You give up polish to get capability. The official 8 ship with Nous&#x27;s review and tend to &quot;just work.&quot; Community plug-ins are typically a bit rougher on the install, have fewer docs, and more chance of hitting a bug. But they unlock things the official set doesn&#x27;t offer like fully-local sub-millisecond retrieval (<a href="/projects/AxDSan/mnemosyne">Mnemosyne</a>), a markdown-and-Postgres knowledge graph that builds itself with zero LLM calls (<a href="/projects/garrytan/gbrain">GBrain</a>), explainable retrieval rankings (<a href="/projects/yantrikos/yantrikdb-hermes-plugin">yantrikdb</a>), and cross-agent memory portability (<a href="/projects/plur-ai/plur">PLUR</a>).</p>
 
-<p>The safe path if you&#x27;re committing to a memory stack for real work: start with one of the official 8 and only reach for Layer 3 when you&#x27;ve identified a specific capability gap a community project fills. The standouts below are GBrain and Mnemosyne.</p>
+<p>The safe path if you&#x27;re committing to a memory stack for real work: start with one of the official 8 and only reach for Layer 3 when you&#x27;ve identified a specific capability gap a community project fills. The standouts below are <a href="/projects/garrytan/gbrain">GBrain</a> and <a href="/projects/AxDSan/mnemosyne">Mnemosyne</a>.</p>
 
-<h2 id="gbrain-by-garrytan-this-is-what-i-personally-use">GBrain (by garrytan) - this is what I personally use</h2>
+<h2 id="gbrain-by-garrytan-this-is-what-i-personally-use"><a href="/projects/garrytan/gbrain">GBrain</a> (by garrytan) - this is what I personally use</h2>
 
 <p>Open-sourced in April, MIT licensed, ~18k+ stars. TypeScript. Built by Garry Tan to run his own production agents. GBrain is structurally different from the official 8. GBrain does not subclass MemoryProvider, it plugs in as skillpack + MCP server (~30 MCP tools), and occupys a different ontological slot. The explicit doctrine in docs/guides/brain-vs-memory.md:</p>
 
@@ -299,7 +327,7 @@
 
 <p>Why pick GBrain over the official 8? If you want a graph cheap, git as system of record, overnight maintenance, you already have a markdown vault (migration covers Obsidian / Logseq / Notion / Roam), or you&#x27;re building a &quot;company of agents.&quot;</p>
 
-<h2 id="mnemosyne-axdsan-mnemosyne">Mnemosyne (AxDSan/mnemosyne)</h2>
+<h2 id="mnemosyne-axdsan-mnemosyne"><a href="/projects/AxDSan/mnemosyne">Mnemosyne</a> (AxDSan/mnemosyne)</h2>
 
 <p>The strongest community alternative when you want a real MemoryProvider plug-in (rather than GBrain, which plays a different role). Runs entirely on your machine - no cloud, no API key, no internet - and recall is fast enough to feel instant (under 2 milliseconds in published tests).</p>
 
@@ -309,15 +337,15 @@
 
 <h2 id="others-worth-knowing-about">Others worth knowing about</h2>
 
-<p>Ladybug Memory - the local-only option with built-in importance ranking. Every memory gets a score from 1 to 10 so the system surfaces the things that matter first instead of treating everything equally. Pick it if you want fully-local memory and the built-in MEMORY.md cap is too small for your knowledge.</p>
+<p><a href="/projects/Ladybug-Memory/hermes-memory-plugin">Ladybug Memory</a> - the local-only option with built-in importance ranking. Every memory gets a score from 1 to 10 so the system surfaces the things that matter first instead of treating everything equally. Pick it if you want fully-local memory and the built-in MEMORY.md cap is too small for your knowledge.</p>
 
-<p>yantrikdb - he one to pick when you need to know why the agent recalled what it did. Every retrieval comes back with a &quot;why retrieved&quot; explanation, which is useful for debugging when the agent surfaces the wrong thing or for high-trust contexts where you need to audit what&#x27;s shaping the agent&#x27;s responses. Runs embedded out of the box, no separate database to manage.</p>
+<p><a href="/projects/yantrikos/yantrikdb-hermes-plugin">yantrikdb</a> - the one to pick when you need to know why the agent recalled what it did. Every retrieval comes back with a &quot;why retrieved&quot; explanation, which is useful for debugging when the agent surfaces the wrong thing or for high-trust contexts where you need to audit what&#x27;s shaping the agent&#x27;s responses. Runs embedded out of the box, no separate database to manage.</p>
 
-<p>hermes-agentmemory - a community fix for a real Hermes problem: when you tell the agent to forget something, it doesn&#x27;t actually forget - it keeps an internal summary that quietly influences future recall. This provider does real deletion (gone is gone) and logs every memory operation so you can audit what happened. Pick it if compliance, privacy, or user-controlled forgetting matters.</p>
+<p><a href="/projects/MukundaKatta/hermes-agentmemory">hermes-agentmemory</a> - a community fix for a real Hermes problem: when you tell the agent to forget something, it doesn&#x27;t actually forget - it keeps an internal summary that quietly influences future recall. This provider does real deletion (gone is gone) and logs every memory operation so you can audit what happened. Pick it if compliance, privacy, or user-controlled forgetting matters.</p>
 
-<p>PLUR - the cross-agent memory bridge. Hermes memory normally doesn&#x27;t reach Cursor, and Cursor&#x27;s doesn&#x27;t reach Claude Code. PLUR stores everything in a shared .plur/ folder that all of them can read, so a fact you teach one agent automatically shows up in the others. Pick it if you work across multiple agents on the same project and don&#x27;t want to teach each one separately.</p>
+<p><a href="/projects/plur-ai/plur">PLUR</a> - the cross-agent memory bridge. Hermes memory normally doesn&#x27;t reach Cursor, and Cursor&#x27;s doesn&#x27;t reach Claude Code. PLUR stores everything in a shared .plur/ folder that all of them can read, so a fact you teach one agent automatically shows up in the others. Pick it if you work across multiple agents on the same project and don&#x27;t want to teach each one separately.</p>
 
-<p>FlowState-QMD - The &quot;guess what you&#x27;ll need next&quot; provider. It tries to predict the agent&#x27;s next likely query and warms up that memory in advance, so by the time the agent actually searches, the result is already cached and responses come back faster. Pick it if your agent does repetitive long-horizon work where the next step is usually guessable from context.</p>
+<p><a href="/projects/amanning3390/flowstate-qmd">FlowState-QMD</a> - The &quot;guess what you&#x27;ll need next&quot; provider. It tries to predict the agent&#x27;s next likely query and warms up that memory in advance, so by the time the agent actually searches, the result is already cached and responses come back faster. Pick it if your agent does repetitive long-horizon work where the next step is usually guessable from context.</p>
 
 <p>One thing I expected to find that doesn&#x27;t exist: memory-as-skill is effectively a non-pattern. The agentskills.io standard means a &quot;skill&quot; could in principle implement memory. In practice all credible persistent memory flows through the MemoryProvider ABC. Even skills that &quot;do memory&quot; (the Mnemosyne SKILL.md, for instance) are wrappers around plug-ins, telling the agent how to use them.</p>
 
@@ -349,7 +377,21 @@
 
 <p>Your work isn&#x27;t actually getting better. This is the one that matters most. You added memory expecting more accurate, more personalized output. After a couple of weeks, can you point at a specific way the agent is genuinely better than before? If you can&#x27;t, the memory layer isn&#x27;t earning its complexity. Pull it.</p>
 
-<p>I hope you enjoyed this Hermes Agent deep dive on all things memory. If you want to explore more within the Hermes ecosystem, check out <a href="https://hermesatlas.com">hermesatlas.com</a> and sign up for the Hermes Atlas newsletter to stay up to date on everything.</p>
+<h2 id="frequently-asked-questions">Frequently asked questions</h2>
+
+<h2 id="what-are-the-layers-of-hermes-agent-memory">What are the layers of Hermes Agent memory?</h2>
+
+<p>Hermes Agent memory has three practical layers: native memory that ships with Hermes, one optional official MemoryProvider, and community plug-ins such as <a href="/projects/garrytan/gbrain">GBrain</a> or <a href="/projects/AxDSan/mnemosyne">Mnemosyne</a> for specialized needs.</p>
+
+<h2 id="which-hermes-memory-provider-should-i-choose">Which Hermes memory provider should I choose?</h2>
+
+<p>Start with native memory unless you need semantic recall, shared team memory, graph memory, or compliance-grade deletion. Then choose the provider that matches that specific gap rather than installing memory infrastructure by default.</p>
+
+<h2 id="can-hermes-agent-use-gbrain-with-another-memoryprovider">Can Hermes Agent use GBrain with another MemoryProvider?</h2>
+
+<p>Yes. <a href="/projects/garrytan/gbrain">GBrain</a> occupies a different knowledge-graph slot than the official MemoryProvider layer, so it can complement a Layer 2 provider that handles operational conversation memory.</p>
+
+<p>I hope you enjoyed this Hermes Agent deep dive on all things memory. If you want to explore more within the Hermes ecosystem, check out <a href="https://hermesatlas.com">hermesatlas.com</a> and sign up for the <a href="/#newsletter">Hermes Atlas newsletter</a> to stay up to date on everything.</p>
 <div class="article-footer">
   <p><strong>Written by <a href="https://x.com/KSimback">Kevin Simback</a></strong> · originally published on X</p>
   <p><strong>Source:</strong> <a href="https://x.com/KSimback/status/2058262328496554021">The Hermes Agent Memory Guidebook</a></p>

--- a/index.html
+++ b/index.html
@@ -186,6 +186,26 @@
 </section>
 <!-- END featured-week -->
 
+<!-- Featured guides -->
+<section class="curated-lists handbook-guides" id="handbook-guides">
+  <div class="cat-meta">
+    <div class="cat-num">§·guides</div>
+    <h2 class="cat-title">Handbook guides</h2>
+    <p class="cat-desc">Evergreen explainers for understanding Hermes Agent, memory, and the ecosystem.</p>
+    <div class="cat-count">2 guides</div>
+  </div>
+  <div class="lists-grid">
+    <a href="/guide/" class="list-card">
+      <div class="lc-title">Hermes Agent beginner guide</div>
+      <div class="lc-desc">Install Hermes, pick a model, ship your first workflow, and understand the core learning loop.</div>
+    </a>
+    <a href="/guide/memory/" class="list-card">
+      <div class="lc-title">Hermes Agent Memory Guidebook</div>
+      <div class="lc-desc">Compare native memory, official MemoryProviders, and community memory plug-ins like GBrain and Mnemosyne.</div>
+    </a>
+  </div>
+</section>
+
 <!-- Newsletter capture (compact, above-the-fold) -->
 <aside class="email-cta email-cta--compact" id="newsletter" aria-label="Newsletter signup">
   <div class="email-cta-kicker">newsletter · free · 1–2× / month</div>


### PR DESCRIPTION
## Summary
- Link the memory guide body and source draft to relevant Hermes Atlas project/list pages and original external targets
- Add a Handbook guides section on the homepage so the memory guide is discoverable without the direct URL
- Cross-link the beginner guide to the memory guide
- Improve memory guide SEO metadata and add visible FAQ content matching FAQ structured data

## Verification
- Ran node scripts/build-pages.js successfully; reverted unrelated generated output caused by missing GITHUB_TOKEN
- Verified no nested anchors in updated HTML
- Verified newly added internal links resolve to local generated pages