### PR TITLE
Harden API endpoints and CI against abuse and injection

### DIFF
--- a/.github/workflows/validate-repo-suggestion.yml
+++ b/.github/workflows/validate-repo-suggestion.yml
@@ -101,10 +101,16 @@ jobs:
         if: steps.gate.outputs.should_run == 'true'
         id: metadata
         uses: actions/github-script@v7
+        env:
+          # Pass via env (not `${{ }}` interpolated into the script body) so an
+          # issue-derived value can never be injected as code. Matches the
+          # pattern used by the validate/create-PR steps below.
+          REPO_OWNER: ${{ steps.extract.outputs.owner }}
+          REPO_NAME: ${{ steps.extract.outputs.repo }}
         with:
           script: |
-            const owner = '${{ steps.extract.outputs.owner }}';
-            const repo = '${{ steps.extract.outputs.repo }}';
+            const owner = process.env.REPO_OWNER;
+            const repo = process.env.REPO_NAME;
 
             try {
               const { data } = await github.rest.repos.get({ owner, repo });

--- a/api/stars-history.js
+++ b/api/stars-history.js
@@ -1,8 +1,26 @@
-import { kvGet } from "../lib/redis.js";
+import { kvGet, rateLimit } from "../lib/redis.js";
+
+const MAX_DAYS = 365;
+// Per-IP limit. This is the most expensive unauthenticated route (it fans out
+// one Redis read per requested day), so cap how often a single IP can hit it.
+const RATE_LIMIT = parseInt(process.env.STARS_HISTORY_RATE_LIMIT || "60", 10); // per minute per IP
 
 export default async function handler(req, res) {
   try {
-    const days = parseInt(req.query.days) || 30;
+    const ip =
+      req.headers["x-real-ip"]?.trim() ||
+      req.headers["x-forwarded-for"]?.split(",")[0]?.trim() ||
+      "unknown";
+    const { allowed } = await rateLimit(`stars-history:ip:${ip}`, RATE_LIMIT, 60);
+    if (!allowed) {
+      return res.status(429).json({ days: 0, history: [], error: "Rate limit reached. Try again shortly." });
+    }
+
+    // Clamp the window. Without an upper bound, a request like ?days=1000000
+    // would build a million date keys and fan them ALL out to Redis at once
+    // (Promise.all), exhausting the function and the shared Redis instance.
+    // parseInt(_, 10) also avoids accepting junk like "30abc" as a larger value.
+    const days = Math.min(Math.max(parseInt(req.query.days, 10) || 30, 1), MAX_DAYS);
 
     // Build date keys for the last N days
     const keys = [];

--- a/api/stars.js
+++ b/api/stars.js
@@ -64,11 +64,19 @@ export default async function handler(req, res) {
     // render live Hermes version without staleness. We pull both the tagName
     // (dated, e.g. "v2026.4.16") and the release name (which contains the
     // numeric version, e.g. "Hermes Agent v0.10.0 (v2026.4.16)").
+    // Use GraphQL variables (not string interpolation) for owner/repo so values
+    // from data/repos.json can never alter query structure. owner/repo are
+    // declared as typed variables and passed in the `variables` map.
+    const varDecls = [];
+    const variables = {};
     const repoQueries = repoList.map((r, i) => {
+      varDecls.push(`$owner${i}: String!`, `$name${i}: String!`);
+      variables[`owner${i}`] = r.owner;
+      variables[`name${i}`] = r.repo;
       const releaseField = (r.owner === "NousResearch" && r.repo === "hermes-agent")
         ? "latestRelease { tagName name publishedAt }"
         : "";
-      return `repo${i}: repository(owner: "${r.owner}", name: "${r.repo}") {
+      return `repo${i}: repository(owner: $owner${i}, name: $name${i}) {
         stargazerCount
         updatedAt
         pushedAt
@@ -76,8 +84,9 @@ export default async function handler(req, res) {
       }`;
     }).join("\n");
 
-    // Also fetch the Hermes Atlas repo's own star count for the masthead CTA
-    const query = `query { ${repoQueries}
+    // Also fetch the Hermes Atlas repo's own star count for the masthead CTA.
+    // (Constant, repo-owned identifiers — safe as literals.)
+    const query = `query (${varDecls.join(", ")}) { ${repoQueries}
       atlas: repository(owner: "ksimback", name: "hermes-ecosystem") {
         stargazerCount
       }
@@ -90,7 +99,7 @@ export default async function handler(req, res) {
         "Content-Type": "application/json",
         "User-Agent": "hermes-ecosystem"
       },
-      body: JSON.stringify({ query })
+      body: JSON.stringify({ query, variables })
     });
 
     if (!ghRes.ok) {

--- a/api/subscribe.js
+++ b/api/subscribe.js
@@ -1,5 +1,12 @@
+import { rateLimit } from "../lib/redis.js";
+
 const PUBLICATION_ID = "pub_cd668a5c-262b-4dd2-882b-6fb542d1a85a";
 const BEEHIIV_URL = `https://api.beehiiv.com/v2/publications/${PUBLICATION_ID}/subscriptions`;
+
+// Per-IP limit. A subscribe call forwards to Beehiiv and (per our payload)
+// triggers a welcome email, so an unthrottled endpoint enables signup-bombing
+// of third parties and quota burn. Keep it low.
+const RATE_LIMIT = parseInt(process.env.SUBSCRIBE_RATE_LIMIT || "5", 10); // per minute per IP
 
 // Local part: letters/digits + the punctuation that actually appears in
 // real-world addresses (`. _ - + '`). RFC 5322 technically allows more
@@ -17,6 +24,24 @@ function json(res, status, body) {
 export default async function handler(req, res) {
   if (req.method !== "POST") {
     return json(res, 405, { ok: false, error: "Method not allowed" });
+  }
+
+  // Reject oversized bodies before doing any work. A subscribe payload is a
+  // tiny JSON object; 8KB is generous.
+  const contentLength = parseInt(req.headers["content-length"] || "0", 10);
+  if (contentLength > 8 * 1024) {
+    return json(res, 413, { ok: false, error: "Request too large" });
+  }
+
+  // Per-IP rate limit (fails open if Redis is down — Beehiiv applies its own
+  // limits downstream as a backstop).
+  const ip =
+    req.headers["x-real-ip"]?.trim() ||
+    req.headers["x-forwarded-for"]?.split(",")[0]?.trim() ||
+    "unknown";
+  const { allowed } = await rateLimit(`subscribe:ip:${ip}`, RATE_LIMIT, 60);
+  if (!allowed) {
+    return json(res, 429, { ok: false, error: "Too many signups — try again in a minute." });
   }
 
   const apiKey = process.env.BEEHIIV_API_KEY;

--- a/lib/github.js
+++ b/lib/github.js
@@ -75,21 +75,27 @@ export async function fetchAllMetadata(repos, headers) {
 }
 
 async function fetchMetadataBatch(repos, headers, offset) {
+  // Use GraphQL variables for owner/repo instead of interpolating them into the
+  // query string, so repo metadata can never alter query structure.
+  const varDecls = [];
+  const variables = {};
   const repoQueries = repos
-    .map(
-      (r, i) =>
-        `repo${i}: repository(owner: "${r.owner}", name: "${r.repo}") {
+    .map((r, i) => {
+      varDecls.push(`$owner${i}: String!`, `$name${i}: String!`);
+      variables[`owner${i}`] = r.owner;
+      variables[`name${i}`] = r.repo;
+      return `repo${i}: repository(owner: $owner${i}, name: $name${i}) {
         stargazerCount
         description
         homepageUrl
         primaryLanguage { name }
         licenseInfo { spdxId }
         pushedAt
-      }`
-    )
+      }`;
+    })
     .join("\n");
 
-  const query = `query { ${repoQueries} }`;
+  const query = `query (${varDecls.join(", ")}) { ${repoQueries} }`;
   let lastError;
 
   for (let attempt = 1; attempt <= GRAPHQL_MAX_ATTEMPTS; attempt++) {
@@ -97,7 +103,7 @@ async function fetchMetadataBatch(repos, headers, offset) {
       const res = await fetch("https://api.github.com/graphql", {
         method: "POST",
         headers: { ...headers, "Content-Type": "application/json" },
-        body: JSON.stringify({ query }),
+        body: JSON.stringify({ query, variables }),
       });
 
       // Throw on failure so the caller (build-pages.js) fails loudly. Returning {}

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -121,3 +121,19 @@ export async function kvExpireNx(key, seconds) {
     return false;
   }
 }
+
+/**
+ * Fixed-window per-key rate limit. Increments the counter and sets the window
+ * TTL idempotently on first hit. Returns { allowed, count }.
+ *
+ * Fails OPEN: if Redis is unavailable (kvIncr returns null), the request is
+ * allowed. Use this for abuse mitigation on cheap endpoints. Cost-bearing
+ * paths that must fail CLOSED (e.g. the LLM chat endpoint) should check
+ * kvIncr directly and reject on null.
+ */
+export async function rateLimit(key, max, windowSec) {
+  const count = await kvIncr(key);
+  if (count === null) return { allowed: true, count: null };
+  await kvExpireNx(key, windowSec);
+  return { allowed: count <= max, count };
+}


### PR DESCRIPTION
## Summary

Security review follow-ups for `hermes-ecosystem`. The one **critical** finding from the review — a leaked OpenRouter key in git history — was **already rotated**, so this PR covers the remaining exploitable + hardening items.

| Finding | Severity | Fix |
|---|---|---|
| Unbounded `days` → Redis fan-out DoS | **MEDIUM** | `api/stars-history.js`: clamp `days` to `[1, 365]` + per-IP rate limit |
| No rate limit on subscribe | LOW | `api/subscribe.js`: per-IP rate limit + 8KB body-size cap |
| GraphQL built by string interpolation | LOW | `api/stars.js`, `lib/github.js`: use typed GraphQL **variables** for owner/repo |
| `${{ }}` interpolated into github-script | LOW | `.github/workflows/validate-repo-suggestion.yml`: pass owner/repo via `env:` |
| — | — | `lib/redis.js`: shared fail-open `rateLimit(key, max, windowSec)` helper |

### Why #2 matters
`/api/stars-history?days=1000000` previously built a million date keys and issued them all via `Promise.all`, exhausting the function and the Redis instance shared with the chat rate limiter. Now clamped, rate-limited, and `parseInt(_, 10)` rejects junk like `30abc`.

## Verification
- `node --check` passes on all 5 edited JS files
- All existing `tests/*.test.js` pass (4/4 each)
- Workflow YAML parses; `days` clamp and GraphQL variable/query symmetry verified by simulation
- No behavior change to happy paths — only new guards (clamp, rate limit, body cap) and a literal→variable swap in the GraphQL queries

## Deliberately out of scope (follow-up)
Splitting the validate workflow's read-only validation from the write/PR-creating step for least-privilege permissions — a riskier restructure of the serialized-merge logic, left for a dedicated PR.

## Not addressed here (no code change needed)
- History purge of the rotated key — optional hygiene only, since the key is already dead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)