### PR TITLE
Add teixeirazeus/fablize-for-hermes to Skills & Skill Registries

### DIFF
--- a/data/repos.json
+++ b/data/repos.json
@@ -1688,5 +1688,15 @@
     "url": "https://github.com/hlothaire/hermes-trace",
     "official": false,
     "category": "Plugins & Extensions"
+  },
+  {
+    "owner": "teixeirazeus",
+    "repo": "fablize-for-hermes",
+    "name": "fablize-for-hermes",
+    "description": "A harness that makes any Hermes Agent see a task through to the end — with evidence and verification — as procedure, not as luck.",
+    "stars": 0,
+    "url": "https://github.com/teixeirazeus/fablize-for-hermes",
+    "official": false,
+    "category": "Skills & Skill Registries"
   }
 ]


### PR DESCRIPTION
## Summary

Adds **fablize-for-hermes** to the Skills & Skill Registries category.

### What is it?

A port of [fablize](https://github.com/fivetaku/fablize) for the [Hermes Agent](https://hermes-agent.nousresearch.com/) ecosystem — a harness that makes any agent see a task through to the end with evidence and verification.

Includes:
- **Hermes Agent skill** (`SKILL.md`) — verification grounding, multi-story evidence gating, investigation protocol, early-stop prevention
- **Goal engine** (`scripts/goals.py`) — self-contained, stdlib-only Python for multi-story decomposition with verification gate
- **Packs** — contextual discipline files (grounding loop, investigation protocol)
- **Setup scripts** — idempotent installation into Hermes

### Criteria check

- ✅ Built specifically for Hermes Agent
- ✅ Created after July 2025
- ✅ Genuine effort (18 tests, CI pipeline, 3-language README, Makefile, MIT license)
- ✅ Adds value to the ecosystem
- ✅ Category: Skills & Skill Registries