### PR TITLE
fix: address Atlas audit findings

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -106,22 +106,8 @@ jobs:
             }
             core.setFailed(`Timed out waiting for Vercel deploy (10min)`);
 
-      # Known-broken-but-deferred check IDs go here. Each entry is a substring
-      # match against the failing check name. When a smoke check matches one of
-      # these, the failure becomes a WARN instead of a FAIL (still reported,
-      # doesn't fail the job). Audit and prune this list quarterly - issues
-      # acknowledged here should become tracked bugs to fix, not permanent.
-      #
-      # Current entries (audit before extending):
-      #   /lists/                 - /lists/ index page returns 404; only /lists/<slug>
-      #                             pages exist. Decide: build an index or remove from test.
-      #   Core & Official count   - homepage shows 5 in Core & Official but
-      #                             repos.json has 6 entries. Fix is a single
-      #                             character in index.html. Track separately.
       - name: Run smoke test
         id: smoke
-        env:
-          SMOKE_ALLOW_FAILURES: '/lists/,Core & Official count'
         run: |
           node scripts/smoke-test-prod.js \
             --base "${{ inputs.base || 'https://hermesatlas.com' }}" \

--- a/.github/workflows/smoke-test-pr.yml
+++ b/.github/workflows/smoke-test-pr.yml
@@ -97,8 +97,6 @@ jobs:
 
       - name: Run smoke test against preview
         id: smoke
-        env:
-          SMOKE_ALLOW_FAILURES: '/lists/,Core & Official count'
         run: |
           node scripts/smoke-test-prod.js \
             --base "${{ steps.vercel.outputs.base_url }}" \

--- a/assets/js/email-capture.js
+++ b/assets/js/email-capture.js
@@ -12,7 +12,14 @@
     var button = form.querySelector("button");
     var status = form.parentElement.querySelector(".email-cta-status");
     var email = (input.value || "").trim();
-    if (!email) return;
+    if (!email || !isValidEmail(email)) {
+      status.setAttribute("data-status", "error");
+      status.textContent = "enter a valid email.";
+      input.setAttribute("aria-invalid", "true");
+      input.focus();
+      return;
+    }
+    input.removeAttribute("aria-invalid");
 
     button.disabled = true;
     button.dataset.label = button.dataset.label || button.textContent;
@@ -48,5 +55,9 @@
         button.disabled = false;
         button.textContent = button.dataset.label;
       });
+  }
+
+  function isValidEmail(email) {
+    return /^[a-zA-Z0-9._'+\-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*\.[a-zA-Z]{2,}$/.test(email) && email.length <= 254;
   }
 })();

--- a/data/repos.json
+++ b/data/repos.json
@@ -4,7 +4,7 @@
     "repo": "hermes-agent",
     "name": "hermes-agent",
     "description": "The self-improving AI agent that grows with you — persistent memory, auto-generated skills, 14 platforms, 6 execution backends",
-    "stars": 194787,
+    "stars": 195214,
     "url": "https://github.com/NousResearch/hermes-agent",
     "official": true,
     "category": "Core & Official"
@@ -24,7 +24,7 @@
     "repo": "atropos",
     "name": "atropos",
     "description": "RL training environments framework for tool-calling models",
-    "stars": 1283,
+    "stars": 1282,
     "url": "https://github.com/NousResearch/atropos",
     "official": true,
     "category": "Core & Official"
@@ -34,7 +34,7 @@
     "repo": "hermes-agent-self-evolution",
     "name": "hermes-agent-self-evolution",
     "description": "Evolutionary self-improvement using DSPy + GEPA — optimizes skills, prompts, and code",
-    "stars": 4110,
+    "stars": 4118,
     "url": "https://github.com/NousResearch/hermes-agent-self-evolution",
     "official": true,
     "category": "Core & Official"
@@ -44,7 +44,7 @@
     "repo": "hermes-paperclip-adapter",
     "name": "hermes-paperclip-adapter",
     "description": "Run Hermes as a managed employee in Paperclip company systems",
-    "stars": 1595,
+    "stars": 1600,
     "url": "https://github.com/NousResearch/hermes-paperclip-adapter",
     "official": true,
     "category": "Core & Official"
@@ -54,7 +54,7 @@
     "repo": "autonovel",
     "name": "autonovel",
     "description": "Autonomous novel-writing pipeline generating 100k+ word manuscripts",
-    "stars": 1145,
+    "stars": 1148,
     "url": "https://github.com/NousResearch/autonovel",
     "official": true,
     "category": "Core & Official"
@@ -64,7 +64,7 @@
     "repo": "hermes-workspace",
     "name": "hermes-workspace",
     "description": "Native web workspace — chat, terminal, memory browser, skills manager, and inspector panel",
-    "stars": 5715,
+    "stars": 5727,
     "url": "https://github.com/outsourc-e/hermes-workspace",
     "official": false,
     "category": "Workspaces & GUIs"
@@ -74,7 +74,7 @@
     "repo": "hermes-desktop",
     "name": "hermes-desktop",
     "description": "Desktop companion app for installing, configuring, and chatting with Hermes Agent",
-    "stars": 12286,
+    "stars": 12302,
     "url": "https://github.com/fathah/hermes-desktop",
     "official": false,
     "category": "Workspaces & GUIs"
@@ -104,7 +104,7 @@
     "repo": "Anthropic-Cybersecurity-Skills",
     "name": "Anthropic-Cybersecurity-Skills",
     "description": "754 structured cybersecurity skills mapped to MITRE ATT&CK, NIST CSF 2.0, ATLAS, D3FEND & NIST AI RMF",
-    "stars": 15877,
+    "stars": 15936,
     "url": "https://github.com/mukul975/Anthropic-Cybersecurity-Skills",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -114,7 +114,7 @@
     "repo": "avoid-ai-writing",
     "name": "avoid-ai-writing",
     "description": "Audits and rewrites content to eliminate detectable AI writing patterns",
-    "stars": 1853,
+    "stars": 1863,
     "url": "https://github.com/conorbronsdon/avoid-ai-writing",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -124,7 +124,7 @@
     "repo": "skills",
     "name": "wondelai/skills",
     "description": "Cross-platform skills library for Claude Code and agentskills.io-compatible agents",
-    "stars": 1359,
+    "stars": 1365,
     "url": "https://github.com/wondelai/skills",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -134,7 +134,7 @@
     "repo": "pydantic-ai-skills",
     "name": "pydantic-ai-skills",
     "description": "Type-safe agentskills.io support with progressive disclosure for Pydantic AI",
-    "stars": 314,
+    "stars": 315,
     "url": "https://github.com/DougTrajano/pydantic-ai-skills",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -144,7 +144,7 @@
     "repo": "drawio-skill",
     "name": "drawio-skill",
     "description": "Generate draw.io diagrams from natural language descriptions",
-    "stars": 3567,
+    "stars": 3642,
     "url": "https://github.com/Agents365-ai/drawio-skill",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -164,7 +164,7 @@
     "repo": "litprog-skill",
     "name": "litprog-skill",
     "description": "Literate programming skill — weave code and documentation across agents",
-    "stars": 175,
+    "stars": 176,
     "url": "https://github.com/tlehman/litprog-skill",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -204,7 +204,7 @@
     "repo": "hermes-skill-factory",
     "name": "hermes-skill-factory",
     "description": "Meta-skill plugin that watches workflows and auto-generates reusable skills",
-    "stars": 379,
+    "stars": 383,
     "url": "https://github.com/Romanescu11/hermes-skill-factory",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -254,7 +254,7 @@
     "repo": "hermeshub",
     "name": "hermeshub",
     "description": "Community skill browsing, search, and one-click installation hub",
-    "stars": 259,
+    "stars": 260,
     "url": "https://github.com/amanning3390/hermeshub",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -274,7 +274,7 @@
     "repo": "mem0",
     "name": "mem0",
     "description": "Universal memory layer for AI Agents — official Hermes Agent memory provider, available as managed cloud or Apache-2.0 self-hosted OSS",
-    "stars": 58675,
+    "stars": 58717,
     "url": "https://github.com/mem0ai/mem0",
     "official": false,
     "category": "Memory & Context"
@@ -284,7 +284,7 @@
     "repo": "hindsight",
     "name": "hindsight",
     "description": "Agent memory that learns — long-term retain/recall/reflect workflows",
-    "stars": 16465,
+    "stars": 16480,
     "url": "https://github.com/vectorize-io/hindsight",
     "official": true,
     "category": "Memory & Context"
@@ -294,7 +294,7 @@
     "repo": "autocontext",
     "name": "autocontext",
     "description": "Recursive self-improving context harness — helps agents succeed on complex tasks",
-    "stars": 1204,
+    "stars": 1205,
     "url": "https://github.com/greyhaven-ai/autocontext",
     "official": false,
     "category": "Memory & Context"
@@ -354,7 +354,7 @@
     "repo": "hermes-web-search-plus",
     "name": "hermes-web-search-plus",
     "description": "Multi-provider web search (Serper, Tavily, Exa, Querit, Perplexity) with auto-routing",
-    "stars": 279,
+    "stars": 280,
     "url": "https://github.com/robbyczgw-cla/hermes-web-search-plus",
     "official": false,
     "category": "Plugins & Extensions"
@@ -364,7 +364,7 @@
     "repo": "hermes-plugins",
     "name": "hermes-plugins",
     "description": "Goal management, inter-agent bridge, model selection, and cost control plugins",
-    "stars": 217,
+    "stars": 220,
     "url": "https://github.com/42-evey/hermes-plugins",
     "official": false,
     "category": "Plugins & Extensions"
@@ -414,7 +414,7 @@
     "repo": "mission-control",
     "name": "mission-control",
     "description": "Self-hosted AI agent orchestration — dispatch tasks, run multi-agent workflows, monitor spend",
-    "stars": 5327,
+    "stars": 5331,
     "url": "https://github.com/builderz-labs/mission-control",
     "official": false,
     "category": "Multi-Agent & Orchestration"
@@ -424,7 +424,7 @@
     "repo": "swarmclaw",
     "name": "swarmclaw",
     "description": "Build autonomous AI agent swarms with orchestration, skills, and multiple model providers",
-    "stars": 583,
+    "stars": 584,
     "url": "https://github.com/swarmclawai/swarmclaw",
     "official": false,
     "category": "Multi-Agent & Orchestration"
@@ -434,7 +434,7 @@
     "repo": "hermes-agent-metaharness",
     "name": "hermes-agent-metaharness",
     "description": "Meta-harness for Hermes Agent — meta-optimization with arxiv paper reference",
-    "stars": 93,
+    "stars": 94,
     "url": "https://github.com/howdymary/hermes-agent-metaharness",
     "official": false,
     "category": "Multi-Agent & Orchestration"
@@ -454,7 +454,7 @@
     "repo": "opencode-hermes-multiagent",
     "name": "opencode-hermes-multiagent",
     "description": "17 specialized agents for research, planning, implementation, quality, and infrastructure",
-    "stars": 140,
+    "stars": 141,
     "url": "https://github.com/1ilkhamov/opencode-hermes-multiagent",
     "official": false,
     "category": "Multi-Agent & Orchestration"
@@ -484,7 +484,7 @@
     "repo": "hermes-agent-cn-desktop",
     "name": "hermes-agent-cn-desktop",
     "description": "Windows-first Chinese desktop app for Hermes Agent built with Tauri, TypeScript, and Rust",
-    "stars": 445,
+    "stars": 456,
     "url": "https://github.com/Eynzof/hermes-agent-cn-desktop",
     "official": false,
     "category": "Workspaces & GUIs"
@@ -494,7 +494,7 @@
     "repo": "kindly-web-search-mcp-server",
     "name": "kindly-web-search-mcp-server",
     "description": "Web search and content retrieval MCP server supporting Hermes Agent, OpenClaw, Claude Code, Codex, Cursor, and other AI tools",
-    "stars": 343,
+    "stars": 345,
     "url": "https://github.com/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server",
     "official": false,
     "category": "Plugins & Extensions"
@@ -504,7 +504,7 @@
     "repo": "minions",
     "name": "minions",
     "description": "Mission Control for Hermes agents: create, supervise, and review autonomous Hermes Agent work from one screen",
-    "stars": 577,
+    "stars": 578,
     "url": "https://github.com/Agent-3-7/minions",
     "official": false,
     "category": "Multi-Agent & Orchestration"
@@ -514,7 +514,7 @@
     "repo": "hermes-agent-control-room",
     "name": "hermes-agent-control-room",
     "description": "Control Room-first template for managing Hermes agents from one VPS agent to specialist teams and orchestrated workflows",
-    "stars": 844,
+    "stars": 856,
     "url": "https://github.com/CryptoDmitry/hermes-agent-control-room",
     "official": false,
     "category": "Multi-Agent & Orchestration"
@@ -524,7 +524,7 @@
     "repo": "codegraph",
     "name": "codegraph",
     "description": "Local pre-indexed code knowledge graph for Hermes Agent and other coding agents to reduce token usage and tool calls",
-    "stars": 49994,
+    "stars": 50244,
     "url": "https://github.com/colbymchenry/codegraph",
     "official": false,
     "category": "Developer Tools"
@@ -544,7 +544,7 @@
     "repo": "hermes-agent-idea-workflow",
     "name": "hermes-agent-idea-workflow",
     "description": "Pre-build idea-to-spec workflow skills for Hermes Agent that turn rough ideas into design docs and implementation handoffs",
-    "stars": 217,
+    "stars": 218,
     "url": "https://github.com/AkoliteZA/hermes-agent-idea-workflow",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -564,7 +564,7 @@
     "repo": "oh-my-hermes",
     "name": "oh-my-hermes",
     "description": "Opinionated workflow layer for building, shipping, and operating apps with Hermes Agent",
-    "stars": 532,
+    "stars": 551,
     "url": "https://github.com/Salomondiei08/oh-my-hermes",
     "official": false,
     "category": "Developer Tools"
@@ -574,7 +574,7 @@
     "repo": "claude-tap",
     "name": "claude-tap",
     "description": "Local trace viewer for inspecting coding-agent API traffic from Hermes Agent, Claude Code, Codex, Gemini, Cursor, OpenCode, and others",
-    "stars": 1798,
+    "stars": 1807,
     "url": "https://github.com/liaohch3/claude-tap",
     "official": false,
     "category": "Developer Tools"
@@ -584,7 +584,7 @@
     "repo": "agent-sessions",
     "name": "agent-sessions",
     "description": "Native macOS session browser, agent cockpit, analytics, and limits tracker for Hermes agents and other coding-agent CLIs",
-    "stars": 640,
+    "stars": 641,
     "url": "https://github.com/jazzyalex/agent-sessions",
     "official": false,
     "category": "Workspaces & GUIs"
@@ -624,7 +624,7 @@
     "repo": "hermes-agent-ultra",
     "name": "hermes-agent-ultra",
     "description": "Rust-based Hermes Agent Ultra derivative focused on performance and Hermes Agent feature parity",
-    "stars": 46,
+    "stars": 49,
     "url": "https://github.com/sheawinkler/hermes-agent-ultra",
     "official": false,
     "category": "Forks & Derivatives"
@@ -674,7 +674,7 @@
     "repo": "hermes-agent-rtk-caveman",
     "name": "hermes-agent-rtk-caveman",
     "description": "Hermes Agent RTK and Caveman setup with preconfigured skills and token-saving CLI workflows",
-    "stars": 61,
+    "stars": 62,
     "url": "https://github.com/adityahimaone/hermes-agent-rtk-caveman",
     "official": false,
     "category": "Developer Tools"
@@ -704,7 +704,7 @@
     "repo": "youtube-skills",
     "name": "youtube-skills",
     "description": "YouTube transcript, search, channel, and playlist skills for Hermes Agent, OpenClaw, Claude Code, Cursor, and Windsurf",
-    "stars": 270,
+    "stars": 271,
     "url": "https://github.com/ZeroPointRepo/youtube-skills",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -714,7 +714,7 @@
     "repo": "hermes-labyrinth",
     "name": "hermes-labyrinth",
     "description": "Read-only observability plugin for Hermes Agent with journeys, crossings, guideposts, and reports",
-    "stars": 284,
+    "stars": 285,
     "url": "https://github.com/stainlu/hermes-labyrinth",
     "official": false,
     "category": "Plugins & Extensions"
@@ -734,7 +734,7 @@
     "repo": "agent-of-empires",
     "name": "agent-of-empires",
     "description": "TUI and web control surface for managing multiple coding agents including Hermes Agent, Claude Code, OpenCode, Codex, Gemini, and others",
-    "stars": 2592,
+    "stars": 2595,
     "url": "https://github.com/agent-of-empires/agent-of-empires",
     "official": false,
     "category": "Multi-Agent & Orchestration"
@@ -744,7 +744,7 @@
     "repo": "open-design",
     "name": "open-design",
     "description": "Local-first open-source design/prototyping system with coding-agent CLI support including Hermes Agent",
-    "stars": 65687,
+    "stars": 65916,
     "url": "https://github.com/nexu-io/open-design",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -754,7 +754,7 @@
     "repo": "cc-switch",
     "name": "cc-switch",
     "description": "Cross-platform all-in-one manager for Claude Code, Codex, OpenCode, OpenClaw, Gemini CLI, and Hermes Agent",
-    "stars": 102148,
+    "stars": 102588,
     "url": "https://github.com/farion1231/cc-switch",
     "official": false,
     "category": "Workspaces & GUIs"
@@ -764,7 +764,7 @@
     "repo": "AionUi",
     "name": "AionUi",
     "description": "Local open-source cowork app for OpenClaw, Hermes Agent, Claude Code, Codex, OpenCode, Gemini CLI, and other agent CLIs",
-    "stars": 28344,
+    "stars": 28371,
     "url": "https://github.com/iOfficeAI/AionUi",
     "official": false,
     "category": "Workspaces & GUIs"
@@ -774,7 +774,7 @@
     "repo": "llm-agents.nix",
     "name": "llm-agents.nix",
     "description": "Nix packages for AI coding agents including Hermes",
-    "stars": 1430,
+    "stars": 1433,
     "url": "https://github.com/numtide/llm-agents.nix",
     "official": false,
     "category": "Deployment & Infra"
@@ -784,7 +784,7 @@
     "repo": "hermesclaw",
     "name": "hermesclaw",
     "description": "Hermes Agent sandboxed with hardware-level enforcement",
-    "stars": 53,
+    "stars": 52,
     "url": "https://github.com/TheAiSingularity/hermesclaw",
     "official": false,
     "category": "Deployment & Infra"
@@ -884,7 +884,7 @@
     "repo": "tokscale",
     "name": "tokscale",
     "description": "CLI tool for tracking token usage from Claude Code, OpenClaw, Hermes, Codex, Gemini, and more",
-    "stars": 3750,
+    "stars": 3768,
     "url": "https://github.com/junhoyeo/tokscale",
     "official": false,
     "category": "Developer Tools"
@@ -1014,7 +1014,7 @@
     "repo": "hermescraft",
     "name": "hermescraft",
     "description": "Embodied AI companion for Minecraft — persistent memory, vision, learning, multi-agent",
-    "stars": 41,
+    "stars": 42,
     "url": "https://github.com/bigph00t/hermescraft",
     "official": false,
     "category": "Domain Applications"
@@ -1044,7 +1044,7 @@
     "repo": "awesome-hermes-agent",
     "name": "awesome-hermes-agent",
     "description": "Curated list of awesome skills, tools, integrations, and resources for Hermes Agent",
-    "stars": 4000,
+    "stars": 4022,
     "url": "https://github.com/0xNyk/awesome-hermes-agent",
     "official": false,
     "category": "Guides & Docs"
@@ -1054,7 +1054,7 @@
     "repo": "hermes-agent-orange-book",
     "name": "hermes-agent-orange-book",
     "description": "Hermes Agent practical guide — Orange Book series (Chinese language)",
-    "stars": 4439,
+    "stars": 4446,
     "url": "https://github.com/alchaincyf/hermes-agent-orange-book",
     "official": false,
     "category": "Guides & Docs"
@@ -1064,7 +1064,7 @@
     "repo": "hermes-optimization-guide",
     "name": "hermes-optimization-guide",
     "description": "Performance optimization guide for Hermes deployments",
-    "stars": 442,
+    "stars": 444,
     "url": "https://github.com/OnlyTerp/hermes-optimization-guide",
     "official": false,
     "category": "Guides & Docs"
@@ -1144,7 +1144,7 @@
     "repo": "hermes-ecosystem",
     "name": "hermes-ecosystem",
     "description": "Hermes Atlas — the community map of every tool, skill, and integration for Hermes Agent by Nous Research",
-    "stars": 1015,
+    "stars": 1018,
     "url": "https://github.com/ksimback/hermes-ecosystem",
     "official": false,
     "category": "Guides & Docs"
@@ -1154,7 +1154,7 @@
     "repo": "hermes-desktop",
     "name": "hermes-desktop",
     "description": "A native Mac workspace for Hermes: real SSH, real terminal, real session data.",
-    "stars": 1884,
+    "stars": 1890,
     "url": "https://github.com/dodo-reach/hermes-desktop",
     "official": false,
     "category": "Workspaces & GUIs"
@@ -1164,7 +1164,7 @@
     "repo": "clawshell",
     "name": "clawshell",
     "description": "The Runtime Security Layer for OpenClaw/Hermes-agent, the essential safety harness for PII & sensitive credentials protection.",
-    "stars": 294,
+    "stars": 295,
     "url": "https://github.com/clawshell/clawshell",
     "official": false,
     "category": "Plugins & Extensions"
@@ -1174,7 +1174,7 @@
     "repo": "hermes-webui",
     "name": "hermes-webui",
     "description": "Hermes WebUI: The best way to use Hermes Agent from the web or from your phone!",
-    "stars": 14520,
+    "stars": 14553,
     "url": "https://github.com/nesquena/hermes-webui",
     "official": false,
     "category": "Workspaces & GUIs"
@@ -1184,7 +1184,7 @@
     "repo": "gbrain",
     "name": "gbrain",
     "description": "Garry's Opinionated OpenClaw/Hermes Agent Brain",
-    "stars": 22951,
+    "stars": 23016,
     "url": "https://github.com/garrytan/gbrain",
     "official": false,
     "category": "Memory & Context"
@@ -1214,7 +1214,7 @@
     "repo": "hermesclaw",
     "name": "hermesclaw",
     "description": "Run Hermes Agent and OpenClaw on the same WeChat account",
-    "stars": 620,
+    "stars": 621,
     "url": "https://github.com/AaronWong1999/hermesclaw",
     "official": false,
     "category": "Integrations & Bridges"
@@ -1224,7 +1224,7 @@
     "repo": "hermes-lcm",
     "name": "hermes-lcm",
     "description": "Lossless Context Management plugin for Hermes Agent — DAG-based context engine that never loses a message",
-    "stars": 734,
+    "stars": 737,
     "url": "https://github.com/stephenschoettler/hermes-lcm",
     "official": false,
     "category": "Memory & Context"
@@ -1234,7 +1234,7 @@
     "repo": "hermes-relay",
     "name": "hermes-relay",
     "description": "Hermes Companion — Android app for Hermes agent platform. Chat, terminal, and device control over WSS.",
-    "stars": 34,
+    "stars": 35,
     "url": "https://github.com/Codename-11/hermes-relay",
     "official": false,
     "category": "Integrations & Bridges"
@@ -1264,7 +1264,7 @@
     "repo": "hermes-web-ui",
     "name": "hermes-web-ui",
     "description": "Web dashboard for Hermes Agent — multi-platform AI chat, session management, scheduled jobs, usage analytics & channel configuration (Telegram, Discord, Slack, WhatsApp)",
-    "stars": 7988,
+    "stars": 8006,
     "url": "https://github.com/EKKOLearnAI/hermes-web-ui",
     "official": false,
     "category": "Workspaces & GUIs"
@@ -1284,7 +1284,7 @@
     "repo": "mnemosyne",
     "name": "mnemosyne",
     "description": "The Zero-Dependency, Sub-Millisecond AI Memory System for Hermes Agents",
-    "stars": 1146,
+    "stars": 1152,
     "url": "https://github.com/AxDSan/mnemosyne",
     "official": false,
     "category": "Memory & Context"
@@ -1294,7 +1294,7 @@
     "repo": "SkillClaw",
     "name": "SkillClaw",
     "description": "Let Skills Evolve Collectively with Agentic Evolver",
-    "stars": 1921,
+    "stars": 1928,
     "url": "https://github.com/AMAP-ML/SkillClaw",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -1314,7 +1314,7 @@
     "repo": "super-hermes",
     "name": "super-hermes",
     "description": "Skills that teach Hermes Agent to write its own analytical prompts",
-    "stars": 240,
+    "stars": 241,
     "url": "https://github.com/Cranot/super-hermes",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -1334,7 +1334,7 @@
     "repo": "agent-browser-mcp",
     "name": "agent-browser-mcp",
     "description": "让 Agent 直接操作真实 Chrome 的 MCP 服务，支持页面扫描、CDP、截图与物理输入",
-    "stars": 230,
+    "stars": 229,
     "url": "https://github.com/335234131/agent-browser-mcp",
     "official": false,
     "category": "Plugins & Extensions"
@@ -1344,7 +1344,7 @@
     "repo": "hermes-agent-guide",
     "name": "hermes-agent-guide",
     "description": "A systematic Chinese-language guide to Hermes Agent — 16 books, 300K+ words, covering installation, advanced development, single- and multi-agent orchestration.",
-    "stars": 367,
+    "stars": 370,
     "url": "https://github.com/jwangkun/hermes-agent-guide",
     "official": false,
     "category": "Guides & Docs"
@@ -1354,7 +1354,7 @@
     "repo": "learn-hermes-agent",
     "name": "learn-hermes-agent",
     "description": "A 27-chapter hands-on tutorial for building an autonomous AI agent from zero in Python — agent loop, tool system, memory, skills, MCP, multi-platform gateway, and self-evolution.",
-    "stars": 153,
+    "stars": 154,
     "url": "https://github.com/longyunfeigu/learn-hermes-agent",
     "official": false,
     "category": "Guides & Docs"
@@ -1374,7 +1374,7 @@
     "repo": "honcho",
     "name": "honcho",
     "description": "Memory library for building stateful agents — the upstream library that the elkimek/honcho-self-hosted Hermes wrapper builds on.",
-    "stars": 5189,
+    "stars": 5204,
     "url": "https://github.com/plastic-labs/honcho",
     "official": true,
     "category": "Memory & Context"
@@ -1394,7 +1394,7 @@
     "repo": "hermes-tweet",
     "name": "hermes-tweet",
     "description": "Native Hermes Agent plugin for X automation through Xquik",
-    "stars": 9,
+    "stars": 10,
     "url": "https://github.com/Xquik-dev/hermes-tweet",
     "official": false,
     "category": "Plugins & Extensions"
@@ -1404,7 +1404,7 @@
     "repo": "klodi-plugin",
     "name": "klodi-plugin",
     "description": "The agent-to-agent marketplace, in your agent host. Your agent lists, haggles, and closes deals for you while you live your life.",
-    "stars": 9,
+    "stars": 12,
     "url": "https://github.com/Context4GPTs/klodi-plugin",
     "official": false,
     "category": "Plugins & Extensions"
@@ -1434,7 +1434,7 @@
     "repo": "MeiGen-AI-Design-MCP",
     "name": "MeiGen-AI-Design-MCP",
     "description": "Supports GPT Image 2, Nanobanana & ComfyUI, with a 1,400+ prompt library, carefully crafted hooks and a multi-task orchestration system",
-    "stars": 1448,
+    "stars": 1451,
     "url": "https://github.com/jau123/MeiGen-AI-Design-MCP",
     "official": false,
     "category": "Plugins & Extensions"
@@ -1444,7 +1444,7 @@
     "repo": "hermes-tool-slimmer",
     "name": "hermes-tool-slimmer",
     "description": "Reduce Hermes Agent tool-schema overhead with keyword selection and Tool Search support",
-    "stars": 23,
+    "stars": 24,
     "url": "https://github.com/alias8818/hermes-tool-slimmer",
     "official": false,
     "category": "Memory & Context"
@@ -1454,7 +1454,7 @@
     "repo": "OpenViking",
     "name": "OpenViking",
     "description": "Open-source context database for AI agents — official Hermes Agent memory provider using viking:// URIs and tiered L0/L1/L2 loading; 91% token reduction and 43-49% task-completion gain over baseline on LoCoMo10. AGPL-3.0.",
-    "stars": 25698,
+    "stars": 25715,
     "url": "https://github.com/volcengine/OpenViking",
     "official": false,
     "category": "Memory & Context"
@@ -1464,7 +1464,7 @@
     "repo": "supermemory",
     "name": "supermemory",
     "description": "Memory engine and API — official Hermes Agent memory provider with sub-300ms recall sustained at 100B+ tokens/month, custom vector graph engine, context fencing, and byte-level dedupe with 100% prompt-cache discount.",
-    "stars": 27080,
+    "stars": 27098,
     "url": "https://github.com/supermemoryai/supermemory",
     "official": false,
     "category": "Memory & Context"
@@ -1544,7 +1544,7 @@
     "repo": "herm",
     "name": "herm",
     "description": "Alternative Hermes TUI and dashboard built with OpenTUI.",
-    "stars": 253,
+    "stars": 254,
     "url": "https://github.com/liftaris/herm",
     "official": false,
     "category": "Workspaces & GUIs"
@@ -1614,7 +1614,7 @@
     "repo": "digital-marketing-pro",
     "name": "digital-marketing-pro",
     "description": "Open-source AI marketing plugin for agencies & in-house teams — 158 skills, 25 specialist agents, 12-Part Strategy Flow, Cowork team-persistent, EU AI Act Article 50 ready, 6-platform AEO/GEO incl. Go",
-    "stars": 142,
+    "stars": 143,
     "url": "https://github.com/indranilbanerjee/digital-marketing-pro",
     "official": false,
     "category": "Plugins & Extensions"
@@ -1624,7 +1624,7 @@
     "repo": "socialforge",
     "name": "socialforge",
     "description": "Open-source agency-grade social media production plugin — 16 skills, 25 commands, AI image (Nano Banana Pro) + AI video (Kling v3.0 Pro) + C2PA signing (EU AI Act Article 50). Installs on Claude Code,",
-    "stars": 5,
+    "stars": 6,
     "url": "https://github.com/indranilbanerjee/socialforge",
     "official": false,
     "category": "Plugins & Extensions"
@@ -1634,7 +1634,7 @@
     "repo": "hermaguard",
     "name": "hermaguard",
     "description": "Adversarial bug-hunting code review for AI agents. 3 parallel subagents attack code from different angles, then a consolidator merges and triages findings. Read-only — finds problems, doesn't fix.",
-    "stars": 8,
+    "stars": 9,
     "url": "https://github.com/Sahil-SS9/hermaguard",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -1664,7 +1664,7 @@
     "repo": "Toolaria",
     "name": "Toolaria",
     "description": "Rescue oversized tool results before they flood context. SHA256-addressed blob store with per-session indexes",
-    "stars": 8,
+    "stars": 9,
     "url": "https://github.com/Sahil-SS9/Toolaria",
     "official": false,
     "category": "Plugins & Extensions"
@@ -1674,7 +1674,7 @@
     "repo": "socialclaw",
     "name": "socialclaw",
     "description": "Social media scheduling CLI and OpenClaw skill for AI agents posting to X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, and Pinterest.",
-    "stars": 24,
+    "stars": 25,
     "url": "https://github.com/ndesv21/socialclaw",
     "official": false,
     "category": "Integrations & Bridges"
@@ -1684,17 +1684,7 @@
     "repo": "hermes-trace",
     "name": "hermes-trace",
     "description": "A Hermes Agent plugin that builds execution trace graphs using agent lifecycle hooks.",
-    "stars": 1,
-    "url": "https://github.com/hlothaire/hermes-trace",
-    "official": false,
-    "category": "Plugins & Extensions"
-  },
-  {
-    "owner": "hlothaire",
-    "repo": "hermes-trace",
-    "name": "hermes-trace",
-    "description": "A Hermes Agent plugin that builds execution trace graphs using agent lifecycle hooks.",
-    "stars": 1,
+    "stars": 0,
     "url": "https://github.com/hlothaire/hermes-trace",
     "official": false,
     "category": "Plugins & Extensions"

--- a/index.html
+++ b/index.html
@@ -281,7 +281,7 @@
     <div class="cat-num">§01</div>
     <h2 class="cat-title">Core &amp; official</h2>
     <p class="cat-desc">Repositories maintained directly by Nous Research — the official stack.</p>
-    <div class="cat-count"><span class="cat-count-n">5</span> repos</div>
+    <div class="cat-count"><span class="cat-count-n">6</span> repos</div>
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/NousResearch/Hermes-Function-Calling" data-github="https://github.com/NousResearch/Hermes-Function-Calling" data-desc="Function calling examples and training data for Hermes LLM models">
@@ -293,7 +293,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/NousResearch/atropos" data-github="https://github.com/NousResearch/atropos" data-desc="RL training environments framework for tool-calling models">
-      <div class="repo-stars">★ 1,283</div>
+      <div class="repo-stars">★ 1,282</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">NousResearch /</span> atropos <span class="repo-flag">official</span></div>
         <div class="repo-desc">RL training environments framework for tool-calling models.</div>
@@ -301,7 +301,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/NousResearch/hermes-agent-self-evolution" data-github="https://github.com/NousResearch/hermes-agent-self-evolution" data-desc="Evolutionary self-improvement using DSPy + GEPA — optimizes skills, prompts, and code">
-      <div class="repo-stars">★ 4,110</div>
+      <div class="repo-stars">★ 4,118</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">NousResearch /</span> hermes-agent-self-evolution <span class="repo-flag">official</span></div>
         <div class="repo-desc">Evolutionary self-improvement using DSPy + GEPA — optimizes skills, prompts, and code.</div>
@@ -309,7 +309,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/NousResearch/hermes-paperclip-adapter" data-github="https://github.com/NousResearch/hermes-paperclip-adapter" data-desc="Run Hermes as a managed employee in Paperclip company systems">
-      <div class="repo-stars">★ 1,595</div>
+      <div class="repo-stars">★ 1,600</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">NousResearch /</span> hermes-paperclip-adapter <span class="repo-flag">official</span></div>
         <div class="repo-desc">Run Hermes as a managed employee in Paperclip company systems.</div>
@@ -317,7 +317,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/NousResearch/autonovel" data-github="https://github.com/NousResearch/autonovel" data-desc="Autonomous novel-writing pipeline generating 100k+ word manuscripts">
-      <div class="repo-stars">★ 1,145</div>
+      <div class="repo-stars">★ 1,148</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">NousResearch /</span> autonovel <span class="repo-flag">official</span></div>
         <div class="repo-desc">Autonomous novel-writing pipeline generating 100k+ word manuscripts.</div>
@@ -336,7 +336,7 @@
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/nesquena/hermes-webui" data-github="https://github.com/nesquena/hermes-webui" data-desc="Hermes WebUI: The best way to use Hermes Agent from the web or from your phone!">
-      <div class="repo-stars">★ 14,520</div>
+      <div class="repo-stars">★ 14,553</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">nesquena /</span> hermes-webui</div>
         <div class="repo-desc">The best way to use Hermes Agent from the web or from your phone.</div>
@@ -344,7 +344,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/outsourc-e/hermes-workspace" data-github="https://github.com/outsourc-e/hermes-workspace" data-desc="Native web workspace — chat, terminal, memory browser, skills manager, and inspector panel">
-      <div class="repo-stars">★ 5,715</div>
+      <div class="repo-stars">★ 5,727</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">outsourc-e /</span> hermes-workspace</div>
         <div class="repo-desc">Native web workspace — chat, terminal, memory browser, skills manager, inspector panel.</div>
@@ -368,7 +368,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/dodo-reach/hermes-desktop" data-github="https://github.com/dodo-reach/hermes-desktop" data-desc="A native Mac workspace for Hermes: real SSH, real terminal, real session data">
-      <div class="repo-stars">★ 1,884</div>
+      <div class="repo-stars">★ 1,890</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">dodo-reach /</span> hermes-desktop</div>
         <div class="repo-desc">Native Mac workspace for Hermes — real SSH, real terminal, real session data.</div>
@@ -376,7 +376,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/fathah/hermes-desktop" data-github="https://github.com/fathah/hermes-desktop" data-desc="Desktop companion app for installing, configuring, and chatting with Hermes Agent">
-      <div class="repo-stars">★ 12,286</div>
+      <div class="repo-stars">★ 12,302</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">fathah /</span> hermes-desktop</div>
         <div class="repo-desc">Desktop companion for installing, configuring, and chatting with Hermes Agent.</div>
@@ -408,7 +408,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/EKKOLearnAI/hermes-web-ui" data-github="https://github.com/EKKOLearnAI/hermes-web-ui" data-desc="Web dashboard for Hermes Agent — multi-platform AI chat, session management, scheduled jobs, usage analytics &amp; channel configuration (Telegram, Discord, Slack, WhatsApp)">
-      <div class="repo-stars">★ 7,988</div>
+      <div class="repo-stars">★ 8,006</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">EKKOLearnAI /</span> hermes-web-ui</div>
         <div class="repo-desc">Web dashboard for Hermes Agent — multi-platform AI chat, session management, scheduled jobs, usage analytics &amp; channel configuration (Telegram, Discord, Slack, WhatsApp).</div>
@@ -424,7 +424,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/farion1231/cc-switch" data-github="https://github.com/farion1231/cc-switch" data-desc="Cross-platform all-in-one manager for Claude Code, Codex, OpenCode, OpenClaw, Gemini CLI, and Hermes Agent">
-      <div class="repo-stars">★ 102,148</div>
+      <div class="repo-stars">★ 102,588</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">farion1231 /</span> cc-switch</div>
         <div class="repo-desc">Cross-platform all-in-one manager for Claude Code, Codex, OpenCode, OpenClaw, Gemini CLI, and Hermes Agent.</div>
@@ -432,7 +432,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/iOfficeAI/AionUi" data-github="https://github.com/iOfficeAI/AionUi" data-desc="Local open-source cowork app for OpenClaw, Hermes Agent, Claude Code, Codex, OpenCode, Gemini CLI, and other agent CLIs">
-      <div class="repo-stars">★ 28,344</div>
+      <div class="repo-stars">★ 28,371</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">iOfficeAI /</span> AionUi</div>
         <div class="repo-desc">Local open-source cowork app for OpenClaw, Hermes Agent, Claude Code, Codex, OpenCode, Gemini CLI, and other agent CLIs.</div>
@@ -440,7 +440,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/jazzyalex/agent-sessions" data-github="https://github.com/jazzyalex/agent-sessions" data-desc="Native macOS session browser, agent cockpit, analytics, and limits tracker for Hermes agents and other coding-agent CLIs">
-      <div class="repo-stars">★ 640</div>
+      <div class="repo-stars">★ 641</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">jazzyalex /</span> agent-sessions</div>
         <div class="repo-desc">Native macOS session browser, agent cockpit, analytics, and limits tracker for Hermes agents and other coding-agent CLIs.</div>
@@ -456,7 +456,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/Eynzof/hermes-agent-cn-desktop" data-github="https://github.com/Eynzof/hermes-agent-cn-desktop" data-desc="Windows-first Chinese desktop app for Hermes Agent built with Tauri, TypeScript, and Rust">
-      <div class="repo-stars">★ 445</div>
+      <div class="repo-stars">★ 456</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
         <div class="repo-desc">Windows-first Chinese desktop app for Hermes Agent built with Tauri, TypeScript, and Rust.</div>
@@ -472,7 +472,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/liftaris/herm" data-github="https://github.com/liftaris/herm" data-desc="Alternative Hermes TUI and dashboard built with OpenTUI.">
-      <div class="repo-stars">★ 253</div>
+      <div class="repo-stars">★ 254</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">liftaris /</span> herm</div>
         <div class="repo-desc">Alternative Hermes TUI and dashboard built with OpenTUI.</div>
@@ -487,11 +487,11 @@
     <div class="cat-num">§03</div>
     <h2 class="cat-title">Skills &amp; skill registries</h2>
     <p class="cat-desc">Reusable capabilities following the agentskills.io open standard — libraries, registries, and meta-tools.</p>
-    <div class="cat-count"><span class="cat-count-n">31</span> repos</div>
+    <div class="cat-count"><span class="cat-count-n">28</span> repos</div>
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills" data-github="https://github.com/mukul975/Anthropic-Cybersecurity-Skills" data-desc="754 structured cybersecurity skills mapped to MITRE ATT&CK, NIST CSF 2.0, ATLAS, D3FEND & NIST AI RMF">
-      <div class="repo-stars">★ 15,877</div>
+      <div class="repo-stars">★ 15,936</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</div>
         <div class="repo-desc">754 structured cybersecurity skills mapped to MITRE ATT&amp;CK, NIST CSF 2.0, ATLAS, D3FEND &amp; NIST AI RMF.</div>
@@ -499,7 +499,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/conorbronsdon/avoid-ai-writing" data-github="https://github.com/conorbronsdon/avoid-ai-writing" data-desc="Audits and rewrites content to eliminate detectable AI writing patterns">
-      <div class="repo-stars">★ 1,853</div>
+      <div class="repo-stars">★ 1,863</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">conorbronsdon /</span> avoid-ai-writing</div>
         <div class="repo-desc">Audits and rewrites content to eliminate detectable AI writing patterns.</div>
@@ -507,7 +507,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/wondelai/skills" data-github="https://github.com/wondelai/skills" data-desc="Cross-platform skills library for Claude Code and agentskills.io-compatible agents">
-      <div class="repo-stars">★ 1,359</div>
+      <div class="repo-stars">★ 1,365</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">wondelai /</span> skills</div>
         <div class="repo-desc">Cross-platform skills library for Claude Code and agentskills.io-compatible agents.</div>
@@ -515,7 +515,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/DougTrajano/pydantic-ai-skills" data-github="https://github.com/DougTrajano/pydantic-ai-skills" data-desc="Type-safe agentskills.io support with progressive disclosure for Pydantic AI">
-      <div class="repo-stars">★ 314</div>
+      <div class="repo-stars">★ 315</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">DougTrajano /</span> pydantic-ai-skills</div>
         <div class="repo-desc">Type-safe agentskills.io support with progressive disclosure for Pydantic AI.</div>
@@ -523,7 +523,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/Agents365-ai/drawio-skill" data-github="https://github.com/Agents365-ai/drawio-skill" data-desc="Generate draw.io diagrams from natural language descriptions">
-      <div class="repo-stars">★ 3,567</div>
+      <div class="repo-stars">★ 3,642</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">Agents365-ai /</span> drawio-skill</div>
         <div class="repo-desc">Generate draw.io diagrams from natural language descriptions.</div>
@@ -539,7 +539,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/tlehman/litprog-skill" data-github="https://github.com/tlehman/litprog-skill" data-desc="Literate programming skill — weave code and documentation across agents">
-      <div class="repo-stars">★ 175</div>
+      <div class="repo-stars">★ 176</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">tlehman /</span> litprog-skill</div>
         <div class="repo-desc">Literate programming — weave code and documentation across agents.</div>
@@ -571,7 +571,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/Romanescu11/hermes-skill-factory" data-github="https://github.com/Romanescu11/hermes-skill-factory" data-desc="Meta-skill plugin that watches workflows and auto-generates reusable skills">
-      <div class="repo-stars">★ 379</div>
+      <div class="repo-stars">★ 383</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">Romanescu11 /</span> hermes-skill-factory</div>
         <div class="repo-desc">Meta-skill plugin that watches workflows and auto-generates reusable skills.</div>
@@ -611,7 +611,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/amanning3390/hermeshub" data-github="https://github.com/amanning3390/hermeshub" data-desc="Community skill browsing, search, and one-click installation hub">
-      <div class="repo-stars">★ 259</div>
+      <div class="repo-stars">★ 260</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">amanning3390 /</span> hermeshub</div>
         <div class="repo-desc">Community skill browsing, search, and one-click installation hub.</div>
@@ -627,7 +627,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/AMAP-ML/SkillClaw" data-github="https://github.com/AMAP-ML/SkillClaw" data-desc="Let Skills Evolve Collectively with Agentic Evolver">
-      <div class="repo-stars">★ 1,921</div>
+      <div class="repo-stars">★ 1,928</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">AMAP-ML /</span> SkillClaw</div>
         <div class="repo-desc">Let Skills Evolve Collectively with Agentic Evolver.</div>
@@ -635,7 +635,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/Cranot/super-hermes" data-github="https://github.com/Cranot/super-hermes" data-desc="Skills that teach Hermes Agent to write its own analytical prompts">
-      <div class="repo-stars">★ 240</div>
+      <div class="repo-stars">★ 241</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">Cranot /</span> super-hermes</div>
         <div class="repo-desc">Skills that teach Hermes Agent to write its own analytical prompts.</div>
@@ -651,7 +651,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/nexu-io/open-design" data-github="https://github.com/nexu-io/open-design" data-desc="Local-first open-source design/prototyping system with coding-agent CLI support including Hermes Agent">
-      <div class="repo-stars">★ 65,687</div>
+      <div class="repo-stars">★ 65,916</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">nexu-io /</span> open-design</div>
         <div class="repo-desc">Local-first open-source design/prototyping system with coding-agent CLI support including Hermes Agent.</div>
@@ -659,7 +659,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/ZeroPointRepo/youtube-skills" data-github="https://github.com/ZeroPointRepo/youtube-skills" data-desc="YouTube transcript, search, channel, and playlist skills for Hermes Agent, OpenClaw, Claude Code, Cursor, and Windsurf">
-      <div class="repo-stars">★ 270</div>
+      <div class="repo-stars">★ 271</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">ZeroPointRepo /</span> youtube-skills</div>
         <div class="repo-desc">YouTube transcript, search, channel, and playlist skills for Hermes Agent, OpenClaw, Claude Code, Cursor, and Windsurf.</div>
@@ -667,7 +667,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/AkoliteZA/hermes-agent-idea-workflow" data-github="https://github.com/AkoliteZA/hermes-agent-idea-workflow" data-desc="Pre-build idea-to-spec workflow skills for Hermes Agent that turn rough ideas into design docs and implementation handoffs">
-      <div class="repo-stars">★ 217</div>
+      <div class="repo-stars">★ 218</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">AkoliteZA /</span> hermes-agent-idea-workflow</div>
         <div class="repo-desc">Pre-build idea-to-spec workflow skills for Hermes Agent that turn rough ideas into design docs and implementation handoffs.</div>
@@ -707,7 +707,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/Sahil-SS9/hermaguard" data-github="https://github.com/Sahil-SS9/hermaguard" data-desc="Adversarial bug-hunting code review for AI agents. 3 parallel subagents attack code from different angles, then a consolidator merges and triages findings. Read-only — finds problems, doesn't fix.">
-      <div class="repo-stars">★ 8</div>
+      <div class="repo-stars">★ 9</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">Sahil-SS9 /</span> hermaguard</div>
         <div class="repo-desc">Adversarial bug-hunting code review for AI agents. 3 parallel subagents attack code from different angles, then a consolidator merges and triages findings. Read-only — finds problems, doesn't fix.</div>
@@ -715,7 +715,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/Sahil-SS9/hermaguard" data-github="https://github.com/Sahil-SS9/hermaguard" data-desc="Adversarial bug-hunting code review for AI agents. 3 parallel subagents attack code from different angles, then a consolidator merges and triages findings. Read-only — finds problems, doesn't fix.">
-      <div class="repo-stars">★ 8</div>
+      <div class="repo-stars">★ 9</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">Sahil-SS9 /</span> hermaguard</div>
         <div class="repo-desc">Adversarial bug-hunting code review for AI agents. 3 parallel subagents attack code from different angles, then a consolidator merges and triages findings. Read-only — finds problems, doesn't fix.</div>
@@ -750,7 +750,7 @@
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/mem0ai/mem0" data-github="https://github.com/mem0ai/mem0" data-desc="Universal memory layer for AI Agents — official Hermes Agent memory provider, managed cloud or Apache-2.0 self-hosted OSS">
-      <div class="repo-stars">★ 58,675</div>
+      <div class="repo-stars">★ 58,717</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">mem0ai /</span> mem0</div>
         <div class="repo-desc">Universal memory layer — official Hermes provider with mem0_profile / mem0_search / mem0_conclude tools; runs managed (app.mem0.ai) or self-hosted Apache-2.0 OSS.</div>
@@ -758,7 +758,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/garrytan/gbrain" data-github="https://github.com/garrytan/gbrain" data-desc="Garry's Opinionated OpenClaw/Hermes Agent Brain">
-      <div class="repo-stars">★ 22,951</div>
+      <div class="repo-stars">★ 23,016</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">garrytan /</span> gbrain</div>
         <div class="repo-desc">Garry's opinionated OpenClaw / Hermes Agent brain.</div>
@@ -766,7 +766,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/vectorize-io/hindsight" data-github="https://github.com/vectorize-io/hindsight" data-desc="Agent memory that learns — long-term retain/recall/reflect workflows">
-      <div class="repo-stars">★ 16,465</div>
+      <div class="repo-stars">★ 16,480</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">vectorize-io /</span> hindsight</div>
         <div class="repo-desc">Agent memory that learns — long-term retain, recall, reflect workflows.</div>
@@ -774,7 +774,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/greyhaven-ai/autocontext" data-github="https://github.com/greyhaven-ai/autocontext" data-desc="Recursive self-improving context harness — helps agents succeed on complex tasks">
-      <div class="repo-stars">★ 1,204</div>
+      <div class="repo-stars">★ 1,205</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">greyhaven-ai /</span> autocontext</div>
         <div class="repo-desc">Recursive self-improving context harness — helps agents succeed on complex tasks.</div>
@@ -782,7 +782,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/stephenschoettler/hermes-lcm" data-github="https://github.com/stephenschoettler/hermes-lcm" data-desc="Lossless Context Management — DAG-based context engine that never loses a message">
-      <div class="repo-stars">★ 734</div>
+      <div class="repo-stars">★ 737</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">stephenschoettler /</span> hermes-lcm</div>
         <div class="repo-desc">Lossless context management — DAG-based engine that never loses a message.</div>
@@ -830,7 +830,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/plastic-labs/honcho" data-github="https://github.com/plastic-labs/honcho" data-desc="Memory library for building stateful agents — the upstream library that the elkimek/honcho-self-hosted Hermes wrapper builds on.">
-      <div class="repo-stars">★ 5,189</div>
+      <div class="repo-stars">★ 5,204</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">plastic-labs /</span> honcho <span class="repo-flag">official</span></div>
         <div class="repo-desc">Memory library for building stateful agents — the upstream library that the elkimek/honcho-self-hosted Hermes wrapper builds on.</div>
@@ -854,7 +854,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/AxDSan/mnemosyne" data-github="https://github.com/AxDSan/mnemosyne" data-desc="The Zero-Dependency, Sub-Millisecond AI Memory System for Hermes Agents">
-      <div class="repo-stars">★ 1,146</div>
+      <div class="repo-stars">★ 1,152</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">AxDSan /</span> mnemosyne</div>
         <div class="repo-desc">The Zero-Dependency, Sub-Millisecond AI Memory System for Hermes Agents.</div>
@@ -870,7 +870,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/alias8818/hermes-tool-slimmer" data-github="https://github.com/alias8818/hermes-tool-slimmer" data-desc="Reduce Hermes Agent tool-schema overhead with keyword selection and Tool Search support">
-      <div class="repo-stars">★ 23</div>
+      <div class="repo-stars">★ 24</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">alias8818 /</span> hermes-tool-slimmer</div>
         <div class="repo-desc">Reduce Hermes Agent tool-schema overhead with keyword selection and Tool Search support.</div>
@@ -878,7 +878,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/volcengine/OpenViking" data-github="https://github.com/volcengine/OpenViking" data-desc="Filesystem-first context database — official Hermes memory provider with tiered loading and 91% token reduction on LoCoMo10">
-      <div class="repo-stars">★ 25,698</div>
+      <div class="repo-stars">★ 25,715</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">volcengine /</span> OpenViking</div>
         <div class="repo-desc">Official Hermes memory provider — viking:// URIs, tiered L0/L1/L2 loading, 91% token reduction + 43-49% task gain over baseline on LoCoMo10. AGPL-3.0.</div>
@@ -886,7 +886,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/supermemoryai/supermemory" data-github="https://github.com/supermemoryai/supermemory" data-desc="Memory engine and API — official Hermes provider with sub-300ms recall at 100B+ tokens/month and context fencing">
-      <div class="repo-stars">★ 27,080</div>
+      <div class="repo-stars">★ 27,098</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">supermemoryai /</span> supermemory</div>
         <div class="repo-desc">Official Hermes memory provider — sub-300ms recall sustained at 100B+ tokens/month, custom vector graph engine, context fencing kills capture pollution, byte-level dedupe.</div>
@@ -941,11 +941,11 @@
     <div class="cat-num">§05</div>
     <h2 class="cat-title">Plugins &amp; extensions</h2>
     <p class="cat-desc">Drop-in modules that add tools, safety, payments, or new capabilities.</p>
-    <div class="cat-count"><span class="cat-count-n">23</span> repos</div>
+    <div class="cat-count"><span class="cat-count-n">22</span> repos</div>
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/clawshell/clawshell" data-github="https://github.com/clawshell/clawshell" data-desc="Runtime Security Layer for OpenClaw/Hermes — PII & sensitive credentials protection">
-      <div class="repo-stars">★ 294</div>
+      <div class="repo-stars">★ 295</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">clawshell /</span> clawshell</div>
         <div class="repo-desc">Runtime security layer — PII and sensitive credentials protection.</div>
@@ -953,7 +953,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/robbyczgw-cla/hermes-web-search-plus" data-github="https://github.com/robbyczgw-cla/hermes-web-search-plus" data-desc="Multi-provider web search (Serper, Tavily, Exa, Querit, Perplexity) with auto-routing">
-      <div class="repo-stars">★ 279</div>
+      <div class="repo-stars">★ 280</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
         <div class="repo-desc">Multi-provider web search — Serper, Tavily, Exa, Querit, Perplexity with auto-routing.</div>
@@ -961,7 +961,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/42-evey/hermes-plugins" data-github="https://github.com/42-evey/hermes-plugins" data-desc="Goal management, inter-agent bridge, model selection, and cost control plugins">
-      <div class="repo-stars">★ 217</div>
+      <div class="repo-stars">★ 220</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">42-evey /</span> hermes-plugins</div>
         <div class="repo-desc">Goal management, inter-agent bridge, model selection, cost control plugins.</div>
@@ -1001,7 +1001,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/335234131/agent-browser-mcp" data-github="https://github.com/335234131/agent-browser-mcp" data-desc="让 Agent 直接操作真实 Chrome 的 MCP 服务，支持页面扫描、CDP、截图与物理输入">
-      <div class="repo-stars">★ 230</div>
+      <div class="repo-stars">★ 229</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">335234131 /</span> agent-browser-mcp</div>
         <div class="repo-desc">让 Agent 直接操作真实 Chrome 的 MCP 服务，支持页面扫描、CDP、截图与物理输入.</div>
@@ -1017,7 +1017,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/jau123/MeiGen-AI-Design-MCP" data-github="https://github.com/jau123/MeiGen-AI-Design-MCP" data-desc="Supports GPT Image 2, Nanobanana &amp; ComfyUI, with a 1,400+ prompt library, carefully crafted hooks and a multi-task orchestration system">
-      <div class="repo-stars">★ 1,448</div>
+      <div class="repo-stars">★ 1,451</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">jau123 /</span> MeiGen-AI-Design-MCP</div>
         <div class="repo-desc">Supports GPT Image 2, Nanobanana &amp; ComfyUI, with a 1,400+ prompt library, carefully crafted hooks and a multi-task orchestration system.</div>
@@ -1025,7 +1025,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/Context4GPTs/klodi-plugin" data-github="https://github.com/Context4GPTs/klodi-plugin" data-desc="The agent-to-agent marketplace, in your agent host. Your agent lists, haggles, and closes deals for you while you live your life.">
-      <div class="repo-stars">★ 9</div>
+      <div class="repo-stars">★ 12</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">Context4GPTs /</span> klodi-plugin</div>
         <div class="repo-desc">The agent-to-agent marketplace, in your agent host. Your agent lists, haggles, and closes deals for you while you live your life.</div>
@@ -1033,7 +1033,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/Xquik-dev/hermes-tweet" data-github="https://github.com/Xquik-dev/hermes-tweet" data-desc="Native Hermes Agent plugin for X automation through Xquik">
-      <div class="repo-stars">★ 9</div>
+      <div class="repo-stars">★ 10</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">Xquik-dev /</span> hermes-tweet</div>
         <div class="repo-desc">Native Hermes Agent plugin for X automation through Xquik.</div>
@@ -1041,7 +1041,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server" data-github="https://github.com/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server" data-desc="Web search and content retrieval MCP server supporting Hermes Agent, OpenClaw, Claude Code, Codex, Cursor, and other AI tools">
-      <div class="repo-stars">★ 343</div>
+      <div class="repo-stars">★ 345</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
         <div class="repo-desc">Web search and content retrieval MCP server supporting Hermes Agent, OpenClaw, Claude Code, Codex, Cursor, and other AI tools.</div>
@@ -1049,7 +1049,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/stainlu/hermes-labyrinth" data-github="https://github.com/stainlu/hermes-labyrinth" data-desc="Read-only observability plugin for Hermes Agent with journeys, crossings, guideposts, and reports">
-      <div class="repo-stars">★ 284</div>
+      <div class="repo-stars">★ 285</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">stainlu /</span> hermes-labyrinth</div>
         <div class="repo-desc">Read-only observability plugin for Hermes Agent with journeys, crossings, guideposts, and reports.</div>
@@ -1081,7 +1081,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/indranilbanerjee/digital-marketing-pro" data-github="https://github.com/indranilbanerjee/digital-marketing-pro" data-desc="Open-source AI marketing plugin for agencies &amp; in-house teams — 158 skills, 25 specialist agents, 12-Part Strategy Flow, Cowork team-persistent, EU AI Act Article 50 ready, 6-platform AEO/GEO incl. Go">
-      <div class="repo-stars">★ 142</div>
+      <div class="repo-stars">★ 143</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">indranilbanerjee /</span> digital-marketing-pro</div>
         <div class="repo-desc">Open-source AI marketing plugin for agencies &amp; in-house teams — 158 skills, 25 specialist agents, 12-Part Strategy Flow, Cowork team-persistent, EU AI Act Article 50 ready, 6-platform AEO/GEO incl. Go.</div>
@@ -1089,7 +1089,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/indranilbanerjee/socialforge" data-github="https://github.com/indranilbanerjee/socialforge" data-desc="Open-source agency-grade social media production plugin — 16 skills, 25 commands, AI image (Nano Banana Pro) + AI video (Kling v3.0 Pro) + C2PA signing (EU AI Act Article 50). Installs on Claude Code,">
-      <div class="repo-stars">★ 5</div>
+      <div class="repo-stars">★ 6</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">indranilbanerjee /</span> socialforge</div>
         <div class="repo-desc">Open-source agency-grade social media production plugin — 16 skills, 25 commands, AI image (Nano Banana Pro) + AI video (Kling v3.0 Pro) + C2PA signing (EU AI Act Article 50). Installs on Claude Code,.</div>
@@ -1113,7 +1113,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/Sahil-SS9/Toolaria" data-github="https://github.com/Sahil-SS9/Toolaria" data-desc="Rescue oversized tool results before they flood context. SHA256-addressed blob store with per-session indexes">
-      <div class="repo-stars">★ 8</div>
+      <div class="repo-stars">★ 9</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">Sahil-SS9 /</span> Toolaria</div>
         <div class="repo-desc">Rescue oversized tool results before they flood context. SHA256-addressed blob store with per-session indexes.</div>
@@ -1121,10 +1121,18 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/Sahil-SS9/Toolaria" data-github="https://github.com/Sahil-SS9/Toolaria" data-desc="Rescue oversized tool results before they flood context. SHA256-addressed blob store with per-session indexes">
-      <div class="repo-stars">★ 8</div>
+      <div class="repo-stars">★ 9</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">Sahil-SS9 /</span> Toolaria</div>
         <div class="repo-desc">Rescue oversized tool results before they flood context. SHA256-addressed blob store with per-session indexes.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/hlothaire/hermes-trace" data-github="https://github.com/hlothaire/hermes-trace" data-desc="A Hermes Agent plugin that builds execution trace graphs using agent lifecycle hooks.">
+      <div class="repo-stars">★ 0</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">hlothaire /</span> hermes-trace</div>
+        <div class="repo-desc">A Hermes Agent plugin that builds execution trace graphs using agent lifecycle hooks.</div>
       </div>
       <div class="repo-delta">— / wk</div>
     </a>
@@ -1136,11 +1144,11 @@
     <div class="cat-num">§06</div>
     <h2 class="cat-title">Multi-agent &amp; orchestration</h2>
     <p class="cat-desc">Fleet management, swarm coordinators, and multi-agent delegation systems.</p>
-    <div class="cat-count"><span class="cat-count-n">13</span> repos</div>
+    <div class="cat-count"><span class="cat-count-n">11</span> repos</div>
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/builderz-labs/mission-control" data-github="https://github.com/builderz-labs/mission-control" data-desc="Self-hosted AI agent orchestration — dispatch tasks, run multi-agent workflows, monitor spend">
-      <div class="repo-stars">★ 5,327</div>
+      <div class="repo-stars">★ 5,331</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">builderz-labs /</span> mission-control</div>
         <div class="repo-desc">Self-hosted orchestration — dispatch tasks, run multi-agent workflows, monitor spend.</div>
@@ -1148,7 +1156,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/swarmclawai/swarmclaw" data-github="https://github.com/swarmclawai/swarmclaw" data-desc="Build autonomous AI agent swarms with orchestration, skills, and multiple model providers">
-      <div class="repo-stars">★ 583</div>
+      <div class="repo-stars">★ 584</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">swarmclawai /</span> swarmclaw</div>
         <div class="repo-desc">Build autonomous AI agent swarms — orchestration, skills, multiple model providers.</div>
@@ -1156,7 +1164,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/howdymary/hermes-agent-metaharness" data-github="https://github.com/howdymary/hermes-agent-metaharness" data-desc="Meta-harness for Hermes Agent — meta-optimization with arxiv paper reference">
-      <div class="repo-stars">★ 93</div>
+      <div class="repo-stars">★ 94</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">howdymary /</span> hermes-agent-metaharness</div>
         <div class="repo-desc">Meta-harness for Hermes Agent — meta-optimization with arxiv paper reference.</div>
@@ -1172,7 +1180,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/1ilkhamov/opencode-hermes-multiagent" data-github="https://github.com/1ilkhamov/opencode-hermes-multiagent" data-desc="17 specialized agents for research, planning, implementation, quality, and infrastructure">
-      <div class="repo-stars">★ 140</div>
+      <div class="repo-stars">★ 141</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">1ilkhamov /</span> opencode-hermes-multiagent</div>
         <div class="repo-desc">17 specialized agents — research, planning, implementation, quality, infrastructure.</div>
@@ -1196,7 +1204,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/agent-of-empires/agent-of-empires" data-github="https://github.com/agent-of-empires/agent-of-empires" data-desc="TUI and web control surface for managing multiple coding agents including Hermes Agent, Claude Code, OpenCode, Codex, Gemini, and others">
-      <div class="repo-stars">★ 2,592</div>
+      <div class="repo-stars">★ 2,595</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">agent-of-empires /</span> agent-of-empires</div>
         <div class="repo-desc">TUI and web control surface for managing multiple coding agents including Hermes Agent, Claude Code, OpenCode, Codex, Gemini, and others.</div>
@@ -1204,7 +1212,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/CryptoDmitry/hermes-agent-control-room" data-github="https://github.com/CryptoDmitry/hermes-agent-control-room" data-desc="Control Room-first template for managing Hermes agents from one VPS agent to specialist teams and orchestrated workflows">
-      <div class="repo-stars">★ 844</div>
+      <div class="repo-stars">★ 856</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">CryptoDmitry /</span> hermes-agent-control-room</div>
         <div class="repo-desc">Control Room-first template for managing Hermes agents from one VPS agent to specialist teams and orchestrated workflows.</div>
@@ -1212,7 +1220,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/Agent-3-7/minions" data-github="https://github.com/Agent-3-7/minions" data-desc="Mission Control for Hermes agents: create, supervise, and review autonomous Hermes Agent work from one screen">
-      <div class="repo-stars">★ 577</div>
+      <div class="repo-stars">★ 578</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">Agent-3-7 /</span> minions</div>
         <div class="repo-desc">Mission Control for Hermes agents: create, supervise, and review autonomous Hermes Agent work from one screen.</div>
@@ -1255,7 +1263,7 @@
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/numtide/llm-agents.nix" data-github="https://github.com/numtide/llm-agents.nix" data-desc="Nix packages for AI coding agents including Hermes">
-      <div class="repo-stars">★ 1,430</div>
+      <div class="repo-stars">★ 1,433</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">numtide /</span> llm-agents.nix</div>
         <div class="repo-desc">Nix packages for AI coding agents including Hermes.</div>
@@ -1263,7 +1271,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/TheAiSingularity/hermesclaw" data-github="https://github.com/TheAiSingularity/hermesclaw" data-desc="Hermes Agent sandboxed with hardware-level enforcement">
-      <div class="repo-stars">★ 53</div>
+      <div class="repo-stars">★ 52</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">TheAiSingularity /</span> hermesclaw</div>
         <div class="repo-desc">Hermes Agent sandboxed with hardware-level enforcement.</div>
@@ -1350,11 +1358,11 @@
     <div class="cat-num">§08</div>
     <h2 class="cat-title">Integrations &amp; bridges</h2>
     <p class="cat-desc">Connect Hermes to other agents, platforms, and specialized systems.</p>
-    <div class="cat-count"><span class="cat-count-n">11</span> repos</div>
+    <div class="cat-count"><span class="cat-count-n">10</span> repos</div>
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/AaronWong1999/hermesclaw" data-github="https://github.com/AaronWong1999/hermesclaw" data-desc="Run Hermes Agent and OpenClaw on the same WeChat account">
-      <div class="repo-stars">★ 620</div>
+      <div class="repo-stars">★ 621</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">AaronWong1999 /</span> hermesclaw</div>
         <div class="repo-desc">Run Hermes Agent and OpenClaw on the same WeChat account.</div>
@@ -1370,7 +1378,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/Codename-11/hermes-relay" data-github="https://github.com/Codename-11/hermes-relay" data-desc="Hermes Companion — Android app for Hermes agent platform. Chat, terminal, and device control over WSS.">
-      <div class="repo-stars">★ 34</div>
+      <div class="repo-stars">★ 35</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">Codename-11 /</span> hermes-relay</div>
         <div class="repo-desc">Hermes Companion — Android app for Hermes agent platform. Chat, terminal, device control over WSS.</div>
@@ -1434,7 +1442,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/ndesv21/socialclaw" data-github="https://github.com/ndesv21/socialclaw" data-desc="Social media scheduling CLI and OpenClaw skill for AI agents posting to X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, and Pinterest.">
-      <div class="repo-stars">★ 24</div>
+      <div class="repo-stars">★ 25</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">ndesv21 /</span> socialclaw</div>
         <div class="repo-desc">Social media scheduling CLI and OpenClaw skill for AI agents posting to X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, and Pinterest.</div>
@@ -1453,7 +1461,7 @@
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/junhoyeo/tokscale" data-github="https://github.com/junhoyeo/tokscale" data-desc="CLI tool for tracking token usage from Claude Code, OpenClaw, Hermes, Codex, Gemini, and more">
-      <div class="repo-stars">★ 3,750</div>
+      <div class="repo-stars">★ 3,768</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">junhoyeo /</span> tokscale</div>
         <div class="repo-desc">CLI for tracking token usage — Claude Code, OpenClaw, Hermes, Codex, Gemini, and more.</div>
@@ -1517,7 +1525,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/colbymchenry/codegraph" data-github="https://github.com/colbymchenry/codegraph" data-desc="Local pre-indexed code knowledge graph for Hermes Agent and other coding agents to reduce token usage and tool calls">
-      <div class="repo-stars">★ 49,994</div>
+      <div class="repo-stars">★ 50,244</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">colbymchenry /</span> codegraph</div>
         <div class="repo-desc">Local pre-indexed code knowledge graph for Hermes Agent and other coding agents to reduce token usage and tool calls.</div>
@@ -1525,7 +1533,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/liaohch3/claude-tap" data-github="https://github.com/liaohch3/claude-tap" data-desc="Local trace viewer for inspecting coding-agent API traffic from Hermes Agent, Claude Code, Codex, Gemini, Cursor, OpenCode, and others">
-      <div class="repo-stars">★ 1,798</div>
+      <div class="repo-stars">★ 1,807</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">liaohch3 /</span> claude-tap</div>
         <div class="repo-desc">Local trace viewer for inspecting coding-agent API traffic from Hermes Agent, Claude Code, Codex, Gemini, Cursor, OpenCode, and others.</div>
@@ -1533,7 +1541,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/Salomondiei08/oh-my-hermes" data-github="https://github.com/Salomondiei08/oh-my-hermes" data-desc="Opinionated workflow layer for building, shipping, and operating apps with Hermes Agent">
-      <div class="repo-stars">★ 532</div>
+      <div class="repo-stars">★ 551</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">Salomondiei08 /</span> oh-my-hermes</div>
         <div class="repo-desc">Opinionated workflow layer for building, shipping, and operating apps with Hermes Agent.</div>
@@ -1541,7 +1549,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/adityahimaone/hermes-agent-rtk-caveman" data-github="https://github.com/adityahimaone/hermes-agent-rtk-caveman" data-desc="Hermes Agent RTK and Caveman setup with preconfigured skills and token-saving CLI workflows">
-      <div class="repo-stars">★ 61</div>
+      <div class="repo-stars">★ 62</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">adityahimaone /</span> hermes-agent-rtk-caveman</div>
         <div class="repo-desc">Hermes Agent RTK and Caveman setup with preconfigured skills and token-saving CLI workflows.</div>
@@ -1600,7 +1608,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/bigph00t/hermescraft" data-github="https://github.com/bigph00t/hermescraft" data-desc="Embodied AI companion for Minecraft — persistent memory, vision, learning, multi-agent">
-      <div class="repo-stars">★ 41</div>
+      <div class="repo-stars">★ 42</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">bigph00t /</span> hermescraft</div>
         <div class="repo-desc">Embodied AI companion for Minecraft — persistent memory, vision, learning, multi-agent.</div>
@@ -1643,7 +1651,7 @@
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/0xNyk/awesome-hermes-agent" data-github="https://github.com/0xNyk/awesome-hermes-agent" data-desc="Curated list of awesome skills, tools, integrations, and resources for Hermes Agent">
-      <div class="repo-stars">★ 4,000</div>
+      <div class="repo-stars">★ 4,022</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">0xNyk /</span> awesome-hermes-agent</div>
         <div class="repo-desc">Curated list of skills, tools, integrations, and resources for Hermes Agent.</div>
@@ -1651,7 +1659,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/alchaincyf/hermes-agent-orange-book" data-github="https://github.com/alchaincyf/hermes-agent-orange-book" data-desc="Hermes Agent practical guide — Orange Book series (Chinese language)">
-      <div class="repo-stars">★ 4,439</div>
+      <div class="repo-stars">★ 4,446</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">alchaincyf /</span> hermes-agent-orange-book</div>
         <div class="repo-desc">Hermes Agent practical guide — Orange Book series (Chinese language).</div>
@@ -1659,7 +1667,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/ksimback/hermes-ecosystem" data-github="https://github.com/ksimback/hermes-ecosystem" data-desc="Hermes Atlas — the community map of every tool, skill, and integration for Hermes Agent">
-      <div class="repo-stars">★ 1,015</div>
+      <div class="repo-stars">★ 1,018</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">ksimback /</span> hermes-ecosystem</div>
         <div class="repo-desc">Hermes Atlas — the community map of every tool, skill, and integration for Hermes Agent.</div>
@@ -1667,7 +1675,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/OnlyTerp/hermes-optimization-guide" data-github="https://github.com/OnlyTerp/hermes-optimization-guide" data-desc="Performance optimization guide for Hermes deployments">
-      <div class="repo-stars">★ 442</div>
+      <div class="repo-stars">★ 444</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">OnlyTerp /</span> hermes-optimization-guide</div>
         <div class="repo-desc">Performance optimization guide for Hermes deployments.</div>
@@ -1699,7 +1707,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/jwangkun/hermes-agent-guide" data-github="https://github.com/jwangkun/hermes-agent-guide" data-desc="A systematic Chinese-language guide to Hermes Agent — 16 books, 300K+ words, covering installation, advanced development, single- and multi-agent orchestration.">
-      <div class="repo-stars">★ 367</div>
+      <div class="repo-stars">★ 370</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">jwangkun /</span> hermes-agent-guide</div>
         <div class="repo-desc">A systematic Chinese-language guide to Hermes Agent — 16 books, 300K+ words, covering installation, advanced development, single- and multi-agent orchestration.</div>
@@ -1707,7 +1715,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/longyunfeigu/learn-hermes-agent" data-github="https://github.com/longyunfeigu/learn-hermes-agent" data-desc="A 27-chapter hands-on tutorial for building an autonomous AI agent from zero in Python — agent loop, tool system, memory, skills, MCP, multi-platform gateway, and self-evolution.">
-      <div class="repo-stars">★ 153</div>
+      <div class="repo-stars">★ 154</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">longyunfeigu /</span> learn-hermes-agent</div>
         <div class="repo-desc">A 27-chapter hands-on tutorial for building an autonomous AI agent from zero in Python — agent loop, tool system, memory, skills, MCP, multi-platform gateway, and self-evolution.</div>
@@ -1790,7 +1798,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/sheawinkler/hermes-agent-ultra" data-github="https://github.com/sheawinkler/hermes-agent-ultra" data-desc="Rust-based Hermes Agent Ultra derivative focused on performance and Hermes Agent feature parity">
-      <div class="repo-stars">★ 46</div>
+      <div class="repo-stars">★ 49</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">sheawinkler /</span> hermes-agent-ultra</div>
         <div class="repo-desc">Rust-based Hermes Agent Ultra derivative focused on performance and Hermes Agent feature parity.</div>

--- a/lists/best-memory-providers.html
+++ b/lists/best-memory-providers.html
@@ -207,7 +207,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -313,7 +313,7 @@
       <div class="list-cell-name"><span class="org">AxDSan /</span> mnemosyne</div>
       <div class="list-cell-desc">The Zero-Dependency, Sub-Millisecond AI Memory System for Hermes Agents and Everyone Else!</div>
     </div>
-    <div class="list-cell-stars">★ 1.1K</div>
+    <div class="list-cell-stars">★ 1.2K</div>
   </a>
   <a class="list-row" href="/projects/stephenschoettler/hermes-lcm">
     <div class="list-rank">10</div>
@@ -321,7 +321,7 @@
       <div class="list-cell-name"><span class="org">stephenschoettler /</span> hermes-lcm</div>
       <div class="list-cell-desc">Lossless Context Management plugin for Hermes Agent — DAG-based context engine that never loses a message</div>
     </div>
-    <div class="list-cell-stars">★ 734</div>
+    <div class="list-cell-stars">★ 737</div>
   </a>
   <a class="list-row" href="/projects/elkimek/honcho-self-hosted">
     <div class="list-rank">11</div>
@@ -401,7 +401,7 @@
       <div class="list-cell-name"><span class="org">alias8818 /</span> hermes-tool-slimmer</div>
       <div class="list-cell-desc">Reduce Hermes Agent tool-schema overhead with keyword selection and Tool Search support</div>
     </div>
-    <div class="list-cell-stars">★ 23</div>
+    <div class="list-cell-stars">★ 24</div>
   </a>
   <a class="list-row" href="/projects/Ladybug-Memory/hermes-memory-plugin">
     <div class="list-rank">21</div>

--- a/lists/deployment-options.html
+++ b/lists/deployment-options.html
@@ -135,7 +135,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -217,7 +217,7 @@
       <div class="list-cell-name"><span class="org">TheAiSingularity /</span> hermesclaw</div>
       <div class="list-cell-desc">Hermes Agent (NousResearch) sandboxed by NVIDIA OpenShell — hardware-enforced network/filesystem/syscall policy, full memory + gateway stack</div>
     </div>
-    <div class="list-cell-stars">★ 53</div>
+    <div class="list-cell-stars">★ 52</div>
   </a>
   <a class="list-row" href="/projects/xmbshwll/hermes-agent-docker">
     <div class="list-rank">07</div>

--- a/lists/developer-tools.html
+++ b/lists/developer-tools.html
@@ -141,7 +141,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -183,7 +183,7 @@
       <div class="list-cell-name"><span class="org">colbymchenry /</span> codegraph</div>
       <div class="list-cell-desc">Pre-indexed code knowledge graph, auto syncs on code changes, for Claude Code, Codex, Gemini, Cursor, OpenCode, AntiGravity, Kiro, and Herme</div>
     </div>
-    <div class="list-cell-stars">★ 50.0K</div>
+    <div class="list-cell-stars">★ 50.2K</div>
   </a>
   <a class="list-row" href="/projects/junhoyeo/tokscale">
     <div class="list-rank">02</div>
@@ -207,7 +207,7 @@
       <div class="list-cell-name"><span class="org">Salomondiei08 /</span> oh-my-hermes</div>
       <div class="list-cell-desc">An opinionated workflow layer for building, shipping, and operating apps with Hermes Agent</div>
     </div>
-    <div class="list-cell-stars">★ 532</div>
+    <div class="list-cell-stars">★ 551</div>
   </a>
   <a class="list-row" href="/projects/joeynyc/hermes-skins">
     <div class="list-rank">05</div>
@@ -247,7 +247,7 @@
       <div class="list-cell-name"><span class="org">adityahimaone /</span> hermes-agent-rtk-caveman</div>
       <div class="list-cell-desc">Hermes Agent RTK + Caveman setup - 90-99% token savings on CLI operations with 35+ pre-configured skills</div>
     </div>
-    <div class="list-cell-stars">★ 61</div>
+    <div class="list-cell-stars">★ 62</div>
   </a>
   <a class="list-row" href="/projects/42-evey/evey-setup">
     <div class="list-rank">10</div>

--- a/lists/multi-agent-frameworks.html
+++ b/lists/multi-agent-frameworks.html
@@ -135,7 +135,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -193,7 +193,7 @@
       <div class="list-cell-name"><span class="org">CryptoDmitry /</span> hermes-agent-control-room</div>
       <div class="list-cell-desc">Control Room-first template for managing Hermes agents from one VPS agent to specialist teams and orchestrated workflows </div>
     </div>
-    <div class="list-cell-stars">★ 844</div>
+    <div class="list-cell-stars">★ 856</div>
   </a>
   <a class="list-row" href="/projects/shannhk/hermes-agent-control-room">
     <div class="list-rank">04</div>
@@ -209,7 +209,7 @@
       <div class="list-cell-name"><span class="org">swarmclawai /</span> swarmclaw</div>
       <div class="list-cell-desc">Open-source self-hosted AI agent runtime and multi-agent framework for autonomous agent swarms. Agent memory, MCP tools, schedules, delegati</div>
     </div>
-    <div class="list-cell-stars">★ 583</div>
+    <div class="list-cell-stars">★ 584</div>
   </a>
   <a class="list-row" href="/projects/Agent-3-7/minions">
     <div class="list-rank">06</div>
@@ -217,7 +217,7 @@
       <div class="list-cell-name"><span class="org">Agent-3-7 /</span> minions</div>
       <div class="list-cell-desc">Mission Control for your Hermes agents</div>
     </div>
-    <div class="list-cell-stars">★ 577</div>
+    <div class="list-cell-stars">★ 578</div>
   </a>
   <a class="list-row" href="/projects/linke-ai/hermes-agent-team">
     <div class="list-rank">07</div>
@@ -233,7 +233,7 @@
       <div class="list-cell-name"><span class="org">1ilkhamov /</span> opencode-hermes-multiagent</div>
       <div class="list-cell-desc">Hermes — a multi-agent system for OpenCode AI. 17 specialized agents for research, planning, implementation, quality, and infrastructure.</div>
     </div>
-    <div class="list-cell-stars">★ 140</div>
+    <div class="list-cell-stars">★ 141</div>
   </a>
   <a class="list-row" href="/projects/howdymary/hermes-agent-metaharness">
     <div class="list-rank">09</div>
@@ -241,7 +241,7 @@
       <div class="list-cell-name"><span class="org">howdymary /</span> hermes-agent-metaharness</div>
       <div class="list-cell-desc">An implementation of a Meta Harness for Hermes.</div>
     </div>
-    <div class="list-cell-stars">★ 93</div>
+    <div class="list-cell-stars">★ 94</div>
   </a>
   <a class="list-row" href="/projects/runtimenoteslabs/gladiator">
     <div class="list-rank">10</div>

--- a/lists/top-skills.html
+++ b/lists/top-skills.html
@@ -237,7 +237,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -279,7 +279,7 @@
       <div class="list-cell-name"><span class="org">nexu-io /</span> open-design</div>
       <div class="list-cell-desc">🎨 Local-first, open-source Claude Design alternative. 🖥️ Native desktop app. ⚡ 259+ Skills · ✨ 142+ Design Systems 🖼️ Web · desktop · mob</div>
     </div>
-    <div class="list-cell-stars">★ 65.7K</div>
+    <div class="list-cell-stars">★ 65.9K</div>
   </a>
   <a class="list-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills">
     <div class="list-rank">02</div>
@@ -327,7 +327,7 @@
       <div class="list-cell-name"><span class="org">Romanescu11 /</span> hermes-skill-factory</div>
       <div class="list-cell-desc"> A meta-skill plugin for Nous Research's Hermes AI agent that watches your workflows and automatically turns them into reusable skills.  Eve</div>
     </div>
-    <div class="list-cell-stars">★ 379</div>
+    <div class="list-cell-stars">★ 383</div>
   </a>
   <a class="list-row" href="/projects/DougTrajano/pydantic-ai-skills">
     <div class="list-rank">08</div>
@@ -335,7 +335,7 @@
       <div class="list-cell-name"><span class="org">DougTrajano /</span> pydantic-ai-skills</div>
       <div class="list-cell-desc">This package implements Agent Skills (https://agentskills.io) support with progressive disclosure for Pydantic AI. Supports filesystem and p</div>
     </div>
-    <div class="list-cell-stars">★ 314</div>
+    <div class="list-cell-stars">★ 315</div>
   </a>
   <a class="list-row" href="/projects/ZeroPointRepo/youtube-skills">
     <div class="list-rank">09</div>
@@ -343,7 +343,7 @@
       <div class="list-cell-name"><span class="org">ZeroPointRepo /</span> youtube-skills</div>
       <div class="list-cell-desc">YouTube Transcript API skills for AI agents. Get transcripts, search videos, browse channels. Works with OpenClaw, Hermes-Agent, Claude Code</div>
     </div>
-    <div class="list-cell-stars">★ 270</div>
+    <div class="list-cell-stars">★ 271</div>
   </a>
   <a class="list-row" href="/projects/amanning3390/hermeshub">
     <div class="list-rank">10</div>
@@ -351,7 +351,7 @@
       <div class="list-cell-name"><span class="org">amanning3390 /</span> hermeshub</div>
       <div class="list-cell-desc">HermesHub - The Skills Hub for Hermes Agent by Nous Research. Browse, share, and install community skills.</div>
     </div>
-    <div class="list-cell-stars">★ 259</div>
+    <div class="list-cell-stars">★ 260</div>
   </a>
   <a class="list-row" href="/projects/Cranot/super-hermes">
     <div class="list-rank">11</div>
@@ -359,7 +359,7 @@
       <div class="list-cell-name"><span class="org">Cranot /</span> super-hermes</div>
       <div class="list-cell-desc">Skills that teach Hermes Agent to write its own analytical prompts</div>
     </div>
-    <div class="list-cell-stars">★ 240</div>
+    <div class="list-cell-stars">★ 241</div>
   </a>
   <a class="list-row" href="/projects/AkoliteZA/hermes-agent-idea-workflow">
     <div class="list-rank">12</div>
@@ -367,7 +367,7 @@
       <div class="list-cell-name"><span class="org">AkoliteZA /</span> hermes-agent-idea-workflow</div>
       <div class="list-cell-desc">Pre-build idea-to-spec workflow skills for Hermes Agent: turn rough ideas into design docs, implementation specs, and Superpowers-ready buil</div>
     </div>
-    <div class="list-cell-stars">★ 217</div>
+    <div class="list-cell-stars">★ 218</div>
   </a>
   <a class="list-row" href="/projects/ReinaMacCredy/maestro">
     <div class="list-rank">13</div>
@@ -383,7 +383,7 @@
       <div class="list-cell-name"><span class="org">tlehman /</span> litprog-skill</div>
       <div class="list-cell-desc">Literate programming skill for agent harnesses like Claude Code, OpenCode and Hermes Agent</div>
     </div>
-    <div class="list-cell-stars">★ 175</div>
+    <div class="list-cell-stars">★ 176</div>
   </a>
   <a class="list-row" href="/projects/esaradev/icarus-plugin">
     <div class="list-rank">15</div>
@@ -471,7 +471,7 @@
       <div class="list-cell-name"><span class="org">Sahil-SS9 /</span> hermaguard</div>
       <div class="list-cell-desc">Adversarial bug-hunting code review for AI agents. 3 parallel subagents attack code from different angles, then a consolidator merges and tr</div>
     </div>
-    <div class="list-cell-stars">★ 8</div>
+    <div class="list-cell-stars">★ 9</div>
   </a>
   <a class="list-row" href="/projects/Sahil-SS9/hermes-simplify-swarm">
     <div class="list-rank">26</div>

--- a/lists/workspaces-and-guis.html
+++ b/lists/workspaces-and-guis.html
@@ -177,7 +177,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -219,7 +219,7 @@
       <div class="list-cell-name"><span class="org">farion1231 /</span> cc-switch</div>
       <div class="list-cell-desc">A cross-platform desktop All-in-One assistant for Claude Code, Codex, OpenCode, OpenClaw, Gemini CLI &amp; Hermes Agent. Only official website: </div>
     </div>
-    <div class="list-cell-stars">★ 102.1K</div>
+    <div class="list-cell-stars">★ 102.6K</div>
   </a>
   <a class="list-row" href="/projects/iOfficeAI/AionUi">
     <div class="list-rank">02</div>
@@ -227,7 +227,7 @@
       <div class="list-cell-name"><span class="org">iOfficeAI /</span> AionUi</div>
       <div class="list-cell-desc">Free, local, open-source 24/7 Cowork app for OpenClaw, Hermes Agent, Claude Code, Codex, OpenCode, Gemini CLI and 20+ more CLI | Customize y</div>
     </div>
-    <div class="list-cell-stars">★ 28.3K</div>
+    <div class="list-cell-stars">★ 28.4K</div>
   </a>
   <a class="list-row" href="/projects/nesquena/hermes-webui">
     <div class="list-rank">03</div>
@@ -235,7 +235,7 @@
       <div class="list-cell-name"><span class="org">nesquena /</span> hermes-webui</div>
       <div class="list-cell-desc">Hermes WebUI: The best way to use Hermes Agent from the web or from your phone!</div>
     </div>
-    <div class="list-cell-stars">★ 14.5K</div>
+    <div class="list-cell-stars">★ 14.6K</div>
   </a>
   <a class="list-row" href="/projects/fathah/hermes-desktop">
     <div class="list-rank">04</div>
@@ -283,7 +283,7 @@
       <div class="list-cell-name"><span class="org">jazzyalex /</span> agent-sessions</div>
       <div class="list-cell-desc">Local-first macOS app to browse, search, analyze, and resume supported AI coding-agent session history across Codex, Claude Code, OpenCode, </div>
     </div>
-    <div class="list-cell-stars">★ 640</div>
+    <div class="list-cell-stars">★ 641</div>
   </a>
   <a class="list-row" href="/projects/nickvasilescu/hermes-desktop-os1">
     <div class="list-rank">10</div>
@@ -299,7 +299,7 @@
       <div class="list-cell-name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       <div class="list-cell-desc">Hermes Agent CN desktop app, Windows-First, built with Tauri, Typescript and Rust. Isolated Hermes Agent core insides. </div>
     </div>
-    <div class="list-cell-stars">★ 445</div>
+    <div class="list-cell-stars">★ 456</div>
   </a>
   <a class="list-row" href="/projects/liftaris/herm">
     <div class="list-rank">12</div>
@@ -307,7 +307,7 @@
       <div class="list-cell-name"><span class="org">liftaris /</span> herm</div>
       <div class="list-cell-desc">The Hermes TUI built with OpenTUI</div>
     </div>
-    <div class="list-cell-stars">★ 253</div>
+    <div class="list-cell-stars">★ 254</div>
   </a>
   <a class="list-row" href="/projects/clawvader-tech/hermes-telegram-miniapp">
     <div class="list-rank">13</div>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1827,7 +1827,7 @@ Skip to content
 
 ---
 
-# Project Catalog (168 projects)
+# Project Catalog (169 projects)
 
 ---
 
@@ -1836,7 +1836,7 @@ Skip to content
 URL: https://hermesatlas.com/projects/NousResearch/hermes-agent
 GitHub: https://github.com/NousResearch/hermes-agent
 Category: Core & Official
-Stars: 194,787
+Stars: 195,214
 Official: Yes (maintained by Nous Research)
 The self-improving AI agent that grows with you — persistent memory, auto-generated skills, 14 platforms, 6 execution backends
 
@@ -1854,7 +1854,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/farion1231/cc-switch
 GitHub: https://github.com/farion1231/cc-switch
 Category: Workspaces & GUIs
-Stars: 102,148
+Stars: 102,588
 Cross-platform all-in-one manager for Claude Code, Codex, OpenCode, OpenClaw, Gemini CLI, and Hermes Agent
 
 CC Switch is a cross-platform manager designed to centralize the administration of various AI coding and CLI tools. It is built using Tauri 2 to provide a native desktop experience across Windows, macOS, and Linux. The tool allows users to manage multiple environments including Claude Code, Gemini CLI, and Hermes Agent from a single interface. This streamlines the workflow for developers using a variety of LLM-based agents and coding assistants.
@@ -1871,7 +1871,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/nexu-io/open-design
 GitHub: https://github.com/nexu-io/open-design
 Category: Skills & Skill Registries
-Stars: 65,687
+Stars: 65,916
 Local-first open-source design/prototyping system with coding-agent CLI support including Hermes Agent
 
 Open Design is a local-first, open-source design and prototyping system that serves as an agent-native alternative to Claude Design. It transforms the design process into a filesystem of skills, design systems, and plugins that can be read and remixed by coding agents. The system generates web, desktop, and mobile prototypes, motion graphics, and decks using real CSS and components. It integrates with various coding agents via a CLI and MCP server, allowing users to export outputs to HTML, PDF, PPTX, and MP4.
@@ -1888,7 +1888,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/mem0ai/mem0
 GitHub: https://github.com/mem0ai/mem0
 Category: Memory & Context
-Stars: 58,675
+Stars: 58,717
 Universal memory layer for AI Agents — official Hermes Agent memory provider, available as managed cloud or Apache-2.0 self-hosted OSS
 
 Mem0 is an intelligent memory layer that provides AI agents with the ability to remember user preferences and adapt over time. It utilizes a multi-signal retrieval system combining semantic, BM25 keyword, and entity matching with temporal reasoning to rank dated instances. The system supports multi-level state retention across users, sessions, and agents through a flexible deployment model. It is available as a Python/npm library, a self-hosted server, or a managed cloud service.
@@ -1905,7 +1905,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/colbymchenry/codegraph
 GitHub: https://github.com/colbymchenry/codegraph
 Category: Developer Tools
-Stars: 49,994
+Stars: 50,244
 Local pre-indexed code knowledge graph for Hermes Agent and other coding agents to reduce token usage and tool calls
 
 CodeGraph is a local CLI tool that provides a pre-indexed knowledge graph of codebases to coding agents like Hermes Agent and Claude Code. It maps symbol relationships, call graphs, and code structures into a local index to replace expensive file-scanning operations like grep and glob. By providing semantic intelligence through an MCP server, it reduces token consumption and the number of tool calls required for architectural analysis. The system features an auto-sync capability that updates the graph in real-time as files are modified.
@@ -1922,7 +1922,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/iOfficeAI/AionUi
 GitHub: https://github.com/iOfficeAI/AionUi
 Category: Workspaces & GUIs
-Stars: 28,344
+Stars: 28,371
 Local open-source cowork app for OpenClaw, Hermes Agent, Claude Code, Codex, OpenCode, Gemini CLI, and other agent CLIs
 
 AionUi is a local cowork platform that provides a unified graphical interface for managing and interacting with multiple AI agents. It integrates a built-in agent engine with file system access and web search capabilities, while also auto-detecting existing CLI agents like Hermes Agent and Claude Code. The platform enables autonomous multi-step task execution, scheduled automation via Cron, and remote access through various messaging apps. Users can leverage specialized assistants to generate editable Office documents, including PPT, Word, and Excel files.
@@ -1939,7 +1939,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/supermemoryai/supermemory
 GitHub: https://github.com/supermemoryai/supermemory
 Category: Memory & Context
-Stars: 27,080
+Stars: 27,098
 Memory engine and API — official Hermes Agent memory provider with sub-300ms recall sustained at 100B+ tokens/month, custom vector graph engine, context fencing, and byte-level dedupe with 100% prompt-cache discount.
 
 Supermemory is a context and memory layer for AI agents that prevents information loss between conversations. It uses a custom vector graph engine to extract facts, maintain user profiles, and handle knowledge updates or contradictions automatically. The system integrates RAG, multi-modal file processing, and real-time connectors for platforms like GitHub and Google Drive into a single API. It is designed to deliver personalized context with sub-300ms recall and supports local deployment via a single binary.
@@ -1956,7 +1956,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/volcengine/OpenViking
 GitHub: https://github.com/volcengine/OpenViking
 Category: Memory & Context
-Stars: 25,698
+Stars: 25,715
 Open-source context database for AI agents — official Hermes Agent memory provider using viking:// URIs and tiered L0/L1/L2 loading; 91% token reduction and 43-49% task-completion gain over baseline on LoCoMo10. AGPL-3.0.
 
 OpenViking is an open-source context database that simplifies context management for AI agents. It replaces traditional flat vector storage with a filesystem paradigm to unify the organization of memories, resources, and skills. The system utilizes a three-tier loading structure (L0/L1/L2) to reduce token consumption and supports recursive directory retrieval for precise context acquisition. It also provides visualized retrieval trajectories to make the retrieval process observable and debuggable.
@@ -1973,7 +1973,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/garrytan/gbrain
 GitHub: https://github.com/garrytan/gbrain
 Category: Memory & Context
-Stars: 22,951
+Stars: 23,016
 Garry's Opinionated OpenClaw/Hermes Agent Brain
 
 GBrain is a memory and context layer for AI agents that transforms raw search results into synthesized answers. It utilizes a self-wiring knowledge graph to extract entity relationships and a synthesis layer to provide cited prose and gap analysis. The system can be deployed as a personal knowledge base or a scoped company brain with permission-based access. It integrates with agents like OpenClaw and Hermes, as well as coding tools like Claude Code and Codex via MCP.
@@ -1990,7 +1990,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/vectorize-io/hindsight
 GitHub: https://github.com/vectorize-io/hindsight
 Category: Memory & Context
-Stars: 16,465
+Stars: 16,480
 Official: Yes (maintained by Nous Research)
 Agent memory that learns — long-term retain/recall/reflect workflows
 
@@ -2008,7 +2008,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/mukul975/Anthropic-Cybersecurity-Skills
 GitHub: https://github.com/mukul975/Anthropic-Cybersecurity-Skills
 Category: Skills & Skill Registries
-Stars: 15,877
+Stars: 15,936
 754 structured cybersecurity skills mapped to MITRE ATT&CK, NIST CSF 2.0, ATLAS, D3FEND & NIST AI RMF
 
 Anthropic Cybersecurity Skills is an open-source knowledge base designed to provide AI agents with the structured domain expertise of a senior security analyst. It utilizes the agentskills.io standard to deliver 754 production-grade skills across 26 security domains using YAML frontmatter and Markdown. Each skill is mapped across five industry frameworks, including MITRE ATT&CK and NIST CSF 2.0, to ensure unified compliance and guidance. The library is compatible with platforms such as Claude Code, GitHub Copilot, and Cursor for threat hunting and DFIR scenarios.
@@ -2025,7 +2025,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/nesquena/hermes-webui
 GitHub: https://github.com/nesquena/hermes-webui
 Category: Workspaces & GUIs
-Stars: 14,520
+Stars: 14,553
 Hermes WebUI: The best way to use Hermes Agent from the web or from your phone!
 
 Hermes WebUI is a lightweight web interface that provides a graphical alternative to the Hermes Agent CLI. It is built using Python and vanilla JavaScript without the need for a build step or framework. The interface features a three-panel layout for managing sessions, chat, and workspace files while maintaining full parity with the terminal experience. Users can securely access their existing agent and models via an SSH tunnel or Docker deployment.
@@ -2042,7 +2042,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/fathah/hermes-desktop
 GitHub: https://github.com/fathah/hermes-desktop
 Category: Workspaces & GUIs
-Stars: 12,286
+Stars: 12,302
 Desktop companion app for installing, configuring, and chatting with Hermes Agent
 
 Hermes Desktop is a native GUI that simplifies the installation and management of the Hermes Agent, replacing manual CLI configuration. It utilizes the official Hermes install script to set up the agent locally or connect to a remote API server. The application provides a comprehensive interface for managing memory, personas, and scheduled tasks across various AI providers. It also integrates numerous messaging gateways and a 3D visual interface called Hermes Office.
@@ -2059,7 +2059,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/EKKOLearnAI/hermes-web-ui
 GitHub: https://github.com/EKKOLearnAI/hermes-web-ui
 Category: Workspaces & GUIs
-Stars: 7,988
+Stars: 8,006
 Web dashboard for Hermes Agent — multi-platform AI chat, session management, scheduled jobs, usage analytics & channel configuration (Telegram, Discord, Slack, WhatsApp)
 
 Hermes Studio is a comprehensive web dashboard and desktop application designed to manage and interact with Hermes Agent environments. It provides a centralized control plane for orchestrating multi-platform AI chats, managing local model providers, and automating scheduled cron jobs. Users can configure integrations for eight messaging platforms, monitor detailed usage analytics, and execute coding-agent sessions through a unified interface. The system ensures data privacy by maintaining local SQLite storage for sessions and managing profile-scoped configurations and files.
@@ -2076,7 +2076,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/outsourc-e/hermes-workspace
 GitHub: https://github.com/outsourc-e/hermes-workspace
 Category: Workspaces & GUIs
-Stars: 5,715
+Stars: 5,727
 Native web workspace — chat, terminal, memory browser, skills manager, and inspector panel
 
 Hermes Workspace is a comprehensive command center designed to orchestrate AI agents through a unified web interface. It integrates with the vanilla hermes-agent to provide a zero-fork environment for managing chat, memory, and system operations. The platform features a Swarm Mode that utilizes tmux-backed workers for autonomous, role-based task dispatching and a Kanban board for tracking progress. Users can manage over 2,000 skills, browse MCP catalogs, and access a cross-platform PTY terminal from a single dashboard.
@@ -2093,7 +2093,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/builderz-labs/mission-control
 GitHub: https://github.com/builderz-labs/mission-control
 Category: Multi-Agent & Orchestration
-Stars: 5,327
+Stars: 5,331
 Self-hosted AI agent orchestration — dispatch tasks, run multi-agent workflows, monitor spend
 
 Mission Control is an open-source dashboard designed to centralize the management and orchestration of AI agent fleets. It utilizes a self-hosted, SQLite-backed architecture to provide real-time telemetry and task dispatching without requiring external dependencies like Redis or Postgres. The platform supports multi-agent workflows with built-in quality gates and integrates with frameworks such as CrewAI, LangGraph, and AutoGen. Users can manage agent skills, monitor costs, and implement role-based access control from a single interface.
@@ -2110,7 +2110,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/plastic-labs/honcho
 GitHub: https://github.com/plastic-labs/honcho
 Category: Memory & Context
-Stars: 5,189
+Stars: 5,204
 Official: Yes (maintained by Nous Research)
 Memory library for building stateful agents — the upstream library that the elkimek/honcho-self-hosted Hermes wrapper builds on.
 
@@ -2145,7 +2145,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/alchaincyf/hermes-agent-orange-book
 GitHub: https://github.com/alchaincyf/hermes-agent-orange-book
 Category: Guides & Docs
-Stars: 4,439
+Stars: 4,446
 Hermes Agent practical guide — Orange Book series (Chinese language)
 
 The Hermes Agent Orange Book is a comprehensive practical guide designed to help users master the Hermes Agent open-source AI framework. It explains the framework's self-improving learning loop, three-layer memory system, and automatic skill evolution. The guide covers deployment, security models, and the use of the multi-agent Kanban platform. It provides detailed instructions for developers and power users across 21 sections, supporting both desktop and browser interfaces.
@@ -2162,7 +2162,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/NousResearch/hermes-agent-self-evolution
 GitHub: https://github.com/NousResearch/hermes-agent-self-evolution
 Category: Core & Official
-Stars: 4,110
+Stars: 4,118
 Official: Yes (maintained by Nous Research)
 Evolutionary self-improvement using DSPy + GEPA — optimizes skills, prompts, and code
 
@@ -2180,7 +2180,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/0xNyk/awesome-hermes-agent
 GitHub: https://github.com/0xNyk/awesome-hermes-agent
 Category: Guides & Docs
-Stars: 4,000
+Stars: 4,022
 Curated list of awesome skills, tools, integrations, and resources for Hermes Agent
 
 This project is a curated directory of resources designed to expand the capabilities and workflows of the Hermes Agent ecosystem. It organizes community-contributed skills, tools, integrations, and documentation into categorized lists for easier discovery. Users can find everything from deployment utilities and messaging bridges to specialized domain applications and multi-agent orchestration tools. The repository also includes maturity tags to help developers distinguish between stable production tools and experimental proofs of concept.
@@ -2197,7 +2197,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/junhoyeo/tokscale
 GitHub: https://github.com/junhoyeo/tokscale
 Category: Developer Tools
-Stars: 3,750
+Stars: 3,768
 CLI tool for tracking token usage from Claude Code, OpenClaw, Hermes, Codex, Gemini, and more
 
 Tokscale is a monitoring tool designed to track token consumption and costs across various AI coding agents. It works by scanning local data directories and database files from multiple AI clients to aggregate usage statistics. The tool provides a native Rust TUI for analysis and a visualization dashboard for tracking daily summaries. It supports a wide range of integrations, including Hermes Agent, Claude Code, and GitHub Copilot CLI.
@@ -2214,7 +2214,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/Agents365-ai/drawio-skill
 GitHub: https://github.com/Agents365-ai/drawio-skill
 Category: Skills & Skill Registries
-Stars: 3,567
+Stars: 3,642
 Generate draw.io diagrams from natural language descriptions
 
 drawio-skill is a tool that converts natural language descriptions and existing codebases into professional draw.io diagrams. It generates .drawio XML files and exports them to PNG, SVG, PDF, or JPG using the native draw.io desktop CLI. The project supports automatic codebase visualization for Python, JS-TS, Go, and Rust, and integrates with agents like Claude Code, Cursor, and Hermes via the Agent Skills format. It includes a self-correction loop that reads PNG outputs to fix layout issues like overlapping labels or stacked edges.
@@ -2231,7 +2231,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/agent-of-empires/agent-of-empires
 GitHub: https://github.com/agent-of-empires/agent-of-empires
 Category: Multi-Agent & Orchestration
-Stars: 2,592
+Stars: 2,595
 TUI and web control surface for managing multiple coding agents including Hermes Agent, Claude Code, OpenCode, Codex, Gemini, and others
 
 Agent of Empires is a session manager for AI coding agents on Linux and macOS that simplifies the management of multiple parallel agent instances. It utilizes tmux sessions to ensure agents persist across terminal crashes or reboots, providing a centralized TUI and web dashboard for monitoring. The tool supports isolated environments via Docker sandboxing and git worktrees to prevent agents from interfering with the main codebase. It integrates with a wide range of agents, including Hermes, Claude Code, and Gemini, while offering remote access via Tailscale or Cloudflare tunnels.
@@ -2248,7 +2248,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/AMAP-ML/SkillClaw
 GitHub: https://github.com/AMAP-ML/SkillClaw
 Category: Skills & Skill Registries
-Stars: 1,921
+Stars: 1,928
 Let Skills Evolve Collectively with Agentic Evolver
 
 SkillClaw is a skill management framework that enables AI agents to evolve their capabilities through real-world interactions. It functions by running a background evolution loop that automatically deduplicates, improves, and merges skills across different sessions and devices. The system creates a unified skill library that synchronizes experience between multiple agents and users, ensuring that improvements made by one instance are available to all others. It natively integrates with the Hermes Agent ecosystem and supports various other platforms including OpenClaw, QwenPaw, and OpenAI-compatible APIs.
@@ -2265,7 +2265,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/dodo-reach/hermes-desktop
 GitHub: https://github.com/dodo-reach/hermes-desktop
 Category: Workspaces & GUIs
-Stars: 1,884
+Stars: 1,890
 A native Mac workspace for Hermes: real SSH, real terminal, real session data.
 
 Hermes Desktop is a native macOS application that provides a dedicated workbench for interacting with Hermes Agent. It connects directly to the Hermes host via SSH to ensure the remote machine remains the sole source of truth without requiring a local mirror or gateway API. The app integrates sessions, Kanban boards, cron jobs, and file editing into a single window, including an embedded terminal for direct shell access. It supports multiple Hermes profiles for multi-agent workflows and is compatible with various hosts, including VPS, Raspberry Pi, and local machines.
@@ -2282,7 +2282,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/conorbronsdon/avoid-ai-writing
 GitHub: https://github.com/conorbronsdon/avoid-ai-writing
 Category: Skills & Skill Registries
-Stars: 1,853
+Stars: 1,863
 Audits and rewrites content to eliminate detectable AI writing patterns
 
 This project is a portable writing skill designed to identify and remove detectable AI writing patterns from text. It utilizes a structured audit process featuring a 109-entry word replacement table and 49 pattern categories to replace robotic phrasing with plainer alternatives. The tool supports three distinct modes—Rewrite, Detect, and Edit—and allows users to apply specific voice profiles like professional or casual. It is compatible with various agents including Hermes, Claude Code, OpenClaw, and Cursor.
@@ -2299,7 +2299,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/liaohch3/claude-tap
 GitHub: https://github.com/liaohch3/claude-tap
 Category: Developer Tools
-Stars: 1,798
+Stars: 1,807
 Local trace viewer for inspecting coding-agent API traffic from Hermes Agent, Claude Code, Codex, Gemini, Cursor, OpenCode, and others
 
 claude-tap is a local proxy and trace viewer designed to help developers inspect the internal API traffic of AI coding agents. It captures real-time data by running CLI agents through its proxy or listening to local app transcripts. Users can analyze system prompts, tool calls, and token usage while comparing request diffs to debug agent behavior. It supports a wide range of clients, including Hermes Agent, Claude Code, Cursor, and Gemini.
@@ -2316,7 +2316,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/NousResearch/hermes-paperclip-adapter
 GitHub: https://github.com/NousResearch/hermes-paperclip-adapter
 Category: Core & Official
-Stars: 1,595
+Stars: 1,600
 Official: Yes (maintained by Nous Research)
 Run Hermes as a managed employee in Paperclip company systems
 
@@ -2334,7 +2334,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/jau123/MeiGen-AI-Design-MCP
 GitHub: https://github.com/jau123/MeiGen-AI-Design-MCP
 Category: Plugins & Extensions
-Stars: 1,448
+Stars: 1,451
 Supports GPT Image 2, Nanobanana & ComfyUI, with a 1,400+ prompt library, carefully crafted hooks and a multi-task orchestration system
 
 MeiGen AI Design MCP is an open-source Model Context Protocol server that enables AI coding tools to perform professional image and video generation tasks. It connects to various backends including the MeiGen cloud, local ComfyUI instances, and OpenAI-compatible APIs to process visual requests directly within development environments. The system features a library of over 1,400 curated prompt templates and supports parallel sub-agent orchestration for batch processing. It is natively compatible with major MCP hosts like Hermes Agent, Claude Code, and Cursor.
@@ -2351,7 +2351,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/numtide/llm-agents.nix
 GitHub: https://github.com/numtide/llm-agents.nix
 Category: Deployment & Infra
-Stars: 1,430
+Stars: 1,433
 Nix packages for AI coding agents including Hermes
 
 llm-agents.nix is a collection of Nix packages that simplifies the installation and management of AI coding agents and development tools. It provides a centralized repository of package definitions, allowing users to run various agentic tools directly via the Nix CLI. The project includes a wide range of tools from providers like Google, OpenAI, and Sourcegraph, as well as open-source alternatives. This approach ensures reproducible environments for developers using different AI-powered terminal assistants.
@@ -2386,7 +2386,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/wondelai/skills
 GitHub: https://github.com/wondelai/skills
 Category: Skills & Skill Registries
-Stars: 1,359
+Stars: 1,365
 Cross-platform skills library for Claude Code and agentskills.io-compatible agents
 
 Wondel.ai Skills is a library of specialized agent capabilities designed to provide AI agents with expert frameworks for business, design, and engineering. It works by providing a set of installable skill modules based on established methodologies and industry-standard literature. These skills can be integrated into Claude Code via its plugin marketplace or through skills.sh. The library covers diverse domains including systems architecture, UX design, product strategy, and marketing.
@@ -2403,7 +2403,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/NousResearch/atropos
 GitHub: https://github.com/NousResearch/atropos
 Category: Core & Official
-Stars: 1,283
+Stars: 1,282
 Official: Yes (maintained by Nous Research)
 RL training environments framework for tool-calling models
 
@@ -2421,7 +2421,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/greyhaven-ai/autocontext
 GitHub: https://github.com/greyhaven-ai/autocontext
 Category: Memory & Context
-Stars: 1,204
+Stars: 1,205
 Recursive self-improving context harness — helps agents succeed on complex tasks
 
 autocontext is a recursive harness that enables AI agents to iteratively improve their performance on specific goals. It works by running an improvement loop that evaluates outputs, retains successful strategies, and discards failures to produce structured traces and playbooks. This process creates a knowledge base of artifacts and distilled models that subsequent agent iterations inherit to ensure consistent progress. The system integrates with various LLM providers and supports MCP for use within coding agents like Claude Code and Hermes.
@@ -2438,7 +2438,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/AxDSan/mnemosyne
 GitHub: https://github.com/AxDSan/mnemosyne
 Category: Memory & Context
-Stars: 1,146
+Stars: 1,152
 The Zero-Dependency, Sub-Millisecond AI Memory System for Hermes Agents
 
 Mnemosyne is a universal memory layer designed to provide AI agents with persistent, long-term context without requiring external cloud services. It utilizes a SQLite-backed architecture featuring working memory, episodic memory, and a temporal knowledge graph for structured data. The system integrates with various platforms via the Model Context Protocol (MCP) and a Python SDK, supporting tools like Cursor, Claude Code, and OpenWebUI. It is optimized for low-latency retrieval and includes features for memory consolidation and bidirectional synchronization.
@@ -2455,7 +2455,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/NousResearch/autonovel
 GitHub: https://github.com/NousResearch/autonovel
 Category: Core & Official
-Stars: 1,145
+Stars: 1,148
 Official: Yes (maintained by Nous Research)
 Autonomous novel-writing pipeline generating 100k+ word manuscripts
 
@@ -2473,7 +2473,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/ksimback/hermes-ecosystem
 GitHub: https://github.com/ksimback/hermes-ecosystem
 Category: Guides & Docs
-Stars: 1,015
+Stars: 1,018
 Hermes Atlas — the community map of every tool, skill, and integration for Hermes Agent by Nous Research
 
 Hermes Atlas is a community-curated directory and ecosystem map for the Hermes Agent by Nous Research. It aggregates over 80 quality-filtered repositories, including skills, plugins, and deployment templates, using a vanilla JavaScript frontend and Vercel serverless functions. The platform features a RAG-powered chatbot that answers technical questions grounded in 27 research files using hybrid retrieval and OpenRouter LLMs. Users can search and filter the ecosystem while viewing live GitHub star counts and growth trends cached via Redis.
@@ -2490,7 +2490,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/CryptoDmitry/hermes-agent-control-room
 GitHub: https://github.com/CryptoDmitry/hermes-agent-control-room
 Category: Multi-Agent & Orchestration
-Stars: 844
+Stars: 856
 Control Room-first template for managing Hermes agents from one VPS agent to specialist teams and orchestrated workflows
 
 Hermes Agent Control Room is a governance template designed to prevent the fragmentation of disconnected bots by providing a centralized management plane. It utilizes a sidecar repository structure to document agent registries, runbooks, and environment maps without acting as an agent itself. The system enables a tiered scaling path from a single agent to orchestrated specialist teams using a task bus pattern for delegation. It includes bundled skills for VPS provisioning, security auditing, and backup management to streamline the operational lifecycle.
@@ -2524,7 +2524,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/stephenschoettler/hermes-lcm
 GitHub: https://github.com/stephenschoettler/hermes-lcm
 Category: Memory & Context
-Stars: 734
+Stars: 737
 Lossless Context Management plugin for Hermes Agent — DAG-based context engine that never loses a message
 
 Hermes-LCM is a context engine plugin for Hermes Agent that prevents the loss of detailed information during conversation compression. It replaces flat summaries with a hierarchical summary DAG and a SQLite message store to preserve raw history. The agent can use specialized tools to drill down into specific compacted material without flooding the active context. This approach improves retrieval quality and autonomy by making historical recall part of the active context engine.
@@ -2541,7 +2541,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/jazzyalex/agent-sessions
 GitHub: https://github.com/jazzyalex/agent-sessions
 Category: Workspaces & GUIs
-Stars: 640
+Stars: 641
 Native macOS session browser, agent cockpit, analytics, and limits tracker for Hermes agents and other coding-agent CLIs
 
 Agent Sessions is a local-first macOS application that aggregates histories from various AI coding agents into a single searchable interface. It indexes local session folders and databases to provide a unified view of transcripts and visual outputs without uploading data to the cloud. The tool allows users to inspect tool calls, browse session images, and execute resume commands for supported CLIs. It also includes an Agent Cockpit for monitoring active sessions and tracking usage limits for Codex and Claude.
@@ -2558,7 +2558,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/AaronWong1999/hermesclaw
 GitHub: https://github.com/AaronWong1999/hermesclaw
 Category: Integrations & Bridges
-Stars: 620
+Stars: 621
 Run Hermes Agent and OpenClaw on the same WeChat account
 
 HermesClaw is a lightweight Python proxy that allows users to run Hermes Agent, OpenClaw, and OpenCode on a single WeChat account. It resolves iLink connection conflicts by acting as the sole poller and routing messages to local proxy servers and an ACP bridge. This enables users to switch between different AI agents using specific commands or run multiple agents simultaneously. The integration also brings OpenCode's Vibe Coding capabilities to WeChat via voice message transcription.
@@ -2592,7 +2592,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/swarmclawai/swarmclaw
 GitHub: https://github.com/swarmclawai/swarmclaw
 Category: Multi-Agent & Orchestration
-Stars: 583
+Stars: 584
 Build autonomous AI agent swarms with orchestration, skills, and multiple model providers
 
 SwarmClaw is a self-hosted AI agent runtime and multi-agent framework designed for managing autonomous agent swarms. It utilizes an orchestration platform that supports durable memory, delegation, and schedules to coordinate complex AI workflows. The system integrates with over 23 LLM providers, including Claude, GPT, Gemini, and Ollama, and provides a visual org chart for monitoring agent activity. It serves as a home base for self-hosted workflows, offering an alternative to LangChain and Claude Code.
@@ -2609,7 +2609,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/Agent-3-7/minions
 GitHub: https://github.com/Agent-3-7/minions
 Category: Multi-Agent & Orchestration
-Stars: 577
+Stars: 578
 Mission Control for Hermes agents: create, supervise, and review autonomous Hermes Agent work from one screen
 
 Minions is a centralized management interface for Hermes Agent that replaces fragmented terminal sessions with a unified dashboard. It utilizes a Kanban-style board to track persistent agent sessions, allowing users to monitor reasoning, tool calls, and task progress in real time. The system enforces a human-in-the-loop workflow where agents propose completions that require manual verification before being marked as done. Users can also manage scheduled recurring jobs and browse agent-created files through a local-first SQLite architecture.
@@ -2618,6 +2618,23 @@ Highlights:
 - Kanban board for tracking autonomous task status and review queues
 - Live streaming of agent reasoning and tool execution
 - Human-in-the-loop verification for all agent-proposed task completions
+
+---
+
+## Salomondiei08/oh-my-hermes
+
+URL: https://hermesatlas.com/projects/Salomondiei08/oh-my-hermes
+GitHub: https://github.com/Salomondiei08/oh-my-hermes
+Category: Developer Tools
+Stars: 551
+Opinionated workflow layer for building, shipping, and operating apps with Hermes Agent
+
+Oh My Hermes is an opinionated workflow layer that transforms the Hermes Agent into an autonomous developer and operations assistant. It functions by loading a curated set of 23 skills and 6 specialized agents that manage the entire software lifecycle from requirement clarification to production deployment. The system orchestrates complex tasks like issue triaging, security scanning, and Vercel deployments through a persistent 'CTO loop' that runs autonomously. Users interact with the agent via common messaging platforms like Telegram or Slack to approve code changes and monitor project health.
+
+Highlights:
+- Orchestrates autonomous CTO loops for issue triage and deployment
+- Includes 23 specialized skills for product briefing and implementation
+- Integrates with GitHub, Vercel, Supabase, and Sentry for full-stack ops
 
 ---
 
@@ -2638,23 +2655,6 @@ Highlights:
 
 ---
 
-## Salomondiei08/oh-my-hermes
-
-URL: https://hermesatlas.com/projects/Salomondiei08/oh-my-hermes
-GitHub: https://github.com/Salomondiei08/oh-my-hermes
-Category: Developer Tools
-Stars: 532
-Opinionated workflow layer for building, shipping, and operating apps with Hermes Agent
-
-Oh My Hermes is an opinionated workflow layer that transforms the Hermes Agent into an autonomous developer and operations assistant. It functions by loading a curated set of 23 skills and 6 specialized agents that manage the entire software lifecycle from requirement clarification to production deployment. The system orchestrates complex tasks like issue triaging, security scanning, and Vercel deployments through a persistent 'CTO loop' that runs autonomously. Users interact with the agent via common messaging platforms like Telegram or Slack to approve code changes and monitor project health.
-
-Highlights:
-- Orchestrates autonomous CTO loops for issue triage and deployment
-- Includes 23 specialized skills for product briefing and implementation
-- Integrates with GitHub, Vercel, Supabase, and Sentry for full-stack ops
-
----
-
 ## nickvasilescu/hermes-desktop-os1
 
 URL: https://hermesatlas.com/projects/nickvasilescu/hermes-desktop-os1
@@ -2669,6 +2669,23 @@ Highlights:
 - Native macOS interface for Orgo cloud VMs and SSH hosts
 - One-click automated Hermes Agent installation on fresh cloud computers
 - Integrated WebRTC voice mode using OpenAI Realtime and Orgo MCP
+
+---
+
+## Eynzof/hermes-agent-cn-desktop
+
+URL: https://hermesatlas.com/projects/Eynzof/hermes-agent-cn-desktop
+GitHub: https://github.com/Eynzof/hermes-agent-cn-desktop
+Category: Workspaces & GUIs
+Stars: 456
+Windows-first Chinese desktop app for Hermes Agent built with Tauri, TypeScript, and Rust
+
+Hermes Agent CN Desktop is a desktop client designed to provide a native user experience for the Hermes Agent, moving beyond the standard web dashboard. It is built using Tauri v2, Rust, React, and TypeScript, integrating a modified Chinese community version of the Hermes Agent kernel. The application simplifies installation for Windows and macOS users and includes a production-grade transmission bridge for secure REST and WebSocket communication. It supports a wide range of local and cloud model providers, as well as integrations with platforms like Feishu.
+
+Highlights:
+- Native Windows and macOS support via Tauri v2
+- Built-in kernel management for installation, updates, and health checks
+- Supports MCP tools, Memory, Skills, and LaTeX/Mermaid rendering
 
 ---
 
@@ -2689,29 +2706,12 @@ Highlights:
 
 ---
 
-## Eynzof/hermes-agent-cn-desktop
-
-URL: https://hermesatlas.com/projects/Eynzof/hermes-agent-cn-desktop
-GitHub: https://github.com/Eynzof/hermes-agent-cn-desktop
-Category: Workspaces & GUIs
-Stars: 445
-Windows-first Chinese desktop app for Hermes Agent built with Tauri, TypeScript, and Rust
-
-Hermes Agent CN Desktop is a desktop client designed to provide a native user experience for the Hermes Agent, moving beyond the standard web dashboard. It is built using Tauri v2, Rust, React, and TypeScript, integrating a modified Chinese community version of the Hermes Agent kernel. The application simplifies installation for Windows and macOS users and includes a production-grade transmission bridge for secure REST and WebSocket communication. It supports a wide range of local and cloud model providers, as well as integrations with platforms like Feishu.
-
-Highlights:
-- Native Windows and macOS support via Tauri v2
-- Built-in kernel management for installation, updates, and health checks
-- Supports MCP tools, Memory, Skills, and LaTeX/Mermaid rendering
-
----
-
 ## OnlyTerp/hermes-optimization-guide
 
 URL: https://hermesatlas.com/projects/OnlyTerp/hermes-optimization-guide
 GitHub: https://github.com/OnlyTerp/hermes-optimization-guide
 Category: Guides & Docs
-Stars: 442
+Stars: 444
 Performance optimization guide for Hermes deployments
 
 This project is a comprehensive performance optimization and deployment guide for Hermes Agent. It provides a structured 24-part tutorial combined with runnable artifacts, including configuration templates, installable skills, and a one-command VPS bootstrap script. The guide enables users to deploy Hermes across 22+ platforms while integrating MCP servers, remote sandboxes, and observability tools like Langfuse. It offers specific paths for various use cases, ranging from cost-optimized setups to high-capability agent configurations.
@@ -2728,7 +2728,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/Romanescu11/hermes-skill-factory
 GitHub: https://github.com/Romanescu11/hermes-skill-factory
 Category: Skills & Skill Registries
-Stars: 379
+Stars: 383
 Meta-skill plugin that watches workflows and auto-generates reusable skills
 
 Skill Factory is a meta-skill for Hermes Agent that automates the creation of reusable skills by monitoring user workflows. It functions by tracking session patterns in the background and proposing structured skill definitions when it detects repeatable sequences. Users can generate both SKILL.md documentation and Python plugin scaffolds directly from these proposals via slash commands or natural language. This tool streamlines the expansion of the Hermes ecosystem by turning manual environment setups and development tasks into permanent, executable assets.
@@ -2745,7 +2745,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/jwangkun/hermes-agent-guide
 GitHub: https://github.com/jwangkun/hermes-agent-guide
 Category: Guides & Docs
-Stars: 367
+Stars: 370
 A systematic Chinese-language guide to Hermes Agent — 16 books, 300K+ words, covering installation, advanced development, single- and multi-agent orchestration.
 
 The Hermes Agent White Paper is a comprehensive Chinese-language technical guide designed to bridge the documentation gap for the Hermes Agent framework. It provides a structured 16-book curriculum covering the system's five-layer architecture, three-tier memory system, and the integration of over 47 built-in tools. The guide details practical implementations including MCP protocol automation, multi-platform deployment on WeChat and Discord, and migration paths from OpenClaw. Users can follow specialized reading tracks for rapid deployment, deep technical development, or commercial application scenarios.
@@ -2762,7 +2762,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server
 GitHub: https://github.com/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server
 Category: Plugins & Extensions
-Stars: 343
+Stars: 345
 Web search and content retrieval MCP server supporting Hermes Agent, OpenClaw, Claude Code, Codex, Cursor, and other AI tools
 
 Kindly Web Search is an MCP server that provides AI coding agents with structured, high-quality web content to reduce the need for multiple scraping calls. It integrates directly with APIs for StackExchange, GitHub Issues, arXiv, and Wikipedia while using a headless Chromium-based browser for real-time page parsing. This approach delivers full conversations, including answers and comments, in LLM-optimized formats. It is designed to work with tools like Claude Code, Cursor, and Windsurf to improve the accuracy of AI-generated code.
@@ -2779,7 +2779,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/DougTrajano/pydantic-ai-skills
 GitHub: https://github.com/DougTrajano/pydantic-ai-skills
 Category: Skills & Skill Registries
-Stars: 314
+Stars: 315
 Type-safe agentskills.io support with progressive disclosure for Pydantic AI
 
 pydantic-ai-skills is a standardized framework for managing modular agent capabilities within the Pydantic AI ecosystem. It implements the Agent Skills open specification by providing a tool-calling mechanism that allows agents to discover and execute specialized scripts or instructions. The library uses a progressive disclosure approach, loading skill details only when relevant to minimize token consumption. Developers can define these skills through local filesystem directories or programmatically using Python decorators and dataclasses.
@@ -2830,7 +2830,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/clawshell/clawshell
 GitHub: https://github.com/clawshell/clawshell
 Category: Plugins & Extensions
-Stars: 294
+Stars: 295
 The Runtime Security Layer for OpenClaw/Hermes-agent, the essential safety harness for PII & sensitive credentials protection.
 
 ClawShell is a security-privileged process that acts as a safety harness for the Hermes Agent ecosystem by protecting sensitive credentials and PII. It functions as a proxy between the agent and upstream LLM providers, swapping virtual keys for real ones stored in a restricted directory to ensure the agent never has direct access to credentials. The system performs Data Loss Prevention (DLP) scanning to redact or block sensitive information in request and response bodies. Additionally, it provides secure email isolation through IMAP sender filtering and supports OAuth-based authentication for providers like OpenAI.
@@ -2847,7 +2847,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/stainlu/hermes-labyrinth
 GitHub: https://github.com/stainlu/hermes-labyrinth
 Category: Plugins & Extensions
-Stars: 284
+Stars: 285
 Read-only observability plugin for Hermes Agent with journeys, crossings, guideposts, and reports
 
 Hermes Labyrinth is a read-only observability plugin for Hermes Agent that visualizes autonomous workflows as a structured map of events. It functions as a black-box recorder, reading local state to track prompts, tool calls, model transitions, and subagent activities without mutating session data. The tool provides deep diagnostic visibility through specialized views for skill overrides, scheduled cron tasks, and redacted journey reports. Users can export evidence in Markdown or JSON formats while relying on built-in redaction to protect sensitive credentials.
@@ -2864,7 +2864,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/robbyczgw-cla/hermes-web-search-plus
 GitHub: https://github.com/robbyczgw-cla/hermes-web-search-plus
 Category: Plugins & Extensions
-Stars: 279
+Stars: 280
 Multi-provider web search (Serper, Tavily, Exa, Querit, Perplexity) with auto-routing
 
 hermes-web-search-plus is a plugin for the Hermes Agent that provides multi-provider web search and URL extraction capabilities. It utilizes a class-aware auto-routing system (Routing v2) to select the best available provider based on the user's configured API keys. The plugin ensures cost control by capping provider work in research mode and offers flexible configuration via a standalone setup wizard.
@@ -2898,7 +2898,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/ZeroPointRepo/youtube-skills
 GitHub: https://github.com/ZeroPointRepo/youtube-skills
 Category: Skills & Skill Registries
-Stars: 270
+Stars: 271
 YouTube transcript, search, channel, and playlist skills for Hermes Agent, OpenClaw, Claude Code, Cursor, and Windsurf
 
 YouTube Skills is a collection of tools that enables AI agents to interact with YouTube content without relying on browser automation or local binaries. It utilizes the TranscriptAPI backend to bypass cloud IP blocks, providing agents with direct access to video transcripts, search results, and channel metadata. The project integrates with Hermes Agent, OpenClaw, and Claude Code using the Agent Skills format. Users can perform tasks like summarizing videos, extracting playlist contents, and searching for specific channel uploads through natural language prompts.
@@ -2915,7 +2915,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/amanning3390/hermeshub
 GitHub: https://github.com/amanning3390/hermeshub
 Category: Skills & Skill Registries
-Stars: 259
+Stars: 260
 Community skill browsing, search, and one-click installation hub
 
 HermesHub is a curated skills registry for Hermes Agent that provides a secure way to browse, install, and share AI agent capabilities. It utilizes the agentskills.io open standard and an automated security scanner that checks for threats like prompt injection and data exfiltration. The platform includes a creator marketplace supporting x402 and Micropayment protocols for premium skills, as well as an agent-to-agent feedback system for trust scoring.
@@ -2932,7 +2932,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/liftaris/herm
 GitHub: https://github.com/liftaris/herm
 Category: Workspaces & GUIs
-Stars: 253
+Stars: 254
 Alternative Hermes TUI and dashboard built with OpenTUI.
 
 Herm is an operator-focused terminal user interface (TUI) and dashboard designed to centralize the management of Hermes Agent. Built with OpenTUI and Bun, it serves as a client for the Hermes Agent gateway, replacing fragmented shell commands and browser windows with a unified terminal workspace. Users can manage sessions, inspect memory, and execute agentic work through an integrated kanban board and task diagnostic views. The interface also supports a marketplace for 'eikons'—terminal-based avatars—and provides deep customization through rebindable keys and themes.
@@ -2941,6 +2941,23 @@ Highlights:
 - Unified dashboard for profiles, skills, cron jobs, and memory management
 - Agentic workflow execution via integrated kanban boards and task diagnostics
 - Rich chat interface with markdown, LaTeX, and inline image support
+
+---
+
+## Cranot/super-hermes
+
+URL: https://hermesatlas.com/projects/Cranot/super-hermes
+GitHub: https://github.com/Cranot/super-hermes
+Category: Skills & Skill Registries
+Stars: 241
+Skills that teach Hermes Agent to write its own analytical prompts
+
+Super Hermes is a skill registry that enables Hermes Agent to dynamically generate its own analytical thinking instructions, known as prisms, to perform deep structural analysis. It shifts the agent from surface-level checklists to deriving structural trade-offs and identifying inherent impossibilities within a codebase or document. The system includes a transparency mechanism that explicitly reports analysis blind spots and constraints to the user.
+
+Highlights:
+- Dynamic generation of custom analytical lenses via /prism-scan
+- Seven pre-built, validated prisms for resilience, optimization, and simulation
+- Constraint reporting to identify analysis blind spots via /prism-reflect
 
 ---
 
@@ -2961,29 +2978,12 @@ Highlights:
 
 ---
 
-## Cranot/super-hermes
-
-URL: https://hermesatlas.com/projects/Cranot/super-hermes
-GitHub: https://github.com/Cranot/super-hermes
-Category: Skills & Skill Registries
-Stars: 240
-Skills that teach Hermes Agent to write its own analytical prompts
-
-Super Hermes is a skill registry that enables Hermes Agent to dynamically generate its own analytical thinking instructions, known as prisms, to perform deep structural analysis. It shifts the agent from surface-level checklists to deriving structural trade-offs and identifying inherent impossibilities within a codebase or document. The system includes a transparency mechanism that explicitly reports analysis blind spots and constraints to the user.
-
-Highlights:
-- Dynamic generation of custom analytical lenses via /prism-scan
-- Seven pre-built, validated prisms for resilience, optimization, and simulation
-- Constraint reporting to identify analysis blind spots via /prism-reflect
-
----
-
 ## 335234131/agent-browser-mcp
 
 URL: https://hermesatlas.com/projects/335234131/agent-browser-mcp
 GitHub: https://github.com/335234131/agent-browser-mcp
 Category: Plugins & Extensions
-Stars: 230
+Stars: 229
 让 Agent 直接操作真实 Chrome 的 MCP 服务，支持页面扫描、CDP、截图与物理输入
 
 Agent-browser-mcp is a Model Context Protocol server that enables AI agents to interact directly with a user's active Chrome browser session rather than a sandboxed environment. It works through a local bridge and a Chrome extension to maintain existing login states, cookies, and open tabs while providing low-level control. The project allows agents to perform page scanning, execute JavaScript, and issue Chrome DevTools Protocol (CDP) commands. It also supports physical hardware interaction, including real mouse movements, keyboard inputs, and desktop screenshots.
@@ -3000,7 +3000,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/42-evey/hermes-plugins
 GitHub: https://github.com/42-evey/hermes-plugins
 Category: Plugins & Extensions
-Stars: 217
+Stars: 220
 Goal management, inter-agent bridge, model selection, and cost control plugins
 
 Evey's Hermes Plugins is a collection of 23 custom extensions designed to enhance the autonomy, observability, and cost-efficiency of the Hermes Agent framework. The suite implements specialized logic for multi-model decision debates, smart task routing with fallback chains, and structured telemetry logging. These tools enable agents to manage their own goals, perform self-correction loops, and consolidate long-term memory into vector storage. Additionally, the project includes a bidirectional bridge for Claude Code and budget enforcement via Langfuse integration.
@@ -3017,7 +3017,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/AkoliteZA/hermes-agent-idea-workflow
 GitHub: https://github.com/AkoliteZA/hermes-agent-idea-workflow
 Category: Skills & Skill Registries
-Stars: 217
+Stars: 218
 Pre-build idea-to-spec workflow skills for Hermes Agent that turn rough ideas into design docs and implementation handoffs
 
 The Hermes Agent Idea Workflow is a suite of skills designed to transform vague product concepts into structured, build-ready specifications. It operates through a staged pipeline that separates product intent from technical implementation, utilizing guided interviews and a reusable question bank to generate markdown artifacts. The system supports both a Lite mode for quick capture and a Full mode that produces comprehensive design docs, UI briefs, and implementation specs. These outputs are specifically formatted to serve as direct handoff material for downstream coding workflows like Superpowers for GPT.
@@ -3136,7 +3136,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/tlehman/litprog-skill
 GitHub: https://github.com/tlehman/litprog-skill
 Category: Skills & Skill Registries
-Stars: 175
+Stars: 176
 Literate programming skill — weave code and documentation across agents
 
 The litprog-skill is a Claude Code extension that implements Donald Knuth's literate programming paradigm by transforming codebases into human-readable narratives. It works by generating a .lit.md file that weaves together prose, Mermaid diagrams, and LaTeX math with the original source code. The tool includes a tangler to extract runnable files and a reverse-sync engine to ensure the documentation stays updated when source files are edited. This approach helps developers document architectural decisions and facilitates easier onboarding through structured, essay-like code explanations.
@@ -3204,7 +3204,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/longyunfeigu/learn-hermes-agent
 GitHub: https://github.com/longyunfeigu/learn-hermes-agent
 Category: Guides & Docs
-Stars: 153
+Stars: 154
 A 27-chapter hands-on tutorial for building an autonomous AI agent from zero in Python — agent loop, tool system, memory, skills, MCP, multi-platform gateway, and self-evolution.
 
 Learn Hermes Agent is a 27-chapter hands-on tutorial for building production-grade autonomous AI agents from scratch using Python. The curriculum guides developers through implementing a core agent loop, tool registration, session persistence with SQLite, and context compression. It covers advanced infrastructure including multi-platform gateways for Telegram and Discord, Model Context Protocol (MCP) integration, and RL-based self-evolution. The project provides runnable reference implementations for each stage to help users understand the design backbone of autonomous systems.
@@ -3238,7 +3238,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/indranilbanerjee/digital-marketing-pro
 GitHub: https://github.com/indranilbanerjee/digital-marketing-pro
 Category: Plugins & Extensions
-Stars: 142
+Stars: 143
 Open-source AI marketing plugin for agencies & in-house teams — 158 skills, 25 specialist agents, 12-Part Strategy Flow, Cowork team-persistent, EU AI Act Article 50 ready, 6-platform AEO/GEO incl. Go
 
 Digital Marketing Pro is an open-source AI plugin designed to standardize marketing strategies for agencies and in-house teams managing multiple brands. It utilizes a 12-part strategy flow and a 61-step structure to generate consistent, auditable documentation across a brand portfolio. The tool integrates with various AI environments including Claude Code, Cursor, and GitHub Copilot CLI, offering specialized agents for tasks ranging from funnel architecture to compliance checks. It specifically supports multi-brand state persistence and provides built-in adherence to the EU AI Act Article 50.
@@ -3255,7 +3255,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/1ilkhamov/opencode-hermes-multiagent
 GitHub: https://github.com/1ilkhamov/opencode-hermes-multiagent
 Category: Multi-Agent & Orchestration
-Stars: 140
+Stars: 141
 17 specialized agents for research, planning, implementation, quality, and infrastructure
 
 Hermes is a multi-agent orchestration system for OpenCode AI designed to automate complex software development lifecycles. It utilizes a master orchestrator to route requests through a strict pipeline of 17 specialized agents covering research, planning, implementation, quality, and infrastructure. The system enforces mandatory quality gates and security audits for critical changes while maintaining full context flow between agents. It supports various workflows including new feature development, bug fixing, and performance optimization.
@@ -3386,6 +3386,23 @@ Highlights:
 
 ---
 
+## howdymary/hermes-agent-metaharness
+
+URL: https://hermesatlas.com/projects/howdymary/hermes-agent-metaharness
+GitHub: https://github.com/howdymary/hermes-agent-metaharness
+Category: Multi-Agent & Orchestration
+Stars: 94
+Meta-harness for Hermes Agent — meta-optimization with arxiv paper reference
+
+Hermes Agent Meta-Harness is a standalone outer-loop optimization framework designed to improve the performance of Hermes agents on verifiable coding benchmarks. It treats the agent as an execution backend and searches for optimal harness configurations—the code governing context collection and retrieval—rather than modifying model weights. The system orchestrates benchmark evaluations, tracks performance frontiers, and performs structured candidate mutations to find superior harness variants. It currently supports TBLite and TB2 benchmarks through a research-safe workflow that emphasizes archive analysis and deterministic search.
+
+Highlights:
+- Optimizes agent harness code through automated outer-loop search
+- Orchestrates TBLite and TB2 benchmark evaluations via Hermes
+- Tracks performance frontiers with structured candidate mutation and comparison
+
+---
+
 ## unmodeled-tyler/vessel-browser
 
 URL: https://hermesatlas.com/projects/unmodeled-tyler/vessel-browser
@@ -3417,23 +3434,6 @@ Highlights:
 - Tracks cost, token counts, and success states via SQLite
 - Visual dashboard for monitoring cost, pace, and failure patterns
 - Agent skill for confidence-graded anomaly detection and diagnostics
-
----
-
-## howdymary/hermes-agent-metaharness
-
-URL: https://hermesatlas.com/projects/howdymary/hermes-agent-metaharness
-GitHub: https://github.com/howdymary/hermes-agent-metaharness
-Category: Multi-Agent & Orchestration
-Stars: 93
-Meta-harness for Hermes Agent — meta-optimization with arxiv paper reference
-
-Hermes Agent Meta-Harness is a standalone outer-loop optimization framework designed to improve the performance of Hermes agents on verifiable coding benchmarks. It treats the agent as an execution backend and searches for optimal harness configurations—the code governing context collection and retrieval—rather than modifying model weights. The system orchestrates benchmark evaluations, tracks performance frontiers, and performs structured candidate mutations to find superior harness variants. It currently supports TBLite and TB2 benchmarks through a research-safe workflow that emphasizes archive analysis and deterministic search.
-
-Highlights:
-- Optimizes agent harness code through automated outer-loop search
-- Orchestrates TBLite and TB2 benchmark evaluations via Hermes
-- Tracks performance frontiers with structured candidate mutation and comparison
 
 ---
 
@@ -3527,7 +3527,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/adityahimaone/hermes-agent-rtk-caveman
 GitHub: https://github.com/adityahimaone/hermes-agent-rtk-caveman
 Category: Developer Tools
-Stars: 61
+Stars: 62
 Hermes Agent RTK and Caveman setup with preconfigured skills and token-saving CLI workflows
 
 This project provides a preconfigured setup for Hermes Agent that integrates Rust Token Killer (RTK) and Caveman templating to reduce token consumption during CLI operations. It works by wrapping standard terminal commands and outputting compact data structures, achieving a reported 90-99% reduction in token usage. The repository includes over 40 pre-configured skills covering finance management, GitHub workflows, research tools, and DevOps automation. Users can deploy the environment via an automated installer to gain immediate access to token-optimized aliases for git, linting, and testing tasks.
@@ -3663,7 +3663,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/TheAiSingularity/hermesclaw
 GitHub: https://github.com/TheAiSingularity/hermesclaw
 Category: Deployment & Infra
-Stars: 53
+Stars: 52
 Hermes Agent sandboxed with hardware-level enforcement
 
 HermesClaw is a community implementation that runs the Hermes Agent within a secure sandbox to prevent rogue agent behavior. It utilizes NVIDIA OpenShell to enforce hardware-level restrictions on network egress, filesystem writes, and system calls at the kernel level. The system supports a wide range of capabilities including multi-agent delegation, MCP server integration, and IDE support. Users can manage security postures through policy presets that control access to web search and messaging platforms.
@@ -3680,7 +3680,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/sheawinkler/hermes-agent-ultra
 GitHub: https://github.com/sheawinkler/hermes-agent-ultra
 Category: Forks & Derivatives
-Stars: 46
+Stars: 49
 Rust-based Hermes Agent Ultra derivative focused on performance and Hermes Agent feature parity
 
 Hermes Agent Ultra is a Rust-native autonomous agent runtime designed to provide a high-performance alternative to the original Hermes Agent. It implements a fully Rust-based core for the agent loop, tools, and CLI/TUI to ensure deterministic execution and improved security. The project introduces advanced operator controls, including session time-travel, a runtime policy engine for tool auditing, and extensive support for local inference backends. It integrates with MCP and various model providers, including Nous Portal for managed access.
@@ -3794,6 +3794,23 @@ Highlights:
 
 ---
 
+## bigph00t/hermescraft
+
+URL: https://hermesatlas.com/projects/bigph00t/hermescraft
+GitHub: https://github.com/bigph00t/hermescraft
+Category: Domain Applications
+Stars: 42
+Embodied AI companion for Minecraft — persistent memory, vision, learning, multi-agent
+
+HermesCraft is an embodied AI framework that integrates Hermes agents into Minecraft as persistent, interactive players. It connects the Hermes agent stack to a Mineflayer bot body through a custom Minecraft CLI and HTTP API, allowing agents to perceive and interact with the game world. Agents can function as individual companions or as part of multi-agent civilizations with private messaging and social memory. The system emphasizes fair-play perception by restricting agent knowledge to line-of-sight visuals and directional audio rather than using privileged game data.
+
+Highlights:
+- Embodied agents with persistent memory, identity, and tool-use capabilities
+- Fair-play perception system using line-of-sight filtering and spatial mapping
+- Multi-agent social features including public chat and private messaging
+
+---
+
 ## yepyhun/Brainstack
 
 URL: https://hermesatlas.com/projects/yepyhun/Brainstack
@@ -3808,23 +3825,6 @@ Highlights:
 - Consolidates temporal continuity, graph truth, and corpus retrieval
 - Uses SQLite, Kuzu, and Chroma for multi-layered data storage
 - Provides bounded evidence packing to reduce prompt noise
-
----
-
-## bigph00t/hermescraft
-
-URL: https://hermesatlas.com/projects/bigph00t/hermescraft
-GitHub: https://github.com/bigph00t/hermescraft
-Category: Domain Applications
-Stars: 41
-Embodied AI companion for Minecraft — persistent memory, vision, learning, multi-agent
-
-HermesCraft is an embodied AI framework that integrates Hermes agents into Minecraft as persistent, interactive players. It connects the Hermes agent stack to a Mineflayer bot body through a custom Minecraft CLI and HTTP API, allowing agents to perceive and interact with the game world. Agents can function as individual companions or as part of multi-agent civilizations with private messaging and social memory. The system emphasizes fair-play perception by restricting agent knowledge to line-of-sight visuals and directional audio rather than using privileged game data.
-
-Highlights:
-- Embodied agents with persistent memory, identity, and tool-use capabilities
-- Fair-play perception system using line-of-sight filtering and spatial mapping
-- Multi-agent social features including public chat and private messaging
 
 ---
 
@@ -3952,7 +3952,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/Codename-11/hermes-relay
 GitHub: https://github.com/Codename-11/hermes-relay
 Category: Integrations & Bridges
-Stars: 34
+Stars: 35
 Hermes Companion — Android app for Hermes agent platform. Chat, terminal, and device control over WSS.
 
 Hermes-Relay is a native Android companion and CLI tool that provides mobile access to a self-hosted Hermes agent. It connects to the agent's API server via LAN or remote routes to enable streaming chat, voice interaction, and agent management from a mobile device. Sideloaded versions allow the agent to read and act on the phone's screen, while the CLI binary enables consent-gated control over paired machines. This ecosystem allows users to maintain the agent's core logic on a central machine while interacting with it across multiple devices.
@@ -4032,6 +4032,23 @@ Highlights:
 
 ---
 
+## ndesv21/socialclaw
+
+URL: https://hermesatlas.com/projects/ndesv21/socialclaw
+GitHub: https://github.com/ndesv21/socialclaw
+Category: Integrations & Bridges
+Stars: 25
+Social media scheduling CLI and OpenClaw skill for AI agents posting to X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, and Pinterest.
+
+SocialClaw is a social media scheduling tool designed to enable AI agents to publish content across multiple platforms. It provides an npm CLI and a Model Context Protocol (MCP) server that interfaces with a hosted workspace via API key authentication. The system supports campaign validation, asset uploads, and analytics tracking for platforms including X, LinkedIn, Instagram, and TikTok. It integrates directly with AI environments like Claude Code, Cursor, and OpenClaw to automate the publishing workflow.
+
+Highlights:
+- Multi-platform posting to X, LinkedIn, Instagram, and more
+- MCP server providing 17 validation-first publishing tools
+- CLI for schedule validation, asset management, and analytics
+
+---
+
 ## 0xrsydn/nix-hermes-agent
 
 URL: https://hermesatlas.com/projects/0xrsydn/nix-hermes-agent
@@ -4066,29 +4083,12 @@ Highlights:
 
 ---
 
-## ndesv21/socialclaw
-
-URL: https://hermesatlas.com/projects/ndesv21/socialclaw
-GitHub: https://github.com/ndesv21/socialclaw
-Category: Integrations & Bridges
-Stars: 24
-Social media scheduling CLI and OpenClaw skill for AI agents posting to X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, and Pinterest.
-
-SocialClaw is a social media scheduling tool designed to enable AI agents to publish content across multiple platforms. It provides an npm CLI and a Model Context Protocol (MCP) server that interfaces with a hosted workspace via API key authentication. The system supports campaign validation, asset uploads, and analytics tracking for platforms including X, LinkedIn, Instagram, and TikTok. It integrates directly with AI environments like Claude Code, Cursor, and OpenClaw to automate the publishing workflow.
-
-Highlights:
-- Multi-platform posting to X, LinkedIn, Instagram, and more
-- MCP server providing 17 validation-first publishing tools
-- CLI for schedule validation, asset management, and analytics
-
----
-
 ## alias8818/hermes-tool-slimmer
 
 URL: https://hermesatlas.com/projects/alias8818/hermes-tool-slimmer
 GitHub: https://github.com/alias8818/hermes-tool-slimmer
 Category: Memory & Context
-Stars: 23
+Stars: 24
 Reduce Hermes Agent tool-schema overhead with keyword selection and Tool Search support
 
 Hermes Tool Slimmer is a schema-selection optimization tool that reduces the token overhead caused by large tool catalogs in Hermes Agent. It creates an indexable corpus of tool schemas and uses local BM25 ranking with explicit boosts to select the smallest useful tool set for each turn. This approach lowers prompt token consumption while providing a dashboard for diagnostics, counters, and visibility. It is designed to complement or replace native tool search depending on the user's need for deterministic one-pass slimming.
@@ -4321,6 +4321,23 @@ Highlights:
 
 ---
 
+## Context4GPTs/klodi-plugin
+
+URL: https://hermesatlas.com/projects/Context4GPTs/klodi-plugin
+GitHub: https://github.com/Context4GPTs/klodi-plugin
+Category: Plugins & Extensions
+Stars: 12
+The agent-to-agent marketplace, in your agent host. Your agent lists, haggles, and closes deals for you while you live your life.
+
+klodi-plugin is a peer-to-peer marketplace adapter that enables AI agents to buy and sell items on behalf of their users. It integrates with various agent hosts via language-specific adapters to handle listing, negotiating, and closing deals based on user-defined markdown policies. This system allows users to maintain a single identity and strategy across different hosts while keeping sensitive negotiation data, such as floor prices, stored locally.
+
+Highlights:
+- Cross-host support for Python, Rust, and TypeScript agent frameworks
+- Local storage of negotiation policies and floor prices for privacy
+- Automated agent-to-agent haggling and transaction coordination
+
+---
+
 ## bryercowan/hermes-embodied
 
 URL: https://hermesatlas.com/projects/bryercowan/hermes-embodied
@@ -4335,6 +4352,23 @@ Highlights:
 - Automates VLA fine-tuning loops using natural language commands
 - Provisions and manages Vast.ai cloud GPU instances autonomously
 - Supports SmolVLA and GR00T models for simulation or physical hardware
+
+---
+
+## Xquik-dev/hermes-tweet
+
+URL: https://hermesatlas.com/projects/Xquik-dev/hermes-tweet
+GitHub: https://github.com/Xquik-dev/hermes-tweet
+Category: Plugins & Extensions
+Stars: 10
+Native Hermes Agent plugin for X automation through Xquik
+
+Hermes Tweet is a native plugin that enables Hermes Agent to perform X (Twitter) automation via the Xquik API. It converts 99 OpenAPI-generated endpoints into structured tools for tasks such as posting tweets, reading trends, and managing direct messages. The plugin implements a least-privilege security model by splitting read and action tools, with write capabilities disabled by default. It is installable via PyPI and includes a bundled skill to provide usage guidance to the agent.
+
+Highlights:
+- 99 agent-callable Xquik endpoints generated from OpenAPI
+- Least-privilege security with action endpoints disabled by default
+- Includes bundled Hermes skill for agent usage guidance
 
 ---
 
@@ -4372,46 +4406,12 @@ Highlights:
 
 ---
 
-## Xquik-dev/hermes-tweet
-
-URL: https://hermesatlas.com/projects/Xquik-dev/hermes-tweet
-GitHub: https://github.com/Xquik-dev/hermes-tweet
-Category: Plugins & Extensions
-Stars: 9
-Native Hermes Agent plugin for X automation through Xquik
-
-Hermes Tweet is a native plugin that enables Hermes Agent to perform X (Twitter) automation via the Xquik API. It converts 99 OpenAPI-generated endpoints into structured tools for tasks such as posting tweets, reading trends, and managing direct messages. The plugin implements a least-privilege security model by splitting read and action tools, with write capabilities disabled by default. It is installable via PyPI and includes a bundled skill to provide usage guidance to the agent.
-
-Highlights:
-- 99 agent-callable Xquik endpoints generated from OpenAPI
-- Least-privilege security with action endpoints disabled by default
-- Includes bundled Hermes skill for agent usage guidance
-
----
-
-## Context4GPTs/klodi-plugin
-
-URL: https://hermesatlas.com/projects/Context4GPTs/klodi-plugin
-GitHub: https://github.com/Context4GPTs/klodi-plugin
-Category: Plugins & Extensions
-Stars: 9
-The agent-to-agent marketplace, in your agent host. Your agent lists, haggles, and closes deals for you while you live your life.
-
-klodi-plugin is a peer-to-peer marketplace adapter that enables AI agents to buy and sell items on behalf of their users. It integrates with various agent hosts via language-specific adapters to handle listing, negotiating, and closing deals based on user-defined markdown policies. This system allows users to maintain a single identity and strategy across different hosts while keeping sensitive negotiation data, such as floor prices, stored locally.
-
-Highlights:
-- Cross-host support for Python, Rust, and TypeScript agent frameworks
-- Local storage of negotiation policies and floor prices for privacy
-- Automated agent-to-agent haggling and transaction coordination
-
----
-
 ## Sahil-SS9/hermaguard
 
 URL: https://hermesatlas.com/projects/Sahil-SS9/hermaguard
 GitHub: https://github.com/Sahil-SS9/hermaguard
 Category: Skills & Skill Registries
-Stars: 8
+Stars: 9
 Adversarial bug-hunting code review for AI agents. 3 parallel subagents attack code from different angles, then a consolidator merges and triages findings. Read-only — finds problems, doesn't fix.
 
 HermaGuard is an adversarial code review skill for AI agents designed to identify vulnerabilities and logic bugs without modifying source code. It utilizes a deterministic pre-scan layer featuring tools like Semgrep and Bandit followed by three parallel subagents that analyze edge cases, exploitability, and integration blast radius. Findings are merged by a consolidator into structured Markdown and JSON reports for triage. The system includes a feedback MCP server to track fix rates and a benchmark suite to measure detection precision and recall.
@@ -4428,7 +4428,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/Sahil-SS9/Toolaria
 GitHub: https://github.com/Sahil-SS9/Toolaria
 Category: Plugins & Extensions
-Stars: 8
+Stars: 9
 Rescue oversized tool results before they flood context. SHA256-addressed blob store with per-session indexes
 
 Toolaria is a zero-config Hermes Agent plugin that prevents oversized tool results from flooding the model's context window. It implements a spill-to-disk pattern by storing large outputs in a SHA256-addressed blob store and providing the model with a compact excerpt and a fetch handle. The model can then retrieve specific slices via search, structural outlines, or pass-by-reference to other tools. This approach allows the agent to handle massive datasets, such as thousands of transaction records, without exceeding context limits.
@@ -4474,6 +4474,23 @@ Highlights:
 
 ---
 
+## indranilbanerjee/socialforge
+
+URL: https://hermesatlas.com/projects/indranilbanerjee/socialforge
+GitHub: https://github.com/indranilbanerjee/socialforge
+Category: Plugins & Extensions
+Stars: 6
+Open-source agency-grade social media production plugin — 16 skills, 25 commands, AI image (Nano Banana Pro) + AI video (Kling v3.0 Pro) + C2PA signing (EU AI Act Article 50). Installs on Claude Code,
+
+SocialForge is an open-source social media production engine designed to automate the creation of monthly content calendars for agencies and in-house teams. It uses asset-first compositing to generate AI backgrounds and scenes around existing brand photos to ensure visual fidelity. The system handles copy adaptation across seven platforms and integrates C2PA signing for EU AI Act compliance. It is compatible with Hermes Agent, Claude Code, and over 35 other Agent Skills platforms.
+
+Highlights:
+- Asset-first compositing keeps brand photos pixel-faithful during AI generation
+- C2PA signing for EU AI Act Article 50 provenance compliance
+- Cross-platform copy adaptation for seven major social media networks
+
+---
+
 ## ellickjohnson/portainer-stack-hermes
 
 URL: https://hermesatlas.com/projects/ellickjohnson/portainer-stack-hermes
@@ -4488,23 +4505,6 @@ Highlights:
 - Includes ttyd web terminal for remote access
 - Deployed as a Portainer Git Repository stack
 - Automated image builds via GitHub Actions
-
----
-
-## indranilbanerjee/socialforge
-
-URL: https://hermesatlas.com/projects/indranilbanerjee/socialforge
-GitHub: https://github.com/indranilbanerjee/socialforge
-Category: Plugins & Extensions
-Stars: 5
-Open-source agency-grade social media production plugin — 16 skills, 25 commands, AI image (Nano Banana Pro) + AI video (Kling v3.0 Pro) + C2PA signing (EU AI Act Article 50). Installs on Claude Code,
-
-SocialForge is an open-source social media production engine designed to automate the creation of monthly content calendars for agencies and in-house teams. It uses asset-first compositing to generate AI backgrounds and scenes around existing brand photos to ensure visual fidelity. The system handles copy adaptation across seven platforms and integrates C2PA signing for EU AI Act compliance. It is compatible with Hermes Agent, Claude Code, and over 35 other Agent Skills platforms.
-
-Highlights:
-- Asset-first compositing keeps brand photos pixel-faithful during AI generation
-- C2PA signing for EU AI Act Article 50 provenance compliance
-- Cross-platform copy adaptation for seven major social media networks
 
 ---
 
@@ -4692,3 +4692,13 @@ Highlights:
 - Automates payments for HTTP 402 responses using USDC
 - Supports Pay Link, x402, MPP, and AP2 protocols
 - Compatible with OpenClaw, Hermes Agent, and agentskills.io standard
+
+---
+
+## hlothaire/hermes-trace
+
+URL: https://hermesatlas.com/projects/hlothaire/hermes-trace
+GitHub: https://github.com/hlothaire/hermes-trace
+Category: Plugins & Extensions
+Stars: 0
+A Hermes Agent plugin that builds execution trace graphs using agent lifecycle hooks.

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Hermes Atlas
 
-> The community-curated ecosystem map for Hermes Agent by Nous Research — 168+ tools, skills, plugins, and integrations with live GitHub data and AI-generated summaries. Updated daily. As of 2026-06-16.
+> The community-curated ecosystem map for Hermes Agent by Nous Research — 169+ tools, skills, plugins, and integrations with live GitHub data and AI-generated summaries. Updated daily. As of 2026-06-16.
 
 Hermes Atlas tracks every open-source project in the Hermes Agent ecosystem across 12 categories. Each project has a dedicated page with a prose summary, live star count, README, and category metadata. The full catalog is also available as JSON at https://hermesatlas.com/data/repos.json for programmatic access.
 
@@ -25,21 +25,21 @@ A hands-on developer tutorial for building on the Hermes Agent codebase, written
 - [Skill authoring template](https://hermesatlas.com/dev/skill-template): A copy-paste SKILL.md with annotated frontmatter.
 
 ## Top Projects
-- [NousResearch/hermes-agent](https://hermesatlas.com/projects/NousResearch/hermes-agent): The self-improving AI agent that grows with you — persistent memory, auto-generated skills, 14 platforms, 6 execution backends (194,787 stars, official)
-- [farion1231/cc-switch](https://hermesatlas.com/projects/farion1231/cc-switch): Cross-platform all-in-one manager for Claude Code, Codex, OpenCode, OpenClaw, Gemini CLI, and Hermes Agent (102,148 stars)
-- [nexu-io/open-design](https://hermesatlas.com/projects/nexu-io/open-design): Local-first open-source design/prototyping system with coding-agent CLI support including Hermes Agent (65,687 stars)
-- [mem0ai/mem0](https://hermesatlas.com/projects/mem0ai/mem0): Universal memory layer for AI Agents — official Hermes Agent memory provider, available as managed cloud or Apache-2.0 self-hosted OSS (58,675 stars)
-- [colbymchenry/codegraph](https://hermesatlas.com/projects/colbymchenry/codegraph): Local pre-indexed code knowledge graph for Hermes Agent and other coding agents to reduce token usage and tool calls (49,994 stars)
-- [iOfficeAI/AionUi](https://hermesatlas.com/projects/iOfficeAI/AionUi): Local open-source cowork app for OpenClaw, Hermes Agent, Claude Code, Codex, OpenCode, Gemini CLI, and other agent CLIs (28,344 stars)
-- [supermemoryai/supermemory](https://hermesatlas.com/projects/supermemoryai/supermemory): Memory engine and API — official Hermes Agent memory provider with sub-300ms recall sustained at 100B+ tokens/month, custom vector graph engine, context fencing, and byte-level dedupe with 100% prompt-cache discount. (27,080 stars)
-- [volcengine/OpenViking](https://hermesatlas.com/projects/volcengine/OpenViking): Open-source context database for AI agents — official Hermes Agent memory provider using viking:// URIs and tiered L0/L1/L2 loading; 91% token reduction and 43-49% task-completion gain over baseline on LoCoMo10. AGPL-3.0. (25,698 stars)
-- [garrytan/gbrain](https://hermesatlas.com/projects/garrytan/gbrain): Garry's Opinionated OpenClaw/Hermes Agent Brain (22,951 stars)
-- [vectorize-io/hindsight](https://hermesatlas.com/projects/vectorize-io/hindsight): Agent memory that learns — long-term retain/recall/reflect workflows (16,465 stars, official)
-- [mukul975/Anthropic-Cybersecurity-Skills](https://hermesatlas.com/projects/mukul975/Anthropic-Cybersecurity-Skills): 754 structured cybersecurity skills mapped to MITRE ATT&CK, NIST CSF 2.0, ATLAS, D3FEND & NIST AI RMF (15,877 stars)
-- [nesquena/hermes-webui](https://hermesatlas.com/projects/nesquena/hermes-webui): Hermes WebUI: The best way to use Hermes Agent from the web or from your phone! (14,520 stars)
-- [fathah/hermes-desktop](https://hermesatlas.com/projects/fathah/hermes-desktop): Desktop companion app for installing, configuring, and chatting with Hermes Agent (12,286 stars)
-- [EKKOLearnAI/hermes-web-ui](https://hermesatlas.com/projects/EKKOLearnAI/hermes-web-ui): Web dashboard for Hermes Agent — multi-platform AI chat, session management, scheduled jobs, usage analytics & channel configuration (Telegram, Discord, Slack, WhatsApp) (7,988 stars)
-- [outsourc-e/hermes-workspace](https://hermesatlas.com/projects/outsourc-e/hermes-workspace): Native web workspace — chat, terminal, memory browser, skills manager, and inspector panel (5,715 stars)
+- [NousResearch/hermes-agent](https://hermesatlas.com/projects/NousResearch/hermes-agent): The self-improving AI agent that grows with you — persistent memory, auto-generated skills, 14 platforms, 6 execution backends (195,214 stars, official)
+- [farion1231/cc-switch](https://hermesatlas.com/projects/farion1231/cc-switch): Cross-platform all-in-one manager for Claude Code, Codex, OpenCode, OpenClaw, Gemini CLI, and Hermes Agent (102,588 stars)
+- [nexu-io/open-design](https://hermesatlas.com/projects/nexu-io/open-design): Local-first open-source design/prototyping system with coding-agent CLI support including Hermes Agent (65,916 stars)
+- [mem0ai/mem0](https://hermesatlas.com/projects/mem0ai/mem0): Universal memory layer for AI Agents — official Hermes Agent memory provider, available as managed cloud or Apache-2.0 self-hosted OSS (58,717 stars)
+- [colbymchenry/codegraph](https://hermesatlas.com/projects/colbymchenry/codegraph): Local pre-indexed code knowledge graph for Hermes Agent and other coding agents to reduce token usage and tool calls (50,244 stars)
+- [iOfficeAI/AionUi](https://hermesatlas.com/projects/iOfficeAI/AionUi): Local open-source cowork app for OpenClaw, Hermes Agent, Claude Code, Codex, OpenCode, Gemini CLI, and other agent CLIs (28,371 stars)
+- [supermemoryai/supermemory](https://hermesatlas.com/projects/supermemoryai/supermemory): Memory engine and API — official Hermes Agent memory provider with sub-300ms recall sustained at 100B+ tokens/month, custom vector graph engine, context fencing, and byte-level dedupe with 100% prompt-cache discount. (27,098 stars)
+- [volcengine/OpenViking](https://hermesatlas.com/projects/volcengine/OpenViking): Open-source context database for AI agents — official Hermes Agent memory provider using viking:// URIs and tiered L0/L1/L2 loading; 91% token reduction and 43-49% task-completion gain over baseline on LoCoMo10. AGPL-3.0. (25,715 stars)
+- [garrytan/gbrain](https://hermesatlas.com/projects/garrytan/gbrain): Garry's Opinionated OpenClaw/Hermes Agent Brain (23,016 stars)
+- [vectorize-io/hindsight](https://hermesatlas.com/projects/vectorize-io/hindsight): Agent memory that learns — long-term retain/recall/reflect workflows (16,480 stars, official)
+- [mukul975/Anthropic-Cybersecurity-Skills](https://hermesatlas.com/projects/mukul975/Anthropic-Cybersecurity-Skills): 754 structured cybersecurity skills mapped to MITRE ATT&CK, NIST CSF 2.0, ATLAS, D3FEND & NIST AI RMF (15,936 stars)
+- [nesquena/hermes-webui](https://hermesatlas.com/projects/nesquena/hermes-webui): Hermes WebUI: The best way to use Hermes Agent from the web or from your phone! (14,553 stars)
+- [fathah/hermes-desktop](https://hermesatlas.com/projects/fathah/hermes-desktop): Desktop companion app for installing, configuring, and chatting with Hermes Agent (12,302 stars)
+- [EKKOLearnAI/hermes-web-ui](https://hermesatlas.com/projects/EKKOLearnAI/hermes-web-ui): Web dashboard for Hermes Agent — multi-platform AI chat, session management, scheduled jobs, usage analytics & channel configuration (Telegram, Discord, Slack, WhatsApp) (8,006 stars)
+- [outsourc-e/hermes-workspace](https://hermesatlas.com/projects/outsourc-e/hermes-workspace): Native web workspace — chat, terminal, memory browser, skills manager, and inspector panel (5,727 stars)
 
 ## Curated Lists
 - [Best Memory Providers for Hermes Agent](https://hermesatlas.com/lists/best-memory-providers): The top community-built memory and context management tools for Hermes Agent, ranked by GitHub stars. Memory is what makes Hermes self-improving — these tools extend its built-in r

--- a/package-lock.json
+++ b/package-lock.json
@@ -956,16 +956,16 @@
       "license": "MIT"
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -1085,9 +1085,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"

--- a/projects/0xNyk/awesome-hermes-agent.html
+++ b/projects/0xNyk/awesome-hermes-agent.html
@@ -51,7 +51,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 4000
+    "userInteractionCount": 4022
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -79,7 +79,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -505,7 +505,7 @@
         <div class="name"><span class="org">alchaincyf /</span> hermes-agent-orange-book</div>
       </a>
       <a class="related-row" href="/projects/OnlyTerp/hermes-optimization-guide">
-        <div class="stars">★ 442</div>
+        <div class="stars">★ 444</div>
         <div class="name"><span class="org">OnlyTerp /</span> hermes-optimization-guide</div>
       </a>
       <a class="related-row" href="/projects/metantonio/hermes-wsl-ubuntu">

--- a/projects/0xNyk/openclaw-to-hermes.html
+++ b/projects/0xNyk/openclaw-to-hermes.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -360,11 +360,11 @@ ruff check .
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/colbymchenry/codegraph">
-        <div class="stars">★ 50.0K</div>
+        <div class="stars">★ 50.2K</div>
         <div class="name"><span class="org">colbymchenry /</span> codegraph</div>
       </a>
       <a class="related-row" href="/projects/Salomondiei08/oh-my-hermes">
-        <div class="stars">★ 532</div>
+        <div class="stars">★ 551</div>
         <div class="name"><span class="org">Salomondiei08 /</span> oh-my-hermes</div>
       </a>
       <a class="related-row" href="/projects/liaohch3/claude-tap">
@@ -372,7 +372,7 @@ ruff check .
         <div class="name"><span class="org">liaohch3 /</span> claude-tap</div>
       </a>
       <a class="related-row" href="/projects/adityahimaone/hermes-agent-rtk-caveman">
-        <div class="stars">★ 61</div>
+        <div class="stars">★ 62</div>
         <div class="name"><span class="org">adityahimaone /</span> hermes-agent-rtk-caveman</div>
       </a>
       <a class="related-row" href="/projects/junhoyeo/tokscale">

--- a/projects/0xrsydn/nix-hermes-agent.html
+++ b/projects/0xrsydn/nix-hermes-agent.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -610,7 +610,7 @@ nixpkgs.overlays = [ nix-hermes.overlays.default ];
         <div class="name"><span class="org">numtide /</span> llm-agents.nix</div>
       </a>
       <a class="related-row" href="/projects/TheAiSingularity/hermesclaw">
-        <div class="stars">★ 53</div>
+        <div class="stars">★ 52</div>
         <div class="name"><span class="org">TheAiSingularity /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/rookiemann/portable-hermes-agent">

--- a/projects/1ilkhamov/opencode-hermes-multiagent.html
+++ b/projects/1ilkhamov/opencode-hermes-multiagent.html
@@ -51,7 +51,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 140
+    "userInteractionCount": 141
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -79,7 +79,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -110,7 +110,7 @@
   <p class="project-desc">Hermes — a multi-agent system for OpenCode AI. 17 specialized agents for research, planning, implementation, quality, and infrastructure.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 140</span>
+    <span class="stars">★ 141</span>
     
     
     
@@ -777,11 +777,11 @@ uvx mcp-server-fetch
         <div class="name"><span class="org">builderz-labs /</span> mission-control</div>
       </a>
       <a class="related-row" href="/projects/swarmclawai/swarmclaw">
-        <div class="stars">★ 583</div>
+        <div class="stars">★ 584</div>
         <div class="name"><span class="org">swarmclawai /</span> swarmclaw</div>
       </a>
       <a class="related-row" href="/projects/howdymary/hermes-agent-metaharness">
-        <div class="stars">★ 93</div>
+        <div class="stars">★ 94</div>
         <div class="name"><span class="org">howdymary /</span> hermes-agent-metaharness</div>
       </a>
       <a class="related-row" href="/projects/runtimenoteslabs/gladiator">
@@ -797,11 +797,11 @@ uvx mcp-server-fetch
         <div class="name"><span class="org">linke-ai /</span> hermes-agent-team</div>
       </a>
       <a class="related-row" href="/projects/Agent-3-7/minions">
-        <div class="stars">★ 577</div>
+        <div class="stars">★ 578</div>
         <div class="name"><span class="org">Agent-3-7 /</span> minions</div>
       </a>
       <a class="related-row" href="/projects/CryptoDmitry/hermes-agent-control-room">
-        <div class="stars">★ 844</div>
+        <div class="stars">★ 856</div>
         <div class="name"><span class="org">CryptoDmitry /</span> hermes-agent-control-room</div>
       </a>
     </div>

--- a/projects/335234131/agent-browser-mcp.html
+++ b/projects/335234131/agent-browser-mcp.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 230
+    "userInteractionCount": 229
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">让 Agent 直接操作真实 Chrome 的 MCP 服务，支持页面扫描、CDP、截图与物理输入</p>
 
   <div class="meta-row">
-    <span class="stars">★ 230</span>
+    <span class="stars">★ 229</span>
     <span><span class="meta-label">lang</span>Python</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -483,11 +483,11 @@ hermes mcp test agent_browser
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 279</div>
+        <div class="stars">★ 280</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 217</div>
+        <div class="stars">★ 220</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -507,11 +507,11 @@ hermes mcp test agent_browser
         <div class="name"><span class="org">raulvidis /</span> hermes-cloudflare</div>
       </a>
       <a class="related-row" href="/projects/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server">
-        <div class="stars">★ 343</div>
+        <div class="stars">★ 345</div>
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 284</div>
+        <div class="stars">★ 285</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
     </div>

--- a/projects/42-evey/evey-bridge-plugin.html
+++ b/projects/42-evey/evey-bridge-plugin.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -169,11 +169,11 @@
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 279</div>
+        <div class="stars">★ 280</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 217</div>
+        <div class="stars">★ 220</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -189,15 +189,15 @@
         <div class="name"><span class="org">raulvidis /</span> hermes-cloudflare</div>
       </a>
       <a class="related-row" href="/projects/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server">
-        <div class="stars">★ 343</div>
+        <div class="stars">★ 345</div>
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 284</div>
+        <div class="stars">★ 285</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
       <a class="related-row" href="/projects/clawshell/clawshell">
-        <div class="stars">★ 294</div>
+        <div class="stars">★ 295</div>
         <div class="name"><span class="org">clawshell /</span> clawshell</div>
       </a>
     </div>

--- a/projects/42-evey/evey-setup.html
+++ b/projects/42-evey/evey-setup.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -524,11 +524,11 @@ docker exec hermes-ollama ollama list               # list local models
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/colbymchenry/codegraph">
-        <div class="stars">★ 50.0K</div>
+        <div class="stars">★ 50.2K</div>
         <div class="name"><span class="org">colbymchenry /</span> codegraph</div>
       </a>
       <a class="related-row" href="/projects/Salomondiei08/oh-my-hermes">
-        <div class="stars">★ 532</div>
+        <div class="stars">★ 551</div>
         <div class="name"><span class="org">Salomondiei08 /</span> oh-my-hermes</div>
       </a>
       <a class="related-row" href="/projects/liaohch3/claude-tap">
@@ -536,7 +536,7 @@ docker exec hermes-ollama ollama list               # list local models
         <div class="name"><span class="org">liaohch3 /</span> claude-tap</div>
       </a>
       <a class="related-row" href="/projects/adityahimaone/hermes-agent-rtk-caveman">
-        <div class="stars">★ 61</div>
+        <div class="stars">★ 62</div>
         <div class="name"><span class="org">adityahimaone /</span> hermes-agent-rtk-caveman</div>
       </a>
       <a class="related-row" href="/projects/junhoyeo/tokscale">

--- a/projects/42-evey/hermes-plugins.html
+++ b/projects/42-evey/hermes-plugins.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 217
+    "userInteractionCount": 220
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Custom plugins for hermes-agent — goal management, inter-agent bridge, model selection, cost control</p>
 
   <div class="meta-row">
-    <span class="stars">★ 217</span>
+    <span class="stars">★ 220</span>
     <span><span class="meta-label">lang</span>Python</span>
     <span><span class="meta-label">license</span>AGPL-3.0</span>
     
@@ -327,7 +327,7 @@ cp hermes-plugins/evey_utils.py ~/.hermes/plugins/
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 279</div>
+        <div class="stars">★ 280</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -347,15 +347,15 @@ cp hermes-plugins/evey_utils.py ~/.hermes/plugins/
         <div class="name"><span class="org">raulvidis /</span> hermes-cloudflare</div>
       </a>
       <a class="related-row" href="/projects/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server">
-        <div class="stars">★ 343</div>
+        <div class="stars">★ 345</div>
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 284</div>
+        <div class="stars">★ 285</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
       <a class="related-row" href="/projects/clawshell/clawshell">
-        <div class="stars">★ 294</div>
+        <div class="stars">★ 295</div>
         <div class="name"><span class="org">clawshell /</span> clawshell</div>
       </a>
     </div>

--- a/projects/8bit64k/cronalytics.html
+++ b/projects/8bit64k/cronalytics.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -528,11 +528,11 @@ provides_hooks:
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 279</div>
+        <div class="stars">★ 280</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 217</div>
+        <div class="stars">★ 220</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -552,11 +552,11 @@ provides_hooks:
         <div class="name"><span class="org">raulvidis /</span> hermes-cloudflare</div>
       </a>
       <a class="related-row" href="/projects/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server">
-        <div class="stars">★ 343</div>
+        <div class="stars">★ 345</div>
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 284</div>
+        <div class="stars">★ 285</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
     </div>

--- a/projects/AMAP-ML/SkillClaw.html
+++ b/projects/AMAP-ML/SkillClaw.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 1921
+    "userInteractionCount": 1928
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -587,7 +587,7 @@ skillclaw skills list-remote   # browse shared skills
         <div class="name"><span class="org">wondelai /</span> skills</div>
       </a>
       <a class="related-row" href="/projects/DougTrajano/pydantic-ai-skills">
-        <div class="stars">★ 314</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">DougTrajano /</span> pydantic-ai-skills</div>
       </a>
       <a class="related-row" href="/projects/Agents365-ai/drawio-skill">
@@ -599,7 +599,7 @@ skillclaw skills list-remote   # browse shared skills
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 175</div>
+        <div class="stars">★ 176</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/AaronWong1999/hermesclaw.html
+++ b/projects/AaronWong1999/hermesclaw.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 620
+    "userInteractionCount": 621
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Run Hermes Agent and OpenClaw on the same WeChat account</p>
 
   <div class="meta-row">
-    <span class="stars">★ 620</span>
+    <span class="stars">★ 621</span>
     <span><span class="meta-label">lang</span>Python</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -492,7 +492,7 @@ rm -rf &quot;$HOME/hermesclaw&quot;
         <div class="name"><span class="org">kevinmarmstrong /</span> hermes-claude-code-rc</div>
       </a>
       <a class="related-row" href="/projects/Codename-11/hermes-relay">
-        <div class="stars">★ 34</div>
+        <div class="stars">★ 35</div>
         <div class="name"><span class="org">Codename-11 /</span> hermes-relay</div>
       </a>
       <a class="related-row" href="/projects/kfa-ai/hermes-timetree-sync">

--- a/projects/Abruptive/Ankh.md.html
+++ b/projects/Abruptive/Ankh.md.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -346,11 +346,11 @@
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/colbymchenry/codegraph">
-        <div class="stars">★ 50.0K</div>
+        <div class="stars">★ 50.2K</div>
         <div class="name"><span class="org">colbymchenry /</span> codegraph</div>
       </a>
       <a class="related-row" href="/projects/Salomondiei08/oh-my-hermes">
-        <div class="stars">★ 532</div>
+        <div class="stars">★ 551</div>
         <div class="name"><span class="org">Salomondiei08 /</span> oh-my-hermes</div>
       </a>
       <a class="related-row" href="/projects/liaohch3/claude-tap">
@@ -358,7 +358,7 @@
         <div class="name"><span class="org">liaohch3 /</span> claude-tap</div>
       </a>
       <a class="related-row" href="/projects/adityahimaone/hermes-agent-rtk-caveman">
-        <div class="stars">★ 61</div>
+        <div class="stars">★ 62</div>
         <div class="name"><span class="org">adityahimaone /</span> hermes-agent-rtk-caveman</div>
       </a>
       <a class="related-row" href="/projects/junhoyeo/tokscale">

--- a/projects/AbuZar-Ansarii/Hermes-Agent-On-Android.html
+++ b/projects/AbuZar-Ansarii/Hermes-Agent-On-Android.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -341,7 +341,7 @@ ollama serve
         <div class="name"><span class="org">numtide /</span> llm-agents.nix</div>
       </a>
       <a class="related-row" href="/projects/TheAiSingularity/hermesclaw">
-        <div class="stars">★ 53</div>
+        <div class="stars">★ 52</div>
         <div class="name"><span class="org">TheAiSingularity /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/0xrsydn/nix-hermes-agent">

--- a/projects/Agent-3-7/minions.html
+++ b/projects/Agent-3-7/minions.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 577
+    "userInteractionCount": 578
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Mission Control for your Hermes agents</p>
 
   <div class="meta-row">
-    <span class="stars">★ 577</span>
+    <span class="stars">★ 578</span>
     <span><span class="meta-label">lang</span>TypeScript</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -210,11 +210,11 @@ Not yet. The adapter interface exists, but launch is Hermes-only. OpenClaw is ne
         <div class="name"><span class="org">builderz-labs /</span> mission-control</div>
       </a>
       <a class="related-row" href="/projects/swarmclawai/swarmclaw">
-        <div class="stars">★ 583</div>
+        <div class="stars">★ 584</div>
         <div class="name"><span class="org">swarmclawai /</span> swarmclaw</div>
       </a>
       <a class="related-row" href="/projects/howdymary/hermes-agent-metaharness">
-        <div class="stars">★ 93</div>
+        <div class="stars">★ 94</div>
         <div class="name"><span class="org">howdymary /</span> hermes-agent-metaharness</div>
       </a>
       <a class="related-row" href="/projects/runtimenoteslabs/gladiator">
@@ -222,7 +222,7 @@ Not yet. The adapter interface exists, but launch is Hermes-only. OpenClaw is ne
         <div class="name"><span class="org">runtimenoteslabs /</span> gladiator</div>
       </a>
       <a class="related-row" href="/projects/1ilkhamov/opencode-hermes-multiagent">
-        <div class="stars">★ 140</div>
+        <div class="stars">★ 141</div>
         <div class="name"><span class="org">1ilkhamov /</span> opencode-hermes-multiagent</div>
       </a>
       <a class="related-row" href="/projects/Rainhoole/hermes-agent-acp-skill">
@@ -234,7 +234,7 @@ Not yet. The adapter interface exists, but launch is Hermes-only. OpenClaw is ne
         <div class="name"><span class="org">linke-ai /</span> hermes-agent-team</div>
       </a>
       <a class="related-row" href="/projects/CryptoDmitry/hermes-agent-control-room">
-        <div class="stars">★ 844</div>
+        <div class="stars">★ 856</div>
         <div class="name"><span class="org">CryptoDmitry /</span> hermes-agent-control-room</div>
       </a>
     </div>

--- a/projects/Agents365-ai/drawio-skill.html
+++ b/projects/Agents365-ai/drawio-skill.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 3567
+    "userInteractionCount": 3642
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -654,7 +654,7 @@ python3 scripts/aiicons.py &quot;openai&quot; --embed     # self-contained data 
         <div class="name"><span class="org">wondelai /</span> skills</div>
       </a>
       <a class="related-row" href="/projects/DougTrajano/pydantic-ai-skills">
-        <div class="stars">★ 314</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">DougTrajano /</span> pydantic-ai-skills</div>
       </a>
       <a class="related-row" href="/projects/smartcontractkit/chainlink-agent-skills">
@@ -662,7 +662,7 @@ python3 scripts/aiicons.py &quot;openai&quot; --embed     # self-contained data 
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 175</div>
+        <div class="stars">★ 176</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/AkoliteZA/hermes-agent-idea-workflow.html
+++ b/projects/AkoliteZA/hermes-agent-idea-workflow.html
@@ -52,7 +52,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 217
+    "userInteractionCount": 218
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -111,7 +111,7 @@
   <p class="project-desc">Pre-build idea-to-spec workflow skills for Hermes Agent: turn rough ideas into design docs, implementation specs, and Superpowers-ready build handoffs.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 217</span>
+    <span class="stars">★ 218</span>
     
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -324,7 +324,7 @@ idea-to-implementation-doc/
         <div class="name"><span class="org">wondelai /</span> skills</div>
       </a>
       <a class="related-row" href="/projects/DougTrajano/pydantic-ai-skills">
-        <div class="stars">★ 314</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">DougTrajano /</span> pydantic-ai-skills</div>
       </a>
       <a class="related-row" href="/projects/Agents365-ai/drawio-skill">
@@ -336,7 +336,7 @@ idea-to-implementation-doc/
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 175</div>
+        <div class="stars">★ 176</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/AlexAI-MCP/hermes-CCC.html
+++ b/projects/AlexAI-MCP/hermes-CCC.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -608,11 +608,11 @@ cd hermes-CCC
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/colbymchenry/codegraph">
-        <div class="stars">★ 50.0K</div>
+        <div class="stars">★ 50.2K</div>
         <div class="name"><span class="org">colbymchenry /</span> codegraph</div>
       </a>
       <a class="related-row" href="/projects/Salomondiei08/oh-my-hermes">
-        <div class="stars">★ 532</div>
+        <div class="stars">★ 551</div>
         <div class="name"><span class="org">Salomondiei08 /</span> oh-my-hermes</div>
       </a>
       <a class="related-row" href="/projects/liaohch3/claude-tap">
@@ -620,7 +620,7 @@ cd hermes-CCC
         <div class="name"><span class="org">liaohch3 /</span> claude-tap</div>
       </a>
       <a class="related-row" href="/projects/adityahimaone/hermes-agent-rtk-caveman">
-        <div class="stars">★ 61</div>
+        <div class="stars">★ 62</div>
         <div class="name"><span class="org">adityahimaone /</span> hermes-agent-rtk-caveman</div>
       </a>
       <a class="related-row" href="/projects/junhoyeo/tokscale">

--- a/projects/AxDSan/mnemosyne.html
+++ b/projects/AxDSan/mnemosyne.html
@@ -47,13 +47,13 @@
     "name": "AxDSan",
     "url": "https://github.com/AxDSan"
   },
-  "dateModified": "2026-06-15T16:42:20.000Z",
+  "dateModified": "2026-06-16T11:06:45.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 1146
+    "userInteractionCount": 1152
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,11 +112,11 @@
   <p class="project-desc">The Zero-Dependency, Sub-Millisecond AI Memory System for Hermes Agents and Everyone Else!</p>
 
   <div class="meta-row">
-    <span class="stars">★ 1.1K</span>
+    <span class="stars">★ 1.2K</span>
     <span><span class="meta-label">lang</span>Python</span>
     <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-06-15</span>
+    <span><span class="meta-label">updated</span>2026-06-16</span>
   </div>
 
   <div class="actions">

--- a/projects/BORT-AGENTS/hermes-bort.html
+++ b/projects/BORT-AGENTS/hermes-bort.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -572,11 +572,11 @@ VPM v2 forwarder, and KR v2 delegated writes.</p>
         <div class="name"><span class="org">kevinmarmstrong /</span> hermes-claude-code-rc</div>
       </a>
       <a class="related-row" href="/projects/AaronWong1999/hermesclaw">
-        <div class="stars">★ 620</div>
+        <div class="stars">★ 621</div>
         <div class="name"><span class="org">AaronWong1999 /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/Codename-11/hermes-relay">
-        <div class="stars">★ 34</div>
+        <div class="stars">★ 35</div>
         <div class="name"><span class="org">Codename-11 /</span> hermes-relay</div>
       </a>
       <a class="related-row" href="/projects/kfa-ai/hermes-timetree-sync">

--- a/projects/Christabel337/job-scout-agent.html
+++ b/projects/Christabel337/job-scout-agent.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -261,7 +261,7 @@
         <div class="name"><span class="org">JackTheGit /</span> hermes-ai-infrastructure-monitoring-toolkit</div>
       </a>
       <a class="related-row" href="/projects/bigph00t/hermescraft">
-        <div class="stars">★ 41</div>
+        <div class="stars">★ 42</div>
         <div class="name"><span class="org">bigph00t /</span> hermescraft</div>
       </a>
       <a class="related-row" href="/projects/hxsteric/mercury">

--- a/projects/Codename-11/hermes-relay.html
+++ b/projects/Codename-11/hermes-relay.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 34
+    "userInteractionCount": 35
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Hermes Relay — Your Hermes AI agent, in your pocket — chat, voice, and control.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 34</span>
+    <span class="stars">★ 35</span>
     <span><span class="meta-label">lang</span>Kotlin</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -520,7 +520,7 @@ ln -s &quot;$PWD/plugin&quot; ~/.hermes/plugins/hermes-relay
         <div class="name"><span class="org">kevinmarmstrong /</span> hermes-claude-code-rc</div>
       </a>
       <a class="related-row" href="/projects/AaronWong1999/hermesclaw">
-        <div class="stars">★ 620</div>
+        <div class="stars">★ 621</div>
         <div class="name"><span class="org">AaronWong1999 /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/kfa-ai/hermes-timetree-sync">

--- a/projects/Context4GPTs/klodi-plugin.html
+++ b/projects/Context4GPTs/klodi-plugin.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 9
+    "userInteractionCount": 12
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">The agent-to-agent marketplace, in your agent host. Your agent lists, haggles, and closes deals for you while you live your life.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 9</span>
+    <span class="stars">★ 12</span>
     <span><span class="meta-label">lang</span>Python</span>
     <span><span class="meta-label">license</span>Apache-2.0</span>
     
@@ -391,11 +391,11 @@ your policies                                     your policies
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 279</div>
+        <div class="stars">★ 280</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 217</div>
+        <div class="stars">★ 220</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -415,11 +415,11 @@ your policies                                     your policies
         <div class="name"><span class="org">raulvidis /</span> hermes-cloudflare</div>
       </a>
       <a class="related-row" href="/projects/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server">
-        <div class="stars">★ 343</div>
+        <div class="stars">★ 345</div>
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 284</div>
+        <div class="stars">★ 285</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
     </div>

--- a/projects/Cranot/super-hermes.html
+++ b/projects/Cranot/super-hermes.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 240
+    "userInteractionCount": 241
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Skills that teach Hermes Agent to write its own analytical prompts</p>
 
   <div class="meta-row">
-    <span class="stars">★ 240</span>
+    <span class="stars">★ 241</span>
     <span><span class="meta-label">lang</span>Shell</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -429,7 +429,7 @@ impact under load, integer overflow on failure_count.
         <div class="name"><span class="org">wondelai /</span> skills</div>
       </a>
       <a class="related-row" href="/projects/DougTrajano/pydantic-ai-skills">
-        <div class="stars">★ 314</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">DougTrajano /</span> pydantic-ai-skills</div>
       </a>
       <a class="related-row" href="/projects/Agents365-ai/drawio-skill">
@@ -441,7 +441,7 @@ impact under load, integer overflow on failure_count.
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 175</div>
+        <div class="stars">★ 176</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/CryptoDmitry/hermes-agent-control-room.html
+++ b/projects/CryptoDmitry/hermes-agent-control-room.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 844
+    "userInteractionCount": 856
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Control Room-first template for managing Hermes agents from one VPS agent to specialist teams and orchestrated workflows </p>
 
   <div class="meta-row">
-    <span class="stars">★ 844</span>
+    <span class="stars">★ 856</span>
     <span><span class="meta-label">lang</span>Shell</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -463,11 +463,11 @@ ls skills/
         <div class="name"><span class="org">builderz-labs /</span> mission-control</div>
       </a>
       <a class="related-row" href="/projects/swarmclawai/swarmclaw">
-        <div class="stars">★ 583</div>
+        <div class="stars">★ 584</div>
         <div class="name"><span class="org">swarmclawai /</span> swarmclaw</div>
       </a>
       <a class="related-row" href="/projects/howdymary/hermes-agent-metaharness">
-        <div class="stars">★ 93</div>
+        <div class="stars">★ 94</div>
         <div class="name"><span class="org">howdymary /</span> hermes-agent-metaharness</div>
       </a>
       <a class="related-row" href="/projects/runtimenoteslabs/gladiator">
@@ -475,7 +475,7 @@ ls skills/
         <div class="name"><span class="org">runtimenoteslabs /</span> gladiator</div>
       </a>
       <a class="related-row" href="/projects/1ilkhamov/opencode-hermes-multiagent">
-        <div class="stars">★ 140</div>
+        <div class="stars">★ 141</div>
         <div class="name"><span class="org">1ilkhamov /</span> opencode-hermes-multiagent</div>
       </a>
       <a class="related-row" href="/projects/Rainhoole/hermes-agent-acp-skill">
@@ -487,7 +487,7 @@ ls skills/
         <div class="name"><span class="org">linke-ai /</span> hermes-agent-team</div>
       </a>
       <a class="related-row" href="/projects/Agent-3-7/minions">
-        <div class="stars">★ 577</div>
+        <div class="stars">★ 578</div>
         <div class="name"><span class="org">Agent-3-7 /</span> minions</div>
       </a>
     </div>

--- a/projects/DougTrajano/pydantic-ai-skills.html
+++ b/projects/DougTrajano/pydantic-ai-skills.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 314
+    "userInteractionCount": 315
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">This package implements Agent Skills (https://agentskills.io) support with progressive disclosure for Pydantic AI. Supports filesystem and programmatic skills.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 314</span>
+    <span class="stars">★ 315</span>
     <span><span class="meta-label">lang</span>Python</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -424,7 +424,7 @@ result = await run_skill_script(
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 175</div>
+        <div class="stars">★ 176</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/EKKOLearnAI/hermes-web-ui.html
+++ b/projects/EKKOLearnAI/hermes-web-ui.html
@@ -46,13 +46,13 @@
     "name": "EKKOLearnAI",
     "url": "https://github.com/EKKOLearnAI"
   },
-  "dateModified": "2026-06-16T07:07:45.000Z",
+  "dateModified": "2026-06-16T10:42:44.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 7988
+    "userInteractionCount": 8006
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -829,7 +829,7 @@ npm run dev
         <div class="name"><span class="org">Euraika-Labs /</span> pan-ui</div>
       </a>
       <a class="related-row" href="/projects/Eynzof/hermes-agent-cn-desktop">
-        <div class="stars">★ 445</div>
+        <div class="stars">★ 456</div>
         <div class="name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       </a>
       <a class="related-row" href="/projects/Felix-Forever/hermes-agent-desktop">
@@ -837,7 +837,7 @@ npm run dev
         <div class="name"><span class="org">Felix-Forever /</span> hermes-agent-desktop</div>
       </a>
       <a class="related-row" href="/projects/jazzyalex/agent-sessions">
-        <div class="stars">★ 640</div>
+        <div class="stars">★ 641</div>
         <div class="name"><span class="org">jazzyalex /</span> agent-sessions</div>
       </a>
       <a class="related-row" href="/projects/nickvasilescu/hermes-desktop-os1">

--- a/projects/EfficientContext/ContextPilot.html
+++ b/projects/EfficientContext/ContextPilot.html
@@ -47,7 +47,7 @@
     "name": "EfficientContext",
     "url": "https://github.com/EfficientContext"
   },
-  "dateModified": "2026-06-15T18:01:05.000Z",
+  "dateModified": "2026-06-16T14:09:50.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -116,7 +116,7 @@
     <span><span class="meta-label">lang</span>Python</span>
     <span><span class="meta-label">license</span>Apache-2.0</span>
     
-    <span><span class="meta-label">updated</span>2026-06-15</span>
+    <span><span class="meta-label">updated</span>2026-06-16</span>
   </div>
 
   <div class="actions">

--- a/projects/Euraika-Labs/pan-ui.html
+++ b/projects/Euraika-Labs/pan-ui.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -568,7 +568,7 @@ npm run dev
         <div class="name"><span class="org">sanchomuzax /</span> hermes-webui</div>
       </a>
       <a class="related-row" href="/projects/Eynzof/hermes-agent-cn-desktop">
-        <div class="stars">★ 445</div>
+        <div class="stars">★ 456</div>
         <div class="name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       </a>
       <a class="related-row" href="/projects/Felix-Forever/hermes-agent-desktop">
@@ -576,7 +576,7 @@ npm run dev
         <div class="name"><span class="org">Felix-Forever /</span> hermes-agent-desktop</div>
       </a>
       <a class="related-row" href="/projects/jazzyalex/agent-sessions">
-        <div class="stars">★ 640</div>
+        <div class="stars">★ 641</div>
         <div class="name"><span class="org">jazzyalex /</span> agent-sessions</div>
       </a>
       <a class="related-row" href="/projects/nickvasilescu/hermes-desktop-os1">
@@ -584,7 +584,7 @@ npm run dev
         <div class="name"><span class="org">nickvasilescu /</span> hermes-desktop-os1</div>
       </a>
       <a class="related-row" href="/projects/farion1231/cc-switch">
-        <div class="stars">★ 102.1K</div>
+        <div class="stars">★ 102.6K</div>
         <div class="name"><span class="org">farion1231 /</span> cc-switch</div>
       </a>
     </div>

--- a/projects/Eynzof/hermes-agent-cn-desktop.html
+++ b/projects/Eynzof/hermes-agent-cn-desktop.html
@@ -46,13 +46,13 @@
     "name": "Eynzof",
     "url": "https://github.com/Eynzof"
   },
-  "dateModified": "2026-06-16T07:55:06.000Z",
+  "dateModified": "2026-06-16T10:03:53.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 445
+    "userInteractionCount": 456
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -111,7 +111,7 @@
   <p class="project-desc">Hermes Agent CN desktop app, Windows-First, built with Tauri, Typescript and Rust. Isolated Hermes Agent core insides. </p>
 
   <div class="meta-row">
-    <span class="stars">★ 445</span>
+    <span class="stars">★ 456</span>
     <span><span class="meta-label">lang</span>TypeScript</span>
     
     
@@ -444,7 +444,7 @@ v0.1.1
         <div class="name"><span class="org">Felix-Forever /</span> hermes-agent-desktop</div>
       </a>
       <a class="related-row" href="/projects/jazzyalex/agent-sessions">
-        <div class="stars">★ 640</div>
+        <div class="stars">★ 641</div>
         <div class="name"><span class="org">jazzyalex /</span> agent-sessions</div>
       </a>
       <a class="related-row" href="/projects/nickvasilescu/hermes-desktop-os1">
@@ -452,7 +452,7 @@ v0.1.1
         <div class="name"><span class="org">nickvasilescu /</span> hermes-desktop-os1</div>
       </a>
       <a class="related-row" href="/projects/farion1231/cc-switch">
-        <div class="stars">★ 102.1K</div>
+        <div class="stars">★ 102.6K</div>
         <div class="name"><span class="org">farion1231 /</span> cc-switch</div>
       </a>
     </div>

--- a/projects/FahrenheitResearch/hermes-weather-plugin.html
+++ b/projects/FahrenheitResearch/hermes-weather-plugin.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -365,11 +365,11 @@ $env:ECAPE_RS_RUNNER = &#39;C:\path\to\run_case.exe&#39;
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 279</div>
+        <div class="stars">★ 280</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 217</div>
+        <div class="stars">★ 220</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/42-evey/evey-bridge-plugin">
@@ -385,15 +385,15 @@ $env:ECAPE_RS_RUNNER = &#39;C:\path\to\run_case.exe&#39;
         <div class="name"><span class="org">raulvidis /</span> hermes-cloudflare</div>
       </a>
       <a class="related-row" href="/projects/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server">
-        <div class="stars">★ 343</div>
+        <div class="stars">★ 345</div>
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 284</div>
+        <div class="stars">★ 285</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
       <a class="related-row" href="/projects/clawshell/clawshell">
-        <div class="stars">★ 294</div>
+        <div class="stars">★ 295</div>
         <div class="name"><span class="org">clawshell /</span> clawshell</div>
       </a>
     </div>

--- a/projects/Felix-Forever/hermes-agent-desktop.html
+++ b/projects/Felix-Forever/hermes-agent-desktop.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -540,11 +540,11 @@ python -c &quot;import re; open(&#39;/tmp/c.js&#39;,&#39;w&#39;).write(re.search
         <div class="name"><span class="org">Euraika-Labs /</span> pan-ui</div>
       </a>
       <a class="related-row" href="/projects/Eynzof/hermes-agent-cn-desktop">
-        <div class="stars">★ 445</div>
+        <div class="stars">★ 456</div>
         <div class="name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       </a>
       <a class="related-row" href="/projects/jazzyalex/agent-sessions">
-        <div class="stars">★ 640</div>
+        <div class="stars">★ 641</div>
         <div class="name"><span class="org">jazzyalex /</span> agent-sessions</div>
       </a>
       <a class="related-row" href="/projects/nickvasilescu/hermes-desktop-os1">
@@ -552,7 +552,7 @@ python -c &quot;import re; open(&#39;/tmp/c.js&#39;,&#39;w&#39;).write(re.search
         <div class="name"><span class="org">nickvasilescu /</span> hermes-desktop-os1</div>
       </a>
       <a class="related-row" href="/projects/farion1231/cc-switch">
-        <div class="stars">★ 102.1K</div>
+        <div class="stars">★ 102.6K</div>
         <div class="name"><span class="org">farion1231 /</span> cc-switch</div>
       </a>
     </div>

--- a/projects/JackTheGit/hermes-ai-infrastructure-monitoring-toolkit.html
+++ b/projects/JackTheGit/hermes-ai-infrastructure-monitoring-toolkit.html
@@ -79,7 +79,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -400,7 +400,7 @@ TOTAL KEYWORDS ANALYZED       44       100%
         <div class="name"><span class="org">rodmarkun /</span> anihermes</div>
       </a>
       <a class="related-row" href="/projects/bigph00t/hermescraft">
-        <div class="stars">★ 41</div>
+        <div class="stars">★ 42</div>
         <div class="name"><span class="org">bigph00t /</span> hermescraft</div>
       </a>
       <a class="related-row" href="/projects/hxsteric/mercury">

--- a/projects/JackTheGit/hermes-autonomous-server.html
+++ b/projects/JackTheGit/hermes-autonomous-server.html
@@ -79,7 +79,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -389,7 +389,7 @@ hermes uninstall
         <div class="name"><span class="org">numtide /</span> llm-agents.nix</div>
       </a>
       <a class="related-row" href="/projects/TheAiSingularity/hermesclaw">
-        <div class="stars">★ 53</div>
+        <div class="stars">★ 52</div>
         <div class="name"><span class="org">TheAiSingularity /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/0xrsydn/nix-hermes-agent">

--- a/projects/Ladybug-Memory/hermes-memory-plugin.html
+++ b/projects/Ladybug-Memory/hermes-memory-plugin.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>

--- a/projects/Lethe044/hermes-incident-commander.html
+++ b/projects/Lethe044/hermes-incident-commander.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -441,7 +441,7 @@ pytest tests/test_incident_env.py::TestSkillFile -v
         <div class="name"><span class="org">JackTheGit /</span> hermes-ai-infrastructure-monitoring-toolkit</div>
       </a>
       <a class="related-row" href="/projects/bigph00t/hermescraft">
-        <div class="stars">★ 41</div>
+        <div class="stars">★ 42</div>
         <div class="name"><span class="org">bigph00t /</span> hermescraft</div>
       </a>
       <a class="related-row" href="/projects/hxsteric/mercury">

--- a/projects/MukundaKatta/hermes-agentmemory.html
+++ b/projects/MukundaKatta/hermes-agentmemory.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>

--- a/projects/NousResearch/Hermes-Function-Calling.html
+++ b/projects/NousResearch/Hermes-Function-Calling.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -382,7 +382,7 @@ You are a helpful assistant that answers in JSON. Here&#39;s the json schema you
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/NousResearch/hermes-agent">
-        <div class="stars">★ 194.8K</div>
+        <div class="stars">★ 195.2K</div>
         <div class="name"><span class="org">NousResearch /</span> hermes-agent</div>
       </a>
       <a class="related-row" href="/projects/NousResearch/atropos">

--- a/projects/NousResearch/atropos.html
+++ b/projects/NousResearch/atropos.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 1283
+    "userInteractionCount": 1282
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -668,7 +668,7 @@ Please follow the <a href="https://github.com/NousResearch/atropos/blob/main/COD
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/NousResearch/hermes-agent">
-        <div class="stars">★ 194.8K</div>
+        <div class="stars">★ 195.2K</div>
         <div class="name"><span class="org">NousResearch /</span> hermes-agent</div>
       </a>
       <a class="related-row" href="/projects/NousResearch/Hermes-Function-Calling">

--- a/projects/NousResearch/autonovel.html
+++ b/projects/NousResearch/autonovel.html
@@ -52,7 +52,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 1145
+    "userInteractionCount": 1148
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -483,7 +483,7 @@ through this pipeline:</p>
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/NousResearch/hermes-agent">
-        <div class="stars">★ 194.8K</div>
+        <div class="stars">★ 195.2K</div>
         <div class="name"><span class="org">NousResearch /</span> hermes-agent</div>
       </a>
       <a class="related-row" href="/projects/NousResearch/Hermes-Function-Calling">

--- a/projects/NousResearch/hermes-agent-self-evolution.html
+++ b/projects/NousResearch/hermes-agent-self-evolution.html
@@ -52,7 +52,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 4110
+    "userInteractionCount": 4118
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -268,7 +268,7 @@ python -m evolution.skills.evolve_skill \
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/NousResearch/hermes-agent">
-        <div class="stars">★ 194.8K</div>
+        <div class="stars">★ 195.2K</div>
         <div class="name"><span class="org">NousResearch /</span> hermes-agent</div>
       </a>
       <a class="related-row" href="/projects/NousResearch/Hermes-Function-Calling">

--- a/projects/NousResearch/hermes-agent.html
+++ b/projects/NousResearch/hermes-agent.html
@@ -47,13 +47,13 @@
     "name": "NousResearch",
     "url": "https://github.com/NousResearch"
   },
-  "dateModified": "2026-06-16T06:10:54.000Z",
+  "dateModified": "2026-06-16T18:11:16.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 194787
+    "userInteractionCount": 195214
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">The agent that grows with you</p>
 
   <div class="meta-row">
-    <span class="stars">★ 194.8K</span>
+    <span class="stars">★ 195.2K</span>
     <span><span class="meta-label">lang</span>Python</span>
     <span><span class="meta-label">license</span>MIT</span>
     <span><span class="meta-label">maintainer</span>Nous Research</span>

--- a/projects/NousResearch/hermes-paperclip-adapter.html
+++ b/projects/NousResearch/hermes-paperclip-adapter.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 1595
+    "userInteractionCount": 1600
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -538,7 +538,7 @@ npm run build
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/NousResearch/hermes-agent">
-        <div class="stars">★ 194.8K</div>
+        <div class="stars">★ 195.2K</div>
         <div class="name"><span class="org">NousResearch /</span> hermes-agent</div>
       </a>
       <a class="related-row" href="/projects/NousResearch/Hermes-Function-Calling">

--- a/projects/OnlyTerp/hermes-optimization-guide.html
+++ b/projects/OnlyTerp/hermes-optimization-guide.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 442
+    "userInteractionCount": 444
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Hermes Agent setup, migration, LightRAG, Telegram, and skill creation guide</p>
 
   <div class="meta-row">
-    <span class="stars">★ 442</span>
+    <span class="stars">★ 444</span>
     <span><span class="meta-label">lang</span>Shell</span>
     <span><span class="meta-label">license</span>MIT</span>
     

--- a/projects/PederHP/skillsdotnet.html
+++ b/projects/PederHP/skillsdotnet.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -456,7 +456,7 @@ Instructions for the agent go here.
         <div class="name"><span class="org">wondelai /</span> skills</div>
       </a>
       <a class="related-row" href="/projects/DougTrajano/pydantic-ai-skills">
-        <div class="stars">★ 314</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">DougTrajano /</span> pydantic-ai-skills</div>
       </a>
       <a class="related-row" href="/projects/Agents365-ai/drawio-skill">
@@ -468,7 +468,7 @@ Instructions for the agent go here.
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 175</div>
+        <div class="stars">★ 176</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/Rainhoole/hermes-agent-acp-skill.html
+++ b/projects/Rainhoole/hermes-agent-acp-skill.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -196,11 +196,11 @@
         <div class="name"><span class="org">builderz-labs /</span> mission-control</div>
       </a>
       <a class="related-row" href="/projects/swarmclawai/swarmclaw">
-        <div class="stars">★ 583</div>
+        <div class="stars">★ 584</div>
         <div class="name"><span class="org">swarmclawai /</span> swarmclaw</div>
       </a>
       <a class="related-row" href="/projects/howdymary/hermes-agent-metaharness">
-        <div class="stars">★ 93</div>
+        <div class="stars">★ 94</div>
         <div class="name"><span class="org">howdymary /</span> hermes-agent-metaharness</div>
       </a>
       <a class="related-row" href="/projects/runtimenoteslabs/gladiator">
@@ -208,7 +208,7 @@
         <div class="name"><span class="org">runtimenoteslabs /</span> gladiator</div>
       </a>
       <a class="related-row" href="/projects/1ilkhamov/opencode-hermes-multiagent">
-        <div class="stars">★ 140</div>
+        <div class="stars">★ 141</div>
         <div class="name"><span class="org">1ilkhamov /</span> opencode-hermes-multiagent</div>
       </a>
       <a class="related-row" href="/projects/linke-ai/hermes-agent-team">
@@ -216,11 +216,11 @@
         <div class="name"><span class="org">linke-ai /</span> hermes-agent-team</div>
       </a>
       <a class="related-row" href="/projects/Agent-3-7/minions">
-        <div class="stars">★ 577</div>
+        <div class="stars">★ 578</div>
         <div class="name"><span class="org">Agent-3-7 /</span> minions</div>
       </a>
       <a class="related-row" href="/projects/CryptoDmitry/hermes-agent-control-room">
-        <div class="stars">★ 844</div>
+        <div class="stars">★ 856</div>
         <div class="name"><span class="org">CryptoDmitry /</span> hermes-agent-control-room</div>
       </a>
     </div>

--- a/projects/ReinaMacCredy/maestro.html
+++ b/projects/ReinaMacCredy/maestro.html
@@ -47,7 +47,7 @@
     "name": "ReinaMacCredy",
     "url": "https://github.com/ReinaMacCredy"
   },
-  "dateModified": "2026-06-15T08:37:36.000Z",
+  "dateModified": "2026-06-16T17:23:46.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -116,7 +116,7 @@
     <span><span class="meta-label">lang</span>Rust</span>
     <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-06-15</span>
+    <span><span class="meta-label">updated</span>2026-06-16</span>
   </div>
 
   <div class="actions">
@@ -882,7 +882,7 @@ embedded/    shipped harness, hook, shell, and skill resources
         <div class="name"><span class="org">wondelai /</span> skills</div>
       </a>
       <a class="related-row" href="/projects/DougTrajano/pydantic-ai-skills">
-        <div class="stars">★ 314</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">DougTrajano /</span> pydantic-ai-skills</div>
       </a>
       <a class="related-row" href="/projects/Agents365-ai/drawio-skill">
@@ -894,7 +894,7 @@ embedded/    shipped harness, hook, shell, and skill resources
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 175</div>
+        <div class="stars">★ 176</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/Ridwannurudeen/hermes-council.html
+++ b/projects/Ridwannurudeen/hermes-council.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -657,11 +657,11 @@ endorsing one community server over others. Install standalone via the
         <div class="name"><span class="org">kevinmarmstrong /</span> hermes-claude-code-rc</div>
       </a>
       <a class="related-row" href="/projects/AaronWong1999/hermesclaw">
-        <div class="stars">★ 620</div>
+        <div class="stars">★ 621</div>
         <div class="name"><span class="org">AaronWong1999 /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/Codename-11/hermes-relay">
-        <div class="stars">★ 34</div>
+        <div class="stars">★ 35</div>
         <div class="name"><span class="org">Codename-11 /</span> hermes-relay</div>
       </a>
       <a class="related-row" href="/projects/kfa-ai/hermes-timetree-sync">

--- a/projects/Romanescu11/hermes-skill-factory.html
+++ b/projects/Romanescu11/hermes-skill-factory.html
@@ -52,7 +52,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 379
+    "userInteractionCount": 383
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -111,7 +111,7 @@
   <p class="project-desc"> A meta-skill plugin for Nous Research's Hermes AI agent that watches your workflows and automatically turns them into reusable skills.  Every time you work with Hermes and solve something — setting up a project, debugging code, creating a PR — that   workflow disappears at the end of the session. You have to explain it again next time.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 379</span>
+    <span class="stars">★ 383</span>
     <span><span class="meta-label">lang</span>Python</span>
     
     
@@ -334,7 +334,7 @@ tags: [python, venv, testing]
         <div class="name"><span class="org">wondelai /</span> skills</div>
       </a>
       <a class="related-row" href="/projects/DougTrajano/pydantic-ai-skills">
-        <div class="stars">★ 314</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">DougTrajano /</span> pydantic-ai-skills</div>
       </a>
       <a class="related-row" href="/projects/Agents365-ai/drawio-skill">
@@ -346,7 +346,7 @@ tags: [python, venv, testing]
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 175</div>
+        <div class="stars">★ 176</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/Sahil-SS9/MrHermagi-tutorbot.html
+++ b/projects/Sahil-SS9/MrHermagi-tutorbot.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -326,7 +326,7 @@ smaller model as a fallback to stay resilient and cheap.</p>
         <div class="name"><span class="org">JackTheGit /</span> hermes-ai-infrastructure-monitoring-toolkit</div>
       </a>
       <a class="related-row" href="/projects/bigph00t/hermescraft">
-        <div class="stars">★ 41</div>
+        <div class="stars">★ 42</div>
         <div class="name"><span class="org">bigph00t /</span> hermescraft</div>
       </a>
       <a class="related-row" href="/projects/hxsteric/mercury">

--- a/projects/Sahil-SS9/Toolaria.html
+++ b/projects/Sahil-SS9/Toolaria.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 8
+    "userInteractionCount": 9
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Rescue oversized tool results before they flood context. SHA256-addressed blob store with per-session indexes</p>
 
   <div class="meta-row">
-    <span class="stars">★ 8</span>
+    <span class="stars">★ 9</span>
     <span><span class="meta-label">lang</span>Python</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -569,11 +569,11 @@ handle. Swept-blob guidance is scoped to the owning session.</li>
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 279</div>
+        <div class="stars">★ 280</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 217</div>
+        <div class="stars">★ 220</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -593,11 +593,11 @@ handle. Swept-blob guidance is scoped to the owning session.</li>
         <div class="name"><span class="org">raulvidis /</span> hermes-cloudflare</div>
       </a>
       <a class="related-row" href="/projects/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server">
-        <div class="stars">★ 343</div>
+        <div class="stars">★ 345</div>
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 284</div>
+        <div class="stars">★ 285</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
     </div>

--- a/projects/Sahil-SS9/hermaguard.html
+++ b/projects/Sahil-SS9/hermaguard.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 8
+    "userInteractionCount": 9
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Adversarial bug-hunting code review for AI agents. 3 parallel subagents attack code from different angles, then a consolidator merges and triages findings. Read-only — finds problems, doesn't fix.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 8</span>
+    <span class="stars">★ 9</span>
     <span><span class="meta-label">lang</span>Python</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -288,7 +288,7 @@ sudo ln -sf $(pwd)/tools/hermaguard-prescan/hermaguard-prescan.py /usr/local/bin
         <div class="name"><span class="org">wondelai /</span> skills</div>
       </a>
       <a class="related-row" href="/projects/DougTrajano/pydantic-ai-skills">
-        <div class="stars">★ 314</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">DougTrajano /</span> pydantic-ai-skills</div>
       </a>
       <a class="related-row" href="/projects/Agents365-ai/drawio-skill">
@@ -300,7 +300,7 @@ sudo ln -sf $(pwd)/tools/hermaguard-prescan/hermaguard-prescan.py /usr/local/bin
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 175</div>
+        <div class="stars">★ 176</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/Sahil-SS9/hermes-Custom-CLI-Themes.html
+++ b/projects/Sahil-SS9/hermes-Custom-CLI-Themes.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -261,11 +261,11 @@ curl -fsSL https://raw.githubusercontent.com/Sahil-SS9/hermes-Custom-CLI-Themes/
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 279</div>
+        <div class="stars">★ 280</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 217</div>
+        <div class="stars">★ 220</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -285,11 +285,11 @@ curl -fsSL https://raw.githubusercontent.com/Sahil-SS9/hermes-Custom-CLI-Themes/
         <div class="name"><span class="org">raulvidis /</span> hermes-cloudflare</div>
       </a>
       <a class="related-row" href="/projects/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server">
-        <div class="stars">★ 343</div>
+        <div class="stars">★ 345</div>
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 284</div>
+        <div class="stars">★ 285</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
     </div>

--- a/projects/Sahil-SS9/hermes-memlock.html
+++ b/projects/Sahil-SS9/hermes-memlock.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -459,11 +459,11 @@ downloads the embedding model on first use.</li>
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 279</div>
+        <div class="stars">★ 280</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 217</div>
+        <div class="stars">★ 220</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -483,11 +483,11 @@ downloads the embedding model on first use.</li>
         <div class="name"><span class="org">raulvidis /</span> hermes-cloudflare</div>
       </a>
       <a class="related-row" href="/projects/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server">
-        <div class="stars">★ 343</div>
+        <div class="stars">★ 345</div>
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 284</div>
+        <div class="stars">★ 285</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
     </div>

--- a/projects/Sahil-SS9/hermes-multichannel-prompt-optimizer.html
+++ b/projects/Sahil-SS9/hermes-multichannel-prompt-optimizer.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -519,7 +519,7 @@ venv/bin/pytest tests/plugins/test_prompt_optimizer_plugin.py -v
         <div class="name"><span class="org">wondelai /</span> skills</div>
       </a>
       <a class="related-row" href="/projects/DougTrajano/pydantic-ai-skills">
-        <div class="stars">★ 314</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">DougTrajano /</span> pydantic-ai-skills</div>
       </a>
       <a class="related-row" href="/projects/Agents365-ai/drawio-skill">
@@ -531,7 +531,7 @@ venv/bin/pytest tests/plugins/test_prompt_optimizer_plugin.py -v
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 175</div>
+        <div class="stars">★ 176</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/Sahil-SS9/hermes-simplify-swarm.html
+++ b/projects/Sahil-SS9/hermes-simplify-swarm.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -227,7 +227,7 @@ git clone https://github.com/Sahil-SS9/hermes-simplify-swarm.git simplify-swarm
         <div class="name"><span class="org">wondelai /</span> skills</div>
       </a>
       <a class="related-row" href="/projects/DougTrajano/pydantic-ai-skills">
-        <div class="stars">★ 314</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">DougTrajano /</span> pydantic-ai-skills</div>
       </a>
       <a class="related-row" href="/projects/Agents365-ai/drawio-skill">
@@ -239,7 +239,7 @@ git clone https://github.com/Sahil-SS9/hermes-simplify-swarm.git simplify-swarm
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 175</div>
+        <div class="stars">★ 176</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/Salomondiei08/oh-my-hermes.html
+++ b/projects/Salomondiei08/oh-my-hermes.html
@@ -52,7 +52,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 532
+    "userInteractionCount": 551
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -111,7 +111,7 @@
   <p class="project-desc">An opinionated workflow layer for building, shipping, and operating apps with Hermes Agent</p>
 
   <div class="meta-row">
-    <span class="stars">★ 532</span>
+    <span class="stars">★ 551</span>
     <span><span class="meta-label">lang</span>Shell</span>
     
     
@@ -652,7 +652,7 @@ Multi-service orchestration, more example apps, hosted setup wizard.</p>
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/colbymchenry/codegraph">
-        <div class="stars">★ 50.0K</div>
+        <div class="stars">★ 50.2K</div>
         <div class="name"><span class="org">colbymchenry /</span> codegraph</div>
       </a>
       <a class="related-row" href="/projects/liaohch3/claude-tap">
@@ -660,7 +660,7 @@ Multi-service orchestration, more example apps, hosted setup wizard.</p>
         <div class="name"><span class="org">liaohch3 /</span> claude-tap</div>
       </a>
       <a class="related-row" href="/projects/adityahimaone/hermes-agent-rtk-caveman">
-        <div class="stars">★ 61</div>
+        <div class="stars">★ 62</div>
         <div class="name"><span class="org">adityahimaone /</span> hermes-agent-rtk-caveman</div>
       </a>
       <a class="related-row" href="/projects/junhoyeo/tokscale">

--- a/projects/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server.html
+++ b/projects/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 343
+    "userInteractionCount": 345
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Kindly Web Search MCP Server: Web search + robust content retrieval for AI coding tools (Claude Code, Codex, Cursor, GitHub Copilot, Gemini, etc.) and AI agents (Claude Desktop, OpenClaw, Hermes, etc.). Supports Serper, Tavily, and SearXNG.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 343</span>
+    <span class="stars">★ 345</span>
     <span><span class="meta-label">lang</span>Python</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -748,11 +748,11 @@ Create <code>.vscode/mcp.json</code>:</p>
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 279</div>
+        <div class="stars">★ 280</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 217</div>
+        <div class="stars">★ 220</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -772,11 +772,11 @@ Create <code>.vscode/mcp.json</code>:</p>
         <div class="name"><span class="org">raulvidis /</span> hermes-cloudflare</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 284</div>
+        <div class="stars">★ 285</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
       <a class="related-row" href="/projects/clawshell/clawshell">
-        <div class="stars">★ 294</div>
+        <div class="stars">★ 295</div>
         <div class="name"><span class="org">clawshell /</span> clawshell</div>
       </a>
     </div>

--- a/projects/Signet-AI/signetai.html
+++ b/projects/Signet-AI/signetai.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>

--- a/projects/TheAiSingularity/hermesclaw.html
+++ b/projects/TheAiSingularity/hermesclaw.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 53
+    "userInteractionCount": 52
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Hermes Agent (NousResearch) sandboxed by NVIDIA OpenShell — hardware-enforced network/filesystem/syscall policy, full memory + gateway stack</p>
 
   <div class="meta-row">
-    <span class="stars">★ 53</span>
+    <span class="stars">★ 52</span>
     <span><span class="meta-label">lang</span>Shell</span>
     <span><span class="meta-label">license</span>MIT</span>
     

--- a/projects/Xquik-dev/hermes-tweet.html
+++ b/projects/Xquik-dev/hermes-tweet.html
@@ -47,13 +47,13 @@
     "name": "Xquik-dev",
     "url": "https://github.com/Xquik-dev"
   },
-  "dateModified": "2026-06-16T06:52:11.000Z",
+  "dateModified": "2026-06-16T18:02:57.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 9
+    "userInteractionCount": 10
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Native Hermes Agent plugin for X/Twitter automation through Xquik</p>
 
   <div class="meta-row">
-    <span class="stars">★ 9</span>
+    <span class="stars">★ 10</span>
     <span><span class="meta-label">lang</span>Python</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -511,11 +511,11 @@ Python plugin. Both use the same Xquik API contract.</p>
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 279</div>
+        <div class="stars">★ 280</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 217</div>
+        <div class="stars">★ 220</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -535,11 +535,11 @@ Python plugin. Both use the same Xquik API contract.</p>
         <div class="name"><span class="org">raulvidis /</span> hermes-cloudflare</div>
       </a>
       <a class="related-row" href="/projects/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server">
-        <div class="stars">★ 343</div>
+        <div class="stars">★ 345</div>
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 284</div>
+        <div class="stars">★ 285</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
     </div>

--- a/projects/ZeroPointRepo/youtube-skills.html
+++ b/projects/ZeroPointRepo/youtube-skills.html
@@ -52,7 +52,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 270
+    "userInteractionCount": 271
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -111,7 +111,7 @@
   <p class="project-desc">YouTube Transcript API skills for AI agents. Get transcripts, search videos, browse channels. Works with OpenClaw, Hermes-Agent, Claude Code, Cursor, Windsurf.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 270</span>
+    <span class="stars">★ 271</span>
     
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -545,7 +545,7 @@ npx skills add ZeroPointRepo/youtube-skills --skill transcript --skill youtube-s
         <div class="name"><span class="org">wondelai /</span> skills</div>
       </a>
       <a class="related-row" href="/projects/DougTrajano/pydantic-ai-skills">
-        <div class="stars">★ 314</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">DougTrajano /</span> pydantic-ai-skills</div>
       </a>
       <a class="related-row" href="/projects/Agents365-ai/drawio-skill">
@@ -557,7 +557,7 @@ npx skills add ZeroPointRepo/youtube-skills --skill transcript --skill youtube-s
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 175</div>
+        <div class="stars">★ 176</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/adityahimaone/hermes-agent-rtk-caveman.html
+++ b/projects/adityahimaone/hermes-agent-rtk-caveman.html
@@ -52,7 +52,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 61
+    "userInteractionCount": 62
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -111,7 +111,7 @@
   <p class="project-desc">Hermes Agent RTK + Caveman setup - 90-99% token savings on CLI operations with 35+ pre-configured skills</p>
 
   <div class="meta-row">
-    <span class="stars">★ 61</span>
+    <span class="stars">★ 62</span>
     <span><span class="meta-label">lang</span>TeX</span>
     
     
@@ -465,11 +465,11 @@ ls -la ~/templates/
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/colbymchenry/codegraph">
-        <div class="stars">★ 50.0K</div>
+        <div class="stars">★ 50.2K</div>
         <div class="name"><span class="org">colbymchenry /</span> codegraph</div>
       </a>
       <a class="related-row" href="/projects/Salomondiei08/oh-my-hermes">
-        <div class="stars">★ 532</div>
+        <div class="stars">★ 551</div>
         <div class="name"><span class="org">Salomondiei08 /</span> oh-my-hermes</div>
       </a>
       <a class="related-row" href="/projects/liaohch3/claude-tap">

--- a/projects/adnw-vinc/hermes-nextcloud.html
+++ b/projects/adnw-vinc/hermes-nextcloud.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -332,7 +332,7 @@ $NC contacts export --uid &lt;contact-uid&gt; --local ./contact.vcf
         <div class="name"><span class="org">wondelai /</span> skills</div>
       </a>
       <a class="related-row" href="/projects/DougTrajano/pydantic-ai-skills">
-        <div class="stars">★ 314</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">DougTrajano /</span> pydantic-ai-skills</div>
       </a>
       <a class="related-row" href="/projects/Agents365-ai/drawio-skill">
@@ -344,7 +344,7 @@ $NC contacts export --uid &lt;contact-uid&gt; --local ./contact.vcf
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 175</div>
+        <div class="stars">★ 176</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/agent-of-empires/agent-of-empires.html
+++ b/projects/agent-of-empires/agent-of-empires.html
@@ -47,13 +47,13 @@
     "name": "agent-of-empires",
     "url": "https://github.com/agent-of-empires"
   },
-  "dateModified": "2026-06-16T08:24:49.000Z",
+  "dateModified": "2026-06-16T18:00:13.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 2592
+    "userInteractionCount": 2595
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -322,11 +322,11 @@ unchanged.</p>
         <div class="name"><span class="org">builderz-labs /</span> mission-control</div>
       </a>
       <a class="related-row" href="/projects/swarmclawai/swarmclaw">
-        <div class="stars">★ 583</div>
+        <div class="stars">★ 584</div>
         <div class="name"><span class="org">swarmclawai /</span> swarmclaw</div>
       </a>
       <a class="related-row" href="/projects/howdymary/hermes-agent-metaharness">
-        <div class="stars">★ 93</div>
+        <div class="stars">★ 94</div>
         <div class="name"><span class="org">howdymary /</span> hermes-agent-metaharness</div>
       </a>
       <a class="related-row" href="/projects/runtimenoteslabs/gladiator">
@@ -334,7 +334,7 @@ unchanged.</p>
         <div class="name"><span class="org">runtimenoteslabs /</span> gladiator</div>
       </a>
       <a class="related-row" href="/projects/1ilkhamov/opencode-hermes-multiagent">
-        <div class="stars">★ 140</div>
+        <div class="stars">★ 141</div>
         <div class="name"><span class="org">1ilkhamov /</span> opencode-hermes-multiagent</div>
       </a>
       <a class="related-row" href="/projects/Rainhoole/hermes-agent-acp-skill">
@@ -346,7 +346,7 @@ unchanged.</p>
         <div class="name"><span class="org">linke-ai /</span> hermes-agent-team</div>
       </a>
       <a class="related-row" href="/projects/Agent-3-7/minions">
-        <div class="stars">★ 577</div>
+        <div class="stars">★ 578</div>
         <div class="name"><span class="org">Agent-3-7 /</span> minions</div>
       </a>
     </div>

--- a/projects/aivrar/portable-hermes-agent.html
+++ b/projects/aivrar/portable-hermes-agent.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -360,7 +360,7 @@ AIAgent (run_agent.py)
         <div class="name"><span class="org">Euraika-Labs /</span> pan-ui</div>
       </a>
       <a class="related-row" href="/projects/Eynzof/hermes-agent-cn-desktop">
-        <div class="stars">★ 445</div>
+        <div class="stars">★ 456</div>
         <div class="name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       </a>
       <a class="related-row" href="/projects/Felix-Forever/hermes-agent-desktop">
@@ -368,7 +368,7 @@ AIAgent (run_agent.py)
         <div class="name"><span class="org">Felix-Forever /</span> hermes-agent-desktop</div>
       </a>
       <a class="related-row" href="/projects/jazzyalex/agent-sessions">
-        <div class="stars">★ 640</div>
+        <div class="stars">★ 641</div>
         <div class="name"><span class="org">jazzyalex /</span> agent-sessions</div>
       </a>
       <a class="related-row" href="/projects/nickvasilescu/hermes-desktop-os1">

--- a/projects/alchaincyf/hermes-agent-orange-book.html
+++ b/projects/alchaincyf/hermes-agent-orange-book.html
@@ -51,7 +51,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 4439
+    "userInteractionCount": 4446
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -79,7 +79,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -288,7 +288,7 @@
         <div class="name"><span class="org">0xNyk /</span> awesome-hermes-agent</div>
       </a>
       <a class="related-row" href="/projects/OnlyTerp/hermes-optimization-guide">
-        <div class="stars">★ 442</div>
+        <div class="stars">★ 444</div>
         <div class="name"><span class="org">OnlyTerp /</span> hermes-optimization-guide</div>
       </a>
       <a class="related-row" href="/projects/metantonio/hermes-wsl-ubuntu">

--- a/projects/alias8818/hermes-tool-slimmer.html
+++ b/projects/alias8818/hermes-tool-slimmer.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 23
+    "userInteractionCount": 24
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Reduce Hermes Agent tool-schema overhead with keyword selection and Tool Search support</p>
 
   <div class="meta-row">
-    <span class="stars">★ 23</span>
+    <span class="stars">★ 24</span>
     <span><span class="meta-label">lang</span>Python</span>
     <span><span class="meta-label">license</span>MIT</span>
     

--- a/projects/amanning3390/flowstate-qmd.html
+++ b/projects/amanning3390/flowstate-qmd.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>

--- a/projects/amanning3390/hermeshub.html
+++ b/projects/amanning3390/hermeshub.html
@@ -52,7 +52,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 259
+    "userInteractionCount": 260
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -111,7 +111,7 @@
   <p class="project-desc">HermesHub - The Skills Hub for Hermes Agent by Nous Research. Browse, share, and install community skills.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 259</span>
+    <span class="stars">★ 260</span>
     <span><span class="meta-label">lang</span>TypeScript</span>
     
     
@@ -539,7 +539,7 @@ hermes skills search &lt;query&gt;
         <div class="name"><span class="org">wondelai /</span> skills</div>
       </a>
       <a class="related-row" href="/projects/DougTrajano/pydantic-ai-skills">
-        <div class="stars">★ 314</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">DougTrajano /</span> pydantic-ai-skills</div>
       </a>
       <a class="related-row" href="/projects/Agents365-ai/drawio-skill">
@@ -551,7 +551,7 @@ hermes skills search &lt;query&gt;
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 175</div>
+        <div class="stars">★ 176</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/anneheartrecord/hermes-agent-anatomy.html
+++ b/projects/anneheartrecord/hermes-agent-anatomy.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -295,7 +295,7 @@
         <div class="name"><span class="org">alchaincyf /</span> hermes-agent-orange-book</div>
       </a>
       <a class="related-row" href="/projects/OnlyTerp/hermes-optimization-guide">
-        <div class="stars">★ 442</div>
+        <div class="stars">★ 444</div>
         <div class="name"><span class="org">OnlyTerp /</span> hermes-optimization-guide</div>
       </a>
       <a class="related-row" href="/projects/metantonio/hermes-wsl-ubuntu">

--- a/projects/armelhbobdad/bmad-module-skill-forge.html
+++ b/projects/armelhbobdad/bmad-module-skill-forge.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -398,7 +398,7 @@ results = await cognee.search(
         <div class="name"><span class="org">wondelai /</span> skills</div>
       </a>
       <a class="related-row" href="/projects/DougTrajano/pydantic-ai-skills">
-        <div class="stars">★ 314</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">DougTrajano /</span> pydantic-ai-skills</div>
       </a>
       <a class="related-row" href="/projects/Agents365-ai/drawio-skill">
@@ -410,7 +410,7 @@ results = await cognee.search(
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 175</div>
+        <div class="stars">★ 176</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/basilisk-labs/agentplane-hermes-plugin.html
+++ b/projects/basilisk-labs/agentplane-hermes-plugin.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -243,11 +243,11 @@ or CLI surfaces.</p>
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 279</div>
+        <div class="stars">★ 280</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 217</div>
+        <div class="stars">★ 220</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -267,11 +267,11 @@ or CLI surfaces.</p>
         <div class="name"><span class="org">raulvidis /</span> hermes-cloudflare</div>
       </a>
       <a class="related-row" href="/projects/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server">
-        <div class="stars">★ 343</div>
+        <div class="stars">★ 345</div>
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 284</div>
+        <div class="stars">★ 285</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
     </div>

--- a/projects/beardthelion/hermes-skill-distillation.html
+++ b/projects/beardthelion/hermes-skill-distillation.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -276,7 +276,7 @@ demo/
         <div class="name"><span class="org">carterwayneskhizeine /</span> hermes-agent-windows-R</div>
       </a>
       <a class="related-row" href="/projects/sheawinkler/hermes-agent-ultra">
-        <div class="stars">★ 46</div>
+        <div class="stars">★ 49</div>
         <div class="name"><span class="org">sheawinkler /</span> hermes-agent-ultra</div>
       </a>
       <a class="related-row" href="/projects/pengchengxia75-arch/hermes-agent-windows">

--- a/projects/bigph00t/hermescraft.html
+++ b/projects/bigph00t/hermescraft.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 41
+    "userInteractionCount": 42
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Embodied AI companion for Minecraft — persistent memory, vision, learning, multi-agent. Built on Hermes Agent.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 41</span>
+    <span class="stars">★ 42</span>
     <span><span class="meta-label">lang</span>JavaScript</span>
     <span><span class="meta-label">license</span>MIT</span>
     

--- a/projects/black-forest-labs/skills.html
+++ b/projects/black-forest-labs/skills.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -291,7 +291,7 @@ while True:
         <div class="name"><span class="org">wondelai /</span> skills</div>
       </a>
       <a class="related-row" href="/projects/DougTrajano/pydantic-ai-skills">
-        <div class="stars">★ 314</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">DougTrajano /</span> pydantic-ai-skills</div>
       </a>
       <a class="related-row" href="/projects/Agents365-ai/drawio-skill">
@@ -303,7 +303,7 @@ while True:
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 175</div>
+        <div class="stars">★ 176</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/briancaffey/hermes-otel.html
+++ b/projects/briancaffey/hermes-otel.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -855,11 +855,11 @@ headers:                        # merged onto outgoing OTLP requests
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 279</div>
+        <div class="stars">★ 280</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 217</div>
+        <div class="stars">★ 220</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -879,11 +879,11 @@ headers:                        # merged onto outgoing OTLP requests
         <div class="name"><span class="org">raulvidis /</span> hermes-cloudflare</div>
       </a>
       <a class="related-row" href="/projects/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server">
-        <div class="stars">★ 343</div>
+        <div class="stars">★ 345</div>
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 284</div>
+        <div class="stars">★ 285</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
     </div>

--- a/projects/bryercowan/hermes-embodied.html
+++ b/projects/bryercowan/hermes-embodied.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -335,7 +335,7 @@
         <div class="name"><span class="org">JackTheGit /</span> hermes-ai-infrastructure-monitoring-toolkit</div>
       </a>
       <a class="related-row" href="/projects/bigph00t/hermescraft">
-        <div class="stars">★ 41</div>
+        <div class="stars">★ 42</div>
         <div class="name"><span class="org">bigph00t /</span> hermescraft</div>
       </a>
       <a class="related-row" href="/projects/hxsteric/mercury">

--- a/projects/builderz-labs/mission-control.html
+++ b/projects/builderz-labs/mission-control.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 5327
+    "userInteractionCount": 5331
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -842,11 +842,11 @@ pnpm dev                    # http://localhost:3000/setup
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/swarmclawai/swarmclaw">
-        <div class="stars">★ 583</div>
+        <div class="stars">★ 584</div>
         <div class="name"><span class="org">swarmclawai /</span> swarmclaw</div>
       </a>
       <a class="related-row" href="/projects/howdymary/hermes-agent-metaharness">
-        <div class="stars">★ 93</div>
+        <div class="stars">★ 94</div>
         <div class="name"><span class="org">howdymary /</span> hermes-agent-metaharness</div>
       </a>
       <a class="related-row" href="/projects/runtimenoteslabs/gladiator">
@@ -854,7 +854,7 @@ pnpm dev                    # http://localhost:3000/setup
         <div class="name"><span class="org">runtimenoteslabs /</span> gladiator</div>
       </a>
       <a class="related-row" href="/projects/1ilkhamov/opencode-hermes-multiagent">
-        <div class="stars">★ 140</div>
+        <div class="stars">★ 141</div>
         <div class="name"><span class="org">1ilkhamov /</span> opencode-hermes-multiagent</div>
       </a>
       <a class="related-row" href="/projects/Rainhoole/hermes-agent-acp-skill">
@@ -866,11 +866,11 @@ pnpm dev                    # http://localhost:3000/setup
         <div class="name"><span class="org">linke-ai /</span> hermes-agent-team</div>
       </a>
       <a class="related-row" href="/projects/Agent-3-7/minions">
-        <div class="stars">★ 577</div>
+        <div class="stars">★ 578</div>
         <div class="name"><span class="org">Agent-3-7 /</span> minions</div>
       </a>
       <a class="related-row" href="/projects/CryptoDmitry/hermes-agent-control-room">
-        <div class="stars">★ 844</div>
+        <div class="stars">★ 856</div>
         <div class="name"><span class="org">CryptoDmitry /</span> hermes-agent-control-room</div>
       </a>
     </div>

--- a/projects/cablate/Agentic-MCP-Skill.html
+++ b/projects/cablate/Agentic-MCP-Skill.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -465,7 +465,7 @@ agentic-mcp call playwright browser_click --params &#39;{&quot;element&quot;: &q
         <div class="name"><span class="org">wondelai /</span> skills</div>
       </a>
       <a class="related-row" href="/projects/DougTrajano/pydantic-ai-skills">
-        <div class="stars">★ 314</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">DougTrajano /</span> pydantic-ai-skills</div>
       </a>
       <a class="related-row" href="/projects/Agents365-ai/drawio-skill">
@@ -477,7 +477,7 @@ agentic-mcp call playwright browser_click --params &#39;{&quot;element&quot;: &q
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 175</div>
+        <div class="stars">★ 176</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/campfirein/byterover-cli.html
+++ b/projects/campfirein/byterover-cli.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>

--- a/projects/carterwayneskhizeine/hermes-agent-windows-R.html
+++ b/projects/carterwayneskhizeine/hermes-agent-windows-R.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -244,7 +244,7 @@ cd ..
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/sheawinkler/hermes-agent-ultra">
-        <div class="stars">★ 46</div>
+        <div class="stars">★ 49</div>
         <div class="name"><span class="org">sheawinkler /</span> hermes-agent-ultra</div>
       </a>
       <a class="related-row" href="/projects/pengchengxia75-arch/hermes-agent-windows">

--- a/projects/chigwell/skilldock.io.html
+++ b/projects/chigwell/skilldock.io.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -417,7 +417,7 @@ The exact details are derived from the OpenAPI <code>securitySchemes</code> when
         <div class="name"><span class="org">wondelai /</span> skills</div>
       </a>
       <a class="related-row" href="/projects/DougTrajano/pydantic-ai-skills">
-        <div class="stars">★ 314</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">DougTrajano /</span> pydantic-ai-skills</div>
       </a>
       <a class="related-row" href="/projects/Agents365-ai/drawio-skill">
@@ -429,7 +429,7 @@ The exact details are derived from the OpenAPI <code>securitySchemes</code> when
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 175</div>
+        <div class="stars">★ 176</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/clawshell/clawshell.html
+++ b/projects/clawshell/clawshell.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 294
+    "userInteractionCount": 295
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">The Runtime Security Layer for OpenClaw/Hermes-agent, the essential safety harness for PII &amp; sensitive credentials protection.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 294</span>
+    <span class="stars">★ 295</span>
     <span><span class="meta-label">lang</span>Rust</span>
     <span><span class="meta-label">license</span>Apache-2.0</span>
     
@@ -469,11 +469,11 @@ hermes config set model.api_key  &lt;your-clawshell-virtual-key&gt;
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 279</div>
+        <div class="stars">★ 280</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 217</div>
+        <div class="stars">★ 220</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -493,11 +493,11 @@ hermes config set model.api_key  &lt;your-clawshell-virtual-key&gt;
         <div class="name"><span class="org">raulvidis /</span> hermes-cloudflare</div>
       </a>
       <a class="related-row" href="/projects/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server">
-        <div class="stars">★ 343</div>
+        <div class="stars">★ 345</div>
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 284</div>
+        <div class="stars">★ 285</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
     </div>

--- a/projects/clawvader-tech/hermes-telegram-miniapp.html
+++ b/projects/clawvader-tech/hermes-telegram-miniapp.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -572,7 +572,7 @@ Optional Local Models (CPU)
         <div class="name"><span class="org">Euraika-Labs /</span> pan-ui</div>
       </a>
       <a class="related-row" href="/projects/Eynzof/hermes-agent-cn-desktop">
-        <div class="stars">★ 445</div>
+        <div class="stars">★ 456</div>
         <div class="name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       </a>
       <a class="related-row" href="/projects/Felix-Forever/hermes-agent-desktop">
@@ -580,7 +580,7 @@ Optional Local Models (CPU)
         <div class="name"><span class="org">Felix-Forever /</span> hermes-agent-desktop</div>
       </a>
       <a class="related-row" href="/projects/jazzyalex/agent-sessions">
-        <div class="stars">★ 640</div>
+        <div class="stars">★ 641</div>
         <div class="name"><span class="org">jazzyalex /</span> agent-sessions</div>
       </a>
       <a class="related-row" href="/projects/nickvasilescu/hermes-desktop-os1">

--- a/projects/colbymchenry/codegraph.html
+++ b/projects/colbymchenry/codegraph.html
@@ -47,13 +47,13 @@
     "name": "colbymchenry",
     "url": "https://github.com/colbymchenry"
   },
-  "dateModified": "2026-06-16T05:06:45.000Z",
+  "dateModified": "2026-06-16T17:16:00.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 49994
+    "userInteractionCount": 50244
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Pre-indexed code knowledge graph, auto syncs on code changes, for Claude Code, Codex, Gemini, Cursor, OpenCode, AntiGravity, Kiro, and Hermes Agent — fewer tokens, fewer tool calls, 100% local</p>
 
   <div class="meta-row">
-    <span class="stars">★ 50.0K</span>
+    <span class="stars">★ 50.2K</span>
     <span><span class="meta-label">lang</span>TypeScript</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -1563,7 +1563,7 @@ is written):</p>
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/Salomondiei08/oh-my-hermes">
-        <div class="stars">★ 532</div>
+        <div class="stars">★ 551</div>
         <div class="name"><span class="org">Salomondiei08 /</span> oh-my-hermes</div>
       </a>
       <a class="related-row" href="/projects/liaohch3/claude-tap">
@@ -1571,7 +1571,7 @@ is written):</p>
         <div class="name"><span class="org">liaohch3 /</span> claude-tap</div>
       </a>
       <a class="related-row" href="/projects/adityahimaone/hermes-agent-rtk-caveman">
-        <div class="stars">★ 61</div>
+        <div class="stars">★ 62</div>
         <div class="name"><span class="org">adityahimaone /</span> hermes-agent-rtk-caveman</div>
       </a>
       <a class="related-row" href="/projects/junhoyeo/tokscale">

--- a/projects/conorbronsdon/avoid-ai-writing.html
+++ b/projects/conorbronsdon/avoid-ai-writing.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 1853
+    "userInteractionCount": 1863
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -757,7 +757,7 @@ map that keeps <code>SKILL.md</code> and the engine in sync.</p>
         <div class="name"><span class="org">wondelai /</span> skills</div>
       </a>
       <a class="related-row" href="/projects/DougTrajano/pydantic-ai-skills">
-        <div class="stars">★ 314</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">DougTrajano /</span> pydantic-ai-skills</div>
       </a>
       <a class="related-row" href="/projects/Agents365-ai/drawio-skill">
@@ -769,7 +769,7 @@ map that keeps <code>SKILL.md</code> and the engine in sync.</p>
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 175</div>
+        <div class="stars">★ 176</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/dodo-reach/hermes-desktop.html
+++ b/projects/dodo-reach/hermes-desktop.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 1884
+    "userInteractionCount": 1890
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -523,7 +523,7 @@ because it is technically possible.</p>
         <div class="name"><span class="org">Euraika-Labs /</span> pan-ui</div>
       </a>
       <a class="related-row" href="/projects/Eynzof/hermes-agent-cn-desktop">
-        <div class="stars">★ 445</div>
+        <div class="stars">★ 456</div>
         <div class="name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       </a>
       <a class="related-row" href="/projects/Felix-Forever/hermes-agent-desktop">
@@ -531,7 +531,7 @@ because it is technically possible.</p>
         <div class="name"><span class="org">Felix-Forever /</span> hermes-agent-desktop</div>
       </a>
       <a class="related-row" href="/projects/jazzyalex/agent-sessions">
-        <div class="stars">★ 640</div>
+        <div class="stars">★ 641</div>
         <div class="name"><span class="org">jazzyalex /</span> agent-sessions</div>
       </a>
       <a class="related-row" href="/projects/nickvasilescu/hermes-desktop-os1">

--- a/projects/elkimek/honcho-self-hosted.html
+++ b/projects/elkimek/honcho-self-hosted.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>

--- a/projects/ellickjohnson/portainer-stack-hermes.html
+++ b/projects/ellickjohnson/portainer-stack-hermes.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -183,7 +183,7 @@
         <div class="name"><span class="org">numtide /</span> llm-agents.nix</div>
       </a>
       <a class="related-row" href="/projects/TheAiSingularity/hermesclaw">
-        <div class="stars">★ 53</div>
+        <div class="stars">★ 52</div>
         <div class="name"><span class="org">TheAiSingularity /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/0xrsydn/nix-hermes-agent">

--- a/projects/esaradev/icarus-plugin.html
+++ b/projects/esaradev/icarus-plugin.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -534,7 +534,7 @@ scripts/
         <div class="name"><span class="org">wondelai /</span> skills</div>
       </a>
       <a class="related-row" href="/projects/DougTrajano/pydantic-ai-skills">
-        <div class="stars">★ 314</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">DougTrajano /</span> pydantic-ai-skills</div>
       </a>
       <a class="related-row" href="/projects/Agents365-ai/drawio-skill">
@@ -546,7 +546,7 @@ scripts/
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 175</div>
+        <div class="stars">★ 176</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/chigwell/skilldock.io">

--- a/projects/farion1231/cc-switch.html
+++ b/projects/farion1231/cc-switch.html
@@ -47,13 +47,13 @@
     "name": "farion1231",
     "url": "https://github.com/farion1231"
   },
-  "dateModified": "2026-06-16T04:08:49.000Z",
+  "dateModified": "2026-06-16T14:01:57.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 102148
+    "userInteractionCount": 102588
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">A cross-platform desktop All-in-One assistant for Claude Code, Codex, OpenCode, OpenClaw, Gemini CLI &amp; Hermes Agent. Only official website: ccswitch.io</p>
 
   <div class="meta-row">
-    <span class="stars">★ 102.1K</span>
+    <span class="stars">★ 102.6K</span>
     <span><span class="meta-label">lang</span>Rust</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -656,7 +656,7 @@ pnpm test:unit --coverage
         <div class="name"><span class="org">Euraika-Labs /</span> pan-ui</div>
       </a>
       <a class="related-row" href="/projects/Eynzof/hermes-agent-cn-desktop">
-        <div class="stars">★ 445</div>
+        <div class="stars">★ 456</div>
         <div class="name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       </a>
       <a class="related-row" href="/projects/Felix-Forever/hermes-agent-desktop">
@@ -664,7 +664,7 @@ pnpm test:unit --coverage
         <div class="name"><span class="org">Felix-Forever /</span> hermes-agent-desktop</div>
       </a>
       <a class="related-row" href="/projects/jazzyalex/agent-sessions">
-        <div class="stars">★ 640</div>
+        <div class="stars">★ 641</div>
         <div class="name"><span class="org">jazzyalex /</span> agent-sessions</div>
       </a>
       <a class="related-row" href="/projects/nickvasilescu/hermes-desktop-os1">

--- a/projects/fathah/hermes-desktop.html
+++ b/projects/fathah/hermes-desktop.html
@@ -47,13 +47,13 @@
     "name": "fathah",
     "url": "https://github.com/fathah"
   },
-  "dateModified": "2026-06-14T16:47:02.000Z",
+  "dateModified": "2026-06-16T09:05:10.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 12286
+    "userInteractionCount": 12302
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -116,7 +116,7 @@
     <span><span class="meta-label">lang</span>TypeScript</span>
     <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-06-14</span>
+    <span><span class="meta-label">updated</span>2026-06-16</span>
   </div>
 
   <div class="actions">
@@ -147,7 +147,7 @@
 
 <br/>
 <p align="center">
-  <a href="https://hermes-agent.nousresearch.com/docs/"><img src="https://img.shields.io/badge/Docs-hermes--agent.nousresearch.com-FFD700?style=for-the-badge" alt="Documentation"></a>
+  <a href="https://x.com/HermesOneApp"><img src="https://img.shields.io/badge/Follow Us-000000?style=for-the-badge&logo=x" alt="Twitter"></a>
   <a href="https://discord.gg/Fqu72h8z"><img src="https://img.shields.io/badge/Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
   <a href="https://github.com/fathah/hermes-desktop/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License: MIT"></a>
   <a href="https://hermesagents.cc/"><img src="https://img.shields.io/badge/Download-Releases-FF6600?style=for-the-badge" alt="Releases"></a>
@@ -158,7 +158,7 @@
   <img src="https://img.shields.io/github/downloads/fathah/hermes-desktop/total?style=for-the-badge&color=00B496&label=Total%20Downloads" alt="Downloads">
 </a>
    <a href="https://bankr.bot/launches/0xfda75f77a22b4f4b783bbbb21915ef64d149bba3">
-  <img src="https://img.shields.io/badge/Token-$HD-purple?style=for-the-badge" alt="Downloads">
+  <img src="https://img.shields.io/badge/Token-$HD-purple?style=for-the-badge&logo=ethereum" alt="Downloads">
 </a>
   
 </p>
@@ -169,6 +169,17 @@
   <a href="README.ja-JP.md">日本語</a> ·
   <a href="README.es-LATAM.md">Español (LATAM)</a>
 </p>
+
+<p align="center">
+ <a href="https://www.star-history.com/fathah/hermes-desktop">
+  <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/badge?repo=fathah/hermes-desktop&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/badge?repo=fathah/hermes-desktop" />
+   <img alt="Star History Rank" src="https://api.star-history.com/badge?repo=fathah/hermes-desktop" />
+  </picture>
+ </a>
+</p>
+
 
 <blockquote>
 <p><strong>This project is in active development.</strong> Features may change, and some things might break. If you run into a problem or have an idea, <a href="https://github.com/fathah/hermes-desktop/issues">open an issue</a>. Contributions are welcome!</p>
@@ -567,7 +578,7 @@ helper loop.</li>
         <div class="name"><span class="org">Euraika-Labs /</span> pan-ui</div>
       </a>
       <a class="related-row" href="/projects/Eynzof/hermes-agent-cn-desktop">
-        <div class="stars">★ 445</div>
+        <div class="stars">★ 456</div>
         <div class="name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       </a>
       <a class="related-row" href="/projects/Felix-Forever/hermes-agent-desktop">
@@ -575,7 +586,7 @@ helper loop.</li>
         <div class="name"><span class="org">Felix-Forever /</span> hermes-agent-desktop</div>
       </a>
       <a class="related-row" href="/projects/jazzyalex/agent-sessions">
-        <div class="stars">★ 640</div>
+        <div class="stars">★ 641</div>
         <div class="name"><span class="org">jazzyalex /</span> agent-sessions</div>
       </a>
       <a class="related-row" href="/projects/nickvasilescu/hermes-desktop-os1">
@@ -583,7 +594,7 @@ helper loop.</li>
         <div class="name"><span class="org">nickvasilescu /</span> hermes-desktop-os1</div>
       </a>
       <a class="related-row" href="/projects/farion1231/cc-switch">
-        <div class="stars">★ 102.1K</div>
+        <div class="stars">★ 102.6K</div>
         <div class="name"><span class="org">farion1231 /</span> cc-switch</div>
       </a>
     </div>

--- a/projects/futurebrowser/hermes-exabase-plugin.html
+++ b/projects/futurebrowser/hermes-exabase-plugin.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>

--- a/projects/garrytan/gbrain.html
+++ b/projects/garrytan/gbrain.html
@@ -47,13 +47,13 @@
     "name": "garrytan",
     "url": "https://github.com/garrytan"
   },
-  "dateModified": "2026-06-15T22:53:28.000Z",
+  "dateModified": "2026-06-16T17:51:37.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 22951
+    "userInteractionCount": 23016
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -116,7 +116,7 @@
     <span><span class="meta-label">lang</span>TypeScript</span>
     <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-06-15</span>
+    <span><span class="meta-label">updated</span>2026-06-16</span>
   </div>
 
   <div class="actions">

--- a/projects/gizdusum/hermes-blockchain-oracle.html
+++ b/projects/gizdusum/hermes-blockchain-oracle.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -480,11 +480,11 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
         <div class="name"><span class="org">kevinmarmstrong /</span> hermes-claude-code-rc</div>
       </a>
       <a class="related-row" href="/projects/AaronWong1999/hermesclaw">
-        <div class="stars">★ 620</div>
+        <div class="stars">★ 621</div>
         <div class="name"><span class="org">AaronWong1999 /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/Codename-11/hermes-relay">
-        <div class="stars">★ 34</div>
+        <div class="stars">★ 35</div>
         <div class="name"><span class="org">Codename-11 /</span> hermes-relay</div>
       </a>
       <a class="related-row" href="/projects/kfa-ai/hermes-timetree-sync">

--- a/projects/greyhaven-ai/autocontext.html
+++ b/projects/greyhaven-ai/autocontext.html
@@ -47,13 +47,13 @@
     "name": "greyhaven-ai",
     "url": "https://github.com/greyhaven-ai"
   },
-  "dateModified": "2026-06-16T05:34:02.000Z",
+  "dateModified": "2026-06-16T17:22:25.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 1204
+    "userInteractionCount": 1205
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>

--- a/projects/hlothaire/hermes-trace.html
+++ b/projects/hlothaire/hermes-trace.html
@@ -1,0 +1,442 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>hermes-trace — Hermes Agent Plugins &amp; Extensions | Hermes Atlas</title>
+<meta name="description" content="A Hermes Agent plugin that builds execution trace graphs using agent lifecycle hooks.">
+<link rel="canonical" href="https://hermesatlas.com/projects/hlothaire/hermes-trace">
+<meta property="og:title" content="hermes-trace — Hermes Atlas">
+<meta property="og:description" content="A Hermes Agent plugin that builds execution trace graphs using agent lifecycle hooks.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://hermesatlas.com/projects/hlothaire/hermes-trace">
+<meta property="og:site_name" content="Hermes Atlas">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-trace&amp;subtitle=A+Hermes+Agent+plugin+that+builds+execution+trace+graphs+using+agent+lifecycle+hooks.&amp;kind=project+%C2%B7+plugins">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="hermes-trace — Hermes Atlas">
+<meta name="twitter:description" content="A Hermes Agent plugin that builds execution trace graphs using agent lifecycle hooks.">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-trace&amp;subtitle=A+Hermes+Agent+plugin+that+builds+execution+trace+graphs+using+agent+lifecycle+hooks.&amp;kind=project+%C2%B7+plugins">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "map", "item": "https://hermesatlas.com/" },
+    { "@type": "ListItem", "position": 2, "name": "plugins &amp; extensions", "item": "https://hermesatlas.com/" },
+    { "@type": "ListItem", "position": 3, "name": "hermes-trace" }
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "@id": "https://hermesatlas.com/projects/hlothaire/hermes-trace#software",
+  "name": "hermes-trace",
+  "description": "A Hermes Agent plugin that builds execution trace graphs using agent lifecycle hooks.",
+  "url": "https://hermesatlas.com/projects/hlothaire/hermes-trace",
+  "codeRepository": "https://github.com/hlothaire/hermes-trace",
+  "applicationCategory": "BrowserApplication",
+  "operatingSystem": "Cross-platform",
+  "programmingLanguage": "Python",
+  "license": "https://spdx.org/licenses/MIT.html",
+  "author": {
+    "@type": "Organization",
+    "name": "hlothaire",
+    "url": "https://github.com/hlothaire"
+  },
+  "dateModified": "2026-06-16T12:14:57.000Z",
+  "isPartOf": {
+    "@id": "https://hermesatlas.com/#website"
+  }
+}
+</script>
+<link rel="alternate" type="application/rss+xml" title="Hermes Atlas — new projects" href="/rss.xml">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+<link rel="apple-touch-icon" href="/apple-touch-icon.png">
+<link rel="manifest" href="/site.webmanifest">
+<script>(function(){try{var s=localStorage.getItem('theme');var o=window.matchMedia&&window.matchMedia('(prefers-color-scheme: light)').matches;var t=s||(o?'light':'dark');document.documentElement.setAttribute('data-theme',t)}catch(e){document.documentElement.setAttribute('data-theme','dark')}})();</script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap">
+<link rel="stylesheet" href="/assets/css/tokens.css">
+<link rel="stylesheet" href="/assets/css/base.css">
+<link rel="stylesheet" href="/assets/css/page.css">
+</head>
+<body>
+
+<a class="skip-link" href="#main">Skip to content</a>
+
+<header class="masthead">
+  <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
+  <div class="mast-meta" aria-label="Site metadata">
+    <span id="meta-count">169·repos</span>
+    <span id="meta-version">hermes·v0.15.2</span>
+    <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
+  </div>
+  <nav class="mast-nav" aria-label="Primary">
+    <a href="/" class="active">map</a>
+    <a href="/#curated-lists">lists</a>
+    <a href="/guide/">handbook</a>
+    <a href="/dev/">dev</a>
+    <a href="/reports/">reports</a>
+    <a href="/#newsletter">newsletter</a>
+    <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
+  </nav>
+  <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
+    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+  </button>
+</header>
+
+<div class="breadcrumb" aria-label="Breadcrumb">
+  <a href="/">map</a><span class="sep">/</span><a href="/">plugins &amp; extensions</a><span class="sep">/</span>hermes-trace
+</div>
+
+<main id="main">
+
+<section class="project">
+  <h1 class="project-name">
+    <span class="org">hlothaire</span><span class="slash">/</span>hermes-trace
+  </h1>
+  <p class="project-desc">A Hermes Agent plugin that builds execution trace graphs using agent lifecycle hooks.</p>
+
+  <div class="meta-row">
+    <span class="stars">★ 0</span>
+    <span><span class="meta-label">lang</span>Python</span>
+    <span><span class="meta-label">license</span>MIT</span>
+    
+    <span><span class="meta-label">updated</span>2026-06-16</span>
+  </div>
+
+  <div class="actions">
+    <a href="https://github.com/hlothaire/hermes-trace" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
+    
+  </div>
+</section>
+
+
+
+
+
+<details class="readme-details" open>
+  <summary class="readme-toggle">readme</summary>
+  <section class="readme" data-nosnippet>
+    <h2>Hermes Trace</h2>
+<p>A Hermes Agent plugin that builds <strong>execution trace graphs</strong> — capturing every
+turn, LLM call, tool call, subagent spawn, and approval request as a structured
+directed graph.  View traces interactively with <code>/trace</code>, export them as JSON
+or Mermaid diagrams, or query them from the terminal with <code>hermes trace</code>.</p>
+<h3>Features</h3>
+<ul>
+<li><p><strong>18 lifecycle hooks</strong> — automatic tracing of every agent event: sessions,
+turns, API requests, tool calls, subagents, approvals, gateway dispatch,
+and result/output transformations.</p>
+</li>
+<li><p><strong><code>/trace</code> slash command</strong> — view the current session&#39;s trace as a text tree,
+list active/saved traces, load past traces, Gantt timeline, or export to JSON/Mermaid.</p>
+</li>
+<li><p><strong><code>hermes trace</code> CLI</strong> — query traces outside a session:</p>
+<pre><code>hermes trace list              # table of saved traces
+hermes trace view &lt;id&gt;         # text tree
+hermes trace stats &lt;id&gt;        # aggregate statistics
+hermes trace gantt &lt;id&gt;        # ASCII Gantt timeline
+hermes trace clean --keep 20   # rotate old traces
+</code></pre>
+</li>
+<li><p><strong>Text tree</strong> — human-readable tree with turn messages, LLM/tool durations,
+token counts, and success/error markers.</p>
+</li>
+<li><p><strong>Stats footer</strong> — totals for turns, LLM calls, tool calls, errors, tokens,
+and slowest span by type.</p>
+</li>
+<li><p><strong>Gantt timeline</strong> — ASCII bar chart showing span concurrency and
+bottlenecks per turn (<code>/trace gantt</code>, <code>hermes trace gantt &lt;id&gt;</code>).</p>
+</li>
+<li><p><strong>Subagent linking</strong> — child traces reference their parent session
+(<code>parent_trace</code> field) for bidirectional navigation.</p>
+</li>
+<li><p><strong>Error resilience</strong> — all 18 hooks wrapped in try/except; a single
+broken callback never orphans spans or crashes the agent.</p>
+</li>
+<li><p><strong>Monotonic LLM numbering</strong> — per-turn counter that never resets,
+even after context compression.</p>
+</li>
+<li><p><strong>Three output formats</strong>, auto-written to <code>~/.hermes/traces/</code> at session end:</p>
+<ul>
+<li><strong>JSON</strong> (<code>&lt;session_id&gt;.json</code>) — full machine-readable graph</li>
+<li><strong>Mermaid</strong> (<code>&lt;session_id&gt;.mmd</code>) — flowchart for embedding in docs/issues</li>
+<li><strong>Text tree</strong> — rendered on demand via <code>/trace</code> or <code>hermes trace view</code></li>
+</ul>
+</li>
+<li><p><strong>Zero runtime dependencies</strong> — pure Python stdlib.</p>
+</li>
+</ul>
+<h3>Installation</h3>
+<h4>hermes plugins install (recommended)</h4>
+<pre><code class="language-bash">hermes plugins install hlothaire/hermes-trace
+hermes plugins enable hermes-trace
+</code></pre>
+<p>This is the official Hermes plugin distribution mechanism — no pip, no PyPI,
+no additional tooling needed.</p>
+<h4>pip (alternative)</h4>
+<pre><code class="language-bash">pip install hermes-trace
+</code></pre>
+<p>Hermes auto-discovers the plugin via the <code>hermes_agent.plugins</code> entry point.
+Then enable it:</p>
+<pre><code class="language-bash">hermes plugins enable hermes-trace
+</code></pre>
+<h4>Manual (development)</h4>
+<pre><code class="language-bash">git clone https://github.com/hlothaire/hermes-trace
+ln -s &quot;$PWD/hermes-trace&quot; ~/.hermes/plugins/hermes-trace/
+hermes plugins enable hermes-trace
+</code></pre>
+<h3>Architecture</h3>
+<pre><code>Session
+  └── Turn 1
+  │     ├── User message
+  │     ├── LLM call #1 (model, provider, tokens, duration)
+  │     ├── Tool call: read_file (args, result, duration)
+  │     ├── LLM call #2
+  │     └── Assistant response
+  ├── Turn 2
+  │     └── ...
+  └── Subagents
+        └── child_session_id (goal, status, duration)
+</code></pre>
+<h4>Source files</h4>
+<table>
+<thead>
+<tr>
+<th>File</th>
+<th>Purpose</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>plugin.yaml</code></td>
+<td>Plugin manifest — name, version, 18 hooks</td>
+</tr>
+<tr>
+<td><code>hermes_trace/__init__.py</code></td>
+<td><code>register()</code> — hooks, slash command, CLI registration</td>
+</tr>
+<tr>
+<td><code>hermes_trace/tracer.py</code></td>
+<td><code>TraceGraph</code>, <code>Span</code>, <code>Turn</code>, <code>Subagent</code> dataclasses + serialisation</td>
+</tr>
+<tr>
+<td><code>hermes_trace/cli.py</code></td>
+<td><code>hermes trace</code> subcommand handlers (list, view, stats, clean)</td>
+</tr>
+</tbody></table>
+<h4>Hooks</h4>
+<table>
+<thead>
+<tr>
+<th>Hook</th>
+<th>What it captures</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><code>on_session_start</code></td>
+<td>Model, platform, start time</td>
+</tr>
+<tr>
+<td><code>on_session_end</code></td>
+<td>Finalise + write JSON/Mermaid</td>
+</tr>
+<tr>
+<td><code>on_session_finalize</code></td>
+<td>Cleanup in-memory trace</td>
+</tr>
+<tr>
+<td><code>on_session_reset</code></td>
+<td>Record <code>/new</code> or <code>/reset</code> events</td>
+</tr>
+<tr>
+<td><code>pre_llm_call</code></td>
+<td>Start a new turn, backfill <code>started_at</code></td>
+</tr>
+<tr>
+<td><code>post_llm_call</code></td>
+<td>End turn, store assistant response</td>
+</tr>
+<tr>
+<td><code>pre_api_request</code></td>
+<td>LLM call start — model, provider, tokens, backfill session metadata</td>
+</tr>
+<tr>
+<td><code>post_api_request</code></td>
+<td>LLM call end — usage, finish reason, duration</td>
+</tr>
+<tr>
+<td><code>api_request_error</code></td>
+<td>Mark LLM call as errored</td>
+</tr>
+<tr>
+<td><code>pre_tool_call</code></td>
+<td>Tool call start — name, args, ID</td>
+</tr>
+<tr>
+<td><code>post_tool_call</code></td>
+<td>Tool call end — result, duration, status</td>
+</tr>
+<tr>
+<td><code>subagent_start</code></td>
+<td>Delegated subagent start — goal</td>
+</tr>
+<tr>
+<td><code>subagent_stop</code></td>
+<td>Subagent end — status, summary, duration</td>
+</tr>
+<tr>
+<td><code>pre_approval_request</code></td>
+<td>Approval prompt shown to user</td>
+</tr>
+<tr>
+<td><code>post_approval_response</code></td>
+<td>User&#39;s approval choice</td>
+</tr>
+<tr>
+<td><code>transform_tool_result</code></td>
+<td>Result seen by the model after plugin transforms</td>
+</tr>
+<tr>
+<td><code>transform_llm_output</code></td>
+<td>Final response after plugin transforms</td>
+</tr>
+<tr>
+<td><code>pre_gateway_dispatch</code></td>
+<td>Inbound gateway message (logged)</td>
+</tr>
+</tbody></table>
+<h3>Usage</h3>
+<h4>In a session</h4>
+<pre><code>/trace                 # show current trace as text tree
+/trace view &lt;id&gt;       # view a specific session
+/trace list            # list active traces
+/trace load &lt;id&gt;       # load and display a saved trace
+/trace gantt           # show ASCII Gantt timeline
+/trace export          # write JSON + Mermaid to ~/.hermes/traces/
+/trace mermaid         # output Mermaid flowchart
+/trace clear           # remove in-memory trace
+</code></pre>
+<h4>From the terminal</h4>
+<pre><code>hermes trace list                    # table of all saved traces
+hermes trace view 20260608_101004   # text tree (supports prefix matching)
+hermes trace stats 20260608_101004  # aggregate statistics
+hermes trace gantt 20260608_101004  # ASCII Gantt timeline
+hermes trace clean --keep 20        # keep the 20 most recent, delete the rest
+</code></pre>
+<h4>Output files</h4>
+<p>Traces are saved to <code>~/.hermes/traces/</code>:</p>
+<pre><code>~/.hermes/traces/
+├── 20260609_203712_a15113.json   # full trace graph
+├── 20260609_203712_a15113.mmd    # Mermaid flowchart
+└── ...
+</code></pre>
+<h3>Example trace</h3>
+<pre><code>Trace: 20260609_203712_a15113
+├── Model: deepseek-v4-pro | Platform: cli | Duration: 720.9s
+├── Turns: 5
+│   ├── Turn 1 (39.0s)
+│   │   ├── User: on va travailler sur hermes-trace...
+│   │   ├── LLM #1 (5359ms, in:13146 out:157)
+│   │   ├── ✓ read_file (58ms)
+│   │   ├── ✓ search_files (39ms)
+│   │   └── LLM #5 (15949ms, in:1317 out:774)
+│   ├── Turn 2 (157.8s)
+│   │   ├── ✓ patch (323ms)
+│   │   ├── ✗ execute_code (300004ms)
+│   │   └── ...
+│   ...
+
+─── Stats ───
+Turns: 5  LLM calls: 28  Tool calls: 22
+Tokens: 48,250 in / 7,894 out
+Slowest LLM: #19 (71.8s)
+Slowest tool: execute_code (300.0s)
+</code></pre>
+<h3>Development</h3>
+<pre><code class="language-bash"># Install dev dependencies
+pip install -e &quot;.[dev]&quot;
+
+# Run tests (46 tests, ~90% coverage on tracer.py)
+pytest tests/ -v
+
+# Lint
+ruff check hermes_trace/
+
+# Format
+ruff format hermes_trace/
+</code></pre>
+<p>Python 3.12+ required.  Zero runtime dependencies — only <code>pytest</code> and <code>ruff</code> for
+development.</p>
+<h3>License</h3>
+<p>MIT</p>
+
+  </section>
+</details>
+
+<aside class="related" aria-label="Related repos">
+  <div>
+    <div class="section-label">more in plugins &amp; extensions</div>
+    <div class="section-sub">other repos in this category, ranked by stars.</div>
+  </div>
+  <div>
+    <div class="related-list">
+      <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
+        <div class="stars">★ 280</div>
+        <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
+      </a>
+      <a class="related-row" href="/projects/42-evey/hermes-plugins">
+        <div class="stars">★ 220</div>
+        <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
+      </a>
+      <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
+        <div class="stars">★ 33</div>
+        <div class="name"><span class="org">FahrenheitResearch /</span> hermes-weather-plugin</div>
+      </a>
+      <a class="related-row" href="/projects/42-evey/evey-bridge-plugin">
+        <div class="stars">★ 13</div>
+        <div class="name"><span class="org">42-evey /</span> evey-bridge-plugin</div>
+      </a>
+      <a class="related-row" href="/projects/nativ3ai/hermes-payguard">
+        <div class="stars">★ 12</div>
+        <div class="name"><span class="org">nativ3ai /</span> hermes-payguard</div>
+      </a>
+      <a class="related-row" href="/projects/raulvidis/hermes-cloudflare">
+        <div class="stars">★ 26</div>
+        <div class="name"><span class="org">raulvidis /</span> hermes-cloudflare</div>
+      </a>
+      <a class="related-row" href="/projects/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server">
+        <div class="stars">★ 345</div>
+        <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
+      </a>
+      <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
+        <div class="stars">★ 285</div>
+        <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
+      </a>
+    </div>
+    
+  </div>
+</aside>
+
+</main>
+
+<footer class="page-footer">
+  <div class="fn-left">hermes atlas · curated by <a href="https://github.com/ksimback">ksimback</a> · <a href="https://github.com/ksimback/hermes-ecosystem/issues">suggest a repo</a> · <a href="/privacy">privacy</a></div>
+  <div>v2 · 2026.04</div>
+</footer>
+
+<script>(function(){var t=document.getElementById('theme-toggle');if(!t)return;function render(){var c=document.documentElement.getAttribute('data-theme');t.querySelector('.tt-light').classList.toggle('tt-active',c==='light');t.querySelector('.tt-dark').classList.toggle('tt-active',c!=='light');}render();t.addEventListener('click',function(){var c=document.documentElement.getAttribute('data-theme');var n=c==='light'?'dark':'light';document.documentElement.setAttribute('data-theme',n);try{localStorage.setItem('theme',n)}catch(e){}render();});})();</script>
+<script src="/assets/js/masthead-fetch.js" defer></script>
+<!-- Cloudflare Web Analytics -->
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js"
+        data-cf-beacon='{"token": "fe0d4d79280b4386b6b0cd99b2d94dbc"}'></script>
+<!-- End Cloudflare Web Analytics -->
+</body>
+</html>

--- a/projects/howdymary/hermes-agent-metaharness.html
+++ b/projects/howdymary/hermes-agent-metaharness.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 93
+    "userInteractionCount": 94
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">An implementation of a Meta Harness for Hermes.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 93</span>
+    <span class="stars">★ 94</span>
     <span><span class="meta-label">lang</span>Python</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -345,7 +345,7 @@ and how they map onto this repo&#39;s next steps.</p>
         <div class="name"><span class="org">builderz-labs /</span> mission-control</div>
       </a>
       <a class="related-row" href="/projects/swarmclawai/swarmclaw">
-        <div class="stars">★ 583</div>
+        <div class="stars">★ 584</div>
         <div class="name"><span class="org">swarmclawai /</span> swarmclaw</div>
       </a>
       <a class="related-row" href="/projects/runtimenoteslabs/gladiator">
@@ -353,7 +353,7 @@ and how they map onto this repo&#39;s next steps.</p>
         <div class="name"><span class="org">runtimenoteslabs /</span> gladiator</div>
       </a>
       <a class="related-row" href="/projects/1ilkhamov/opencode-hermes-multiagent">
-        <div class="stars">★ 140</div>
+        <div class="stars">★ 141</div>
         <div class="name"><span class="org">1ilkhamov /</span> opencode-hermes-multiagent</div>
       </a>
       <a class="related-row" href="/projects/Rainhoole/hermes-agent-acp-skill">
@@ -365,11 +365,11 @@ and how they map onto this repo&#39;s next steps.</p>
         <div class="name"><span class="org">linke-ai /</span> hermes-agent-team</div>
       </a>
       <a class="related-row" href="/projects/Agent-3-7/minions">
-        <div class="stars">★ 577</div>
+        <div class="stars">★ 578</div>
         <div class="name"><span class="org">Agent-3-7 /</span> minions</div>
       </a>
       <a class="related-row" href="/projects/CryptoDmitry/hermes-agent-control-room">
-        <div class="stars">★ 844</div>
+        <div class="stars">★ 856</div>
         <div class="name"><span class="org">CryptoDmitry /</span> hermes-agent-control-room</div>
       </a>
     </div>

--- a/projects/hxsteric/mercury.html
+++ b/projects/hxsteric/mercury.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -321,7 +321,7 @@ python3 scripts/dashboard_server.py \
         <div class="name"><span class="org">JackTheGit /</span> hermes-ai-infrastructure-monitoring-toolkit</div>
       </a>
       <a class="related-row" href="/projects/bigph00t/hermescraft">
-        <div class="stars">★ 41</div>
+        <div class="stars">★ 42</div>
         <div class="name"><span class="org">bigph00t /</span> hermescraft</div>
       </a>
       <a class="related-row" href="/projects/bryercowan/hermes-embodied">

--- a/projects/iOfficeAI/AionUi.html
+++ b/projects/iOfficeAI/AionUi.html
@@ -47,13 +47,13 @@
     "name": "iOfficeAI",
     "url": "https://github.com/iOfficeAI"
   },
-  "dateModified": "2026-06-16T08:05:07.000Z",
+  "dateModified": "2026-06-16T13:08:33.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 28344
+    "userInteractionCount": 28371
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Free, local, open-source 24/7 Cowork app for OpenClaw, Hermes Agent, Claude Code, Codex, OpenCode, Gemini CLI and 20+ more CLI | Customize your assistants | Star if you like it!</p>
 
   <div class="meta-row">
-    <span class="stars">★ 28.3K</span>
+    <span class="stars">★ 28.4K</span>
     <span><span class="meta-label">lang</span>TypeScript</span>
     <span><span class="meta-label">license</span>Apache-2.0</span>
     
@@ -922,7 +922,7 @@ bun run test       # run unit tests
         <div class="name"><span class="org">Euraika-Labs /</span> pan-ui</div>
       </a>
       <a class="related-row" href="/projects/Eynzof/hermes-agent-cn-desktop">
-        <div class="stars">★ 445</div>
+        <div class="stars">★ 456</div>
         <div class="name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       </a>
       <a class="related-row" href="/projects/Felix-Forever/hermes-agent-desktop">
@@ -930,7 +930,7 @@ bun run test       # run unit tests
         <div class="name"><span class="org">Felix-Forever /</span> hermes-agent-desktop</div>
       </a>
       <a class="related-row" href="/projects/jazzyalex/agent-sessions">
-        <div class="stars">★ 640</div>
+        <div class="stars">★ 641</div>
         <div class="name"><span class="org">jazzyalex /</span> agent-sessions</div>
       </a>
       <a class="related-row" href="/projects/nickvasilescu/hermes-desktop-os1">

--- a/projects/indranilbanerjee/digital-marketing-pro.html
+++ b/projects/indranilbanerjee/digital-marketing-pro.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 142
+    "userInteractionCount": 143
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Open-source AI marketing plugin for agencies &amp; in-house teams — 158 skills, 25 specialist agents, 12-Part Strategy Flow, Cowork team-persistent, EU AI Act Article 50 ready, 6-platform AEO/GEO incl. Google AI Mode. Installs on Claude Code, Cowork, Codex, Cursor, Copilot CLI, Antigravity. MIT-licensed.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 142</span>
+    <span class="stars">★ 143</span>
     <span><span class="meta-label">lang</span>Python</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -1039,11 +1039,11 @@ Removed the v3.6 / v3.7 era invented manifests for OpenAI Codex (<code>.codex-pl
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 279</div>
+        <div class="stars">★ 280</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 217</div>
+        <div class="stars">★ 220</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -1063,11 +1063,11 @@ Removed the v3.6 / v3.7 era invented manifests for OpenAI Codex (<code>.codex-pl
         <div class="name"><span class="org">raulvidis /</span> hermes-cloudflare</div>
       </a>
       <a class="related-row" href="/projects/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server">
-        <div class="stars">★ 343</div>
+        <div class="stars">★ 345</div>
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 284</div>
+        <div class="stars">★ 285</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
     </div>

--- a/projects/indranilbanerjee/socialforge.html
+++ b/projects/indranilbanerjee/socialforge.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 5
+    "userInteractionCount": 6
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Open-source agency-grade social media production plugin — 16 skills, 25 commands, AI image (Nano Banana Pro) + AI video (Kling v3.0 Pro) + C2PA signing (EU AI Act Article 50). Installs on Claude Code, Cowork, Codex, Cursor, Copilot CLI, Antigravity. By Indranil Banerjee (indranil.in).</p>
 
   <div class="meta-row">
-    <span class="stars">★ 5</span>
+    <span class="stars">★ 6</span>
     <span><span class="meta-label">lang</span>Python</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -641,11 +641,11 @@ claude plugin install socialforge@neels-plugins
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 279</div>
+        <div class="stars">★ 280</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 217</div>
+        <div class="stars">★ 220</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -665,11 +665,11 @@ claude plugin install socialforge@neels-plugins
         <div class="name"><span class="org">raulvidis /</span> hermes-cloudflare</div>
       </a>
       <a class="related-row" href="/projects/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server">
-        <div class="stars">★ 343</div>
+        <div class="stars">★ 345</div>
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 284</div>
+        <div class="stars">★ 285</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
     </div>

--- a/projects/jau123/MeiGen-AI-Design-MCP.html
+++ b/projects/jau123/MeiGen-AI-Design-MCP.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 1448
+    "userInteractionCount": 1451
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Supports GPT Image 2, Nanobanana &amp; ComfyUI, with a 1,400+ prompt library, carefully crafted hooks and a multi-task orchestration system</p>
 
   <div class="meta-row">
-    <span class="stars">★ 1.4K</span>
+    <span class="stars">★ 1.5K</span>
     <span><span class="meta-label">lang</span>TypeScript</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -562,11 +562,11 @@ Response: { &quot;success&quot;: true, &quot;presignedUrl&quot;: &quot;https://.
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 279</div>
+        <div class="stars">★ 280</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 217</div>
+        <div class="stars">★ 220</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -586,11 +586,11 @@ Response: { &quot;success&quot;: true, &quot;presignedUrl&quot;: &quot;https://.
         <div class="name"><span class="org">raulvidis /</span> hermes-cloudflare</div>
       </a>
       <a class="related-row" href="/projects/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server">
-        <div class="stars">★ 343</div>
+        <div class="stars">★ 345</div>
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 284</div>
+        <div class="stars">★ 285</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
     </div>

--- a/projects/jazzyalex/agent-sessions.html
+++ b/projects/jazzyalex/agent-sessions.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 640
+    "userInteractionCount": 641
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Local-first macOS app to browse, search, analyze, and resume supported AI coding-agent session history across Codex, Claude Code, OpenCode, Cursor Agent, Hermes, OpenClaw, Copilot CLI, and more.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 640</span>
+    <span class="stars">★ 641</span>
     <span><span class="meta-label">lang</span>Swift</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -370,7 +370,7 @@ open &quot;/Applications/Agent Sessions.app&quot;
         <div class="name"><span class="org">Euraika-Labs /</span> pan-ui</div>
       </a>
       <a class="related-row" href="/projects/Eynzof/hermes-agent-cn-desktop">
-        <div class="stars">★ 445</div>
+        <div class="stars">★ 456</div>
         <div class="name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       </a>
       <a class="related-row" href="/projects/Felix-Forever/hermes-agent-desktop">
@@ -382,7 +382,7 @@ open &quot;/Applications/Agent Sessions.app&quot;
         <div class="name"><span class="org">nickvasilescu /</span> hermes-desktop-os1</div>
       </a>
       <a class="related-row" href="/projects/farion1231/cc-switch">
-        <div class="stars">★ 102.1K</div>
+        <div class="stars">★ 102.6K</div>
         <div class="name"><span class="org">farion1231 /</span> cc-switch</div>
       </a>
     </div>

--- a/projects/jefferyjob/awesome-hermes-agent-zh.html
+++ b/projects/jefferyjob/awesome-hermes-agent-zh.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -482,7 +482,7 @@
         <div class="name"><span class="org">alchaincyf /</span> hermes-agent-orange-book</div>
       </a>
       <a class="related-row" href="/projects/OnlyTerp/hermes-optimization-guide">
-        <div class="stars">★ 442</div>
+        <div class="stars">★ 444</div>
         <div class="name"><span class="org">OnlyTerp /</span> hermes-optimization-guide</div>
       </a>
       <a class="related-row" href="/projects/metantonio/hermes-wsl-ubuntu">

--- a/projects/joeynyc/hermes-skins.html
+++ b/projects/joeynyc/hermes-skins.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -320,11 +320,11 @@ branding:
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/colbymchenry/codegraph">
-        <div class="stars">★ 50.0K</div>
+        <div class="stars">★ 50.2K</div>
         <div class="name"><span class="org">colbymchenry /</span> codegraph</div>
       </a>
       <a class="related-row" href="/projects/Salomondiei08/oh-my-hermes">
-        <div class="stars">★ 532</div>
+        <div class="stars">★ 551</div>
         <div class="name"><span class="org">Salomondiei08 /</span> oh-my-hermes</div>
       </a>
       <a class="related-row" href="/projects/liaohch3/claude-tap">
@@ -332,7 +332,7 @@ branding:
         <div class="name"><span class="org">liaohch3 /</span> claude-tap</div>
       </a>
       <a class="related-row" href="/projects/adityahimaone/hermes-agent-rtk-caveman">
-        <div class="stars">★ 61</div>
+        <div class="stars">★ 62</div>
         <div class="name"><span class="org">adityahimaone /</span> hermes-agent-rtk-caveman</div>
       </a>
       <a class="related-row" href="/projects/junhoyeo/tokscale">

--- a/projects/jpalmae/hermeshq.html
+++ b/projects/jpalmae/hermeshq.html
@@ -46,7 +46,7 @@
     "name": "jpalmae",
     "url": "https://github.com/jpalmae"
   },
-  "dateModified": "2026-06-16T00:14:53.000Z",
+  "dateModified": "2026-06-16T15:05:36.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -605,7 +605,7 @@ tts:
         <div class="name"><span class="org">numtide /</span> llm-agents.nix</div>
       </a>
       <a class="related-row" href="/projects/TheAiSingularity/hermesclaw">
-        <div class="stars">★ 53</div>
+        <div class="stars">★ 52</div>
         <div class="name"><span class="org">TheAiSingularity /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/0xrsydn/nix-hermes-agent">

--- a/projects/junhoyeo/tokscale.html
+++ b/projects/junhoyeo/tokscale.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 3750
+    "userInteractionCount": 3768
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -1390,11 +1390,11 @@ bun run dev
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/colbymchenry/codegraph">
-        <div class="stars">★ 50.0K</div>
+        <div class="stars">★ 50.2K</div>
         <div class="name"><span class="org">colbymchenry /</span> codegraph</div>
       </a>
       <a class="related-row" href="/projects/Salomondiei08/oh-my-hermes">
-        <div class="stars">★ 532</div>
+        <div class="stars">★ 551</div>
         <div class="name"><span class="org">Salomondiei08 /</span> oh-my-hermes</div>
       </a>
       <a class="related-row" href="/projects/liaohch3/claude-tap">
@@ -1402,7 +1402,7 @@ bun run dev
         <div class="name"><span class="org">liaohch3 /</span> claude-tap</div>
       </a>
       <a class="related-row" href="/projects/adityahimaone/hermes-agent-rtk-caveman">
-        <div class="stars">★ 61</div>
+        <div class="stars">★ 62</div>
         <div class="name"><span class="org">adityahimaone /</span> hermes-agent-rtk-caveman</div>
       </a>
       <a class="related-row" href="/projects/joeynyc/hermes-skins">

--- a/projects/jwangkun/hermes-agent-guide.html
+++ b/projects/jwangkun/hermes-agent-guide.html
@@ -52,7 +52,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 367
+    "userInteractionCount": 370
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -111,7 +111,7 @@
   <p class="project-desc">Hermes Agent 是目前开源社区最具潜力的 AI Agent 框架之一。它继承了 OpenClaw 的优秀基因，在架构设计、记忆系统、技能生态和自动化能力上实现全面升级。但 Hermes 的文档分散在多个仓库和平台，缺乏一本系统性的中文指南。  本书填补的正是这个空白。全书 16 册、30 万+ 字，覆盖从安装部署到高阶开发、从个人玩赚到企业服务、从单 Agent 操控到多 Agent 编排的完整知识图谱。</p>
 
   <div class="meta-row">
-    <span class="stars">★ 367</span>
+    <span class="stars">★ 370</span>
     <span><span class="meta-label">lang</span>Python</span>
     
     
@@ -413,7 +413,7 @@ python generate_pdf.py
         <div class="name"><span class="org">alchaincyf /</span> hermes-agent-orange-book</div>
       </a>
       <a class="related-row" href="/projects/OnlyTerp/hermes-optimization-guide">
-        <div class="stars">★ 442</div>
+        <div class="stars">★ 444</div>
         <div class="name"><span class="org">OnlyTerp /</span> hermes-optimization-guide</div>
       </a>
       <a class="related-row" href="/projects/metantonio/hermes-wsl-ubuntu">

--- a/projects/kaminocorp/hermes-alpha.html
+++ b/projects/kaminocorp/hermes-alpha.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -437,7 +437,7 @@ SLACK_BOT_TOKEN=...
         <div class="name"><span class="org">carterwayneskhizeine /</span> hermes-agent-windows-R</div>
       </a>
       <a class="related-row" href="/projects/sheawinkler/hermes-agent-ultra">
-        <div class="stars">★ 46</div>
+        <div class="stars">★ 49</div>
         <div class="name"><span class="org">sheawinkler /</span> hermes-agent-ultra</div>
       </a>
       <a class="related-row" href="/projects/pengchengxia75-arch/hermes-agent-windows">

--- a/projects/keepnotes-ai/keep.html
+++ b/projects/keepnotes-ai/keep.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>

--- a/projects/kevinmarmstrong/hermes-claude-code-rc.html
+++ b/projects/kevinmarmstrong/hermes-claude-code-rc.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -400,11 +400,11 @@ Phone (Claude app) &lt;-- claude.ai session URL &lt;-- stdout scan
         <div class="name"><span class="org">gizdusum /</span> hermes-blockchain-oracle</div>
       </a>
       <a class="related-row" href="/projects/AaronWong1999/hermesclaw">
-        <div class="stars">★ 620</div>
+        <div class="stars">★ 621</div>
         <div class="name"><span class="org">AaronWong1999 /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/Codename-11/hermes-relay">
-        <div class="stars">★ 34</div>
+        <div class="stars">★ 35</div>
         <div class="name"><span class="org">Codename-11 /</span> hermes-relay</div>
       </a>
       <a class="related-row" href="/projects/kfa-ai/hermes-timetree-sync">

--- a/projects/kfa-ai/hermes-timetree-sync.html
+++ b/projects/kfa-ai/hermes-timetree-sync.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -325,11 +325,11 @@ TIMETREE_PASSWORD=...
         <div class="name"><span class="org">kevinmarmstrong /</span> hermes-claude-code-rc</div>
       </a>
       <a class="related-row" href="/projects/AaronWong1999/hermesclaw">
-        <div class="stars">★ 620</div>
+        <div class="stars">★ 621</div>
         <div class="name"><span class="org">AaronWong1999 /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/Codename-11/hermes-relay">
-        <div class="stars">★ 34</div>
+        <div class="stars">★ 35</div>
         <div class="name"><span class="org">Codename-11 /</span> hermes-relay</div>
       </a>
       <a class="related-row" href="/projects/BORT-AGENTS/hermes-bort">

--- a/projects/ksimback/hermes-ecosystem.html
+++ b/projects/ksimback/hermes-ecosystem.html
@@ -46,13 +46,13 @@
     "name": "ksimback",
     "url": "https://github.com/ksimback"
   },
-  "dateModified": "2026-06-15T14:45:42.000Z",
+  "dateModified": "2026-06-16T12:08:24.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 1015
+    "userInteractionCount": 1018
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -115,7 +115,7 @@
     <span><span class="meta-label">lang</span>HTML</span>
     
     
-    <span><span class="meta-label">updated</span>2026-06-15</span>
+    <span><span class="meta-label">updated</span>2026-06-16</span>
   </div>
 
   <div class="actions">
@@ -310,7 +310,7 @@ OPENROUTER_API_KEY=sk-or-... node scripts/test-rag.js
         <div class="name"><span class="org">alchaincyf /</span> hermes-agent-orange-book</div>
       </a>
       <a class="related-row" href="/projects/OnlyTerp/hermes-optimization-guide">
-        <div class="stars">★ 442</div>
+        <div class="stars">★ 444</div>
         <div class="name"><span class="org">OnlyTerp /</span> hermes-optimization-guide</div>
       </a>
       <a class="related-row" href="/projects/metantonio/hermes-wsl-ubuntu">

--- a/projects/liaohch3/claude-tap.html
+++ b/projects/liaohch3/claude-tap.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 1798
+    "userInteractionCount": 1807
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -717,15 +717,15 @@ claude-tap --tap-no-open
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/colbymchenry/codegraph">
-        <div class="stars">★ 50.0K</div>
+        <div class="stars">★ 50.2K</div>
         <div class="name"><span class="org">colbymchenry /</span> codegraph</div>
       </a>
       <a class="related-row" href="/projects/Salomondiei08/oh-my-hermes">
-        <div class="stars">★ 532</div>
+        <div class="stars">★ 551</div>
         <div class="name"><span class="org">Salomondiei08 /</span> oh-my-hermes</div>
       </a>
       <a class="related-row" href="/projects/adityahimaone/hermes-agent-rtk-caveman">
-        <div class="stars">★ 61</div>
+        <div class="stars">★ 62</div>
         <div class="name"><span class="org">adityahimaone /</span> hermes-agent-rtk-caveman</div>
       </a>
       <a class="related-row" href="/projects/junhoyeo/tokscale">

--- a/projects/liftaris/herm.html
+++ b/projects/liftaris/herm.html
@@ -47,13 +47,13 @@
     "name": "liftaris",
     "url": "https://github.com/liftaris"
   },
-  "dateModified": "2026-06-16T06:28:47.000Z",
+  "dateModified": "2026-06-16T15:28:39.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 253
+    "userInteractionCount": 254
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">The Hermes TUI built with OpenTUI</p>
 
   <div class="meta-row">
-    <span class="stars">★ 253</span>
+    <span class="stars">★ 254</span>
     <span><span class="meta-label">lang</span>TypeScript</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -222,43 +222,49 @@ the same shell you use for chat.</li>
 discover, inspect, install, use, update, and remove.</p>
 <p>In Herm:</p>
 <ul>
-<li>Open Eikon → Marketplace, or run <code>/marketplace</code>, to browse shared catalog
+<li>Open Eikon → Catalog, or run <code>/catalog</code>, to browse shared catalog
 entries.</li>
 <li>Preview rows before installing. Trust is shown as <code>Verified</code>, <code>Unverified</code>,
 or <code>Mismatch</code> beside source and compatibility state.</li>
 <li>Install adds the eikon to your local library without activating it.</li>
 <li>Use selects an installed eikon as the active avatar.</li>
+<li>Installing over the currently active eikon name also requires confirmation or
+<code>--active-ok</code> because it replaces the active avatar&#39;s backing package.</li>
 <li>Update or remove an active eikon only after confirming that the active
 avatar&#39;s backing package will change or be cleared.</li>
 </ul>
 <p>From the shell:</p>
-<pre><code class="language-bash">herm eikon search [query]
-herm eikon inspect &lt;name|github.com/user/repo/eikon-name|dir&gt;
-herm eikon install &lt;name|github.com/user/repo/eikon-name|dir&gt;
-herm eikon use &lt;name&gt;
-herm eikon info &lt;name&gt;
-herm eikon update &lt;name&gt; --active-ok
-herm eikon remove &lt;name&gt; --active-ok
+<pre><code class="language-bash">herm eikon search [query] [--json]
+herm eikon browse [query] [--json]
+herm eikon inspect &lt;name|url|dir&gt; [--json]
+herm eikon install &lt;name|url|dir&gt; [--name N] [--no-source] [--active-ok] [--json]
+herm eikon list [--json]
+herm eikon use &lt;name&gt; [--json]
+herm eikon info &lt;name&gt; [--json]
+herm eikon update &lt;name&gt; [--active-ok] [--json]
+herm eikon remove &lt;name&gt; [--active-ok] [--json]
+herm eikon delist &lt;name|id&gt; [--json]
 </code></pre>
 <p><code>install</code> never activates. <code>use</code> is the activation action. JSON output is
 available for automation with <code>--json</code>.</p>
-<p>Default Marketplace installs fetch built package artifacts referenced by the
+<p>Default Catalog installs fetch built package artifacts referenced by the
 catalog, not creator repositories. Direct GitHub installs are for sharing
 outside the default catalog and support both single-package repos and
 multi-eikon catalog repos addressed as <code>github.com/user/repo/eikon-name</code>.
 Private GitHub repos use normal git authentication.</p>
 <p>Creators can share Eikons through normal GitHub repositories. For official
-registry listing, use Eikon → Studio/Gallery → submit after baking. Herm previews
-the exact public bundle, asks for title/author/description/glyph, and either
-creates a GitHub PR through local <code>gh</code> auth or gives a browser/manual PR
-fallback with copyable bundle and PR text. Direct-install repos can still be
-prepared with upstream <code>eikon pack</code>, <code>eikon index</code>, and <code>eikon manifest</code>.
+registry listing, press <code>u</code> in Studio or use Library&#39;s Share to catalog action
+after baking. Herm previews metadata, the prepared public bundle, and the GitHub
+PR target; with local <code>gh</code> auth it creates the PR, otherwise it shows manual PR
+steps with the prepared bundle path and compare URL. Direct-install repos can
+still be prepared with upstream <code>eikon pack</code>, <code>eikon index</code>, and
+<code>eikon manifest</code>.
 <code>eikon publish</code> remains the lower-level GitHub PR contribution helper for the
 configured/default catalog repo; it is not a hosted marketplace account, upload,
 dashboard, or moderation flow.</p>
 <p>Use <code>eikon.liftaris.dev</code> as a discovery gallery only; it previews catalog
 entries and gives copyable Herm install instructions.</p>
-<p>Herm owns native Marketplace behavior. The eikon repo owns the registry,
+<p>Herm owns native Catalog behavior. The eikon repo owns the registry,
 browser mirror, shared catalog/player exports, install resolver, and publish
 preflight. Herm imports public eikon package exports rather than browser mirror
 internals or unexported source paths.</p>
@@ -324,7 +330,7 @@ runtime Herm operates</li>
         <div class="name"><span class="org">Euraika-Labs /</span> pan-ui</div>
       </a>
       <a class="related-row" href="/projects/Eynzof/hermes-agent-cn-desktop">
-        <div class="stars">★ 445</div>
+        <div class="stars">★ 456</div>
         <div class="name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       </a>
       <a class="related-row" href="/projects/Felix-Forever/hermes-agent-desktop">
@@ -332,7 +338,7 @@ runtime Herm operates</li>
         <div class="name"><span class="org">Felix-Forever /</span> hermes-agent-desktop</div>
       </a>
       <a class="related-row" href="/projects/jazzyalex/agent-sessions">
-        <div class="stars">★ 640</div>
+        <div class="stars">★ 641</div>
         <div class="name"><span class="org">jazzyalex /</span> agent-sessions</div>
       </a>
       <a class="related-row" href="/projects/nickvasilescu/hermes-desktop-os1">

--- a/projects/linke-ai/hermes-agent-team.html
+++ b/projects/linke-ai/hermes-agent-team.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -347,11 +347,11 @@ pip install -r requirements.txt
         <div class="name"><span class="org">builderz-labs /</span> mission-control</div>
       </a>
       <a class="related-row" href="/projects/swarmclawai/swarmclaw">
-        <div class="stars">★ 583</div>
+        <div class="stars">★ 584</div>
         <div class="name"><span class="org">swarmclawai /</span> swarmclaw</div>
       </a>
       <a class="related-row" href="/projects/howdymary/hermes-agent-metaharness">
-        <div class="stars">★ 93</div>
+        <div class="stars">★ 94</div>
         <div class="name"><span class="org">howdymary /</span> hermes-agent-metaharness</div>
       </a>
       <a class="related-row" href="/projects/runtimenoteslabs/gladiator">
@@ -359,7 +359,7 @@ pip install -r requirements.txt
         <div class="name"><span class="org">runtimenoteslabs /</span> gladiator</div>
       </a>
       <a class="related-row" href="/projects/1ilkhamov/opencode-hermes-multiagent">
-        <div class="stars">★ 140</div>
+        <div class="stars">★ 141</div>
         <div class="name"><span class="org">1ilkhamov /</span> opencode-hermes-multiagent</div>
       </a>
       <a class="related-row" href="/projects/Rainhoole/hermes-agent-acp-skill">
@@ -367,11 +367,11 @@ pip install -r requirements.txt
         <div class="name"><span class="org">Rainhoole /</span> hermes-agent-acp-skill</div>
       </a>
       <a class="related-row" href="/projects/Agent-3-7/minions">
-        <div class="stars">★ 577</div>
+        <div class="stars">★ 578</div>
         <div class="name"><span class="org">Agent-3-7 /</span> minions</div>
       </a>
       <a class="related-row" href="/projects/CryptoDmitry/hermes-agent-control-room">
-        <div class="stars">★ 844</div>
+        <div class="stars">★ 856</div>
         <div class="name"><span class="org">CryptoDmitry /</span> hermes-agent-control-room</div>
       </a>
     </div>

--- a/projects/longyunfeigu/learn-hermes-agent.html
+++ b/projects/longyunfeigu/learn-hermes-agent.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 153
+    "userInteractionCount": 154
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">A 27-chapter hands-on tutorial for building an autonomous AI agent from zero in Python. Agent loop, tool system, memory, skills, MCP,     multi-platform gateway, and self-evolution — inspired by Hermes Agent.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 153</span>
+    <span class="stars">★ 154</span>
     <span><span class="meta-label">lang</span>Python</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -695,7 +695,7 @@ cp .env.example .env
         <div class="name"><span class="org">alchaincyf /</span> hermes-agent-orange-book</div>
       </a>
       <a class="related-row" href="/projects/OnlyTerp/hermes-optimization-guide">
-        <div class="stars">★ 442</div>
+        <div class="stars">★ 444</div>
         <div class="name"><span class="org">OnlyTerp /</span> hermes-optimization-guide</div>
       </a>
       <a class="related-row" href="/projects/metantonio/hermes-wsl-ubuntu">

--- a/projects/mag3nt-com/openclaw-skill.html
+++ b/projects/mag3nt-com/openclaw-skill.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -334,7 +334,7 @@ Agent: Calling the market feed API...
         <div class="name"><span class="org">wondelai /</span> skills</div>
       </a>
       <a class="related-row" href="/projects/DougTrajano/pydantic-ai-skills">
-        <div class="stars">★ 314</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">DougTrajano /</span> pydantic-ai-skills</div>
       </a>
       <a class="related-row" href="/projects/Agents365-ai/drawio-skill">
@@ -346,7 +346,7 @@ Agent: Calling the market feed API...
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 175</div>
+        <div class="stars">★ 176</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/marshallrichards/ClawPhone.html
+++ b/projects/marshallrichards/ClawPhone.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -213,7 +213,7 @@ export TEMP=&quot;$TMPDIR&quot;
         <div class="name"><span class="org">numtide /</span> llm-agents.nix</div>
       </a>
       <a class="related-row" href="/projects/TheAiSingularity/hermesclaw">
-        <div class="stars">★ 53</div>
+        <div class="stars">★ 52</div>
         <div class="name"><span class="org">TheAiSingularity /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/0xrsydn/nix-hermes-agent">

--- a/projects/martymcenroe/HermesWiki.html
+++ b/projects/martymcenroe/HermesWiki.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -181,7 +181,7 @@
         <div class="name"><span class="org">alchaincyf /</span> hermes-agent-orange-book</div>
       </a>
       <a class="related-row" href="/projects/OnlyTerp/hermes-optimization-guide">
-        <div class="stars">★ 442</div>
+        <div class="stars">★ 444</div>
         <div class="name"><span class="org">OnlyTerp /</span> hermes-optimization-guide</div>
       </a>
       <a class="related-row" href="/projects/metantonio/hermes-wsl-ubuntu">

--- a/projects/mem0ai/mem0.html
+++ b/projects/mem0ai/mem0.html
@@ -47,13 +47,13 @@
     "name": "mem0ai",
     "url": "https://github.com/mem0ai"
   },
-  "dateModified": "2026-06-16T07:10:33.000Z",
+  "dateModified": "2026-06-16T11:29:06.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 58675
+    "userInteractionCount": 58717
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>

--- a/projects/metantonio/hermes-wsl-ubuntu.html
+++ b/projects/metantonio/hermes-wsl-ubuntu.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -825,7 +825,7 @@ chmod 755 /opt/llama.cpp/build/bin/llama-server
         <div class="name"><span class="org">alchaincyf /</span> hermes-agent-orange-book</div>
       </a>
       <a class="related-row" href="/projects/OnlyTerp/hermes-optimization-guide">
-        <div class="stars">★ 442</div>
+        <div class="stars">★ 444</div>
         <div class="name"><span class="org">OnlyTerp /</span> hermes-optimization-guide</div>
       </a>
       <a class="related-row" href="/projects/mudrii/hermes-agent-docs">

--- a/projects/mudrii/hermes-agent-docs.html
+++ b/projects/mudrii/hermes-agent-docs.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -1009,7 +1009,7 @@ hermes update       # Update to the latest version (with auto-restart for gatewa
         <div class="name"><span class="org">alchaincyf /</span> hermes-agent-orange-book</div>
       </a>
       <a class="related-row" href="/projects/OnlyTerp/hermes-optimization-guide">
-        <div class="stars">★ 442</div>
+        <div class="stars">★ 444</div>
         <div class="name"><span class="org">OnlyTerp /</span> hermes-optimization-guide</div>
       </a>
       <a class="related-row" href="/projects/metantonio/hermes-wsl-ubuntu">

--- a/projects/mukul975/Anthropic-Cybersecurity-Skills.html
+++ b/projects/mukul975/Anthropic-Cybersecurity-Skills.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 15877
+    "userInteractionCount": 15936
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -865,7 +865,7 @@ LangChain · CrewAI · AutoGen · Semantic Kernel · Haystack · Vercel AI SDK �
         <div class="name"><span class="org">wondelai /</span> skills</div>
       </a>
       <a class="related-row" href="/projects/DougTrajano/pydantic-ai-skills">
-        <div class="stars">★ 314</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">DougTrajano /</span> pydantic-ai-skills</div>
       </a>
       <a class="related-row" href="/projects/Agents365-ai/drawio-skill">
@@ -877,7 +877,7 @@ LangChain · CrewAI · AutoGen · Semantic Kernel · Haystack · Vercel AI SDK �
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 175</div>
+        <div class="stars">★ 176</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/nativ3ai/hermes-agent-camel.html
+++ b/projects/nativ3ai/hermes-agent-camel.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -403,7 +403,7 @@ scripts/run_tests.sh
         <div class="name"><span class="org">carterwayneskhizeine /</span> hermes-agent-windows-R</div>
       </a>
       <a class="related-row" href="/projects/sheawinkler/hermes-agent-ultra">
-        <div class="stars">★ 46</div>
+        <div class="stars">★ 49</div>
         <div class="name"><span class="org">sheawinkler /</span> hermes-agent-ultra</div>
       </a>
       <a class="related-row" href="/projects/pengchengxia75-arch/hermes-agent-windows">

--- a/projects/nativ3ai/hermes-payguard.html
+++ b/projects/nativ3ai/hermes-payguard.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -326,11 +326,11 @@ pytest -q
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 279</div>
+        <div class="stars">★ 280</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 217</div>
+        <div class="stars">★ 220</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -346,15 +346,15 @@ pytest -q
         <div class="name"><span class="org">raulvidis /</span> hermes-cloudflare</div>
       </a>
       <a class="related-row" href="/projects/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server">
-        <div class="stars">★ 343</div>
+        <div class="stars">★ 345</div>
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 284</div>
+        <div class="stars">★ 285</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
       <a class="related-row" href="/projects/clawshell/clawshell">
-        <div class="stars">★ 294</div>
+        <div class="stars">★ 295</div>
         <div class="name"><span class="org">clawshell /</span> clawshell</div>
       </a>
     </div>

--- a/projects/ndesv21/socialclaw.html
+++ b/projects/ndesv21/socialclaw.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 24
+    "userInteractionCount": 25
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Social media scheduling CLI and OpenClaw skill for AI agents posting to X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, and Pinterest.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 24</span>
+    <span class="stars">★ 25</span>
     <span><span class="meta-label">lang</span>JavaScript</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -399,11 +399,11 @@ npm publish --access public
         <div class="name"><span class="org">kevinmarmstrong /</span> hermes-claude-code-rc</div>
       </a>
       <a class="related-row" href="/projects/AaronWong1999/hermesclaw">
-        <div class="stars">★ 620</div>
+        <div class="stars">★ 621</div>
         <div class="name"><span class="org">AaronWong1999 /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/Codename-11/hermes-relay">
-        <div class="stars">★ 34</div>
+        <div class="stars">★ 35</div>
         <div class="name"><span class="org">Codename-11 /</span> hermes-relay</div>
       </a>
       <a class="related-row" href="/projects/kfa-ai/hermes-timetree-sync">

--- a/projects/nesquena/hermes-webui.html
+++ b/projects/nesquena/hermes-webui.html
@@ -47,13 +47,13 @@
     "name": "nesquena",
     "url": "https://github.com/nesquena"
   },
-  "dateModified": "2026-06-16T06:00:59.000Z",
+  "dateModified": "2026-06-16T18:22:09.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 14520
+    "userInteractionCount": 14553
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Hermes WebUI: The best way to use Hermes Agent from the web or from your phone!</p>
 
   <div class="meta-row">
-    <span class="stars">★ 14.5K</span>
+    <span class="stars">★ 14.6K</span>
     <span><span class="meta-label">lang</span>Python</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -329,15 +329,15 @@ python3 bootstrap.py
 </tr>
 </thead>
 <tbody><tr>
-<td><code>python3 bootstrap.py</code> or <code>./start.sh</code></td>
-<td><strong>Ctrl-C</strong> in the terminal (both run in the foreground)</td>
+<td><code>python3 bootstrap.py</code></td>
+<td><strong>Ctrl-C</strong> in the terminal (runs in the foreground)</td>
 </tr>
 <tr>
 <td><code>./ctl.sh start</code></td>
 <td><code>./ctl.sh stop</code> (sends SIGTERM, waits, then SIGKILL)</td>
 </tr>
 <tr>
-<td>Detached <code>bootstrap.py</code> (no <code>--foreground</code>)</td>
+<td>Detached <code>bootstrap.py</code> (no <code>--foreground</code>) or <code>./start.sh</code></td>
 <td>Find the PID via <code>lsof -i :8787</code> (or <code>ss -tlnp</code>) and <code>kill</code> it</td>
 </tr>
 </tbody></table>
@@ -887,7 +887,7 @@ Full design notes and the endpoint catalog are in <a href="https://github.com/ne
 <td>1</td>
 <td><a href="https://github.com/franksong2702">@franksong2702</a></td>
 <td align="right">181</td>
-<td><code>v0.49.3</code> → <code>v0.51.384</code></td>
+<td><code>v0.49.3</code> → <code>v0.51.405</code></td>
 </tr>
 <tr>
 <td>2</td>
@@ -898,14 +898,14 @@ Full design notes and the endpoint catalog are in <a href="https://github.com/ne
 <tr>
 <td>3</td>
 <td><a href="https://github.com/rodboev">@rodboev</a></td>
-<td align="right">83</td>
-<td><code>v0.51.223</code> → <code>v0.51.384</code></td>
+<td align="right">97</td>
+<td><code>v0.51.223</code> → <code>v0.51.414</code></td>
 </tr>
 <tr>
 <td>4</td>
 <td><a href="https://github.com/ai-ag2026">@ai-ag2026</a></td>
-<td align="right">75</td>
-<td><code>v0.50.279</code> → <code>v0.51.367</code></td>
+<td align="right">79</td>
+<td><code>v0.50.279</code> → <code>v0.51.425</code></td>
 </tr>
 <tr>
 <td>5</td>
@@ -1012,9 +1012,7 @@ Proper <code>Content-Disposition</code> with RFC 5987 <code>filename*=UTF-8&#39;
 A real-world blocker for anyone hosting behind Nginx Proxy Manager or similar on a port other than 80/443.</p>
 <p><strong><a href="https://github.com/betamod">@betamod</a></strong> — Security audit (PR #171)
 A comprehensive CSRF / SSRF / XSS / env-race-condition audit that shipped in v0.39.0.</p>
-<ul>
-<li></li>
-</ul>
+<p>**[@T</p>
 <hr>
 <p><em>README truncated. <a href="https://github.com/nesquena/hermes-webui#readme">Continue reading on GitHub</a></em></p>
 
@@ -1045,7 +1043,7 @@ A comprehensive CSRF / SSRF / XSS / env-race-condition audit that shipped in v0.
         <div class="name"><span class="org">Euraika-Labs /</span> pan-ui</div>
       </a>
       <a class="related-row" href="/projects/Eynzof/hermes-agent-cn-desktop">
-        <div class="stars">★ 445</div>
+        <div class="stars">★ 456</div>
         <div class="name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       </a>
       <a class="related-row" href="/projects/Felix-Forever/hermes-agent-desktop">
@@ -1053,7 +1051,7 @@ A comprehensive CSRF / SSRF / XSS / env-race-condition audit that shipped in v0.
         <div class="name"><span class="org">Felix-Forever /</span> hermes-agent-desktop</div>
       </a>
       <a class="related-row" href="/projects/jazzyalex/agent-sessions">
-        <div class="stars">★ 640</div>
+        <div class="stars">★ 641</div>
         <div class="name"><span class="org">jazzyalex /</span> agent-sessions</div>
       </a>
       <a class="related-row" href="/projects/nickvasilescu/hermes-desktop-os1">

--- a/projects/nexu-io/open-design.html
+++ b/projects/nexu-io/open-design.html
@@ -47,13 +47,13 @@
     "name": "nexu-io",
     "url": "https://github.com/nexu-io"
   },
-  "dateModified": "2026-06-16T08:28:43.000Z",
+  "dateModified": "2026-06-16T15:28:41.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 65687
+    "userInteractionCount": 65916
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">🎨 Local-first, open-source Claude Design alternative. 🖥️ Native desktop app. ⚡ 259+ Skills · ✨ 142+ Design Systems 🖼️ Web · desktop · mobile prototypes · slides · images · videos · HyperFrames 📦 Sandboxed preview · HTML/PDF/PPTX/MP4 export 🤖 Claude Code / OpenClaw / Codex / Cursor / OpenCode / Qwen / Copilot / Hermes / Kimi &amp; 17+ CLIs.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 65.7K</span>
+    <span class="stars">★ 65.9K</span>
     <span><span class="meta-label">lang</span>TypeScript</span>
     <span><span class="meta-label">license</span>Apache-2.0</span>
     
@@ -1103,7 +1103,7 @@ gh pr create --fill
         <div class="name"><span class="org">wondelai /</span> skills</div>
       </a>
       <a class="related-row" href="/projects/DougTrajano/pydantic-ai-skills">
-        <div class="stars">★ 314</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">DougTrajano /</span> pydantic-ai-skills</div>
       </a>
       <a class="related-row" href="/projects/Agents365-ai/drawio-skill">
@@ -1115,7 +1115,7 @@ gh pr create --fill
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 175</div>
+        <div class="stars">★ 176</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/nickvasilescu/hermes-desktop-os1.html
+++ b/projects/nickvasilescu/hermes-desktop-os1.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -343,7 +343,7 @@ for bugs and feature requests.</p>
         <div class="name"><span class="org">Euraika-Labs /</span> pan-ui</div>
       </a>
       <a class="related-row" href="/projects/Eynzof/hermes-agent-cn-desktop">
-        <div class="stars">★ 445</div>
+        <div class="stars">★ 456</div>
         <div class="name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       </a>
       <a class="related-row" href="/projects/Felix-Forever/hermes-agent-desktop">
@@ -351,11 +351,11 @@ for bugs and feature requests.</p>
         <div class="name"><span class="org">Felix-Forever /</span> hermes-agent-desktop</div>
       </a>
       <a class="related-row" href="/projects/jazzyalex/agent-sessions">
-        <div class="stars">★ 640</div>
+        <div class="stars">★ 641</div>
         <div class="name"><span class="org">jazzyalex /</span> agent-sessions</div>
       </a>
       <a class="related-row" href="/projects/farion1231/cc-switch">
-        <div class="stars">★ 102.1K</div>
+        <div class="stars">★ 102.6K</div>
         <div class="name"><span class="org">farion1231 /</span> cc-switch</div>
       </a>
     </div>

--- a/projects/numtide/llm-agents.nix.html
+++ b/projects/numtide/llm-agents.nix.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 1430
+    "userInteractionCount": 1433
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -1621,7 +1621,7 @@ nix flake check
         <div class="name"><span class="org">marshallrichards /</span> ClawPhone</div>
       </a>
       <a class="related-row" href="/projects/TheAiSingularity/hermesclaw">
-        <div class="stars">★ 53</div>
+        <div class="stars">★ 52</div>
         <div class="name"><span class="org">TheAiSingularity /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/0xrsydn/nix-hermes-agent">

--- a/projects/outsourc-e/hermes-workspace.html
+++ b/projects/outsourc-e/hermes-workspace.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 5715
+    "userInteractionCount": 5727
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -991,7 +991,7 @@ hermes dashboard      # dashboard plugin on :9119 (sessions/skills/jobs/config)
         <div class="name"><span class="org">Euraika-Labs /</span> pan-ui</div>
       </a>
       <a class="related-row" href="/projects/Eynzof/hermes-agent-cn-desktop">
-        <div class="stars">★ 445</div>
+        <div class="stars">★ 456</div>
         <div class="name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       </a>
       <a class="related-row" href="/projects/Felix-Forever/hermes-agent-desktop">
@@ -999,7 +999,7 @@ hermes dashboard      # dashboard plugin on :9119 (sessions/skills/jobs/config)
         <div class="name"><span class="org">Felix-Forever /</span> hermes-agent-desktop</div>
       </a>
       <a class="related-row" href="/projects/jazzyalex/agent-sessions">
-        <div class="stars">★ 640</div>
+        <div class="stars">★ 641</div>
         <div class="name"><span class="org">jazzyalex /</span> agent-sessions</div>
       </a>
       <a class="related-row" href="/projects/nickvasilescu/hermes-desktop-os1">
@@ -1007,7 +1007,7 @@ hermes dashboard      # dashboard plugin on :9119 (sessions/skills/jobs/config)
         <div class="name"><span class="org">nickvasilescu /</span> hermes-desktop-os1</div>
       </a>
       <a class="related-row" href="/projects/farion1231/cc-switch">
-        <div class="stars">★ 102.1K</div>
+        <div class="stars">★ 102.6K</div>
         <div class="name"><span class="org">farion1231 /</span> cc-switch</div>
       </a>
     </div>

--- a/projects/pengchengxia75-arch/hermes-agent-windows.html
+++ b/projects/pengchengxia75-arch/hermes-agent-windows.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -254,7 +254,7 @@ hermes            # 启动命令行对话
         <div class="name"><span class="org">carterwayneskhizeine /</span> hermes-agent-windows-R</div>
       </a>
       <a class="related-row" href="/projects/sheawinkler/hermes-agent-ultra">
-        <div class="stars">★ 46</div>
+        <div class="stars">★ 49</div>
         <div class="name"><span class="org">sheawinkler /</span> hermes-agent-ultra</div>
       </a>
       <a class="related-row" href="/projects/nativ3ai/hermes-agent-camel">

--- a/projects/plastic-labs/honcho.html
+++ b/projects/plastic-labs/honcho.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 5189
+    "userInteractionCount": 5204
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>

--- a/projects/plur-ai/plur.html
+++ b/projects/plur-ai/plur.html
@@ -47,7 +47,7 @@
     "name": "plur-ai",
     "url": "https://github.com/plur-ai"
   },
-  "dateModified": "2026-06-16T07:13:37.000Z",
+  "dateModified": "2026-06-16T11:25:35.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>

--- a/projects/pyrate-llama/hermes-ui.html
+++ b/projects/pyrate-llama/hermes-ui.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -749,7 +749,7 @@ tailscale up
         <div class="name"><span class="org">Euraika-Labs /</span> pan-ui</div>
       </a>
       <a class="related-row" href="/projects/Eynzof/hermes-agent-cn-desktop">
-        <div class="stars">★ 445</div>
+        <div class="stars">★ 456</div>
         <div class="name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       </a>
       <a class="related-row" href="/projects/Felix-Forever/hermes-agent-desktop">
@@ -757,7 +757,7 @@ tailscale up
         <div class="name"><span class="org">Felix-Forever /</span> hermes-agent-desktop</div>
       </a>
       <a class="related-row" href="/projects/jazzyalex/agent-sessions">
-        <div class="stars">★ 640</div>
+        <div class="stars">★ 641</div>
         <div class="name"><span class="org">jazzyalex /</span> agent-sessions</div>
       </a>
       <a class="related-row" href="/projects/nickvasilescu/hermes-desktop-os1">

--- a/projects/raulvidis/hermes-android.html
+++ b/projects/raulvidis/hermes-android.html
@@ -46,7 +46,7 @@
     "name": "raulvidis",
     "url": "https://github.com/raulvidis"
   },
-  "dateModified": "2026-06-15T08:07:22.000Z",
+  "dateModified": "2026-06-16T11:44:52.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -115,7 +115,7 @@
     <span><span class="meta-label">lang</span>Python</span>
     
     
-    <span><span class="meta-label">updated</span>2026-06-15</span>
+    <span><span class="meta-label">updated</span>2026-06-16</span>
   </div>
 
   <div class="actions">
@@ -591,11 +591,11 @@ cd hermes-android-bridge
         <div class="name"><span class="org">kevinmarmstrong /</span> hermes-claude-code-rc</div>
       </a>
       <a class="related-row" href="/projects/AaronWong1999/hermesclaw">
-        <div class="stars">★ 620</div>
+        <div class="stars">★ 621</div>
         <div class="name"><span class="org">AaronWong1999 /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/Codename-11/hermes-relay">
-        <div class="stars">★ 34</div>
+        <div class="stars">★ 35</div>
         <div class="name"><span class="org">Codename-11 /</span> hermes-relay</div>
       </a>
       <a class="related-row" href="/projects/kfa-ai/hermes-timetree-sync">

--- a/projects/raulvidis/hermes-cloudflare.html
+++ b/projects/raulvidis/hermes-cloudflare.html
@@ -46,7 +46,7 @@
     "name": "raulvidis",
     "url": "https://github.com/raulvidis"
   },
-  "dateModified": "2026-06-15T08:06:25.000Z",
+  "dateModified": "2026-06-16T11:40:05.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -115,7 +115,7 @@
     <span><span class="meta-label">lang</span>Python</span>
     
     
-    <span><span class="meta-label">updated</span>2026-06-15</span>
+    <span><span class="meta-label">updated</span>2026-06-16</span>
   </div>
 
   <div class="actions">
@@ -249,11 +249,11 @@ export CLOUDFLARE_ACCOUNT_ID=&quot;your-account-id&quot;
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 279</div>
+        <div class="stars">★ 280</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 217</div>
+        <div class="stars">★ 220</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -269,15 +269,15 @@ export CLOUDFLARE_ACCOUNT_ID=&quot;your-account-id&quot;
         <div class="name"><span class="org">nativ3ai /</span> hermes-payguard</div>
       </a>
       <a class="related-row" href="/projects/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server">
-        <div class="stars">★ 343</div>
+        <div class="stars">★ 345</div>
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 284</div>
+        <div class="stars">★ 285</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
       <a class="related-row" href="/projects/clawshell/clawshell">
-        <div class="stars">★ 294</div>
+        <div class="stars">★ 295</div>
         <div class="name"><span class="org">clawshell /</span> clawshell</div>
       </a>
     </div>

--- a/projects/robbyczgw-cla/hermes-web-search-plus.html
+++ b/projects/robbyczgw-cla/hermes-web-search-plus.html
@@ -47,13 +47,13 @@
     "name": "robbyczgw-cla",
     "url": "https://github.com/robbyczgw-cla"
   },
-  "dateModified": "2026-06-09T19:57:53.000Z",
+  "dateModified": "2026-06-16T16:50:26.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 279
+    "userInteractionCount": 280
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,11 +112,11 @@
   <p class="project-desc">Hermes Agent flagship plugin for multi-provider web search and extraction with intelligent routing, quality reports, and research mode.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 279</span>
+    <span class="stars">★ 280</span>
     <span><span class="meta-label">lang</span>Python</span>
     <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-06-09</span>
+    <span><span class="meta-label">updated</span>2026-06-16</span>
   </div>
 
   <div class="actions">
@@ -555,6 +555,13 @@ QUERIT_API_KEY=***        # https://querit.ai — explicit/fallback-only by defa
 KILOCODE_API_KEY=***
 </code></pre>
 <hr>
+<h3>Result quality and adaptive routing</h3>
+<ul>
+<li><strong>Adaptive routing:</strong> every real provider call records latency, error, and empty-result outcomes (rolling window, last 50 calls / 7 days). Routing blends a bounded adjustment (±1.0) into the scores, so providers that are currently fast and productive win close calls — strong query-class signals are never overridden. Disable with <code>auto_routing.adaptive_routing: false</code> in <code>config.json</code>; adjustments are visible in <code>quality_report.adaptive_adjustments</code>.</li>
+<li><strong>Spam/mirror filter:</strong> results from known Stack Overflow/GitHub content mirrors and SEO scrapers are removed (reported in <code>metadata.spam_filtered</code>). Extend via <code>quality.blocked_domains</code>, rescue a domain via <code>quality.allowed_domains</code>, or disable with <code>quality.filter_spam: false</code>.</li>
+<li><strong>Domain diversity:</strong> at most 2 results per domain keep their position; overflow is moved behind the diverse head (<code>quality.max_results_per_domain</code>, <code>0</code> disables).</li>
+<li><strong>Explicit intent wins:</strong> queries with <code>site:</code> operators or <code>include_domains</code> are exempt — constrained domains bypass the spam filter and the diversity rerank is skipped entirely.</li>
+</ul>
 <h3>Reliability and cost controls</h3>
 <ul>
 <li><strong>Provider cooldowns:</strong> failed providers are skipped for 1 hour before retry.</li>
@@ -610,7 +617,7 @@ LICENSE          MIT license
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 217</div>
+        <div class="stars">★ 220</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -630,15 +637,15 @@ LICENSE          MIT license
         <div class="name"><span class="org">raulvidis /</span> hermes-cloudflare</div>
       </a>
       <a class="related-row" href="/projects/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server">
-        <div class="stars">★ 343</div>
+        <div class="stars">★ 345</div>
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 284</div>
+        <div class="stars">★ 285</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
       <a class="related-row" href="/projects/clawshell/clawshell">
-        <div class="stars">★ 294</div>
+        <div class="stars">★ 295</div>
         <div class="name"><span class="org">clawshell /</span> clawshell</div>
       </a>
     </div>

--- a/projects/rodmarkun/anihermes.html
+++ b/projects/rodmarkun/anihermes.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -352,7 +352,7 @@ python3 ~/.hermes/scripts/anihermes_add_torrent.py --series &quot;Frieren&quot; 
         <div class="name"><span class="org">JackTheGit /</span> hermes-ai-infrastructure-monitoring-toolkit</div>
       </a>
       <a class="related-row" href="/projects/bigph00t/hermescraft">
-        <div class="stars">★ 41</div>
+        <div class="stars">★ 42</div>
         <div class="name"><span class="org">bigph00t /</span> hermescraft</div>
       </a>
       <a class="related-row" href="/projects/hxsteric/mercury">

--- a/projects/roli-lpci/lintlang.html
+++ b/projects/roli-lpci/lintlang.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -484,11 +484,11 @@ pytest
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/colbymchenry/codegraph">
-        <div class="stars">★ 50.0K</div>
+        <div class="stars">★ 50.2K</div>
         <div class="name"><span class="org">colbymchenry /</span> codegraph</div>
       </a>
       <a class="related-row" href="/projects/Salomondiei08/oh-my-hermes">
-        <div class="stars">★ 532</div>
+        <div class="stars">★ 551</div>
         <div class="name"><span class="org">Salomondiei08 /</span> oh-my-hermes</div>
       </a>
       <a class="related-row" href="/projects/liaohch3/claude-tap">
@@ -496,7 +496,7 @@ pytest
         <div class="name"><span class="org">liaohch3 /</span> claude-tap</div>
       </a>
       <a class="related-row" href="/projects/adityahimaone/hermes-agent-rtk-caveman">
-        <div class="stars">★ 61</div>
+        <div class="stars">★ 62</div>
         <div class="name"><span class="org">adityahimaone /</span> hermes-agent-rtk-caveman</div>
       </a>
       <a class="related-row" href="/projects/junhoyeo/tokscale">

--- a/projects/rookiemann/portable-hermes-agent.html
+++ b/projects/rookiemann/portable-hermes-agent.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -360,7 +360,7 @@ AIAgent (run_agent.py)
         <div class="name"><span class="org">numtide /</span> llm-agents.nix</div>
       </a>
       <a class="related-row" href="/projects/TheAiSingularity/hermesclaw">
-        <div class="stars">★ 53</div>
+        <div class="stars">★ 52</div>
         <div class="name"><span class="org">TheAiSingularity /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/0xrsydn/nix-hermes-agent">

--- a/projects/runtimenoteslabs/gladiator.html
+++ b/projects/runtimenoteslabs/gladiator.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -638,15 +638,15 @@ sudo service postgresql start
         <div class="name"><span class="org">builderz-labs /</span> mission-control</div>
       </a>
       <a class="related-row" href="/projects/swarmclawai/swarmclaw">
-        <div class="stars">★ 583</div>
+        <div class="stars">★ 584</div>
         <div class="name"><span class="org">swarmclawai /</span> swarmclaw</div>
       </a>
       <a class="related-row" href="/projects/howdymary/hermes-agent-metaharness">
-        <div class="stars">★ 93</div>
+        <div class="stars">★ 94</div>
         <div class="name"><span class="org">howdymary /</span> hermes-agent-metaharness</div>
       </a>
       <a class="related-row" href="/projects/1ilkhamov/opencode-hermes-multiagent">
-        <div class="stars">★ 140</div>
+        <div class="stars">★ 141</div>
         <div class="name"><span class="org">1ilkhamov /</span> opencode-hermes-multiagent</div>
       </a>
       <a class="related-row" href="/projects/Rainhoole/hermes-agent-acp-skill">
@@ -658,11 +658,11 @@ sudo service postgresql start
         <div class="name"><span class="org">linke-ai /</span> hermes-agent-team</div>
       </a>
       <a class="related-row" href="/projects/Agent-3-7/minions">
-        <div class="stars">★ 577</div>
+        <div class="stars">★ 578</div>
         <div class="name"><span class="org">Agent-3-7 /</span> minions</div>
       </a>
       <a class="related-row" href="/projects/CryptoDmitry/hermes-agent-control-room">
-        <div class="stars">★ 844</div>
+        <div class="stars">★ 856</div>
         <div class="name"><span class="org">CryptoDmitry /</span> hermes-agent-control-room</div>
       </a>
     </div>

--- a/projects/sanchomuzax/hermes-webui.html
+++ b/projects/sanchomuzax/hermes-webui.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -403,7 +403,7 @@ journalctl -u hermes-webui -f
         <div class="name"><span class="org">Euraika-Labs /</span> pan-ui</div>
       </a>
       <a class="related-row" href="/projects/Eynzof/hermes-agent-cn-desktop">
-        <div class="stars">★ 445</div>
+        <div class="stars">★ 456</div>
         <div class="name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       </a>
       <a class="related-row" href="/projects/Felix-Forever/hermes-agent-desktop">
@@ -411,7 +411,7 @@ journalctl -u hermes-webui -f
         <div class="name"><span class="org">Felix-Forever /</span> hermes-agent-desktop</div>
       </a>
       <a class="related-row" href="/projects/jazzyalex/agent-sessions">
-        <div class="stars">★ 640</div>
+        <div class="stars">★ 641</div>
         <div class="name"><span class="org">jazzyalex /</span> agent-sessions</div>
       </a>
       <a class="related-row" href="/projects/nickvasilescu/hermes-desktop-os1">
@@ -419,7 +419,7 @@ journalctl -u hermes-webui -f
         <div class="name"><span class="org">nickvasilescu /</span> hermes-desktop-os1</div>
       </a>
       <a class="related-row" href="/projects/farion1231/cc-switch">
-        <div class="stars">★ 102.1K</div>
+        <div class="stars">★ 102.6K</div>
         <div class="name"><span class="org">farion1231 /</span> cc-switch</div>
       </a>
     </div>

--- a/projects/shannhk/hermes-agent-control-room.html
+++ b/projects/shannhk/hermes-agent-control-room.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -461,11 +461,11 @@ ls skills/
         <div class="name"><span class="org">builderz-labs /</span> mission-control</div>
       </a>
       <a class="related-row" href="/projects/swarmclawai/swarmclaw">
-        <div class="stars">★ 583</div>
+        <div class="stars">★ 584</div>
         <div class="name"><span class="org">swarmclawai /</span> swarmclaw</div>
       </a>
       <a class="related-row" href="/projects/howdymary/hermes-agent-metaharness">
-        <div class="stars">★ 93</div>
+        <div class="stars">★ 94</div>
         <div class="name"><span class="org">howdymary /</span> hermes-agent-metaharness</div>
       </a>
       <a class="related-row" href="/projects/runtimenoteslabs/gladiator">
@@ -473,7 +473,7 @@ ls skills/
         <div class="name"><span class="org">runtimenoteslabs /</span> gladiator</div>
       </a>
       <a class="related-row" href="/projects/1ilkhamov/opencode-hermes-multiagent">
-        <div class="stars">★ 140</div>
+        <div class="stars">★ 141</div>
         <div class="name"><span class="org">1ilkhamov /</span> opencode-hermes-multiagent</div>
       </a>
       <a class="related-row" href="/projects/Rainhoole/hermes-agent-acp-skill">
@@ -485,7 +485,7 @@ ls skills/
         <div class="name"><span class="org">linke-ai /</span> hermes-agent-team</div>
       </a>
       <a class="related-row" href="/projects/Agent-3-7/minions">
-        <div class="stars">★ 577</div>
+        <div class="stars">★ 578</div>
         <div class="name"><span class="org">Agent-3-7 /</span> minions</div>
       </a>
     </div>

--- a/projects/sheawinkler/hermes-agent-ultra.html
+++ b/projects/sheawinkler/hermes-agent-ultra.html
@@ -46,13 +46,13 @@
     "name": "sheawinkler",
     "url": "https://github.com/sheawinkler"
   },
-  "dateModified": "2026-06-16T07:35:22.000Z",
+  "dateModified": "2026-06-16T17:00:40.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 46
+    "userInteractionCount": 49
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -111,7 +111,7 @@
   <p class="project-desc">Hermes Agent Ultra (built from hermes-agent-rs core by lumioresearch, @oxterrybit). Hermes-agent feature parity at commit level. Rust Performance</p>
 
   <div class="meta-row">
-    <span class="stars">★ 46</span>
+    <span class="stars">★ 49</span>
     <span><span class="meta-label">lang</span>Rust</span>
     
     

--- a/projects/smartcontractkit/chainlink-agent-skills.html
+++ b/projects/smartcontractkit/chainlink-agent-skills.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -236,7 +236,7 @@ Any questions before you start?
         <div class="name"><span class="org">wondelai /</span> skills</div>
       </a>
       <a class="related-row" href="/projects/DougTrajano/pydantic-ai-skills">
-        <div class="stars">★ 314</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">DougTrajano /</span> pydantic-ai-skills</div>
       </a>
       <a class="related-row" href="/projects/Agents365-ai/drawio-skill">
@@ -244,7 +244,7 @@ Any questions before you start?
         <div class="name"><span class="org">Agents365-ai /</span> drawio-skill</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 175</div>
+        <div class="stars">★ 176</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/stainlu/hermes-labyrinth.html
+++ b/projects/stainlu/hermes-labyrinth.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 284
+    "userInteractionCount": 285
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Read-only observability plugin for Hermes Agent: journeys, crossings, guideposts, and reports.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 284</span>
+    <span class="stars">★ 285</span>
     <span><span class="meta-label">lang</span>HTML</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -340,11 +340,11 @@ roadmap.</p>
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 279</div>
+        <div class="stars">★ 280</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 217</div>
+        <div class="stars">★ 220</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -364,11 +364,11 @@ roadmap.</p>
         <div class="name"><span class="org">raulvidis /</span> hermes-cloudflare</div>
       </a>
       <a class="related-row" href="/projects/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server">
-        <div class="stars">★ 343</div>
+        <div class="stars">★ 345</div>
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/clawshell/clawshell">
-        <div class="stars">★ 294</div>
+        <div class="stars">★ 295</div>
         <div class="name"><span class="org">clawshell /</span> clawshell</div>
       </a>
     </div>

--- a/projects/stephenschoettler/hermes-lcm.html
+++ b/projects/stephenschoettler/hermes-lcm.html
@@ -52,7 +52,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 734
+    "userInteractionCount": 737
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -111,7 +111,7 @@
   <p class="project-desc">Lossless Context Management plugin for Hermes Agent — DAG-based context engine that never loses a message</p>
 
   <div class="meta-row">
-    <span class="stars">★ 734</span>
+    <span class="stars">★ 737</span>
     <span><span class="meta-label">lang</span>Python</span>
     
     

--- a/projects/supermemoryai/supermemory.html
+++ b/projects/supermemoryai/supermemory.html
@@ -47,13 +47,13 @@
     "name": "supermemoryai",
     "url": "https://github.com/supermemoryai"
   },
-  "dateModified": "2026-06-16T06:40:36.000Z",
+  "dateModified": "2026-06-16T17:34:30.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 27080
+    "userInteractionCount": 27098
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>

--- a/projects/swarmclawai/swarmclaw.html
+++ b/projects/swarmclawai/swarmclaw.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 583
+    "userInteractionCount": 584
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Open-source self-hosted AI agent runtime and multi-agent framework for autonomous agent swarms. Agent memory, MCP tools, schedules, delegation, and 23+ LLM providers (Claude, GPT, Gemini, OpenRouter, Ollama). A practical Claude Code and LangChain alternative.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 583</span>
+    <span class="stars">★ 584</span>
     <span><span class="meta-label">lang</span>TypeScript</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -800,7 +800,7 @@ OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer your-token
         <div class="name"><span class="org">builderz-labs /</span> mission-control</div>
       </a>
       <a class="related-row" href="/projects/howdymary/hermes-agent-metaharness">
-        <div class="stars">★ 93</div>
+        <div class="stars">★ 94</div>
         <div class="name"><span class="org">howdymary /</span> hermes-agent-metaharness</div>
       </a>
       <a class="related-row" href="/projects/runtimenoteslabs/gladiator">
@@ -808,7 +808,7 @@ OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer your-token
         <div class="name"><span class="org">runtimenoteslabs /</span> gladiator</div>
       </a>
       <a class="related-row" href="/projects/1ilkhamov/opencode-hermes-multiagent">
-        <div class="stars">★ 140</div>
+        <div class="stars">★ 141</div>
         <div class="name"><span class="org">1ilkhamov /</span> opencode-hermes-multiagent</div>
       </a>
       <a class="related-row" href="/projects/Rainhoole/hermes-agent-acp-skill">
@@ -820,11 +820,11 @@ OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer your-token
         <div class="name"><span class="org">linke-ai /</span> hermes-agent-team</div>
       </a>
       <a class="related-row" href="/projects/Agent-3-7/minions">
-        <div class="stars">★ 577</div>
+        <div class="stars">★ 578</div>
         <div class="name"><span class="org">Agent-3-7 /</span> minions</div>
       </a>
       <a class="related-row" href="/projects/CryptoDmitry/hermes-agent-control-room">
-        <div class="stars">★ 844</div>
+        <div class="stars">★ 856</div>
         <div class="name"><span class="org">CryptoDmitry /</span> hermes-agent-control-room</div>
       </a>
     </div>

--- a/projects/teknium1/hermes-miniverse.html
+++ b/projects/teknium1/hermes-miniverse.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -279,11 +279,11 @@ python bridge.py --agent hermes-researcher --name &quot;Hermes (Research)&quot; 
         <div class="name"><span class="org">kevinmarmstrong /</span> hermes-claude-code-rc</div>
       </a>
       <a class="related-row" href="/projects/AaronWong1999/hermesclaw">
-        <div class="stars">★ 620</div>
+        <div class="stars">★ 621</div>
         <div class="name"><span class="org">AaronWong1999 /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/Codename-11/hermes-relay">
-        <div class="stars">★ 34</div>
+        <div class="stars">★ 35</div>
         <div class="name"><span class="org">Codename-11 /</span> hermes-relay</div>
       </a>
       <a class="related-row" href="/projects/kfa-ai/hermes-timetree-sync">

--- a/projects/tiann/execplan-skill.html
+++ b/projects/tiann/execplan-skill.html
@@ -79,7 +79,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -191,7 +191,7 @@
         <div class="name"><span class="org">wondelai /</span> skills</div>
       </a>
       <a class="related-row" href="/projects/DougTrajano/pydantic-ai-skills">
-        <div class="stars">★ 314</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">DougTrajano /</span> pydantic-ai-skills</div>
       </a>
       <a class="related-row" href="/projects/Agents365-ai/drawio-skill">
@@ -203,7 +203,7 @@
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 175</div>
+        <div class="stars">★ 176</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/tlehman/litprog-skill.html
+++ b/projects/tlehman/litprog-skill.html
@@ -52,7 +52,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 175
+    "userInteractionCount": 176
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -111,7 +111,7 @@
   <p class="project-desc">Literate programming skill for agent harnesses like Claude Code, OpenCode and Hermes Agent</p>
 
   <div class="meta-row">
-    <span class="stars">★ 175</span>
+    <span class="stars">★ 176</span>
     <span><span class="meta-label">lang</span>TypeScript</span>
     
     
@@ -227,7 +227,7 @@ cp litprog-skill/SKILL.md your-project/.claude/skills/literate-programming.md
         <div class="name"><span class="org">wondelai /</span> skills</div>
       </a>
       <a class="related-row" href="/projects/DougTrajano/pydantic-ai-skills">
-        <div class="stars">★ 314</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">DougTrajano /</span> pydantic-ai-skills</div>
       </a>
       <a class="related-row" href="/projects/Agents365-ai/drawio-skill">

--- a/projects/ucsandman/DashClaw.html
+++ b/projects/ucsandman/DashClaw.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -679,7 +679,7 @@ await claw.createAction({ /* ... */, idempotency_key: key });
         <div class="name"><span class="org">JackTheGit /</span> hermes-ai-infrastructure-monitoring-toolkit</div>
       </a>
       <a class="related-row" href="/projects/bigph00t/hermescraft">
-        <div class="stars">★ 41</div>
+        <div class="stars">★ 42</div>
         <div class="name"><span class="org">bigph00t /</span> hermescraft</div>
       </a>
       <a class="related-row" href="/projects/hxsteric/mercury">

--- a/projects/ultraworkers/hermes-agent-helm-chart.html
+++ b/projects/ultraworkers/hermes-agent-helm-chart.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -466,7 +466,7 @@ bash ci/verify.sh
         <div class="name"><span class="org">numtide /</span> llm-agents.nix</div>
       </a>
       <a class="related-row" href="/projects/TheAiSingularity/hermesclaw">
-        <div class="stars">★ 53</div>
+        <div class="stars">★ 52</div>
         <div class="name"><span class="org">TheAiSingularity /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/0xrsydn/nix-hermes-agent">

--- a/projects/unmodeled-tyler/vessel-browser.html
+++ b/projects/unmodeled-tyler/vessel-browser.html
@@ -47,7 +47,7 @@
     "name": "unmodeled-tyler",
     "url": "https://github.com/unmodeled-tyler"
   },
-  "dateModified": "2026-06-16T02:00:27.000Z",
+  "dateModified": "2026-06-16T17:37:36.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -729,11 +729,11 @@ vessel-browser-launch --dry-run
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/colbymchenry/codegraph">
-        <div class="stars">★ 50.0K</div>
+        <div class="stars">★ 50.2K</div>
         <div class="name"><span class="org">colbymchenry /</span> codegraph</div>
       </a>
       <a class="related-row" href="/projects/Salomondiei08/oh-my-hermes">
-        <div class="stars">★ 532</div>
+        <div class="stars">★ 551</div>
         <div class="name"><span class="org">Salomondiei08 /</span> oh-my-hermes</div>
       </a>
       <a class="related-row" href="/projects/liaohch3/claude-tap">
@@ -741,7 +741,7 @@ vessel-browser-launch --dry-run
         <div class="name"><span class="org">liaohch3 /</span> claude-tap</div>
       </a>
       <a class="related-row" href="/projects/adityahimaone/hermes-agent-rtk-caveman">
-        <div class="stars">★ 61</div>
+        <div class="stars">★ 62</div>
         <div class="name"><span class="org">adityahimaone /</span> hermes-agent-rtk-caveman</div>
       </a>
       <a class="related-row" href="/projects/junhoyeo/tokscale">

--- a/projects/vectorize-io/hindsight.html
+++ b/projects/vectorize-io/hindsight.html
@@ -47,13 +47,13 @@
     "name": "vectorize-io",
     "url": "https://github.com/vectorize-io"
   },
-  "dateModified": "2026-06-16T08:29:20.000Z",
+  "dateModified": "2026-06-16T16:42:14.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 16465
+    "userInteractionCount": 16480
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -403,7 +403,7 @@ client.reflect(bank_id=&quot;my-bank&quot;, query=&quot;What should I know about
 <td>✅</td>
 </tr>
 </tbody></table>
-<p>⚠️ Intel Macs: use <code>hindsight-all-slim</code> — see the <a href="https://docs.hindsight.vectorize.io/docs/developer/installation#supported-platforms">installation guide</a> for details.</p>
+<p>⚠️ Intel Macs: use <code>hindsight-all-slim</code> — see the <a href="https://hindsight.vectorize.io/developer/installation#supported-platforms">installation guide</a> for details.</p>
 <hr>
 <h3>Contributing</h3>
 <p>See <a href="https://github.com/vectorize-io/hindsight/blob/main/CONTRIBUTING.md">CONTRIBUTING.md</a>.</p>

--- a/projects/vectrocomputers/Hermes-Agent-Action-Plan.html
+++ b/projects/vectrocomputers/Hermes-Agent-Action-Plan.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -357,7 +357,7 @@
         <div class="name"><span class="org">alchaincyf /</span> hermes-agent-orange-book</div>
       </a>
       <a class="related-row" href="/projects/OnlyTerp/hermes-optimization-guide">
-        <div class="stars">★ 442</div>
+        <div class="stars">★ 444</div>
         <div class="name"><span class="org">OnlyTerp /</span> hermes-optimization-guide</div>
       </a>
       <a class="related-row" href="/projects/metantonio/hermes-wsl-ubuntu">

--- a/projects/volcengine/OpenViking.html
+++ b/projects/volcengine/OpenViking.html
@@ -47,13 +47,13 @@
     "name": "volcengine",
     "url": "https://github.com/volcengine"
   },
-  "dateModified": "2026-06-16T07:33:14.000Z",
+  "dateModified": "2026-06-16T17:07:50.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 25698
+    "userInteractionCount": 25715
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>

--- a/projects/willingning-coder/eagle-eye.html
+++ b/projects/willingning-coder/eagle-eye.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -385,7 +385,7 @@ python scripts/generate_config.py --scan-only
         <div class="name"><span class="org">wondelai /</span> skills</div>
       </a>
       <a class="related-row" href="/projects/DougTrajano/pydantic-ai-skills">
-        <div class="stars">★ 314</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">DougTrajano /</span> pydantic-ai-skills</div>
       </a>
       <a class="related-row" href="/projects/Agents365-ai/drawio-skill">
@@ -397,7 +397,7 @@ python scripts/generate_config.py --scan-only
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 175</div>
+        <div class="stars">★ 176</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/wondelai/skills.html
+++ b/projects/wondelai/skills.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 1359
+    "userInteractionCount": 1365
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -865,7 +865,7 @@ npx skills add wondelai/skills/lean-analytics
         <div class="name"><span class="org">conorbronsdon /</span> avoid-ai-writing</div>
       </a>
       <a class="related-row" href="/projects/DougTrajano/pydantic-ai-skills">
-        <div class="stars">★ 314</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">DougTrajano /</span> pydantic-ai-skills</div>
       </a>
       <a class="related-row" href="/projects/Agents365-ai/drawio-skill">
@@ -877,7 +877,7 @@ npx skills add wondelai/skills/lean-analytics
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 175</div>
+        <div class="stars">★ 176</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/xaspx/hermes-control-interface.html
+++ b/projects/xaspx/hermes-control-interface.html
@@ -47,7 +47,7 @@
     "name": "xaspx",
     "url": "https://github.com/xaspx"
   },
-  "dateModified": "2026-06-05T07:15:47.000Z",
+  "dateModified": "2026-06-16T16:48:05.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -116,7 +116,7 @@
     <span><span class="meta-label">lang</span>JavaScript</span>
     <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-06-05</span>
+    <span><span class="meta-label">updated</span>2026-06-16</span>
   </div>
 
   <div class="actions">
@@ -145,7 +145,7 @@
   <section class="readme" data-nosnippet>
     <h2>Hermes Control Interface</h2>
 <p>A self-hosted web dashboard for the <a href="https://github.com/NousResearch/hermes-agent">Hermes AI agent</a> stack. Manage agents, chat, terminals, files, cron, token analytics, MCP servers, and swarm pipelines — behind a password gate.</p>
-<p><strong>Stack:</strong> Vanilla JS + Vite · Node.js · Express · WebSocket · xterm.js · Chart.js · better-sqlite3<br><strong>Version:</strong> 3.6.0 · <strong>License:</strong> MIT</p>
+<p><strong>Stack:</strong> Vanilla JS + Vite · Node.js · Express · WebSocket · xterm.js · Chart.js · better-sqlite3<br><strong>Version:</strong> 3.6.1 · <strong>License:</strong> MIT</p>
 <hr>
 <h3>Quick Start</h3>
 <pre><code class="language-bash">git clone https://github.com/xaspx/hermes-control-interface.git
@@ -170,7 +170,11 @@ node server.js            # → http://localhost:10274
 </tr>
 <tr>
 <td><strong>Chat</strong></td>
-<td>Real-time streaming via gateway API, tool call cards, multi-profile</td>
+<td>Real-time streaming, tool call cards, multi-profile</td>
+</tr>
+<tr>
+<td><strong>Workspace</strong></td>
+<td>Browse, edit files and chat with Hermes scoped to a project directory</td>
 </tr>
 <tr>
 <td><strong>Agents</strong></td>
@@ -410,7 +414,7 @@ node server.js            # → http://localhost:10274
 </ul>
 <hr>
 <h3>Updating</h3>
-<pre><code class="language-bash">git pull origin main
+<pre><code class="language-bash">git pull upstream main
 npm install
 npm run build
 # Restart your HCI service (adjust service name):
@@ -456,65 +460,27 @@ systemctl restart hci-staging
 </tr>
 </tbody></table>
 <hr>
-<p>Built for the <a href="https://github.com/NousResearch/hermes-agent">Hermes Agent</a> ecosystem.<br><a href="https://x.com/bayendor">@bayendor</a> · <a href="https://github.com/xaspx/hermes-control-interface">GitHub</a></p>
+<p>Built for the <a href="https://github.com/NousResearch/hermes-agent">Hermes Agent</a> ecosystem.<br>Upstream <a href="https://x.com/bayendor">@bayendor</a> · <a href="https://github.com/xaspx/hermes-control-interface">GitHub</a></p>
 <hr>
 <h3>❓ Frequently Asked Questions</h3>
 <h4>General</h4>
 <p><strong>Q: What is Hermes Control Interface (HCI)?</strong></p>
 <p>HCI is a <strong>self-hosted web dashboard</strong> for the Hermes AI agent stack. Manage agents, chat, terminals, files, cron, token analytics, MCP servers, and swarm pipelines — all behind a password gate.</p>
 <p><strong>Q: What can I manage with HCI?</strong></p>
-<table>
-<thead>
-<tr>
-<th>Page</th>
-<th>Capabilities</th>
-</tr>
-</thead>
-<tbody><tr>
-<td><strong>Home</strong></td>
-<td>System health, agent overview, gateway status, token usage</td>
-</tr>
-<tr>
-<td><strong>Chat</strong></td>
-<td>Real-time streaming, tool call cards, multi-profile</td>
-</tr>
-<tr>
-<td><strong>Agents</strong></td>
-<td>Profile CRUD, gateway lifecycle, dashboard/sessions/cron</td>
-</tr>
-<tr>
-<td><strong>Office</strong></td>
-<td>3-panel swarm monitor — agent health, kanban, live feed</td>
-</tr>
-<tr>
-<td><strong>Monitor</strong></td>
-<td>Gateway logs, CPU/RAM metrics, live process view</td>
-</tr>
-<tr>
-<td><strong>Usage</strong></td>
-<td>Token analytics, daily trends, cost projections, alerts</td>
-</tr>
-<tr>
-<td><strong>Logs</strong></td>
-<td>Agent/error/gateway logs with level filter</td>
-</tr>
-<tr>
-<td><strong>Skills</strong></td>
-<td>Browse, install, remove Hermes skills</td>
-</tr>
-<tr>
-<td><strong>Files</strong></td>
-<td>Browse and edit server files</td>
-</tr>
-<tr>
-<td><strong>MCP</strong></td>
-<td>Start, stop, restart MCP servers, log tail, config editor</td>
-</tr>
-<tr>
-<td><strong>Maintenance</strong></td>
-<td>Backup, restore, HCI update, system doctor</td>
-</tr>
-</tbody></table>
+<p>| Page | Capabilities |
+|---|---|---|
+| <strong>Home</strong> | System health, agent overview, gateway status, token usage |
+| <strong>Chat</strong> | Real-time streaming, tool call cards, multi-profile |
+| <strong>Workspace</strong> | Browse, edit files and chat with Hermes scoped to a project directory |
+| <strong>Agents</strong> | Profile CRUD, gateway lifecycle, dashboard/sessions/cron |
+| <strong>Office</strong> | 3-panel swarm monitor — agent health, kanban, live feed |
+| <strong>Monitor</strong> | Gateway logs, CPU/RAM metrics, live process view |
+| <strong>Usage</strong> | Token analytics, daily trends, cost projections, alerts |
+| <strong>Logs</strong> | Agent/error/gateway logs with level filter |
+| <strong>Skills</strong> | Browse, install, remove Hermes skills |
+| <strong>Files</strong> | Browse and edit server files |
+| <strong>MCP</strong> | Start, stop, restart MCP servers, log tail, config editor |
+| <strong>Maintenance</strong> | Backup, restore, HCI update, system doctor |</p>
 <h4>Features</h4>
 <p><strong>Q: What is Office v3 — ZOO Swarm Monitor?</strong></p>
 <p>Three-panel dashboard with <strong>zero-subprocess agent states</strong> (~100ms vs 3000ms):</p>
@@ -573,7 +539,7 @@ cp .env.example .env     # set HERMES_CONTROL_PASSWORD + HERMES_CONTROL_SECRET
 npm install &amp;&amp; npm run build
 node server.js            # → http://localhost:10274
 </code></pre>
-<p>See <a href="https://github.com/xaspx/hermes-control-interface/blob/main/docs/INSTALL.md">docs/INSTALL.md</a> for production setup.</p>
+<p>See <a href="https://github.com/xaspx/hermes-control-interface/blob/main/docs/INSTALL.md">docs/INSTALL.md</a> for full setup.</p>
 <p><strong>Q: What are the requirements?</strong></p>
 <ul>
 <li>Node.js 20+</li>
@@ -581,7 +547,7 @@ node server.js            # → http://localhost:10274
 <li><code>hermes</code> CLI available on PATH</li>
 </ul>
 <p><strong>Q: How do I update HCI?</strong></p>
-<pre><code class="language-bash">git pull origin main
+<pre><code class="language-bash">git pull upstream main
 npm install
 npm run build
 # Restart your HCI service (adjust service name):
@@ -618,7 +584,7 @@ systemctl restart hci-staging
 </tr>
 <tr>
 <td><strong>Version</strong></td>
-<td>3.6.0</td>
+<td>3.6.1</td>
 </tr>
 </tbody></table>
 <h4>Security</h4>
@@ -859,7 +825,7 @@ systemctl restart hci-staging
         <div class="name"><span class="org">Euraika-Labs /</span> pan-ui</div>
       </a>
       <a class="related-row" href="/projects/Eynzof/hermes-agent-cn-desktop">
-        <div class="stars">★ 445</div>
+        <div class="stars">★ 456</div>
         <div class="name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       </a>
       <a class="related-row" href="/projects/Felix-Forever/hermes-agent-desktop">
@@ -867,7 +833,7 @@ systemctl restart hci-staging
         <div class="name"><span class="org">Felix-Forever /</span> hermes-agent-desktop</div>
       </a>
       <a class="related-row" href="/projects/jazzyalex/agent-sessions">
-        <div class="stars">★ 640</div>
+        <div class="stars">★ 641</div>
         <div class="name"><span class="org">jazzyalex /</span> agent-sessions</div>
       </a>
       <a class="related-row" href="/projects/nickvasilescu/hermes-desktop-os1">

--- a/projects/xiaonancs/hermes-agent-study.html
+++ b/projects/xiaonancs/hermes-agent-study.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -497,7 +497,7 @@
         <div class="name"><span class="org">alchaincyf /</span> hermes-agent-orange-book</div>
       </a>
       <a class="related-row" href="/projects/OnlyTerp/hermes-optimization-guide">
-        <div class="stars">★ 442</div>
+        <div class="stars">★ 444</div>
         <div class="name"><span class="org">OnlyTerp /</span> hermes-optimization-guide</div>
       </a>
       <a class="related-row" href="/projects/metantonio/hermes-wsl-ubuntu">

--- a/projects/xmbshwll/hermes-agent-docker.html
+++ b/projects/xmbshwll/hermes-agent-docker.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -216,7 +216,7 @@
         <div class="name"><span class="org">numtide /</span> llm-agents.nix</div>
       </a>
       <a class="related-row" href="/projects/TheAiSingularity/hermesclaw">
-        <div class="stars">★ 53</div>
+        <div class="stars">★ 52</div>
         <div class="name"><span class="org">TheAiSingularity /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/0xrsydn/nix-hermes-agent">

--- a/projects/yantrikos/yantrikdb-hermes-plugin.html
+++ b/projects/yantrikos/yantrikdb-hermes-plugin.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>

--- a/projects/yepyhun/Brainstack.html
+++ b/projects/yepyhun/Brainstack.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>

--- a/projects/yoloshii/ClawMem.html
+++ b/projects/yoloshii/ClawMem.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>

--- a/reports/index.html
+++ b/reports/index.html
@@ -89,7 +89,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
+    <span id="meta-count">169·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>

--- a/rss.xml
+++ b/rss.xml
@@ -6,13 +6,21 @@
     <atom:link href="https://hermesatlas.com/rss.xml" rel="self" type="application/rss+xml" />
     <description>Newly added community-built tools, skills, plugins, and integrations for Nous Research's Hermes Agent. Updated daily.</description>
     <language>en</language>
-    <lastBuildDate>Tue, 16 Jun 2026 08:33:47 GMT</lastBuildDate>
+    <lastBuildDate>Tue, 16 Jun 2026 18:25:29 GMT</lastBuildDate>
     <generator>hermesatlas.com/scripts/build-pages.js</generator>
+    <item>
+      <title>hermes-trace (Plugins &amp; Extensions)</title>
+      <link>https://hermesatlas.com/projects/hlothaire/hermes-trace</link>
+      <guid isPermaLink="true">https://hermesatlas.com/projects/hlothaire/hermes-trace</guid>
+      <pubDate>Tue, 16 Jun 2026 12:07:30 GMT</pubDate>
+      <category>Plugins &amp; Extensions</category>
+      <description>A Hermes Agent plugin that builds execution trace graphs using agent lifecycle hooks.</description>
+    </item>
     <item>
       <title>socialclaw (Integrations &amp; Bridges)</title>
       <link>https://hermesatlas.com/projects/ndesv21/socialclaw</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/ndesv21/socialclaw</guid>
-      <pubDate>Mon, 15 Jun 2026 14:45:40 GMT</pubDate>
+      <pubDate>Mon, 15 Jun 2026 13:24:17 GMT</pubDate>
       <category>Integrations &amp; Bridges</category>
       <description>SocialClaw is a social media scheduling tool designed to enable AI agents to publish content across multiple platforms. It provides an npm CLI and a Model Context Protocol (MCP) server that interfaces with a hosted workspace via API key authentication. The system supports campaign validation, asset uploads, and analytics tracking for platforms including X, LinkedIn, Instagram, and TikTok. It integrates directly with AI environments like Claude Code, Cursor, and OpenClaw to automate the publishin</description>
     </item>
@@ -20,7 +28,7 @@
       <title>Toolaria (Plugins &amp; Extensions)</title>
       <link>https://hermesatlas.com/projects/Sahil-SS9/Toolaria</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/Sahil-SS9/Toolaria</guid>
-      <pubDate>Mon, 15 Jun 2026 14:45:40 GMT</pubDate>
+      <pubDate>Thu, 11 Jun 2026 19:07:54 GMT</pubDate>
       <category>Plugins &amp; Extensions</category>
       <description>Toolaria is a zero-config Hermes Agent plugin that prevents oversized tool results from flooding the model's context window. It implements a spill-to-disk pattern by storing large outputs in a SHA256-addressed blob store and providing the model with a compact excerpt and a fetch handle. The model can then retrieve specific slices via search, structural outlines, or pass-by-reference to other tools. This approach allows the agent to handle massive datasets, such as thousands of transaction record</description>
     </item>
@@ -28,7 +36,7 @@
       <title>hermes-memlock (Plugins &amp; Extensions)</title>
       <link>https://hermesatlas.com/projects/Sahil-SS9/hermes-memlock</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/Sahil-SS9/hermes-memlock</guid>
-      <pubDate>Mon, 15 Jun 2026 14:45:40 GMT</pubDate>
+      <pubDate>Thu, 11 Jun 2026 15:00:34 GMT</pubDate>
       <category>Plugins &amp; Extensions</category>
       <description>MemLock is a plugin for Hermes Agent that prevents the loss of standing instructions during context compaction. It monitors the conversation for compaction markers and audits the active context region to identify pinned instructions that have been demoted to background reference. When drift is detected, the tool rehydrates the missing instructions as a reminder block appended to the user's turn. This approach optimizes token usage and prompt cache stability by only reinjecting necessary instruct</description>
     </item>
@@ -36,7 +44,7 @@
       <title>hermes-simplify-swarm (Skills &amp; Skill Registries)</title>
       <link>https://hermesatlas.com/projects/Sahil-SS9/hermes-simplify-swarm</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/Sahil-SS9/hermes-simplify-swarm</guid>
-      <pubDate>Mon, 15 Jun 2026 14:45:40 GMT</pubDate>
+      <pubDate>Tue, 09 Jun 2026 07:43:52 GMT</pubDate>
       <category>Skills &amp; Skill Registries</category>
       <description>Simplify Swarm is a multi-agent code refinement skill for Hermes Agent designed to automate deep code cleaning and technical debt reduction. It utilizes three specialized sub-agents—Hygiene, Clarity, and Correctness—to analyze codebases for dead code, structural bloat, and complex bugs like N+1 queries or memory leaks. Findings are triaged into a risk-tiered system that separates safe automated fixes from risky architectural changes requiring human review. The tool supports TypeScript, JavaScrip</description>
     </item>
@@ -44,7 +52,7 @@
       <title>hermaguard (Skills &amp; Skill Registries)</title>
       <link>https://hermesatlas.com/projects/Sahil-SS9/hermaguard</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/Sahil-SS9/hermaguard</guid>
-      <pubDate>Mon, 15 Jun 2026 14:45:40 GMT</pubDate>
+      <pubDate>Tue, 09 Jun 2026 07:41:22 GMT</pubDate>
       <category>Skills &amp; Skill Registries</category>
       <description>HermaGuard is an adversarial code review skill for AI agents designed to identify vulnerabilities and logic bugs without modifying source code. It utilizes a deterministic pre-scan layer featuring tools like Semgrep and Bandit followed by three parallel subagents that analyze edge cases, exploitability, and integration blast radius. Findings are merged by a consolidator into structured Markdown and JSON reports for triage. The system includes a feedback MCP server to track fix rates and a benchm</description>
     </item>
@@ -52,7 +60,7 @@
       <title>socialforge (Plugins &amp; Extensions)</title>
       <link>https://hermesatlas.com/projects/indranilbanerjee/socialforge</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/indranilbanerjee/socialforge</guid>
-      <pubDate>Mon, 15 Jun 2026 14:45:40 GMT</pubDate>
+      <pubDate>Tue, 09 Jun 2026 06:27:11 GMT</pubDate>
       <category>Plugins &amp; Extensions</category>
       <description>SocialForge is an open-source social media production engine designed to automate the creation of monthly content calendars for agencies and in-house teams. It uses asset-first compositing to generate AI backgrounds and scenes around existing brand photos to ensure visual fidelity. The system handles copy adaptation across seven platforms and integrates C2PA signing for EU AI Act compliance. It is compatible with Hermes Agent, Claude Code, and over 35 other Agent Skills platforms.</description>
     </item>
@@ -60,7 +68,7 @@
       <title>digital-marketing-pro (Plugins &amp; Extensions)</title>
       <link>https://hermesatlas.com/projects/indranilbanerjee/digital-marketing-pro</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/indranilbanerjee/digital-marketing-pro</guid>
-      <pubDate>Mon, 15 Jun 2026 14:45:40 GMT</pubDate>
+      <pubDate>Tue, 09 Jun 2026 06:26:21 GMT</pubDate>
       <category>Plugins &amp; Extensions</category>
       <description>Digital Marketing Pro is an open-source AI plugin designed to standardize marketing strategies for agencies and in-house teams managing multiple brands. It utilizes a 12-part strategy flow and a 61-step structure to generate consistent, auditable documentation across a brand portfolio. The tool integrates with various AI environments including Claude Code, Cursor, and GitHub Copilot CLI, offering specialized agents for tasks ranging from funnel architecture to compliance checks. It specifically </description>
     </item>
@@ -68,7 +76,7 @@
       <title>openclaw-skill (Skills &amp; Skill Registries)</title>
       <link>https://hermesatlas.com/projects/mag3nt-com/openclaw-skill</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/mag3nt-com/openclaw-skill</guid>
-      <pubDate>Mon, 15 Jun 2026 14:45:40 GMT</pubDate>
+      <pubDate>Sun, 07 Jun 2026 04:18:33 GMT</pubDate>
       <category>Skills &amp; Skill Registries</category>
       <description>mag3nt-pay is an agent payment skill that enables AI agents to autonomously pay for APIs that return HTTP 402 Payment Required errors. It works by detecting payment protocols from response headers, decoding the payment challenge, and settling the transaction using USDC via Mag3nt virtual cards. The skill supports Base, Solana, and most EVM networks, allowing agents to handle micropayments and subscriptions without human intervention. It is compatible with OpenClaw, Hermes Agent, and any framewor</description>
     </item>
@@ -76,7 +84,7 @@
       <title>hermes-Custom-CLI-Themes (Plugins &amp; Extensions)</title>
       <link>https://hermesatlas.com/projects/Sahil-SS9/hermes-Custom-CLI-Themes</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/Sahil-SS9/hermes-Custom-CLI-Themes</guid>
-      <pubDate>Mon, 15 Jun 2026 14:45:40 GMT</pubDate>
+      <pubDate>Tue, 02 Jun 2026 15:56:01 GMT</pubDate>
       <category>Plugins &amp; Extensions</category>
       <description>Hermes Custom CLI Themes is a collection of visual skins designed to personalize the Hermes Agent terminal interface. Each theme is defined in a single YAML file that configures color palettes, spinners, branding, and ASCII banner art. Users can apply these skins by placing them in a specific local directory and updating their configuration or using an in-app command. The project includes a variety of themed presets ranging from tactical and sci-fi aesthetics to minimalist investigator styles.</description>
     </item>
@@ -84,7 +92,7 @@
       <title>MrHermagi-tutorbot (Domain Applications)</title>
       <link>https://hermesatlas.com/projects/Sahil-SS9/MrHermagi-tutorbot</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/Sahil-SS9/MrHermagi-tutorbot</guid>
-      <pubDate>Mon, 15 Jun 2026 14:45:40 GMT</pubDate>
+      <pubDate>Tue, 02 Jun 2026 15:56:01 GMT</pubDate>
       <category>Domain Applications</category>
       <description>MrHermagi-tutorbot is a Discord-based AI educational assistant that automates the delivery of structured learning paths using Hermes Agent profiles. The bot utilizes YAML-defined curricula to generate daily lessons consisting of Discord summaries, dark-mode HTML deep-dives, and TTS audio for mobile listening. It features a Socratic teacher persona that delivers content to forum channels and provides interactive Q&amp;A support in dedicated text channels. Users can swap subjects by updating a configu</description>
     </item>
@@ -92,7 +100,7 @@
       <title>hermes-multichannel-prompt-optimizer (Skills &amp; Skill Registries)</title>
       <link>https://hermesatlas.com/projects/Sahil-SS9/hermes-multichannel-prompt-optimizer</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/Sahil-SS9/hermes-multichannel-prompt-optimizer</guid>
-      <pubDate>Mon, 15 Jun 2026 14:45:40 GMT</pubDate>
+      <pubDate>Tue, 02 Jun 2026 15:56:01 GMT</pubDate>
       <category>Skills &amp; Skill Registries</category>
       <description>This Hermes Agent plugin optimizes user prompts by rewriting them for clarity and efficiency before they reach the LLM. It intercepts messages across CLI, TUI, and gateway platforms, tailoring the rewrite based on the target model's vendor family and reasoning capabilities. The system supports multi-language detection to preserve original languages and records all interactions in a local SQLite database for longitudinal analysis. Users can monitor performance through dedicated slash commands for</description>
     </item>
@@ -100,7 +108,7 @@
       <title>cronalytics (Plugins &amp; Extensions)</title>
       <link>https://hermesatlas.com/projects/8bit64k/cronalytics</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/8bit64k/cronalytics</guid>
-      <pubDate>Mon, 15 Jun 2026 14:45:40 GMT</pubDate>
+      <pubDate>Tue, 02 Jun 2026 15:56:01 GMT</pubDate>
       <category>Plugins &amp; Extensions</category>
       <description>Cronalytics is an observability plugin for Hermes Agent that tracks the usage and estimated costs of scheduled cron jobs. It utilizes the on_session_end hook to capture session-level data and store it in a local SQLite fact database. Users can monitor their automations through a visual dashboard, a programmatic CLI, and a specialized agent skill for diagnostics. This allows for detailed analysis of model economics, failure patterns, and job performance.</description>
     </item>
@@ -108,7 +116,7 @@
       <title>agentplane-hermes-plugin (Plugins &amp; Extensions)</title>
       <link>https://hermesatlas.com/projects/basilisk-labs/agentplane-hermes-plugin</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/basilisk-labs/agentplane-hermes-plugin</guid>
-      <pubDate>Mon, 15 Jun 2026 14:45:40 GMT</pubDate>
+      <pubDate>Tue, 02 Jun 2026 15:56:01 GMT</pubDate>
       <category>Plugins &amp; Extensions</category>
       <description>This plugin integrates AgentPlane into the Hermes ecosystem by enabling external Kanban worker lanes. It functions by intercepting Kanban assignees matching specific patterns and resolving them to an external supervisor command rather than a standard Hermes profile. The integration maintains strict boundaries by requiring AgentPlane to manage task lifecycles through official APIs instead of direct database mutations. It supports path allowlisting for secure workspace management and includes a di</description>
     </item>
@@ -116,7 +124,7 @@
       <title>herm (Workspaces &amp; GUIs)</title>
       <link>https://hermesatlas.com/projects/liftaris/herm</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/liftaris/herm</guid>
-      <pubDate>Mon, 15 Jun 2026 14:45:40 GMT</pubDate>
+      <pubDate>Tue, 02 Jun 2026 15:56:01 GMT</pubDate>
       <category>Workspaces &amp; GUIs</category>
       <description>Herm is an operator-focused terminal user interface (TUI) and dashboard designed to centralize the management of Hermes Agent. Built with OpenTUI and Bun, it serves as a client for the Hermes Agent gateway, replacing fragmented shell commands and browser windows with a unified terminal workspace. Users can manage sessions, inspect memory, and execute agentic work through an integrated kanban board and task diagnostic views. The interface also supports a marketplace for 'eikons'—terminal-based av</description>
     </item>
@@ -124,7 +132,7 @@
       <title>eagle-eye (Skills &amp; Skill Registries)</title>
       <link>https://hermesatlas.com/projects/willingning-coder/eagle-eye</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/willingning-coder/eagle-eye</guid>
-      <pubDate>Mon, 15 Jun 2026 14:45:40 GMT</pubDate>
+      <pubDate>Tue, 02 Jun 2026 15:56:01 GMT</pubDate>
       <category>Skills &amp; Skill Registries</category>
       <description>Eagle Eye is a zero-invasive plugin for Hermes Agent that prevents token bloat and LLM confusion by filtering large skill libraries. It utilizes a five-layer retrieval pipeline consisting of deterministic hard triggers, FTS5 BM25, synonym dictionaries, dense embeddings, and RRF fusion to narrow down candidates to the top five most relevant skills. This system provides hints to the LLM without overriding its final decision and degrades gracefully if optional dependencies are missing.</description>
     </item>
@@ -132,121 +140,113 @@
       <title>hermes-exabase-plugin (Memory &amp; Context)</title>
       <link>https://hermesatlas.com/projects/futurebrowser/hermes-exabase-plugin</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/futurebrowser/hermes-exabase-plugin</guid>
-      <pubDate>Mon, 15 Jun 2026 14:45:40 GMT</pubDate>
+      <pubDate>Tue, 02 Jun 2026 15:56:01 GMT</pubDate>
       <category>Memory &amp; Context</category>
       <description>This plugin integrates the Exabase M-1 memory engine into Hermes Agent to provide persistent, long-term context for AI interactions. It functions by storing conversation turns and inferred memories in a self-organizing knowledge graph that resolves contradictions and evolves over time. Users can configure retrieval precision, enable query expansion, and utilize result reranking to fine-tune how the agent accesses stored facts and preferences. The integration includes dedicated tools for manual m</description>
     </item>
     <item>
-      <title>hermes-bort (Integrations &amp; Bridges)</title>
-      <link>https://hermesatlas.com/projects/BORT-AGENTS/hermes-bort</link>
-      <guid isPermaLink="true">https://hermesatlas.com/projects/BORT-AGENTS/hermes-bort</guid>
-      <pubDate>Mon, 15 Jun 2026 14:45:40 GMT</pubDate>
-      <category>Integrations &amp; Bridges</category>
-      <description>hermes-bort is a plugin for Hermes Agent that enables interaction with BORT (BAP-578) agent NFTs on the BSC mainnet. It allows Hermes processes to read on-chain agent states, execute actions via operator-signed writes, and manage portable session memory anchored to IPFS. The plugin integrates with the hermes-agent-self-evolution optimizer to commit verifiable on-chain learning records and evolved skills directly to an agent's knowledge registry.</description>
+      <title>AionUi (Workspaces &amp; GUIs)</title>
+      <link>https://hermesatlas.com/projects/iOfficeAI/AionUi</link>
+      <guid isPermaLink="true">https://hermesatlas.com/projects/iOfficeAI/AionUi</guid>
+      <pubDate>Thu, 28 May 2026 12:08:49 GMT</pubDate>
+      <category>Workspaces &amp; GUIs</category>
+      <description>AionUi is a local cowork platform that provides a unified graphical interface for managing and interacting with multiple AI agents. It integrates a built-in agent engine with file system access and web search capabilities, while also auto-detecting existing CLI agents like Hermes Agent and Claude Code. The platform enables autonomous multi-step task execution, scheduled automation via Cron, and remote access through various messaging apps. Users can leverage specialized assistants to generate ed</description>
     </item>
     <item>
-      <title>hermes-agentmemory (Memory &amp; Context)</title>
-      <link>https://hermesatlas.com/projects/MukundaKatta/hermes-agentmemory</link>
-      <guid isPermaLink="true">https://hermesatlas.com/projects/MukundaKatta/hermes-agentmemory</guid>
-      <pubDate>Mon, 15 Jun 2026 14:45:40 GMT</pubDate>
-      <category>Memory &amp; Context</category>
-      <description>This standalone plugin for Hermes Agent provides a pull-model episodic memory system designed for strict data deletion and transparency. It utilizes synchronous, on-demand summarization via Claude models instead of background processing to ensure that deleted memories are fully removed without leaving traces in persistent summaries. The system maintains a detailed audit log in a JSONL format, allowing users to track exactly which past events were injected into the agent's prompt. This approach p</description>
+      <title>cc-switch (Workspaces &amp; GUIs)</title>
+      <link>https://hermesatlas.com/projects/farion1231/cc-switch</link>
+      <guid isPermaLink="true">https://hermesatlas.com/projects/farion1231/cc-switch</guid>
+      <pubDate>Thu, 28 May 2026 12:08:49 GMT</pubDate>
+      <category>Workspaces &amp; GUIs</category>
+      <description>CC Switch is a cross-platform manager designed to centralize the administration of various AI coding and CLI tools. It is built using Tauri 2 to provide a native desktop experience across Windows, macOS, and Linux. The tool allows users to manage multiple environments including Claude Code, Gemini CLI, and Hermes Agent from a single interface. This streamlines the workflow for developers using a variety of LLM-based agents and coding assistants.</description>
     </item>
     <item>
-      <title>hermes-memory-plugin (Memory &amp; Context)</title>
-      <link>https://hermesatlas.com/projects/Ladybug-Memory/hermes-memory-plugin</link>
-      <guid isPermaLink="true">https://hermesatlas.com/projects/Ladybug-Memory/hermes-memory-plugin</guid>
-      <pubDate>Mon, 15 Jun 2026 14:45:40 GMT</pubDate>
-      <category>Memory &amp; Context</category>
-      <description>Hermes Ladybug Memory is a local-first memory provider plugin that enables Hermes agents to store and retrieve information without relying on cloud services or external APIs. It utilizes a columnar embedded graph database to manage typed memory entries, named relationships, and importance-weighted recall. The system prioritizes high-value information using a 1-10 importance scale and supports BM25 keyword search for precise retrieval. Users can also enable optional entity extraction via GLiNER2 </description>
-    </item>
-    <item>
-      <title>yantrikdb-hermes-plugin (Memory &amp; Context)</title>
-      <link>https://hermesatlas.com/projects/yantrikos/yantrikdb-hermes-plugin</link>
-      <guid isPermaLink="true">https://hermesatlas.com/projects/yantrikos/yantrikdb-hermes-plugin</guid>
-      <pubDate>Mon, 15 Jun 2026 14:45:40 GMT</pubDate>
-      <category>Memory &amp; Context</category>
-      <description>yantrikdb-hermes-plugin is a memory provider for Hermes Agent designed to prevent the loss of important constraints during long sessions. It utilizes a temporal context graph and a maintenance pass to manage memory lifecycles through promotion, demotion, and supersession. The plugin features an embedded in-process backend by default, eliminating the need for a separate server or GPU. It also enables agents to author and track the outcomes of their own skills natively within the database.</description>
-    </item>
-    <item>
-      <title>byterover-cli (Memory &amp; Context)</title>
-      <link>https://hermesatlas.com/projects/campfirein/byterover-cli</link>
-      <guid isPermaLink="true">https://hermesatlas.com/projects/campfirein/byterover-cli</guid>
-      <pubDate>Mon, 15 Jun 2026 14:45:40 GMT</pubDate>
-      <category>Memory &amp; Context</category>
-      <description>ByteRover CLI is a persistent, structured memory provider that gives AI coding agents a way to store and retrieve project knowledge. It organizes information into a context tree using a git-like version control system for branching, committing, and merging markdown-based context. The tool features an interactive REPL, a web dashboard, and integration with over 20 LLM providers and 22+ AI coding agents. Users can sync their knowledge trees via ByteRover Cloud for team collaboration and multi-mach</description>
-    </item>
-    <item>
-      <title>supermemory (Memory &amp; Context)</title>
-      <link>https://hermesatlas.com/projects/supermemoryai/supermemory</link>
-      <guid isPermaLink="true">https://hermesatlas.com/projects/supermemoryai/supermemory</guid>
-      <pubDate>Mon, 15 Jun 2026 14:45:40 GMT</pubDate>
-      <category>Memory &amp; Context</category>
-      <description>Supermemory is a context and memory layer for AI agents that prevents information loss between conversations. It uses a custom vector graph engine to extract facts, maintain user profiles, and handle knowledge updates or contradictions automatically. The system integrates RAG, multi-modal file processing, and real-time connectors for platforms like GitHub and Google Drive into a single API. It is designed to deliver personalized context with sub-300ms recall and supports local deployment via a s</description>
-    </item>
-    <item>
-      <title>OpenViking (Memory &amp; Context)</title>
-      <link>https://hermesatlas.com/projects/volcengine/OpenViking</link>
-      <guid isPermaLink="true">https://hermesatlas.com/projects/volcengine/OpenViking</guid>
-      <pubDate>Mon, 15 Jun 2026 14:45:40 GMT</pubDate>
-      <category>Memory &amp; Context</category>
-      <description>OpenViking is an open-source context database that simplifies context management for AI agents. It replaces traditional flat vector storage with a filesystem paradigm to unify the organization of memories, resources, and skills. The system utilizes a three-tier loading structure (L0/L1/L2) to reduce token consumption and supports recursive directory retrieval for precise context acquisition. It also provides visualized retrieval trajectories to make the retrieval process observable and debuggabl</description>
-    </item>
-    <item>
-      <title>hermes-tool-slimmer (Memory &amp; Context)</title>
-      <link>https://hermesatlas.com/projects/alias8818/hermes-tool-slimmer</link>
-      <guid isPermaLink="true">https://hermesatlas.com/projects/alias8818/hermes-tool-slimmer</guid>
-      <pubDate>Mon, 15 Jun 2026 14:45:40 GMT</pubDate>
-      <category>Memory &amp; Context</category>
-      <description>Hermes Tool Slimmer is a schema-selection optimization tool that reduces the token overhead caused by large tool catalogs in Hermes Agent. It creates an indexable corpus of tool schemas and uses local BM25 ranking with explicit boosts to select the smallest useful tool set for each turn. This approach lowers prompt token consumption while providing a dashboard for diagnostics, counters, and visibility. It is designed to complement or replace native tool search depending on the user's need for de</description>
-    </item>
-    <item>
-      <title>MeiGen-AI-Design-MCP (Plugins &amp; Extensions)</title>
-      <link>https://hermesatlas.com/projects/jau123/MeiGen-AI-Design-MCP</link>
-      <guid isPermaLink="true">https://hermesatlas.com/projects/jau123/MeiGen-AI-Design-MCP</guid>
-      <pubDate>Mon, 15 Jun 2026 14:45:40 GMT</pubDate>
-      <category>Plugins &amp; Extensions</category>
-      <description>MeiGen AI Design MCP is an open-source Model Context Protocol server that enables AI coding tools to perform professional image and video generation tasks. It connects to various backends including the MeiGen cloud, local ComfyUI instances, and OpenAI-compatible APIs to process visual requests directly within development environments. The system features a library of over 1,400 curated prompt templates and supports parallel sub-agent orchestration for batch processing. It is natively compatible </description>
-    </item>
-    <item>
-      <title>hermes-timetree-sync (Integrations &amp; Bridges)</title>
-      <link>https://hermesatlas.com/projects/kfa-ai/hermes-timetree-sync</link>
-      <guid isPermaLink="true">https://hermesatlas.com/projects/kfa-ai/hermes-timetree-sync</guid>
-      <pubDate>Mon, 15 Jun 2026 14:45:40 GMT</pubDate>
-      <category>Integrations &amp; Bridges</category>
-      <description>hermes-timetree-sync is a Python-based CLI and library that enables Hermes Agents to manage TimeTree calendar events without manual user intervention. Since TimeTree discontinued its official API, this bridge uses authenticated web endpoints and session cookies to perform non-interactive writes. It supports creating all-day events directly via HTTP requests and timed events through a Safari-backed automation path. The tool allows agents to translate natural language requests into structured cale</description>
-    </item>
-    <item>
-      <title>Brainstack (Memory &amp; Context)</title>
-      <link>https://hermesatlas.com/projects/yepyhun/Brainstack</link>
-      <guid isPermaLink="true">https://hermesatlas.com/projects/yepyhun/Brainstack</guid>
-      <pubDate>Mon, 15 Jun 2026 14:45:40 GMT</pubDate>
-      <category>Memory &amp; Context</category>
-      <description>Brainstack is a local-first memory kernel designed to replace flat memory blobs in Hermes agents with a structured, multi-layered memory model. It integrates three distinct memory lines—Hindsight, Graphiti, and MemPalace—to handle session continuity, temporal graph relations, and large-corpus retrieval through a single memory owner. By categorizing information into specific &quot;shelves&quot; like profile, graph, and corpus, it prevents prompt stuffing and ensures Hermes receives only the most relevant, </description>
-    </item>
-    <item>
-      <title>klodi-plugin (Plugins &amp; Extensions)</title>
-      <link>https://hermesatlas.com/projects/Context4GPTs/klodi-plugin</link>
-      <guid isPermaLink="true">https://hermesatlas.com/projects/Context4GPTs/klodi-plugin</guid>
-      <pubDate>Mon, 15 Jun 2026 14:45:40 GMT</pubDate>
-      <category>Plugins &amp; Extensions</category>
-      <description>klodi-plugin is a peer-to-peer marketplace adapter that enables AI agents to buy and sell items on behalf of their users. It integrates with various agent hosts via language-specific adapters to handle listing, negotiating, and closing deals based on user-defined markdown policies. This system allows users to maintain a single identity and strategy across different hosts while keeping sensitive negotiation data, such as floor prices, stored locally.</description>
-    </item>
-    <item>
-      <title>hermes-tweet (Plugins &amp; Extensions)</title>
-      <link>https://hermesatlas.com/projects/Xquik-dev/hermes-tweet</link>
-      <guid isPermaLink="true">https://hermesatlas.com/projects/Xquik-dev/hermes-tweet</guid>
-      <pubDate>Mon, 15 Jun 2026 14:45:40 GMT</pubDate>
-      <category>Plugins &amp; Extensions</category>
-      <description>Hermes Tweet is a native plugin that enables Hermes Agent to perform X (Twitter) automation via the Xquik API. It converts 99 OpenAPI-generated endpoints into structured tools for tasks such as posting tweets, reading trends, and managing direct messages. The plugin implements a least-privilege security model by splitting read and action tools, with write capabilities disabled by default. It is installable via PyPI and includes a bundled skill to provide usage guidance to the agent.</description>
-    </item>
-    <item>
-      <title>hermes-nextcloud (Skills &amp; Skill Registries)</title>
-      <link>https://hermesatlas.com/projects/adnw-vinc/hermes-nextcloud</link>
-      <guid isPermaLink="true">https://hermesatlas.com/projects/adnw-vinc/hermes-nextcloud</guid>
-      <pubDate>Mon, 15 Jun 2026 14:45:40 GMT</pubDate>
+      <title>open-design (Skills &amp; Skill Registries)</title>
+      <link>https://hermesatlas.com/projects/nexu-io/open-design</link>
+      <guid isPermaLink="true">https://hermesatlas.com/projects/nexu-io/open-design</guid>
+      <pubDate>Thu, 28 May 2026 12:08:49 GMT</pubDate>
       <category>Skills &amp; Skill Registries</category>
-      <description>This project is a Hermes Agent skill that enables direct interaction with self-hosted Nextcloud instances for personal data management. It interfaces with Nextcloud using WebDAV, CalDAV, CardDAV, and the Notes API to perform operations without requiring a browser or third-party sync services. Users can manage files, edit notes, schedule calendar events, track tasks, and search contacts through a command-line interface. The skill prioritizes security by utilizing Nextcloud App Passwords and stori</description>
+      <description>Open Design is a local-first, open-source design and prototyping system that serves as an agent-native alternative to Claude Design. It transforms the design process into a filesystem of skills, design systems, and plugins that can be read and remixed by coding agents. The system generates web, desktop, and mobile prototypes, motion graphics, and decks using real CSS and components. It integrates with various coding agents via a CLI and MCP server, allowing users to export outputs to HTML, PDF, </description>
+    </item>
+    <item>
+      <title>agent-of-empires (Multi-Agent &amp; Orchestration)</title>
+      <link>https://hermesatlas.com/projects/agent-of-empires/agent-of-empires</link>
+      <guid isPermaLink="true">https://hermesatlas.com/projects/agent-of-empires/agent-of-empires</guid>
+      <pubDate>Thu, 28 May 2026 12:08:49 GMT</pubDate>
+      <category>Multi-Agent &amp; Orchestration</category>
+      <description>Agent of Empires is a session manager for AI coding agents on Linux and macOS that simplifies the management of multiple parallel agent instances. It utilizes tmux sessions to ensure agents persist across terminal crashes or reboots, providing a centralized TUI and web dashboard for monitoring. The tool supports isolated environments via Docker sandboxing and git worktrees to prevent agents from interfering with the main codebase. It integrates with a wide range of agents, including Hermes, Clau</description>
+    </item>
+    <item>
+      <title>ClawPhone (Deployment &amp; Infra)</title>
+      <link>https://hermesatlas.com/projects/marshallrichards/ClawPhone</link>
+      <guid isPermaLink="true">https://hermesatlas.com/projects/marshallrichards/ClawPhone</guid>
+      <pubDate>Thu, 28 May 2026 12:08:49 GMT</pubDate>
+      <category>Deployment &amp; Infra</category>
+      <description>ClawPhone provides scripts and configuration guides for deploying agent CLIs on Android devices. It leverages Termux to run these agents natively, utilizing proot or compatibility layers only when necessary. The project includes a streamlined installer for Google's Antigravity CLI and detailed implementation notes for running OpenClaw. This setup allows agents to operate in the background with potential access to phone hardware via Termux:API and Termux:GUI.</description>
+    </item>
+    <item>
+      <title>hermes-labyrinth (Plugins &amp; Extensions)</title>
+      <link>https://hermesatlas.com/projects/stainlu/hermes-labyrinth</link>
+      <guid isPermaLink="true">https://hermesatlas.com/projects/stainlu/hermes-labyrinth</guid>
+      <pubDate>Thu, 28 May 2026 12:08:49 GMT</pubDate>
+      <category>Plugins &amp; Extensions</category>
+      <description>Hermes Labyrinth is a read-only observability plugin for Hermes Agent that visualizes autonomous workflows as a structured map of events. It functions as a black-box recorder, reading local state to track prompts, tool calls, model transitions, and subagent activities without mutating session data. The tool provides deep diagnostic visibility through specialized views for skill overrides, scheduled cron tasks, and redacted journey reports. Users can export evidence in Markdown or JSON formats wh</description>
+    </item>
+    <item>
+      <title>youtube-skills (Skills &amp; Skill Registries)</title>
+      <link>https://hermesatlas.com/projects/ZeroPointRepo/youtube-skills</link>
+      <guid isPermaLink="true">https://hermesatlas.com/projects/ZeroPointRepo/youtube-skills</guid>
+      <pubDate>Thu, 28 May 2026 12:08:49 GMT</pubDate>
+      <category>Skills &amp; Skill Registries</category>
+      <description>YouTube Skills is a collection of tools that enables AI agents to interact with YouTube content without relying on browser automation or local binaries. It utilizes the TranscriptAPI backend to bypass cloud IP blocks, providing agents with direct access to video transcripts, search results, and channel metadata. The project integrates with Hermes Agent, OpenClaw, and Claude Code using the Agent Skills format. Users can perform tasks like summarizing videos, extracting playlist contents, and sear</description>
+    </item>
+    <item>
+      <title>hermes-agent-helm-chart (Deployment &amp; Infra)</title>
+      <link>https://hermesatlas.com/projects/ultraworkers/hermes-agent-helm-chart</link>
+      <guid isPermaLink="true">https://hermesatlas.com/projects/ultraworkers/hermes-agent-helm-chart</guid>
+      <pubDate>Thu, 28 May 2026 12:08:49 GMT</pubDate>
+      <category>Deployment &amp; Infra</category>
+      <description>This unofficial community Helm chart facilitates the deployment of Nous Research's Hermes Agent on Kubernetes clusters. It provides a structured configuration model that enforces state-safety guardrails, such as single-replica constraints and specific update strategies, to prevent data corruption in persistent environments. The chart supports both direct workload management and an operator-ready mode for platform teams using custom resource definitions. It is optimized for multi-tenant isolation</description>
+    </item>
+    <item>
+      <title>hermes-agent-windows (Forks &amp; Derivatives)</title>
+      <link>https://hermesatlas.com/projects/pengchengxia75-arch/hermes-agent-windows</link>
+      <guid isPermaLink="true">https://hermesatlas.com/projects/pengchengxia75-arch/hermes-agent-windows</guid>
+      <pubDate>Thu, 28 May 2026 12:08:49 GMT</pubDate>
+      <category>Forks &amp; Derivatives</category>
+      <description>This project is a Windows-native adaptation of the Hermes Agent that eliminates the need for WSL2 or Linux environments. It utilizes a PowerShell-based installer to deploy the agent directly into the Windows ecosystem while resolving platform-specific issues like process signal handling. The fork introduces a dedicated Web UI management panel for real-time chat, session history, and visual configuration of skills and API keys.</description>
+    </item>
+    <item>
+      <title>hermes-agent-rtk-caveman (Developer Tools)</title>
+      <link>https://hermesatlas.com/projects/adityahimaone/hermes-agent-rtk-caveman</link>
+      <guid isPermaLink="true">https://hermesatlas.com/projects/adityahimaone/hermes-agent-rtk-caveman</guid>
+      <pubDate>Thu, 28 May 2026 12:08:49 GMT</pubDate>
+      <category>Developer Tools</category>
+      <description>This project provides a preconfigured setup for Hermes Agent that integrates Rust Token Killer (RTK) and Caveman templating to reduce token consumption during CLI operations. It works by wrapping standard terminal commands and outputting compact data structures, achieving a reported 90-99% reduction in token usage. The repository includes over 40 pre-configured skills covering finance management, GitHub workflows, research tools, and DevOps automation. Users can deploy the environment via an aut</description>
+    </item>
+    <item>
+      <title>hermes-desktop-os1 (Workspaces &amp; GUIs)</title>
+      <link>https://hermesatlas.com/projects/nickvasilescu/hermes-desktop-os1</link>
+      <guid isPermaLink="true">https://hermesatlas.com/projects/nickvasilescu/hermes-desktop-os1</guid>
+      <pubDate>Thu, 28 May 2026 12:08:49 GMT</pubDate>
+      <category>Workspaces &amp; GUIs</category>
+      <description>Hermes Desktop - OS1 Edition is a native macOS workspace designed to manage Hermes Agents running on Orgo cloud computers or SSH hosts. It provides a unified interface for VM provisioning, one-click agent installation, and real-time terminal access via websockets. The application includes built-in tools for session management, Kanban boards, and file editing with conflict checks. Additionally, it features a WebRTC-based voice mode that integrates OpenAI's Realtime API with Orgo MCP tools for voi</description>
+    </item>
+    <item>
+      <title>hermes-agent-anatomy (Guides &amp; Docs)</title>
+      <link>https://hermesatlas.com/projects/anneheartrecord/hermes-agent-anatomy</link>
+      <guid isPermaLink="true">https://hermesatlas.com/projects/anneheartrecord/hermes-agent-anatomy</guid>
+      <pubDate>Thu, 28 May 2026 12:08:49 GMT</pubDate>
+      <category>Guides &amp; Docs</category>
+      <description>This project provides a systematic technical decomposition and architectural analysis of the Hermes Agent source code. It breaks down the framework's 334,000 lines of Python code into modular guides covering the core agent loop, tool registration, and multi-provider adapters. The documentation includes visual technical illustrations and a 13-dimension comparative study against other frameworks like Claude Code and OpenClaw. Users can leverage these docs to understand complex features such as con</description>
+    </item>
+    <item>
+      <title>awesome-hermes-agent-zh (Guides &amp; Docs)</title>
+      <link>https://hermesatlas.com/projects/jefferyjob/awesome-hermes-agent-zh</link>
+      <guid isPermaLink="true">https://hermesatlas.com/projects/jefferyjob/awesome-hermes-agent-zh</guid>
+      <pubDate>Thu, 28 May 2026 12:08:49 GMT</pubDate>
+      <category>Guides &amp; Docs</category>
+      <description>This project is a curated Chinese translation and synchronization of the Awesome Hermes Agent list, providing a centralized directory of resources for the self-improving AI agent ecosystem. It organizes a wide array of community-contributed skills, plugins, and deployment tools to help users extend the agent's capabilities. The collection includes categorized resources ranging from production-ready tools to experimental prototypes, covering areas like cybersecurity, image generation, and SRE aut</description>
     </item>
   </channel>
 </rss>

--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -1131,8 +1131,11 @@ function syncHomepageRepos(repos) {
   }
 
   const missingByCategory = {};
+  const queuedMissing = new Set();
   for (const r of repos) {
-    if (!onPage.has(`${r.owner}/${r.repo}`)) {
+    const key = `${r.owner}/${r.repo}`;
+    if (!onPage.has(key) && !queuedMissing.has(key)) {
+      queuedMissing.add(key);
       (missingByCategory[r.category] = missingByCategory[r.category] || []).push(r);
     }
   }
@@ -1169,22 +1172,27 @@ function syncHomepageRepos(repos) {
     }
   }
 
-  // Refresh per-category counts. Use ACTUAL rendered repo-rows in each
-  // section, not repos.json category totals — the homepage convention is
-  // that featured repos (NousResearch/hermes-agent) appear in the hero
-  // section, not as a category row, so counting repos.json would over-count.
+  // Refresh per-category counts from repos.json, which is the public source
+  // of truth used by smoke-test-prod.js and external consumers. Some homepage
+  // sections intentionally omit or retain hand-curated rows (for example the
+  // featured Hermes Agent hero), so rendered row counts are not reliable
+  // catalog counts.
+  const categoryTotals = repos.reduce((acc, r) => {
+    acc.set(r.category, (acc.get(r.category) || 0) + 1);
+    return acc;
+  }, new Map());
   const sectionRe = /<section class="cat" data-category="([^"]+)">([\s\S]*?)<\/section>/g;
   let sm;
   while ((sm = sectionRe.exec(html)) !== null) {
     const category = sm[1];
     const sectionContent = sm[2];
-    const renderedCount = (sectionContent.match(/<a class="repo-row"/g) || []).length;
+    const expectedCount = categoryTotals.get(category) || 0;
     const countMatch = sectionContent.match(/<span class="cat-count-n">(\d+)<\/span>/);
-    if (countMatch && parseInt(countMatch[1], 10) !== renderedCount) {
+    if (countMatch && parseInt(countMatch[1], 10) !== expectedCount) {
       const absoluteIdx = sm.index + sm[0].indexOf(countMatch[0]);
       html =
         html.slice(0, absoluteIdx) +
-        `<span class="cat-count-n">${renderedCount}</span>` +
+        `<span class="cat-count-n">${expectedCount}</span>` +
         html.slice(absoluteIdx + countMatch[0].length);
       // Re-prime the regex to re-scan from current position since string length changed
       sectionRe.lastIndex = absoluteIdx;
@@ -1227,9 +1235,11 @@ async function main() {
     }
     if (starsRefreshed > 0) {
       const reposPath = path.join(ROOT, "data", "repos.json");
-      // Preserve CRLF + trailing newline so the diff is stars-only and
-      // doesn't churn the whole file on every build.
-      const body = JSON.stringify(repos, null, 2).replace(/\n/g, "\r\n") + "\r\n";
+      const existingReposText = fs.readFileSync(reposPath, "utf-8");
+      const eol = existingReposText.includes("\r\n") ? "\r\n" : "\n";
+      // Preserve the repo file's existing line endings + trailing newline so
+      // star refreshes do not churn the entire generated-data diff.
+      const body = JSON.stringify(repos, null, 2).replace(/\n/g, eol) + eol;
       fs.writeFileSync(reposPath, body);
       console.log(`  Refreshed stars on ${starsRefreshed} repos in data/repos.json\n`);
     }

--- a/scripts/check-dead-repos.js
+++ b/scripts/check-dead-repos.js
@@ -15,8 +15,14 @@ import { githubHeaders } from "../lib/github.js";
 
 const TOKEN = process.env.GITHUB_TOKEN;
 if (!TOKEN) {
-  console.error("GITHUB_TOKEN required");
-  process.exit(1);
+  console.warn(
+    "GITHUB_TOKEN not set; skipping live dead-repo check. " +
+    "Set GITHUB_TOKEN to audit GitHub repo availability."
+  );
+  // Keep CI fail-loud if this script is wired into automation without auth,
+  // but let local developers run it during smoke/audit sessions without a
+  // hard failure that looks like repo health failed.
+  process.exit(process.env.CI ? 1 : 0);
 }
 
 const repos = JSON.parse(await fs.readFile("data/repos.json", "utf8"));

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -188,6 +188,7 @@
   <url><loc>https://hermesatlas.com/projects/Sahil-SS9/hermes-memlock</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-06-16</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/Sahil-SS9/Toolaria</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-06-16</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/ndesv21/socialclaw</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-06-16</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/hlothaire/hermes-trace</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-06-16</lastmod></url>
   <url><loc>https://hermesatlas.com/lists/best-memory-providers</loc><changefreq>weekly</changefreq><priority>0.6</priority><lastmod>2026-06-16</lastmod></url>
   <url><loc>https://hermesatlas.com/lists/top-skills</loc><changefreq>weekly</changefreq><priority>0.6</priority><lastmod>2026-06-16</lastmod></url>
   <url><loc>https://hermesatlas.com/lists/deployment-options</loc><changefreq>weekly</changefreq><priority>0.6</priority><lastmod>2026-06-16</lastmod></url>


### PR DESCRIPTION
## Summary
- Fix homepage category-count drift by deriving counts from `data/repos.json` during build
- Add client-side newsletter email validation before calling `/api/subscribe`
- Make `scripts/check-dead-repos.js` graceful for local no-token runs while keeping CI fail-loud
- Remove the smoke-test allowlist now that the known count drift is fixed
- Remove a duplicate `hlothaire/hermes-trace` repo entry and rebuild generated Atlas artifacts with fresh GitHub metadata
- Keep Bob's npm audit fix for the `form-data` high-severity advisory

## Test Plan
- [x] `node scripts/build-pages.js` with GitHub token
- [x] `node scripts/smoke-test-prod.js --base http://127.0.0.1:8765 --sample 25 --continue`
- [x] `node --test tests/*.test.js`
- [x] `npm audit --audit-level=high`
- [x] `node scripts/check-dead-repos.js` without token exits 0 locally with a warning
