### PR TITLE
Add Hermes Browser Extension to Atlas

### DIFF
--- a/data/repos.json
+++ b/data/repos.json
@@ -4,7 +4,7 @@
     "repo": "hermes-agent",
     "name": "hermes-agent",
     "description": "The self-improving AI agent that grows with you — persistent memory, auto-generated skills, 14 platforms, 6 execution backends",
-    "stars": 203319,
+    "stars": 203579,
     "url": "https://github.com/NousResearch/hermes-agent",
     "official": true,
     "category": "Core & Official"
@@ -14,7 +14,7 @@
     "repo": "Hermes-Function-Calling",
     "name": "Hermes-Function-Calling",
     "description": "Function calling examples and training data for Hermes LLM models",
-    "stars": 1404,
+    "stars": 1405,
     "url": "https://github.com/NousResearch/Hermes-Function-Calling",
     "official": true,
     "category": "Core & Official"
@@ -34,7 +34,7 @@
     "repo": "hermes-agent-self-evolution",
     "name": "hermes-agent-self-evolution",
     "description": "Evolutionary self-improvement using DSPy + GEPA — optimizes skills, prompts, and code",
-    "stars": 4348,
+    "stars": 4354,
     "url": "https://github.com/NousResearch/hermes-agent-self-evolution",
     "official": true,
     "category": "Core & Official"
@@ -44,7 +44,7 @@
     "repo": "hermes-paperclip-adapter",
     "name": "hermes-paperclip-adapter",
     "description": "Run Hermes as a managed employee in Paperclip company systems",
-    "stars": 1645,
+    "stars": 1646,
     "url": "https://github.com/NousResearch/hermes-paperclip-adapter",
     "official": true,
     "category": "Core & Official"
@@ -54,7 +54,7 @@
     "repo": "autonovel",
     "name": "autonovel",
     "description": "Autonomous novel-writing pipeline generating 100k+ word manuscripts",
-    "stars": 1202,
+    "stars": 1205,
     "url": "https://github.com/NousResearch/autonovel",
     "official": true,
     "category": "Core & Official"
@@ -64,7 +64,7 @@
     "repo": "hermes-workspace",
     "name": "hermes-workspace",
     "description": "Native web workspace — chat, terminal, memory browser, skills manager, and inspector panel",
-    "stars": 5854,
+    "stars": 5859,
     "url": "https://github.com/outsourc-e/hermes-workspace",
     "official": false,
     "category": "Workspaces & GUIs"
@@ -74,7 +74,7 @@
     "repo": "hermes-desktop",
     "name": "hermes-desktop",
     "description": "Desktop companion app for installing, configuring, and chatting with Hermes Agent",
-    "stars": 12734,
+    "stars": 12744,
     "url": "https://github.com/fathah/hermes-desktop",
     "official": false,
     "category": "Workspaces & GUIs"
@@ -100,11 +100,21 @@
     "category": "Workspaces & GUIs"
   },
   {
+    "owner": "abundantbeing",
+    "repo": "hermes-browser-extension",
+    "name": "hermes-browser-extension",
+    "description": "Chromium side-panel extension that connects active browser context to a local or remote Hermes Agent runtime",
+    "stars": 95,
+    "url": "https://github.com/abundantbeing/hermes-browser-extension",
+    "official": false,
+    "category": "Workspaces & GUIs"
+  },
+  {
     "owner": "mukul975",
     "repo": "Anthropic-Cybersecurity-Skills",
     "name": "Anthropic-Cybersecurity-Skills",
     "description": "754 structured cybersecurity skills mapped to MITRE ATT&CK, NIST CSF 2.0, ATLAS, D3FEND & NIST AI RMF",
-    "stars": 21479,
+    "stars": 21659,
     "url": "https://github.com/mukul975/Anthropic-Cybersecurity-Skills",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -114,7 +124,7 @@
     "repo": "avoid-ai-writing",
     "name": "avoid-ai-writing",
     "description": "Audits and rewrites content to eliminate detectable AI writing patterns",
-    "stars": 2011,
+    "stars": 2016,
     "url": "https://github.com/conorbronsdon/avoid-ai-writing",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -124,7 +134,7 @@
     "repo": "skills",
     "name": "wondelai/skills",
     "description": "Cross-platform skills library for Claude Code and agentskills.io-compatible agents",
-    "stars": 1461,
+    "stars": 1467,
     "url": "https://github.com/wondelai/skills",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -144,7 +154,7 @@
     "repo": "drawio-skill",
     "name": "drawio-skill",
     "description": "Generate draw.io diagrams from natural language descriptions",
-    "stars": 4695,
+    "stars": 4722,
     "url": "https://github.com/Agents365-ai/drawio-skill",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -164,7 +174,7 @@
     "repo": "litprog-skill",
     "name": "litprog-skill",
     "description": "Literate programming skill — weave code and documentation across agents",
-    "stars": 192,
+    "stars": 194,
     "url": "https://github.com/tlehman/litprog-skill",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -214,7 +224,7 @@
     "repo": "maestro",
     "name": "maestro",
     "description": "Harness for long-running AI agents — structured memory, cross-feature learning, plan-approve-execute",
-    "stars": 201,
+    "stars": 202,
     "url": "https://github.com/ReinaMacCredy/maestro",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -254,7 +264,7 @@
     "repo": "hermeshub",
     "name": "hermeshub",
     "description": "Community skill browsing, search, and one-click installation hub",
-    "stars": 285,
+    "stars": 286,
     "url": "https://github.com/amanning3390/hermeshub",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -274,7 +284,7 @@
     "repo": "mem0",
     "name": "mem0",
     "description": "Universal memory layer for AI Agents — official Hermes Agent memory provider, available as managed cloud or Apache-2.0 self-hosted OSS",
-    "stars": 59479,
+    "stars": 59502,
     "url": "https://github.com/mem0ai/mem0",
     "official": false,
     "category": "Memory & Context"
@@ -284,7 +294,7 @@
     "repo": "hindsight",
     "name": "hindsight",
     "description": "Agent memory that learns — long-term retain/recall/reflect workflows",
-    "stars": 17588,
+    "stars": 17611,
     "url": "https://github.com/vectorize-io/hindsight",
     "official": true,
     "category": "Memory & Context"
@@ -294,7 +304,7 @@
     "repo": "autocontext",
     "name": "autocontext",
     "description": "Recursive self-improving context harness — helps agents succeed on complex tasks",
-    "stars": 1224,
+    "stars": 1225,
     "url": "https://github.com/greyhaven-ai/autocontext",
     "official": false,
     "category": "Memory & Context"
@@ -304,7 +314,7 @@
     "repo": "honcho-self-hosted",
     "name": "honcho-self-hosted",
     "description": "Self-hosted Honcho memory backend for cross-session persistence",
-    "stars": 328,
+    "stars": 329,
     "url": "https://github.com/elkimek/honcho-self-hosted",
     "official": false,
     "category": "Memory & Context"
@@ -324,7 +334,7 @@
     "repo": "signetai",
     "name": "signetai",
     "description": "Local-first identity, memory, and secrets layer for AI agents — portable state across Hermes Agent, Claude Code, Codex, OpenCode, OpenClaw, and MCP clients",
-    "stars": 203,
+    "stars": 205,
     "url": "https://github.com/Signet-AI/signetai",
     "official": false,
     "category": "Memory & Context"
@@ -354,7 +364,7 @@
     "repo": "hermes-web-search-plus",
     "name": "hermes-web-search-plus",
     "description": "Multi-provider web search (Serper, Tavily, Exa, Querit, Perplexity) with auto-routing",
-    "stars": 316,
+    "stars": 315,
     "url": "https://github.com/robbyczgw-cla/hermes-web-search-plus",
     "official": false,
     "category": "Plugins & Extensions"
@@ -364,7 +374,7 @@
     "repo": "hermes-plugins",
     "name": "hermes-plugins",
     "description": "Goal management, inter-agent bridge, model selection, and cost control plugins",
-    "stars": 246,
+    "stars": 247,
     "url": "https://github.com/42-evey/hermes-plugins",
     "official": false,
     "category": "Plugins & Extensions"
@@ -414,7 +424,7 @@
     "repo": "mission-control",
     "name": "mission-control",
     "description": "Self-hosted AI agent orchestration — dispatch tasks, run multi-agent workflows, monitor spend",
-    "stars": 5422,
+    "stars": 5428,
     "url": "https://github.com/builderz-labs/mission-control",
     "official": false,
     "category": "Multi-Agent & Orchestration"
@@ -454,7 +464,7 @@
     "repo": "opencode-hermes-multiagent",
     "name": "opencode-hermes-multiagent",
     "description": "17 specialized agents for research, planning, implementation, quality, and infrastructure",
-    "stars": 152,
+    "stars": 153,
     "url": "https://github.com/1ilkhamov/opencode-hermes-multiagent",
     "official": false,
     "category": "Multi-Agent & Orchestration"
@@ -484,7 +494,7 @@
     "repo": "hermes-agent-cn-desktop",
     "name": "hermes-agent-cn-desktop",
     "description": "Windows-first Chinese desktop app for Hermes Agent built with Tauri, TypeScript, and Rust",
-    "stars": 578,
+    "stars": 584,
     "url": "https://github.com/Eynzof/hermes-agent-cn-desktop",
     "official": false,
     "category": "Workspaces & GUIs"
@@ -524,7 +534,7 @@
     "repo": "codegraph",
     "name": "codegraph",
     "description": "Local pre-indexed code knowledge graph for Hermes Agent and other coding agents to reduce token usage and tool calls",
-    "stars": 54767,
+    "stars": 54917,
     "url": "https://github.com/colbymchenry/codegraph",
     "official": false,
     "category": "Developer Tools"
@@ -554,7 +564,7 @@
     "repo": "hermes-agent-control-room",
     "name": "hermes-agent-control-room",
     "description": "Control Room-first template for scaling Hermes Agent from one VPS agent to specialist teams and automated workflows",
-    "stars": 599,
+    "stars": 600,
     "url": "https://github.com/shannhk/hermes-agent-control-room",
     "official": false,
     "category": "Multi-Agent & Orchestration"
@@ -564,7 +574,7 @@
     "repo": "oh-my-hermes",
     "name": "oh-my-hermes",
     "description": "Opinionated workflow layer for building, shipping, and operating apps with Hermes Agent",
-    "stars": 658,
+    "stars": 659,
     "url": "https://github.com/Salomondiei08/oh-my-hermes",
     "official": false,
     "category": "Developer Tools"
@@ -574,7 +584,7 @@
     "repo": "claude-tap",
     "name": "claude-tap",
     "description": "Local trace viewer for inspecting coding-agent API traffic from Hermes Agent, Claude Code, Codex, Gemini, Cursor, OpenCode, and others",
-    "stars": 2006,
+    "stars": 2011,
     "url": "https://github.com/liaohch3/claude-tap",
     "official": false,
     "category": "Developer Tools"
@@ -624,7 +634,7 @@
     "repo": "hermes-agent-ultra",
     "name": "hermes-agent-ultra",
     "description": "Rust-based Hermes Agent Ultra derivative focused on performance and Hermes Agent feature parity",
-    "stars": 56,
+    "stars": 57,
     "url": "https://github.com/sheawinkler/hermes-agent-ultra",
     "official": false,
     "category": "Forks & Derivatives"
@@ -714,7 +724,7 @@
     "repo": "hermes-labyrinth",
     "name": "hermes-labyrinth",
     "description": "Read-only observability plugin for Hermes Agent with journeys, crossings, guideposts, and reports",
-    "stars": 290,
+    "stars": 291,
     "url": "https://github.com/stainlu/hermes-labyrinth",
     "official": false,
     "category": "Plugins & Extensions"
@@ -744,7 +754,7 @@
     "repo": "open-design",
     "name": "open-design",
     "description": "Local-first open-source design/prototyping system with coding-agent CLI support including Hermes Agent",
-    "stars": 71353,
+    "stars": 71525,
     "url": "https://github.com/nexu-io/open-design",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -754,7 +764,7 @@
     "repo": "cc-switch",
     "name": "cc-switch",
     "description": "Cross-platform all-in-one manager for Claude Code, Codex, OpenCode, OpenClaw, Gemini CLI, and Hermes Agent",
-    "stars": 108709,
+    "stars": 108925,
     "url": "https://github.com/farion1231/cc-switch",
     "official": false,
     "category": "Workspaces & GUIs"
@@ -764,7 +774,7 @@
     "repo": "AionUi",
     "name": "AionUi",
     "description": "Local open-source cowork app for OpenClaw, Hermes Agent, Claude Code, Codex, OpenCode, Gemini CLI, and other agent CLIs",
-    "stars": 28886,
+    "stars": 28906,
     "url": "https://github.com/iOfficeAI/AionUi",
     "official": false,
     "category": "Workspaces & GUIs"
@@ -774,7 +784,7 @@
     "repo": "llm-agents.nix",
     "name": "llm-agents.nix",
     "description": "Nix packages for AI coding agents including Hermes",
-    "stars": 1474,
+    "stars": 1475,
     "url": "https://github.com/numtide/llm-agents.nix",
     "official": false,
     "category": "Deployment & Infra"
@@ -794,7 +804,7 @@
     "repo": "nix-hermes-agent",
     "name": "nix-hermes-agent",
     "description": "Nix package and NixOS module for reproducible Hermes deployment",
-    "stars": 25,
+    "stars": 26,
     "url": "https://github.com/0xrsydn/nix-hermes-agent",
     "official": false,
     "category": "Deployment & Infra"
@@ -884,7 +894,7 @@
     "repo": "tokscale",
     "name": "tokscale",
     "description": "CLI tool for tracking token usage from Claude Code, OpenClaw, Hermes, Codex, Gemini, and more",
-    "stars": 3963,
+    "stars": 3969,
     "url": "https://github.com/junhoyeo/tokscale",
     "official": false,
     "category": "Developer Tools"
@@ -894,7 +904,7 @@
     "repo": "hermes-skins",
     "name": "hermes-skins",
     "description": "Community CLI skins and themes for Hermes terminal UI",
-    "stars": 471,
+    "stars": 472,
     "url": "https://github.com/joeynyc/hermes-skins",
     "official": false,
     "category": "Developer Tools"
@@ -954,7 +964,7 @@
     "repo": "evey-setup",
     "name": "evey-setup",
     "description": "Get a hermes-agent stack running in minutes — free models, 29 plugins, zero cost",
-    "stars": 46,
+    "stars": 47,
     "url": "https://github.com/42-evey/evey-setup",
     "official": false,
     "category": "Developer Tools"
@@ -964,7 +974,7 @@
     "repo": "DashClaw",
     "name": "DashClaw",
     "description": "Decision infrastructure with guard policies and risk assessment for agents",
-    "stars": 277,
+    "stars": 278,
     "url": "https://github.com/ucsandman/DashClaw",
     "official": false,
     "category": "Domain Applications"
@@ -984,7 +994,7 @@
     "repo": "job-scout-agent",
     "name": "job-scout-agent",
     "description": "Autonomous job hunting — scans listings, writes cover letters, tracks applications",
-    "stars": 47,
+    "stars": 48,
     "url": "https://github.com/Christabel337/job-scout-agent",
     "official": false,
     "category": "Domain Applications"
@@ -1044,7 +1054,7 @@
     "repo": "awesome-hermes-agent",
     "name": "awesome-hermes-agent",
     "description": "Curated list of awesome skills, tools, integrations, and resources for Hermes Agent",
-    "stars": 4215,
+    "stars": 4226,
     "url": "https://github.com/0xNyk/awesome-hermes-agent",
     "official": false,
     "category": "Guides & Docs"
@@ -1054,7 +1064,7 @@
     "repo": "hermes-agent-orange-book",
     "name": "hermes-agent-orange-book",
     "description": "Hermes Agent practical guide — Orange Book series (Chinese language)",
-    "stars": 4548,
+    "stars": 4549,
     "url": "https://github.com/alchaincyf/hermes-agent-orange-book",
     "official": false,
     "category": "Guides & Docs"
@@ -1134,7 +1144,7 @@
     "repo": "hermes-control-interface",
     "name": "hermes-control-interface",
     "description": "A self-hosted web dashboard for the Hermes AI agent stack. Provides a browser-based terminal, file explorer, session overview, cron management, system metrics, and an agent status panel — all behind a",
-    "stars": 784,
+    "stars": 785,
     "url": "https://github.com/xaspx/hermes-control-interface",
     "official": false,
     "category": "Workspaces & GUIs"
@@ -1144,7 +1154,7 @@
     "repo": "hermes-ecosystem",
     "name": "hermes-ecosystem",
     "description": "Hermes Atlas — the community map of every tool, skill, and integration for Hermes Agent by Nous Research",
-    "stars": 1061,
+    "stars": 1064,
     "url": "https://github.com/ksimback/hermes-ecosystem",
     "official": false,
     "category": "Guides & Docs"
@@ -1154,7 +1164,7 @@
     "repo": "hermes-desktop",
     "name": "hermes-desktop",
     "description": "A native Mac workspace for Hermes: real SSH, real terminal, real session data.",
-    "stars": 1927,
+    "stars": 1926,
     "url": "https://github.com/dodo-reach/hermes-desktop",
     "official": false,
     "category": "Workspaces & GUIs"
@@ -1174,7 +1184,7 @@
     "repo": "hermes-webui",
     "name": "hermes-webui",
     "description": "Hermes WebUI: The best way to use Hermes Agent from the web or from your phone!",
-    "stars": 15041,
+    "stars": 15060,
     "url": "https://github.com/nesquena/hermes-webui",
     "official": false,
     "category": "Workspaces & GUIs"
@@ -1184,7 +1194,7 @@
     "repo": "gbrain",
     "name": "gbrain",
     "description": "Garry's Opinionated OpenClaw/Hermes Agent Brain",
-    "stars": 24154,
+    "stars": 24185,
     "url": "https://github.com/garrytan/gbrain",
     "official": false,
     "category": "Memory & Context"
@@ -1214,7 +1224,7 @@
     "repo": "hermesclaw",
     "name": "hermesclaw",
     "description": "Run Hermes Agent and OpenClaw on the same WeChat account",
-    "stars": 647,
+    "stars": 648,
     "url": "https://github.com/AaronWong1999/hermesclaw",
     "official": false,
     "category": "Integrations & Bridges"
@@ -1254,7 +1264,7 @@
     "repo": "hermes-otel",
     "name": "hermes-otel",
     "description": "OTel Plugin for Hermes Agent",
-    "stars": 30,
+    "stars": 31,
     "url": "https://github.com/briancaffey/hermes-otel",
     "official": false,
     "category": "Plugins & Extensions"
@@ -1264,7 +1274,7 @@
     "repo": "hermes-web-ui",
     "name": "hermes-web-ui",
     "description": "Web dashboard for Hermes Agent — multi-platform AI chat, session management, scheduled jobs, usage analytics & channel configuration (Telegram, Discord, Slack, WhatsApp)",
-    "stars": 8530,
+    "stars": 8541,
     "url": "https://github.com/EKKOLearnAI/hermes-web-ui",
     "official": false,
     "category": "Workspaces & GUIs"
@@ -1284,7 +1294,7 @@
     "repo": "mnemosyne",
     "name": "mnemosyne",
     "description": "The Zero-Dependency, Sub-Millisecond AI Memory System for Hermes Agents",
-    "stars": 1288,
+    "stars": 1293,
     "url": "https://github.com/AxDSan/mnemosyne",
     "official": false,
     "category": "Memory & Context"
@@ -1294,7 +1304,7 @@
     "repo": "SkillClaw",
     "name": "SkillClaw",
     "description": "Let Skills Evolve Collectively with Agentic Evolver",
-    "stars": 2024,
+    "stars": 2026,
     "url": "https://github.com/AMAP-ML/SkillClaw",
     "official": false,
     "category": "Skills & Skill Registries"
@@ -1344,7 +1354,7 @@
     "repo": "hermes-agent-guide",
     "name": "hermes-agent-guide",
     "description": "A systematic Chinese-language guide to Hermes Agent — 16 books, 300K+ words, covering installation, advanced development, single- and multi-agent orchestration.",
-    "stars": 416,
+    "stars": 422,
     "url": "https://github.com/jwangkun/hermes-agent-guide",
     "official": false,
     "category": "Guides & Docs"
@@ -1364,7 +1374,7 @@
     "repo": "hermeshq",
     "name": "hermeshq",
     "description": "HermesHQ is a Docker-first control plane for running and operating multiple Hermes Agent instances from one web application.",
-    "stars": 12,
+    "stars": 13,
     "url": "https://github.com/jpalmae/hermeshq",
     "official": false,
     "category": "Deployment & Infra"
@@ -1374,7 +1384,7 @@
     "repo": "honcho",
     "name": "honcho",
     "description": "Memory library for building stateful agents — the upstream library that the elkimek/honcho-self-hosted Hermes wrapper builds on.",
-    "stars": 5551,
+    "stars": 5560,
     "url": "https://github.com/plastic-labs/honcho",
     "official": true,
     "category": "Memory & Context"
@@ -1404,7 +1414,7 @@
     "repo": "klodi-plugin",
     "name": "klodi-plugin",
     "description": "The agent-to-agent marketplace, in your agent host. Your agent lists, haggles, and closes deals for you while you live your life.",
-    "stars": 13,
+    "stars": 14,
     "url": "https://github.com/Context4GPTs/klodi-plugin",
     "official": false,
     "category": "Plugins & Extensions"
@@ -1414,7 +1424,7 @@
     "repo": "Brainstack",
     "name": "Brainstack",
     "description": "Memory kernel stack for Hermes agent",
-    "stars": 42,
+    "stars": 43,
     "url": "https://github.com/yepyhun/Brainstack",
     "official": false,
     "category": "Memory & Context"
@@ -1434,7 +1444,7 @@
     "repo": "MeiGen-AI-Design-MCP",
     "name": "MeiGen-AI-Design-MCP",
     "description": "Supports GPT Image 2, Nanobanana & ComfyUI, with a 1,400+ prompt library, carefully crafted hooks and a multi-task orchestration system",
-    "stars": 1491,
+    "stars": 1493,
     "url": "https://github.com/jau123/MeiGen-AI-Design-MCP",
     "official": false,
     "category": "Plugins & Extensions"
@@ -1454,7 +1464,7 @@
     "repo": "OpenViking",
     "name": "OpenViking",
     "description": "Open-source context database for AI agents — official Hermes Agent memory provider using viking:// URIs and tiered L0/L1/L2 loading; 91% token reduction and 43-49% task-completion gain over baseline on LoCoMo10. AGPL-3.0.",
-    "stars": 26065,
+    "stars": 26083,
     "url": "https://github.com/volcengine/OpenViking",
     "official": false,
     "category": "Memory & Context"
@@ -1464,7 +1474,7 @@
     "repo": "supermemory",
     "name": "supermemory",
     "description": "Memory engine and API — official Hermes Agent memory provider with sub-300ms recall sustained at 100B+ tokens/month, custom vector graph engine, context fencing, and byte-level dedupe with 100% prompt-cache discount.",
-    "stars": 27600,
+    "stars": 27627,
     "url": "https://github.com/supermemoryai/supermemory",
     "official": false,
     "category": "Memory & Context"
@@ -1474,7 +1484,7 @@
     "repo": "byterover-cli",
     "name": "byterover-cli",
     "description": "Memory as a git repo (formerly Cipher) — official Hermes Agent memory provider with 5-tier retrieval (4 tiers non-LLM, sub-100ms), brv vc commit/branch/merge versioning over plain markdown context tree. Elastic License 2.0.",
-    "stars": 4878,
+    "stars": 4882,
     "url": "https://github.com/campfirein/byterover-cli",
     "official": false,
     "category": "Memory & Context"
@@ -1484,7 +1494,7 @@
     "repo": "yantrikdb-hermes-plugin",
     "name": "yantrikdb-hermes-plugin",
     "description": "Self-maintaining Hermes memory plugin with explainable retrieval — every recall comes back with a why_retrieved tag, plus canonicalization, contradiction tracking, and recency ranking. Embedded by default.",
-    "stars": 62,
+    "stars": 63,
     "url": "https://github.com/yantrikos/yantrikdb-hermes-plugin",
     "official": false,
     "category": "Memory & Context"
@@ -1504,7 +1514,7 @@
     "repo": "hermes-agentmemory",
     "name": "hermes-agentmemory",
     "description": "Pull-model episodic memory plugin for Hermes Agent with real deletion (no persistent summaries that haunt future recall) and a trace.jsonl audit log of every memory operation. Community fix for issue #6715. MIT.",
-    "stars": 6,
+    "stars": 7,
     "url": "https://github.com/MukundaKatta/hermes-agentmemory",
     "official": false,
     "category": "Memory & Context"
@@ -1544,7 +1554,7 @@
     "repo": "herm",
     "name": "herm",
     "description": "Alternative Hermes TUI and dashboard built with OpenTUI.",
-    "stars": 260,
+    "stars": 261,
     "url": "https://github.com/liftaris/herm",
     "official": false,
     "category": "Workspaces & GUIs"
@@ -1614,7 +1624,7 @@
     "repo": "digital-marketing-pro",
     "name": "digital-marketing-pro",
     "description": "Open-source AI marketing plugin for agencies & in-house teams — 158 skills, 25 specialist agents, 12-Part Strategy Flow, Cowork team-persistent, EU AI Act Article 50 ready, 6-platform AEO/GEO incl. Go",
-    "stars": 162,
+    "stars": 163,
     "url": "https://github.com/indranilbanerjee/digital-marketing-pro",
     "official": false,
     "category": "Plugins & Extensions"
@@ -1674,7 +1684,7 @@
     "repo": "socialclaw",
     "name": "socialclaw",
     "description": "Social media scheduling CLI and OpenClaw skill for AI agents posting to X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, and Pinterest.",
-    "stars": 45,
+    "stars": 47,
     "url": "https://github.com/ndesv21/socialclaw",
     "official": false,
     "category": "Integrations & Bridges"
@@ -1686,16 +1696,6 @@
     "description": "A Hermes Agent plugin that builds execution trace graphs using agent lifecycle hooks.",
     "stars": 0,
     "url": "https://github.com/hlothaire/hermes-trace",
-    "official": false,
-    "category": "Plugins & Extensions"
-  },
-  {
-    "owner": "nujovich",
-    "repo": "hermes-telemetry",
-    "name": "hermes-telemetry",
-    "description": "Budget enforcement + observability plugin for Hermes Agent. Stops runaway costs before they happen.",
-    "stars": 11,
-    "url": "https://github.com/nujovich/hermes-telemetry",
     "official": false,
     "category": "Plugins & Extensions"
   },
@@ -1728,16 +1728,6 @@
     "url": "https://github.com/yonro/hermes-xmemo-plugin",
     "official": false,
     "category": "Memory & Context"
-  },
-  {
-    "owner": "DIALLOUBE-RESEARCH",
-    "repo": "hypernatt-terminal",
-    "name": "hypernatt-terminal",
-    "description": "BTC Decision Terminal for AI Agents — live vault-backed signals, on-chain proof, cross-chain swap. Verify in real time.",
-    "stars": 1,
-    "url": "https://github.com/DIALLOUBE-RESEARCH/hypernatt-terminal",
-    "official": false,
-    "category": "Integrations & Bridges"
   },
   {
     "owner": "DIALLOUBE-RESEARCH",

--- a/index.html
+++ b/index.html
@@ -285,7 +285,7 @@
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/NousResearch/Hermes-Function-Calling" data-github="https://github.com/NousResearch/Hermes-Function-Calling" data-desc="Function calling examples and training data for Hermes LLM models">
-      <div class="repo-stars">★ 1,404</div>
+      <div class="repo-stars">★ 1,405</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">NousResearch /</span> Hermes-Function-Calling <span class="repo-flag">official</span></div>
         <div class="repo-desc">Function calling examples and training data for Hermes LLM models.</div>
@@ -301,7 +301,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/NousResearch/hermes-agent-self-evolution" data-github="https://github.com/NousResearch/hermes-agent-self-evolution" data-desc="Evolutionary self-improvement using DSPy + GEPA — optimizes skills, prompts, and code">
-      <div class="repo-stars">★ 4,348</div>
+      <div class="repo-stars">★ 4,354</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">NousResearch /</span> hermes-agent-self-evolution <span class="repo-flag">official</span></div>
         <div class="repo-desc">Evolutionary self-improvement using DSPy + GEPA — optimizes skills, prompts, and code.</div>
@@ -309,7 +309,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/NousResearch/hermes-paperclip-adapter" data-github="https://github.com/NousResearch/hermes-paperclip-adapter" data-desc="Run Hermes as a managed employee in Paperclip company systems">
-      <div class="repo-stars">★ 1,645</div>
+      <div class="repo-stars">★ 1,646</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">NousResearch /</span> hermes-paperclip-adapter <span class="repo-flag">official</span></div>
         <div class="repo-desc">Run Hermes as a managed employee in Paperclip company systems.</div>
@@ -317,7 +317,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/NousResearch/autonovel" data-github="https://github.com/NousResearch/autonovel" data-desc="Autonomous novel-writing pipeline generating 100k+ word manuscripts">
-      <div class="repo-stars">★ 1,202</div>
+      <div class="repo-stars">★ 1,205</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">NousResearch /</span> autonovel <span class="repo-flag">official</span></div>
         <div class="repo-desc">Autonomous novel-writing pipeline generating 100k+ word manuscripts.</div>
@@ -332,11 +332,11 @@
     <div class="cat-num">§02</div>
     <h2 class="cat-title">Workspaces &amp; GUIs</h2>
     <p class="cat-desc">Web and desktop interfaces — chat UIs, memory browsers, config dashboards.</p>
-    <div class="cat-count"><span class="cat-count-n">18</span> repos</div>
+    <div class="cat-count"><span class="cat-count-n">19</span> repos</div>
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/nesquena/hermes-webui" data-github="https://github.com/nesquena/hermes-webui" data-desc="Hermes WebUI: The best way to use Hermes Agent from the web or from your phone!">
-      <div class="repo-stars">★ 15,041</div>
+      <div class="repo-stars">★ 15,060</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">nesquena /</span> hermes-webui</div>
         <div class="repo-desc">The best way to use Hermes Agent from the web or from your phone.</div>
@@ -344,7 +344,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/outsourc-e/hermes-workspace" data-github="https://github.com/outsourc-e/hermes-workspace" data-desc="Native web workspace — chat, terminal, memory browser, skills manager, and inspector panel">
-      <div class="repo-stars">★ 5,854</div>
+      <div class="repo-stars">★ 5,859</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">outsourc-e /</span> hermes-workspace</div>
         <div class="repo-desc">Native web workspace — chat, terminal, memory browser, skills manager, inspector panel.</div>
@@ -360,7 +360,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/xaspx/hermes-control-interface" data-github="https://github.com/xaspx/hermes-control-interface" data-desc="Self-hosted web dashboard — terminal, file explorer, cron, metrics, and agent status panel">
-      <div class="repo-stars">★ 784</div>
+      <div class="repo-stars">★ 785</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">xaspx /</span> hermes-control-interface</div>
         <div class="repo-desc">Self-hosted dashboard — terminal, file explorer, cron, metrics, agent status panel.</div>
@@ -368,7 +368,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/dodo-reach/hermes-desktop" data-github="https://github.com/dodo-reach/hermes-desktop" data-desc="A native Mac workspace for Hermes: real SSH, real terminal, real session data">
-      <div class="repo-stars">★ 1,927</div>
+      <div class="repo-stars">★ 1,926</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">dodo-reach /</span> hermes-desktop</div>
         <div class="repo-desc">Native Mac workspace for Hermes — real SSH, real terminal, real session data.</div>
@@ -376,7 +376,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/fathah/hermes-desktop" data-github="https://github.com/fathah/hermes-desktop" data-desc="Desktop companion app for installing, configuring, and chatting with Hermes Agent">
-      <div class="repo-stars">★ 12,734</div>
+      <div class="repo-stars">★ 12,744</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">fathah /</span> hermes-desktop</div>
         <div class="repo-desc">Desktop companion for installing, configuring, and chatting with Hermes Agent.</div>
@@ -408,7 +408,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/EKKOLearnAI/hermes-web-ui" data-github="https://github.com/EKKOLearnAI/hermes-web-ui" data-desc="Web dashboard for Hermes Agent — multi-platform AI chat, session management, scheduled jobs, usage analytics &amp; channel configuration (Telegram, Discord, Slack, WhatsApp)">
-      <div class="repo-stars">★ 8,530</div>
+      <div class="repo-stars">★ 8,541</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">EKKOLearnAI /</span> hermes-web-ui</div>
         <div class="repo-desc">Web dashboard for Hermes Agent — multi-platform AI chat, session management, scheduled jobs, usage analytics &amp; channel configuration (Telegram, Discord, Slack, WhatsApp).</div>
@@ -424,7 +424,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/farion1231/cc-switch" data-github="https://github.com/farion1231/cc-switch" data-desc="Cross-platform all-in-one manager for Claude Code, Codex, OpenCode, OpenClaw, Gemini CLI, and Hermes Agent">
-      <div class="repo-stars">★ 108,709</div>
+      <div class="repo-stars">★ 108,925</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">farion1231 /</span> cc-switch</div>
         <div class="repo-desc">Cross-platform all-in-one manager for Claude Code, Codex, OpenCode, OpenClaw, Gemini CLI, and Hermes Agent.</div>
@@ -432,7 +432,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/iOfficeAI/AionUi" data-github="https://github.com/iOfficeAI/AionUi" data-desc="Local open-source cowork app for OpenClaw, Hermes Agent, Claude Code, Codex, OpenCode, Gemini CLI, and other agent CLIs">
-      <div class="repo-stars">★ 28,886</div>
+      <div class="repo-stars">★ 28,906</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">iOfficeAI /</span> AionUi</div>
         <div class="repo-desc">Local open-source cowork app for OpenClaw, Hermes Agent, Claude Code, Codex, OpenCode, Gemini CLI, and other agent CLIs.</div>
@@ -456,7 +456,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/Eynzof/hermes-agent-cn-desktop" data-github="https://github.com/Eynzof/hermes-agent-cn-desktop" data-desc="Windows-first Chinese desktop app for Hermes Agent built with Tauri, TypeScript, and Rust">
-      <div class="repo-stars">★ 578</div>
+      <div class="repo-stars">★ 584</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
         <div class="repo-desc">Windows-first Chinese desktop app for Hermes Agent built with Tauri, TypeScript, and Rust.</div>
@@ -472,10 +472,18 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/liftaris/herm" data-github="https://github.com/liftaris/herm" data-desc="Alternative Hermes TUI and dashboard built with OpenTUI.">
-      <div class="repo-stars">★ 260</div>
+      <div class="repo-stars">★ 261</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">liftaris /</span> herm</div>
         <div class="repo-desc">Alternative Hermes TUI and dashboard built with OpenTUI.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/abundantbeing/hermes-browser-extension" data-github="https://github.com/abundantbeing/hermes-browser-extension" data-desc="Chromium side-panel extension that connects active browser context to a local or remote Hermes Agent runtime">
+      <div class="repo-stars">★ 95</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">abundantbeing /</span> hermes-browser-extension</div>
+        <div class="repo-desc">Chromium side-panel extension that connects active browser context to a local or remote Hermes Agent runtime.</div>
       </div>
       <div class="repo-delta">— / wk</div>
     </a>
@@ -491,7 +499,7 @@
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills" data-github="https://github.com/mukul975/Anthropic-Cybersecurity-Skills" data-desc="754 structured cybersecurity skills mapped to MITRE ATT&CK, NIST CSF 2.0, ATLAS, D3FEND & NIST AI RMF">
-      <div class="repo-stars">★ 21,479</div>
+      <div class="repo-stars">★ 21,659</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</div>
         <div class="repo-desc">754 structured cybersecurity skills mapped to MITRE ATT&amp;CK, NIST CSF 2.0, ATLAS, D3FEND &amp; NIST AI RMF.</div>
@@ -499,7 +507,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/conorbronsdon/avoid-ai-writing" data-github="https://github.com/conorbronsdon/avoid-ai-writing" data-desc="Audits and rewrites content to eliminate detectable AI writing patterns">
-      <div class="repo-stars">★ 2,011</div>
+      <div class="repo-stars">★ 2,016</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">conorbronsdon /</span> avoid-ai-writing</div>
         <div class="repo-desc">Audits and rewrites content to eliminate detectable AI writing patterns.</div>
@@ -507,7 +515,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/wondelai/skills" data-github="https://github.com/wondelai/skills" data-desc="Cross-platform skills library for Claude Code and agentskills.io-compatible agents">
-      <div class="repo-stars">★ 1,461</div>
+      <div class="repo-stars">★ 1,467</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">wondelai /</span> skills</div>
         <div class="repo-desc">Cross-platform skills library for Claude Code and agentskills.io-compatible agents.</div>
@@ -523,7 +531,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/Agents365-ai/drawio-skill" data-github="https://github.com/Agents365-ai/drawio-skill" data-desc="Generate draw.io diagrams from natural language descriptions">
-      <div class="repo-stars">★ 4,695</div>
+      <div class="repo-stars">★ 4,722</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">Agents365-ai /</span> drawio-skill</div>
         <div class="repo-desc">Generate draw.io diagrams from natural language descriptions.</div>
@@ -539,7 +547,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/tlehman/litprog-skill" data-github="https://github.com/tlehman/litprog-skill" data-desc="Literate programming skill — weave code and documentation across agents">
-      <div class="repo-stars">★ 192</div>
+      <div class="repo-stars">★ 194</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">tlehman /</span> litprog-skill</div>
         <div class="repo-desc">Literate programming — weave code and documentation across agents.</div>
@@ -579,7 +587,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/ReinaMacCredy/maestro" data-github="https://github.com/ReinaMacCredy/maestro" data-desc="Harness for long-running AI agents — structured memory, cross-feature learning, plan-approve-execute">
-      <div class="repo-stars">★ 201</div>
+      <div class="repo-stars">★ 202</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">ReinaMacCredy /</span> maestro</div>
         <div class="repo-desc">Harness for long-running AI agents — structured memory, cross-feature learning, plan-approve-execute.</div>
@@ -611,7 +619,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/amanning3390/hermeshub" data-github="https://github.com/amanning3390/hermeshub" data-desc="Community skill browsing, search, and one-click installation hub">
-      <div class="repo-stars">★ 285</div>
+      <div class="repo-stars">★ 286</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">amanning3390 /</span> hermeshub</div>
         <div class="repo-desc">Community skill browsing, search, and one-click installation hub.</div>
@@ -627,7 +635,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/AMAP-ML/SkillClaw" data-github="https://github.com/AMAP-ML/SkillClaw" data-desc="Let Skills Evolve Collectively with Agentic Evolver">
-      <div class="repo-stars">★ 2,024</div>
+      <div class="repo-stars">★ 2,026</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">AMAP-ML /</span> SkillClaw</div>
         <div class="repo-desc">Let Skills Evolve Collectively with Agentic Evolver.</div>
@@ -651,7 +659,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/nexu-io/open-design" data-github="https://github.com/nexu-io/open-design" data-desc="Local-first open-source design/prototyping system with coding-agent CLI support including Hermes Agent">
-      <div class="repo-stars">★ 71,353</div>
+      <div class="repo-stars">★ 71,525</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">nexu-io /</span> open-design</div>
         <div class="repo-desc">Local-first open-source design/prototyping system with coding-agent CLI support including Hermes Agent.</div>
@@ -750,7 +758,7 @@
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/mem0ai/mem0" data-github="https://github.com/mem0ai/mem0" data-desc="Universal memory layer for AI Agents — official Hermes Agent memory provider, managed cloud or Apache-2.0 self-hosted OSS">
-      <div class="repo-stars">★ 59,479</div>
+      <div class="repo-stars">★ 59,502</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">mem0ai /</span> mem0</div>
         <div class="repo-desc">Universal memory layer — official Hermes provider with mem0_profile / mem0_search / mem0_conclude tools; runs managed (app.mem0.ai) or self-hosted Apache-2.0 OSS.</div>
@@ -758,7 +766,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/garrytan/gbrain" data-github="https://github.com/garrytan/gbrain" data-desc="Garry's Opinionated OpenClaw/Hermes Agent Brain">
-      <div class="repo-stars">★ 24,154</div>
+      <div class="repo-stars">★ 24,185</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">garrytan /</span> gbrain</div>
         <div class="repo-desc">Garry's opinionated OpenClaw / Hermes Agent brain.</div>
@@ -766,7 +774,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/vectorize-io/hindsight" data-github="https://github.com/vectorize-io/hindsight" data-desc="Agent memory that learns — long-term retain/recall/reflect workflows">
-      <div class="repo-stars">★ 17,588</div>
+      <div class="repo-stars">★ 17,611</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">vectorize-io /</span> hindsight</div>
         <div class="repo-desc">Agent memory that learns — long-term retain, recall, reflect workflows.</div>
@@ -774,7 +782,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/greyhaven-ai/autocontext" data-github="https://github.com/greyhaven-ai/autocontext" data-desc="Recursive self-improving context harness — helps agents succeed on complex tasks">
-      <div class="repo-stars">★ 1,224</div>
+      <div class="repo-stars">★ 1,225</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">greyhaven-ai /</span> autocontext</div>
         <div class="repo-desc">Recursive self-improving context harness — helps agents succeed on complex tasks.</div>
@@ -790,7 +798,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/elkimek/honcho-self-hosted" data-github="https://github.com/elkimek/honcho-self-hosted" data-desc="Self-hosted Honcho memory backend for cross-session persistence">
-      <div class="repo-stars">★ 328</div>
+      <div class="repo-stars">★ 329</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">elkimek /</span> honcho-self-hosted</div>
         <div class="repo-desc">Self-hosted Honcho memory backend for cross-session persistence.</div>
@@ -806,7 +814,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/Signet-AI/signetai" data-github="https://github.com/Signet-AI/signetai" data-desc="Local-first identity, memory, and secrets layer for AI agents — portable state across Hermes Agent, Claude Code, Codex, OpenCode, OpenClaw, and MCP clients">
-      <div class="repo-stars">★ 203</div>
+      <div class="repo-stars">★ 205</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">Signet-AI /</span> signetai</div>
         <div class="repo-desc">Local-first identity, memory, and secrets layer for AI agents — portable state across Hermes Agent, Claude Code, Codex, OpenCode, OpenClaw, and MCP clients.</div>
@@ -830,7 +838,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/plastic-labs/honcho" data-github="https://github.com/plastic-labs/honcho" data-desc="Memory library for building stateful agents — the upstream library that the elkimek/honcho-self-hosted Hermes wrapper builds on.">
-      <div class="repo-stars">★ 5,551</div>
+      <div class="repo-stars">★ 5,560</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">plastic-labs /</span> honcho <span class="repo-flag">official</span></div>
         <div class="repo-desc">Memory library for building stateful agents — the upstream library that the elkimek/honcho-self-hosted Hermes wrapper builds on.</div>
@@ -854,7 +862,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/AxDSan/mnemosyne" data-github="https://github.com/AxDSan/mnemosyne" data-desc="The Zero-Dependency, Sub-Millisecond AI Memory System for Hermes Agents">
-      <div class="repo-stars">★ 1,288</div>
+      <div class="repo-stars">★ 1,293</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">AxDSan /</span> mnemosyne</div>
         <div class="repo-desc">The Zero-Dependency, Sub-Millisecond AI Memory System for Hermes Agents.</div>
@@ -862,7 +870,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/yepyhun/Brainstack" data-github="https://github.com/yepyhun/Brainstack" data-desc="Memory kernel stack for Hermes agent">
-      <div class="repo-stars">★ 42</div>
+      <div class="repo-stars">★ 43</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">yepyhun /</span> Brainstack</div>
         <div class="repo-desc">Memory kernel stack for Hermes agent.</div>
@@ -878,7 +886,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/volcengine/OpenViking" data-github="https://github.com/volcengine/OpenViking" data-desc="Filesystem-first context database — official Hermes memory provider with tiered loading and 91% token reduction on LoCoMo10">
-      <div class="repo-stars">★ 26,065</div>
+      <div class="repo-stars">★ 26,083</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">volcengine /</span> OpenViking</div>
         <div class="repo-desc">Official Hermes memory provider — viking:// URIs, tiered L0/L1/L2 loading, 91% token reduction + 43-49% task gain over baseline on LoCoMo10. AGPL-3.0.</div>
@@ -886,7 +894,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/supermemoryai/supermemory" data-github="https://github.com/supermemoryai/supermemory" data-desc="Memory engine and API — official Hermes provider with sub-300ms recall at 100B+ tokens/month and context fencing">
-      <div class="repo-stars">★ 27,600</div>
+      <div class="repo-stars">★ 27,627</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">supermemoryai /</span> supermemory</div>
         <div class="repo-desc">Official Hermes memory provider — sub-300ms recall sustained at 100B+ tokens/month, custom vector graph engine, context fencing kills capture pollution, byte-level dedupe.</div>
@@ -894,7 +902,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/campfirein/byterover-cli" data-github="https://github.com/campfirein/byterover-cli" data-desc="ByteRover CLI (brv) — official Hermes memory provider storing memory as a git-versionable markdown context tree">
-      <div class="repo-stars">★ 4,878</div>
+      <div class="repo-stars">★ 4,882</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">campfirein /</span> byterover-cli</div>
         <div class="repo-desc">Memory as a git repo (formerly Cipher) — official Hermes provider with 5-tier retrieval (4 tiers non-LLM, sub-100ms), brv vc commit/branch/merge versioning.</div>
@@ -902,7 +910,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/yantrikos/yantrikdb-hermes-plugin" data-github="https://github.com/yantrikos/yantrikdb-hermes-plugin" data-desc="Self-maintaining Hermes memory plugin with explainable retrieval — every recall comes with a why_retrieved tag">
-      <div class="repo-stars">★ 62</div>
+      <div class="repo-stars">★ 63</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">yantrikos /</span> yantrikdb-hermes-plugin</div>
         <div class="repo-desc">Embedded-by-default Hermes plugin with canonicalization, contradiction tracking, recency ranking, and explainable why_retrieved tags on every recall.</div>
@@ -918,7 +926,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/MukundaKatta/hermes-agentmemory" data-github="https://github.com/MukundaKatta/hermes-agentmemory" data-desc="Pull-model Hermes memory plugin with real deletion (no persistent summaries) and full audit trace">
-      <div class="repo-stars">★ 6</div>
+      <div class="repo-stars">★ 7</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">MukundaKatta /</span> hermes-agentmemory</div>
         <div class="repo-desc">Real deletion (gone is gone), trace.jsonl audit log of every memory op, 200ms-2s first-turn cost. Community fix for issue #6715. MIT.</div>
@@ -949,7 +957,7 @@
     <div class="cat-num">§05</div>
     <h2 class="cat-title">Plugins &amp; extensions</h2>
     <p class="cat-desc">Drop-in modules that add tools, safety, payments, or new capabilities.</p>
-    <div class="cat-count"><span class="cat-count-n">25</span> repos</div>
+    <div class="cat-count"><span class="cat-count-n">24</span> repos</div>
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/clawshell/clawshell" data-github="https://github.com/clawshell/clawshell" data-desc="Runtime Security Layer for OpenClaw/Hermes — PII & sensitive credentials protection">
@@ -961,7 +969,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/robbyczgw-cla/hermes-web-search-plus" data-github="https://github.com/robbyczgw-cla/hermes-web-search-plus" data-desc="Multi-provider web search (Serper, Tavily, Exa, Querit, Perplexity) with auto-routing">
-      <div class="repo-stars">★ 316</div>
+      <div class="repo-stars">★ 315</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
         <div class="repo-desc">Multi-provider web search — Serper, Tavily, Exa, Querit, Perplexity with auto-routing.</div>
@@ -969,7 +977,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/42-evey/hermes-plugins" data-github="https://github.com/42-evey/hermes-plugins" data-desc="Goal management, inter-agent bridge, model selection, and cost control plugins">
-      <div class="repo-stars">★ 246</div>
+      <div class="repo-stars">★ 247</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">42-evey /</span> hermes-plugins</div>
         <div class="repo-desc">Goal management, inter-agent bridge, model selection, cost control plugins.</div>
@@ -1017,7 +1025,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/briancaffey/hermes-otel" data-github="https://github.com/briancaffey/hermes-otel" data-desc="OTel Plugin for Hermes Agent">
-      <div class="repo-stars">★ 30</div>
+      <div class="repo-stars">★ 31</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">briancaffey /</span> hermes-otel</div>
         <div class="repo-desc">OTel Plugin for Hermes Agent.</div>
@@ -1025,7 +1033,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/jau123/MeiGen-AI-Design-MCP" data-github="https://github.com/jau123/MeiGen-AI-Design-MCP" data-desc="Supports GPT Image 2, Nanobanana &amp; ComfyUI, with a 1,400+ prompt library, carefully crafted hooks and a multi-task orchestration system">
-      <div class="repo-stars">★ 1,491</div>
+      <div class="repo-stars">★ 1,493</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">jau123 /</span> MeiGen-AI-Design-MCP</div>
         <div class="repo-desc">Supports GPT Image 2, Nanobanana &amp; ComfyUI, with a 1,400+ prompt library, carefully crafted hooks and a multi-task orchestration system.</div>
@@ -1033,7 +1041,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/Context4GPTs/klodi-plugin" data-github="https://github.com/Context4GPTs/klodi-plugin" data-desc="The agent-to-agent marketplace, in your agent host. Your agent lists, haggles, and closes deals for you while you live your life.">
-      <div class="repo-stars">★ 13</div>
+      <div class="repo-stars">★ 14</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">Context4GPTs /</span> klodi-plugin</div>
         <div class="repo-desc">The agent-to-agent marketplace, in your agent host. Your agent lists, haggles, and closes deals for you while you live your life.</div>
@@ -1057,7 +1065,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/stainlu/hermes-labyrinth" data-github="https://github.com/stainlu/hermes-labyrinth" data-desc="Read-only observability plugin for Hermes Agent with journeys, crossings, guideposts, and reports">
-      <div class="repo-stars">★ 290</div>
+      <div class="repo-stars">★ 291</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">stainlu /</span> hermes-labyrinth</div>
         <div class="repo-desc">Read-only observability plugin for Hermes Agent with journeys, crossings, guideposts, and reports.</div>
@@ -1089,7 +1097,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/indranilbanerjee/digital-marketing-pro" data-github="https://github.com/indranilbanerjee/digital-marketing-pro" data-desc="Open-source AI marketing plugin for agencies &amp; in-house teams — 158 skills, 25 specialist agents, 12-Part Strategy Flow, Cowork team-persistent, EU AI Act Article 50 ready, 6-platform AEO/GEO incl. Go">
-      <div class="repo-stars">★ 162</div>
+      <div class="repo-stars">★ 163</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">indranilbanerjee /</span> digital-marketing-pro</div>
         <div class="repo-desc">Open-source AI marketing plugin for agencies &amp; in-house teams — 158 skills, 25 specialist agents, 12-Part Strategy Flow, Cowork team-persistent, EU AI Act Article 50 ready, 6-platform AEO/GEO incl. Go.</div>
@@ -1172,7 +1180,7 @@
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/builderz-labs/mission-control" data-github="https://github.com/builderz-labs/mission-control" data-desc="Self-hosted AI agent orchestration — dispatch tasks, run multi-agent workflows, monitor spend">
-      <div class="repo-stars">★ 5,422</div>
+      <div class="repo-stars">★ 5,428</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">builderz-labs /</span> mission-control</div>
         <div class="repo-desc">Self-hosted orchestration — dispatch tasks, run multi-agent workflows, monitor spend.</div>
@@ -1204,7 +1212,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/1ilkhamov/opencode-hermes-multiagent" data-github="https://github.com/1ilkhamov/opencode-hermes-multiagent" data-desc="17 specialized agents for research, planning, implementation, quality, and infrastructure">
-      <div class="repo-stars">★ 152</div>
+      <div class="repo-stars">★ 153</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">1ilkhamov /</span> opencode-hermes-multiagent</div>
         <div class="repo-desc">17 specialized agents — research, planning, implementation, quality, infrastructure.</div>
@@ -1252,7 +1260,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/shannhk/hermes-agent-control-room" data-github="https://github.com/shannhk/hermes-agent-control-room" data-desc="Control Room-first template for scaling Hermes Agent from one VPS agent to specialist teams and automated workflows">
-      <div class="repo-stars">★ 599</div>
+      <div class="repo-stars">★ 600</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">shannhk /</span> hermes-agent-control-room</div>
         <div class="repo-desc">Control Room-first template for scaling Hermes Agent from one VPS agent to specialist teams and automated workflows.</div>
@@ -1287,7 +1295,7 @@
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/numtide/llm-agents.nix" data-github="https://github.com/numtide/llm-agents.nix" data-desc="Nix packages for AI coding agents including Hermes">
-      <div class="repo-stars">★ 1,474</div>
+      <div class="repo-stars">★ 1,475</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">numtide /</span> llm-agents.nix</div>
         <div class="repo-desc">Nix packages for AI coding agents including Hermes.</div>
@@ -1303,7 +1311,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/0xrsydn/nix-hermes-agent" data-github="https://github.com/0xrsydn/nix-hermes-agent" data-desc="Nix package and NixOS module for reproducible Hermes deployment">
-      <div class="repo-stars">★ 25</div>
+      <div class="repo-stars">★ 26</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">0xrsydn /</span> nix-hermes-agent</div>
         <div class="repo-desc">Nix package and NixOS module for reproducible Hermes deployment.</div>
@@ -1343,7 +1351,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/jpalmae/hermeshq" data-github="https://github.com/jpalmae/hermeshq" data-desc="HermesHQ is a Docker-first control plane for running and operating multiple Hermes Agent instances from one web application.">
-      <div class="repo-stars">★ 12</div>
+      <div class="repo-stars">★ 13</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">jpalmae /</span> hermeshq</div>
         <div class="repo-desc">HermesHQ is a Docker-first control plane for running and operating multiple Hermes Agent instances from one web application.</div>
@@ -1382,11 +1390,11 @@
     <div class="cat-num">§08</div>
     <h2 class="cat-title">Integrations &amp; bridges</h2>
     <p class="cat-desc">Connect Hermes to other agents, platforms, and specialized systems.</p>
-    <div class="cat-count"><span class="cat-count-n">12</span> repos</div>
+    <div class="cat-count"><span class="cat-count-n">11</span> repos</div>
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/AaronWong1999/hermesclaw" data-github="https://github.com/AaronWong1999/hermesclaw" data-desc="Run Hermes Agent and OpenClaw on the same WeChat account">
-      <div class="repo-stars">★ 647</div>
+      <div class="repo-stars">★ 648</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">AaronWong1999 /</span> hermesclaw</div>
         <div class="repo-desc">Run Hermes Agent and OpenClaw on the same WeChat account.</div>
@@ -1466,7 +1474,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/ndesv21/socialclaw" data-github="https://github.com/ndesv21/socialclaw" data-desc="Social media scheduling CLI and OpenClaw skill for AI agents posting to X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, and Pinterest.">
-      <div class="repo-stars">★ 45</div>
+      <div class="repo-stars">★ 47</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">ndesv21 /</span> socialclaw</div>
         <div class="repo-desc">Social media scheduling CLI and OpenClaw skill for AI agents posting to X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, and Pinterest.</div>
@@ -1493,7 +1501,7 @@
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/junhoyeo/tokscale" data-github="https://github.com/junhoyeo/tokscale" data-desc="CLI tool for tracking token usage from Claude Code, OpenClaw, Hermes, Codex, Gemini, and more">
-      <div class="repo-stars">★ 3,963</div>
+      <div class="repo-stars">★ 3,969</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">junhoyeo /</span> tokscale</div>
         <div class="repo-desc">CLI for tracking token usage — Claude Code, OpenClaw, Hermes, Codex, Gemini, and more.</div>
@@ -1501,7 +1509,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/joeynyc/hermes-skins" data-github="https://github.com/joeynyc/hermes-skins" data-desc="Community CLI skins and themes for Hermes terminal UI">
-      <div class="repo-stars">★ 471</div>
+      <div class="repo-stars">★ 472</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">joeynyc /</span> hermes-skins</div>
         <div class="repo-desc">Community CLI skins and themes for Hermes terminal UI.</div>
@@ -1549,7 +1557,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/42-evey/evey-setup" data-github="https://github.com/42-evey/evey-setup" data-desc="Get a hermes-agent stack running in minutes — free models, 29 plugins, zero cost">
-      <div class="repo-stars">★ 46</div>
+      <div class="repo-stars">★ 47</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">42-evey /</span> evey-setup</div>
         <div class="repo-desc">Get a hermes-agent stack running in minutes — free models, 29 plugins, zero cost.</div>
@@ -1557,7 +1565,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/colbymchenry/codegraph" data-github="https://github.com/colbymchenry/codegraph" data-desc="Local pre-indexed code knowledge graph for Hermes Agent and other coding agents to reduce token usage and tool calls">
-      <div class="repo-stars">★ 54,767</div>
+      <div class="repo-stars">★ 54,917</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">colbymchenry /</span> codegraph</div>
         <div class="repo-desc">Local pre-indexed code knowledge graph for Hermes Agent and other coding agents to reduce token usage and tool calls.</div>
@@ -1565,7 +1573,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/liaohch3/claude-tap" data-github="https://github.com/liaohch3/claude-tap" data-desc="Local trace viewer for inspecting coding-agent API traffic from Hermes Agent, Claude Code, Codex, Gemini, Cursor, OpenCode, and others">
-      <div class="repo-stars">★ 2,006</div>
+      <div class="repo-stars">★ 2,011</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">liaohch3 /</span> claude-tap</div>
         <div class="repo-desc">Local trace viewer for inspecting coding-agent API traffic from Hermes Agent, Claude Code, Codex, Gemini, Cursor, OpenCode, and others.</div>
@@ -1573,7 +1581,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/Salomondiei08/oh-my-hermes" data-github="https://github.com/Salomondiei08/oh-my-hermes" data-desc="Opinionated workflow layer for building, shipping, and operating apps with Hermes Agent">
-      <div class="repo-stars">★ 658</div>
+      <div class="repo-stars">★ 659</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">Salomondiei08 /</span> oh-my-hermes</div>
         <div class="repo-desc">Opinionated workflow layer for building, shipping, and operating apps with Hermes Agent.</div>
@@ -1600,7 +1608,7 @@
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/ucsandman/DashClaw" data-github="https://github.com/ucsandman/DashClaw" data-desc="Decision infrastructure with guard policies and risk assessment for agents">
-      <div class="repo-stars">★ 277</div>
+      <div class="repo-stars">★ 278</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">ucsandman /</span> DashClaw</div>
         <div class="repo-desc">Decision infrastructure with guard policies and risk assessment for agents.</div>
@@ -1616,7 +1624,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/Christabel337/job-scout-agent" data-github="https://github.com/Christabel337/job-scout-agent" data-desc="Autonomous job hunting — scans listings, writes cover letters, tracks applications">
-      <div class="repo-stars">★ 47</div>
+      <div class="repo-stars">★ 48</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">Christabel337 /</span> job-scout-agent</div>
         <div class="repo-desc">Autonomous job hunting — scans listings, writes cover letters, tracks applications.</div>
@@ -1683,7 +1691,7 @@
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/0xNyk/awesome-hermes-agent" data-github="https://github.com/0xNyk/awesome-hermes-agent" data-desc="Curated list of awesome skills, tools, integrations, and resources for Hermes Agent">
-      <div class="repo-stars">★ 4,215</div>
+      <div class="repo-stars">★ 4,226</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">0xNyk /</span> awesome-hermes-agent</div>
         <div class="repo-desc">Curated list of skills, tools, integrations, and resources for Hermes Agent.</div>
@@ -1691,7 +1699,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/alchaincyf/hermes-agent-orange-book" data-github="https://github.com/alchaincyf/hermes-agent-orange-book" data-desc="Hermes Agent practical guide — Orange Book series (Chinese language)">
-      <div class="repo-stars">★ 4,548</div>
+      <div class="repo-stars">★ 4,549</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">alchaincyf /</span> hermes-agent-orange-book</div>
         <div class="repo-desc">Hermes Agent practical guide — Orange Book series (Chinese language).</div>
@@ -1699,7 +1707,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/ksimback/hermes-ecosystem" data-github="https://github.com/ksimback/hermes-ecosystem" data-desc="Hermes Atlas — the community map of every tool, skill, and integration for Hermes Agent">
-      <div class="repo-stars">★ 1,061</div>
+      <div class="repo-stars">★ 1,064</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">ksimback /</span> hermes-ecosystem</div>
         <div class="repo-desc">Hermes Atlas — the community map of every tool, skill, and integration for Hermes Agent.</div>
@@ -1739,7 +1747,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/jwangkun/hermes-agent-guide" data-github="https://github.com/jwangkun/hermes-agent-guide" data-desc="A systematic Chinese-language guide to Hermes Agent — 16 books, 300K+ words, covering installation, advanced development, single- and multi-agent orchestration.">
-      <div class="repo-stars">★ 416</div>
+      <div class="repo-stars">★ 422</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">jwangkun /</span> hermes-agent-guide</div>
         <div class="repo-desc">A systematic Chinese-language guide to Hermes Agent — 16 books, 300K+ words, covering installation, advanced development, single- and multi-agent orchestration.</div>
@@ -1830,7 +1838,7 @@
       <div class="repo-delta">— / wk</div>
     </a>
     <a class="repo-row" href="/projects/sheawinkler/hermes-agent-ultra" data-github="https://github.com/sheawinkler/hermes-agent-ultra" data-desc="Rust-based Hermes Agent Ultra derivative focused on performance and Hermes Agent feature parity">
-      <div class="repo-stars">★ 56</div>
+      <div class="repo-stars">★ 57</div>
       <div class="repo-body">
         <div class="repo-name"><span class="org">sheawinkler /</span> hermes-agent-ultra</div>
         <div class="repo-desc">Rust-based Hermes Agent Ultra derivative focused on performance and Hermes Agent feature parity.</div>

--- a/lists/best-memory-providers.html
+++ b/lists/best-memory-providers.html
@@ -173,14 +173,14 @@
       {
         "@type": "ListItem",
         "position": 22,
-        "url": "https://hermesatlas.com/projects/yonro/hermes-xmemo-plugin",
-        "name": "yonro/hermes-xmemo-plugin"
+        "url": "https://hermesatlas.com/projects/MukundaKatta/hermes-agentmemory",
+        "name": "MukundaKatta/hermes-agentmemory"
       },
       {
         "@type": "ListItem",
         "position": 23,
-        "url": "https://hermesatlas.com/projects/MukundaKatta/hermes-agentmemory",
-        "name": "MukundaKatta/hermes-agentmemory"
+        "url": "https://hermesatlas.com/projects/yonro/hermes-xmemo-plugin",
+        "name": "yonro/hermes-xmemo-plugin"
       },
       {
         "@type": "ListItem",
@@ -213,7 +213,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -335,7 +335,7 @@
       <div class="list-cell-name"><span class="org">elkimek /</span> honcho-self-hosted</div>
       <div class="list-cell-desc">Self-host Honcho memory layer for Hermes Agent — OpenRouter + Venice, no code changes</div>
     </div>
-    <div class="list-cell-stars">★ 328</div>
+    <div class="list-cell-stars">★ 329</div>
   </a>
   <a class="list-row" href="/projects/plur-ai/plur">
     <div class="list-rank">12</div>
@@ -351,7 +351,7 @@
       <div class="list-cell-name"><span class="org">Signet-AI /</span> signetai</div>
       <div class="list-cell-desc">Local-first identity, memory, and secrets for AI agents. Portable state across models and harnesses.</div>
     </div>
-    <div class="list-cell-stars">★ 203</div>
+    <div class="list-cell-stars">★ 205</div>
   </a>
   <a class="list-row" href="/projects/yoloshii/ClawMem">
     <div class="list-rank">14</div>
@@ -375,7 +375,7 @@
       <div class="list-cell-name"><span class="org">yantrikos /</span> yantrikdb-hermes-plugin</div>
       <div class="list-cell-desc">YantrikDB memory provider for NousResearch/hermes-agent — self-maintaining memory with benchmarked recall, self-tuning ranking, contradictio</div>
     </div>
-    <div class="list-cell-stars">★ 62</div>
+    <div class="list-cell-stars">★ 63</div>
   </a>
   <a class="list-row" href="/projects/yepyhun/Brainstack">
     <div class="list-rank">17</div>
@@ -383,7 +383,7 @@
       <div class="list-cell-name"><span class="org">yepyhun /</span> Brainstack</div>
       <div class="list-cell-desc">Memory kernel stack for Hermes agent</div>
     </div>
-    <div class="list-cell-stars">★ 42</div>
+    <div class="list-cell-stars">★ 43</div>
   </a>
   <a class="list-row" href="/projects/amanning3390/flowstate-qmd">
     <div class="list-rank">18</div>
@@ -417,21 +417,21 @@
     </div>
     <div class="list-cell-stars">★ 17</div>
   </a>
-  <a class="list-row" href="/projects/yonro/hermes-xmemo-plugin">
+  <a class="list-row" href="/projects/MukundaKatta/hermes-agentmemory">
     <div class="list-rank">22</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">MukundaKatta /</span> hermes-agentmemory</div>
+      <div class="list-cell-desc">Pull-model episodic memory plugin for Hermes Agent. Real deletes, audit trace, BYO Claude. MIT.</div>
+    </div>
+    <div class="list-cell-stars">★ 7</div>
+  </a>
+  <a class="list-row" href="/projects/yonro/hermes-xmemo-plugin">
+    <div class="list-rank">23</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">yonro /</span> hermes-xmemo-plugin</div>
       <div class="list-cell-desc">XMemo memory provider for Hermes Agent — durable cross-session AI memory with semantic search</div>
     </div>
     <div class="list-cell-stars">★ 7</div>
-  </a>
-  <a class="list-row" href="/projects/MukundaKatta/hermes-agentmemory">
-    <div class="list-rank">23</div>
-    <div class="list-cell-body">
-      <div class="list-cell-name"><span class="org">MukundaKatta /</span> hermes-agentmemory</div>
-      <div class="list-cell-desc">Pull-model episodic memory plugin for Hermes Agent. Real deletes, audit trace, BYO Claude. MIT.</div>
-    </div>
-    <div class="list-cell-stars">★ 6</div>
   </a>
   <a class="list-row" href="/projects/futurebrowser/hermes-exabase-plugin">
     <div class="list-rank">24</div>
@@ -531,12 +531,12 @@
       <p>A local-only plugin using a columnar .lbdb embedded graph database with importance-weighted recall. It prioritizes high-priority memories during prefetch and supports GLiNER2 entity extraction.</p>
     </article>
     <article class="listicle-entry">
-      <h3><a href="/projects/yonro/hermes-xmemo-plugin">yonro / hermes-xmemo-plugin</a></h3>
-      <p>A durable cross-session memory provider that features semantic search and provenance tracking. It automatically mirrors native Hermes memory tools and supports session snapshots with TTL.</p>
-    </article>
-    <article class="listicle-entry">
       <h3><a href="/projects/MukundaKatta/hermes-agentmemory">MukundaKatta / hermes-agentmemory</a></h3>
       <p>A pull-model episodic memory plugin that ensures complete deletion of events without leaving derived artifacts. It provides a trace.jsonl audit log for every operation and on-demand summarization via Claude.</p>
+    </article>
+    <article class="listicle-entry">
+      <h3><a href="/projects/yonro/hermes-xmemo-plugin">yonro / hermes-xmemo-plugin</a></h3>
+      <p>A durable cross-session memory provider that features semantic search and provenance tracking. It automatically mirrors native Hermes memory tools and supports session snapshots with TTL.</p>
     </article>
     <article class="listicle-entry">
       <h3><a href="/projects/futurebrowser/hermes-exabase-plugin">futurebrowser / hermes-exabase-plugin</a></h3>

--- a/lists/deployment-options.html
+++ b/lists/deployment-options.html
@@ -135,7 +135,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -233,7 +233,7 @@
       <div class="list-cell-name"><span class="org">0xrsydn /</span> nix-hermes-agent</div>
       <div class="list-cell-desc">Nix package and NixOS module for Hermes Agent by Nous Research</div>
     </div>
-    <div class="list-cell-stars">★ 25</div>
+    <div class="list-cell-stars">★ 26</div>
   </a>
   <a class="list-row" href="/projects/JackTheGit/hermes-autonomous-server">
     <div class="list-rank">09</div>
@@ -249,7 +249,7 @@
       <div class="list-cell-name"><span class="org">jpalmae /</span> hermeshq</div>
       <div class="list-cell-desc">HermesHQ is a Docker-first control plane for running and operating multiple Hermes Agent instances from one web application.</div>
     </div>
-    <div class="list-cell-stars">★ 12</div>
+    <div class="list-cell-stars">★ 13</div>
   </a>
   <a class="list-row" href="/projects/ellickjohnson/portainer-stack-hermes">
     <div class="list-rank">11</div>

--- a/lists/developer-tools.html
+++ b/lists/developer-tools.html
@@ -141,7 +141,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -183,7 +183,7 @@
       <div class="list-cell-name"><span class="org">colbymchenry /</span> codegraph</div>
       <div class="list-cell-desc">Pre-indexed code knowledge graph, auto syncs on code changes, for Claude Code, Codex, Gemini, Cursor, OpenCode, AntiGravity, Kiro, and Herme</div>
     </div>
-    <div class="list-cell-stars">★ 54.8K</div>
+    <div class="list-cell-stars">★ 54.9K</div>
   </a>
   <a class="list-row" href="/projects/junhoyeo/tokscale">
     <div class="list-rank">02</div>
@@ -207,7 +207,7 @@
       <div class="list-cell-name"><span class="org">Salomondiei08 /</span> oh-my-hermes</div>
       <div class="list-cell-desc">An opinionated workflow layer for building, shipping, and operating apps with Hermes Agent</div>
     </div>
-    <div class="list-cell-stars">★ 658</div>
+    <div class="list-cell-stars">★ 659</div>
   </a>
   <a class="list-row" href="/projects/joeynyc/hermes-skins">
     <div class="list-rank">05</div>
@@ -215,7 +215,7 @@
       <div class="list-cell-name"><span class="org">joeynyc /</span> hermes-skins</div>
       <div class="list-cell-desc">Custom skins (visual themes) for the Hermes CLI agent</div>
     </div>
-    <div class="list-cell-stars">★ 471</div>
+    <div class="list-cell-stars">★ 472</div>
   </a>
   <a class="list-row" href="/projects/AlexAI-MCP/hermes-CCC">
     <div class="list-rank">06</div>
@@ -255,7 +255,7 @@
       <div class="list-cell-name"><span class="org">42-evey /</span> evey-setup</div>
       <div class="list-cell-desc">Get a hermes-agent stack running in minutes. Free models, 29 plugins, zero cost.</div>
     </div>
-    <div class="list-cell-stars">★ 46</div>
+    <div class="list-cell-stars">★ 47</div>
   </a>
   <a class="list-row" href="/projects/roli-lpci/lintlang">
     <div class="list-rank">11</div>

--- a/lists/multi-agent-frameworks.html
+++ b/lists/multi-agent-frameworks.html
@@ -135,7 +135,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -201,7 +201,7 @@
       <div class="list-cell-name"><span class="org">shannhk /</span> hermes-agent-control-room</div>
       <div class="list-cell-desc">Control Room-first template for managing Hermes agents from one VPS agent to specialist teams and orchestrated workflows</div>
     </div>
-    <div class="list-cell-stars">★ 599</div>
+    <div class="list-cell-stars">★ 600</div>
   </a>
   <a class="list-row" href="/projects/swarmclawai/swarmclaw">
     <div class="list-rank">05</div>
@@ -225,7 +225,7 @@
       <div class="list-cell-name"><span class="org">1ilkhamov /</span> opencode-hermes-multiagent</div>
       <div class="list-cell-desc">Hermes — a multi-agent system for OpenCode AI. 17 specialized agents for research, planning, implementation, quality, and infrastructure.</div>
     </div>
-    <div class="list-cell-stars">★ 152</div>
+    <div class="list-cell-stars">★ 153</div>
   </a>
   <a class="list-row" href="/projects/linke-ai/hermes-agent-team">
     <div class="list-rank">08</div>

--- a/lists/top-skills.html
+++ b/lists/top-skills.html
@@ -237,7 +237,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -279,7 +279,7 @@
       <div class="list-cell-name"><span class="org">nexu-io /</span> open-design</div>
       <div class="list-cell-desc">🎨 Local-first, open-source Claude Design alternative. 🖥️ Native desktop app. ⚡ 259+ Skills · ✨ 142+ Design Systems 🖼️ Web · desktop · mob</div>
     </div>
-    <div class="list-cell-stars">★ 71.4K</div>
+    <div class="list-cell-stars">★ 71.5K</div>
   </a>
   <a class="list-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills">
     <div class="list-rank">02</div>
@@ -287,7 +287,7 @@
       <div class="list-cell-name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</div>
       <div class="list-cell-desc">817 structured cybersecurity skills for AI agents · Mapped to 6 frameworks: MITRE ATT&amp;CK, NIST CSF 2.0, MITRE ATLAS, D3FEND, NIST AI RMF &amp; M</div>
     </div>
-    <div class="list-cell-stars">★ 21.5K</div>
+    <div class="list-cell-stars">★ 21.7K</div>
   </a>
   <a class="list-row" href="/projects/Agents365-ai/drawio-skill">
     <div class="list-rank">03</div>
@@ -351,7 +351,7 @@
       <div class="list-cell-name"><span class="org">amanning3390 /</span> hermeshub</div>
       <div class="list-cell-desc">HermesHub - The Skills Hub for Hermes Agent by Nous Research. Browse, share, and install community skills.</div>
     </div>
-    <div class="list-cell-stars">★ 285</div>
+    <div class="list-cell-stars">★ 286</div>
   </a>
   <a class="list-row" href="/projects/Cranot/super-hermes">
     <div class="list-rank">11</div>
@@ -375,7 +375,7 @@
       <div class="list-cell-name"><span class="org">ReinaMacCredy /</span> maestro</div>
       <div class="list-cell-desc">Agent harness for codebases. Gives Claude Code, Codex, and CI a shared task system, verdict ledger, and state store so agent work is traceab</div>
     </div>
-    <div class="list-cell-stars">★ 201</div>
+    <div class="list-cell-stars">★ 202</div>
   </a>
   <a class="list-row" href="/projects/tlehman/litprog-skill">
     <div class="list-rank">14</div>
@@ -383,7 +383,7 @@
       <div class="list-cell-name"><span class="org">tlehman /</span> litprog-skill</div>
       <div class="list-cell-desc">Literate programming skill for agent harnesses like Claude Code, OpenCode and Hermes Agent</div>
     </div>
-    <div class="list-cell-stars">★ 192</div>
+    <div class="list-cell-stars">★ 194</div>
   </a>
   <a class="list-row" href="/projects/esaradev/icarus-plugin">
     <div class="list-rank">15</div>

--- a/lists/workspaces-and-guis.html
+++ b/lists/workspaces-and-guis.html
@@ -41,7 +41,7 @@
   },
   "mainEntity": {
     "@type": "ItemList",
-    "numberOfItems": 18,
+    "numberOfItems": 19,
     "itemListOrder": "https://schema.org/ItemListOrderDescending",
     "itemListElement": [
       {
@@ -143,12 +143,18 @@
       {
         "@type": "ListItem",
         "position": 17,
+        "url": "https://hermesatlas.com/projects/abundantbeing/hermes-browser-extension",
+        "name": "abundantbeing/hermes-browser-extension"
+      },
+      {
+        "@type": "ListItem",
+        "position": 18,
         "url": "https://hermesatlas.com/projects/Euraika-Labs/pan-ui",
         "name": "Euraika-Labs/pan-ui"
       },
       {
         "@type": "ListItem",
-        "position": 18,
+        "position": 19,
         "url": "https://hermesatlas.com/projects/Felix-Forever/hermes-agent-desktop",
         "name": "Felix-Forever/hermes-agent-desktop"
       }
@@ -177,7 +183,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -219,7 +225,7 @@
       <div class="list-cell-name"><span class="org">farion1231 /</span> cc-switch</div>
       <div class="list-cell-desc">A cross-platform desktop All-in-One assistant for Claude Code, Codex, OpenCode, OpenClaw, Gemini CLI &amp; Hermes Agent. Only official website: </div>
     </div>
-    <div class="list-cell-stars">★ 108.7K</div>
+    <div class="list-cell-stars">★ 108.9K</div>
   </a>
   <a class="list-row" href="/projects/iOfficeAI/AionUi">
     <div class="list-rank">02</div>
@@ -235,7 +241,7 @@
       <div class="list-cell-name"><span class="org">nesquena /</span> hermes-webui</div>
       <div class="list-cell-desc">Hermes WebUI: The best way to use Hermes Agent from the web or from your phone!</div>
     </div>
-    <div class="list-cell-stars">★ 15.0K</div>
+    <div class="list-cell-stars">★ 15.1K</div>
   </a>
   <a class="list-row" href="/projects/fathah/hermes-desktop">
     <div class="list-rank">04</div>
@@ -275,7 +281,7 @@
       <div class="list-cell-name"><span class="org">xaspx /</span> hermes-control-interface</div>
       <div class="list-cell-desc">A self-hosted web dashboard for the Hermes AI agent stack. Provides a browser-based terminal, file explorer, session overview, cron manageme</div>
     </div>
-    <div class="list-cell-stars">★ 784</div>
+    <div class="list-cell-stars">★ 785</div>
   </a>
   <a class="list-row" href="/projects/jazzyalex/agent-sessions">
     <div class="list-rank">09</div>
@@ -291,7 +297,7 @@
       <div class="list-cell-name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       <div class="list-cell-desc">Hermes Agent CN desktop app, Windows-First, built with Tauri, Typescript and Rust. Isolated Hermes Agent core insides. </div>
     </div>
-    <div class="list-cell-stars">★ 578</div>
+    <div class="list-cell-stars">★ 584</div>
   </a>
   <a class="list-row" href="/projects/nickvasilescu/hermes-desktop-os1">
     <div class="list-rank">11</div>
@@ -307,7 +313,7 @@
       <div class="list-cell-name"><span class="org">liftaris /</span> herm</div>
       <div class="list-cell-desc">The Hermes TUI built with OpenTUI</div>
     </div>
-    <div class="list-cell-stars">★ 260</div>
+    <div class="list-cell-stars">★ 261</div>
   </a>
   <a class="list-row" href="/projects/clawvader-tech/hermes-telegram-miniapp">
     <div class="list-rank">13</div>
@@ -341,8 +347,16 @@
     </div>
     <div class="list-cell-stars">★ 108</div>
   </a>
-  <a class="list-row" href="/projects/Euraika-Labs/pan-ui">
+  <a class="list-row" href="/projects/abundantbeing/hermes-browser-extension">
     <div class="list-rank">17</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">abundantbeing /</span> hermes-browser-extension</div>
+      <div class="list-cell-desc">Browser-native side panel for Hermes Agent — connect web context to your local Hermes runtime.</div>
+    </div>
+    <div class="list-cell-stars">★ 95</div>
+  </a>
+  <a class="list-row" href="/projects/Euraika-Labs/pan-ui">
+    <div class="list-rank">18</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">Euraika-Labs /</span> pan-ui</div>
       <div class="list-cell-desc">Pan by Euraika — a self-hosted AI workspace for Hermes Agent. Chat, skills, extensions, memory, profiles, and runtime controls.</div>
@@ -350,7 +364,7 @@
     <div class="list-cell-stars">★ 85</div>
   </a>
   <a class="list-row" href="/projects/Felix-Forever/hermes-agent-desktop">
-    <div class="list-rank">18</div>
+    <div class="list-rank">19</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">Felix-Forever /</span> hermes-agent-desktop</div>
       <div class="list-cell-desc">Multi-Agent AI Desktop Client — 20 specialists auto-collaborate on your tasks. Visual Skill Store, PM orchestrator, streaming chat. Works wi</div>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1827,7 +1827,7 @@ Skip to content
 
 ---
 
-# Project Catalog (175 projects)
+# Project Catalog (174 projects)
 
 ---
 
@@ -1836,7 +1836,7 @@ Skip to content
 URL: https://hermesatlas.com/projects/NousResearch/hermes-agent
 GitHub: https://github.com/NousResearch/hermes-agent
 Category: Core & Official
-Stars: 203,319
+Stars: 203,579
 Official: Yes (maintained by Nous Research)
 The self-improving AI agent that grows with you — persistent memory, auto-generated skills, 14 platforms, 6 execution backends
 
@@ -1854,7 +1854,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/farion1231/cc-switch
 GitHub: https://github.com/farion1231/cc-switch
 Category: Workspaces & GUIs
-Stars: 108,709
+Stars: 108,925
 Cross-platform all-in-one manager for Claude Code, Codex, OpenCode, OpenClaw, Gemini CLI, and Hermes Agent
 
 CC Switch is a cross-platform management tool designed to centralize the administration of various AI coding agents and CLI tools. It is built using the Tauri 2 framework to provide a native desktop experience across different operating systems. The application allows users to manage tools including Claude Code, Claude Desktop, Codex, Gemini CLI, OpenCode, OpenClaw, and Hermes Agent from a single interface.
@@ -1871,7 +1871,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/nexu-io/open-design
 GitHub: https://github.com/nexu-io/open-design
 Category: Skills & Skill Registries
-Stars: 71,353
+Stars: 71,525
 Local-first open-source design/prototyping system with coding-agent CLI support including Hermes Agent
 
 Open Design is a local-first, open-source design and prototyping system that serves as an agent-native alternative to Claude Design. It transforms the design process into a filesystem of skills, plugins, and design systems that can be read and remixed by coding agents. The system enables the generation of web, desktop, and mobile prototypes, motion graphics, and pitch decks using real CSS and components. It integrates with various local CLIs, including Hermes Agent, and supports OpenAI-compatible endpoints via BYOK.
@@ -1888,7 +1888,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/mem0ai/mem0
 GitHub: https://github.com/mem0ai/mem0
 Category: Memory & Context
-Stars: 59,479
+Stars: 59,502
 Universal memory layer for AI Agents — official Hermes Agent memory provider, available as managed cloud or Apache-2.0 self-hosted OSS
 
 Mem0 is an intelligent memory layer that provides AI agents with the ability to remember user preferences and adapt over time. It utilizes a multi-signal retrieval system combining semantic, BM25 keyword, and entity matching with temporal reasoning to rank dated instances. The system supports multi-level state retention across users, sessions, and agents through a flexible deployment model. It is available as a Python/npm library, a self-hosted server, or a managed cloud service.
@@ -1905,7 +1905,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/colbymchenry/codegraph
 GitHub: https://github.com/colbymchenry/codegraph
 Category: Developer Tools
-Stars: 54,767
+Stars: 54,917
 Local pre-indexed code knowledge graph for Hermes Agent and other coding agents to reduce token usage and tool calls
 
 CodeGraph is a local pre-indexed code knowledge graph designed to reduce the number of tool calls and token usage for coding agents. It builds a map of every symbol, call edge, and dependency in a codebase to provide agents with surgical context instead of relying on file-by-file searches. This approach allows agents to retrieve relevant source code and call paths in a single query, significantly speeding up response times. It integrates with several agents including Hermes Agent, Claude Code, and Cursor via an MCP server.
@@ -1922,7 +1922,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/iOfficeAI/AionUi
 GitHub: https://github.com/iOfficeAI/AionUi
 Category: Workspaces & GUIs
-Stars: 28,886
+Stars: 28,906
 Local open-source cowork app for OpenClaw, Hermes Agent, Claude Code, Codex, OpenCode, Gemini CLI, and other agent CLIs
 
 AionUi is a cross-platform cowork application that provides a unified graphical interface for managing and interacting with multiple AI agents. It integrates a built-in agent engine with file system access and web search capabilities, eliminating the need for separate CLI installations. The platform supports a wide range of external agents like Claude Code and Hermes Agent, while offering specialized assistants for generating editable Office documents via OfficeCLI. Users can manage these agents through a WebUI or via remote access through services like Telegram and WeChat.
@@ -1939,7 +1939,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/supermemoryai/supermemory
 GitHub: https://github.com/supermemoryai/supermemory
 Category: Memory & Context
-Stars: 27,600
+Stars: 27,627
 Memory engine and API — official Hermes Agent memory provider with sub-300ms recall sustained at 100B+ tokens/month, custom vector graph engine, context fencing, and byte-level dedupe with 100% prompt-cache discount.
 
 Supermemory is a memory and context engine that provides AI agents with persistent memory across conversations. It automatically extracts facts, maintains user profiles, and manages knowledge updates to prevent AI forgetfulness. The system integrates RAG, multi-modal extractors, and third-party connectors into a single API for developers or a standalone app for users. It supports various clients via an MCP server and provides dedicated plugins for tools like Claude Code and Hermes.
@@ -1956,7 +1956,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/volcengine/OpenViking
 GitHub: https://github.com/volcengine/OpenViking
 Category: Memory & Context
-Stars: 26,065
+Stars: 26,083
 Open-source context database for AI agents — official Hermes Agent memory provider using viking:// URIs and tiered L0/L1/L2 loading; 91% token reduction and 43-49% task-completion gain over baseline on LoCoMo10. AGPL-3.0.
 
 OpenViking is an open-source context database that simplifies context management for AI agents. It replaces traditional flat vector storage with a filesystem paradigm to unify the organization of memories, resources, and skills. The system utilizes a three-tier loading structure (L0/L1/L2) to reduce token consumption and supports recursive directory retrieval for precise context acquisition. It also provides visualized retrieval trajectories to make the retrieval process observable and debuggable.
@@ -1973,7 +1973,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/garrytan/gbrain
 GitHub: https://github.com/garrytan/gbrain
 Category: Memory & Context
-Stars: 24,154
+Stars: 24,185
 Garry's Opinionated OpenClaw/Hermes Agent Brain
 
 GBrain is a memory and synthesis layer designed to provide AI agents with persistent context across meetings, emails, and personal notes. It combines a self-wiring knowledge graph that extracts entity relationships without LLM calls with a synthesis layer that generates cited answers and performs gap analysis on missing information. The system features a 24/7 autonomous "dream cycle" for data enrichment and memory consolidation while supporting multi-user scoped access for company-wide deployments. It integrates directly with Hermes and OpenClaw agents and provides an MCP server for tools like Claude Code and Codex.
@@ -1990,7 +1990,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/mukul975/Anthropic-Cybersecurity-Skills
 GitHub: https://github.com/mukul975/Anthropic-Cybersecurity-Skills
 Category: Skills & Skill Registries
-Stars: 21,479
+Stars: 21,659
 754 structured cybersecurity skills mapped to MITRE ATT&CK, NIST CSF 2.0, ATLAS, D3FEND & NIST AI RMF
 
 Anthropic Cybersecurity Skills is an open-source library designed to provide AI agents with the domain knowledge of a senior security analyst. It provides 817 structured skills across 29 security domains, following the agentskills.io open standard. Each skill is mapped across six industry frameworks, including MITRE ATT&CK, NIST CSF 2.0, and the MITRE Fight Fraud Framework (F3). The library is compatible with over 26 AI platforms, including Claude Code, Cursor, and Gemini CLI.
@@ -2007,7 +2007,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/vectorize-io/hindsight
 GitHub: https://github.com/vectorize-io/hindsight
 Category: Memory & Context
-Stars: 17,588
+Stars: 17,611
 Official: Yes (maintained by Nous Research)
 Agent memory that learns — long-term retain/recall/reflect workflows
 
@@ -2025,7 +2025,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/nesquena/hermes-webui
 GitHub: https://github.com/nesquena/hermes-webui
 Category: Workspaces & GUIs
-Stars: 15,041
+Stars: 15,060
 Hermes WebUI: The best way to use Hermes Agent from the web or from your phone!
 
 Hermes WebUI is a lightweight browser-based interface that provides a graphical alternative to the Hermes Agent CLI. It is built using Python and vanilla JavaScript without the need for a build step, framework, or bundler. The interface features a three-panel layout for managing sessions, chat, and workspace files while maintaining full parity with the terminal experience. It integrates directly with existing Hermes agent setups and models, allowing secure access via SSH tunnels.
@@ -2042,7 +2042,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/fathah/hermes-desktop
 GitHub: https://github.com/fathah/hermes-desktop
 Category: Workspaces & GUIs
-Stars: 12,734
+Stars: 12,744
 Desktop companion app for installing, configuring, and chatting with Hermes Agent
 
 Hermes One is a native desktop application that provides a graphical interface for installing, configuring, and interacting with the Hermes Agent. It replaces manual CLI management by utilizing the official Hermes install script to set up the agent in a local directory. The app supports a wide array of AI providers, including OpenAI, Anthropic, and local endpoints like Ollama. Users can manage isolated environments through profile switching and utilize a streaming chat UI with integrated token tracking and slash commands.
@@ -2059,7 +2059,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/EKKOLearnAI/hermes-web-ui
 GitHub: https://github.com/EKKOLearnAI/hermes-web-ui
 Category: Workspaces & GUIs
-Stars: 8,530
+Stars: 8,541
 Web dashboard for Hermes Agent — multi-platform AI chat, session management, scheduled jobs, usage analytics & channel configuration (Telegram, Discord, Slack, WhatsApp)
 
 Hermes Studio is a comprehensive management interface for Hermes Agent that provides a centralized control plane for AI agent orchestration. It utilizes a local runtime and a web console to manage profiles, models, and persistent sessions via a local SQLite database. The platform integrates multi-agent group chats, a file browser for remote backends, and a dedicated dashboard for tracking token usage and costs. It also simplifies the deployment of agents across eight different communication platforms including Telegram, Discord, and Slack.
@@ -2076,7 +2076,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/outsourc-e/hermes-workspace
 GitHub: https://github.com/outsourc-e/hermes-workspace
 Category: Workspaces & GUIs
-Stars: 5,854
+Stars: 5,859
 Native web workspace — chat, terminal, memory browser, skills manager, and inspector panel
 
 Hermes Workspace is a comprehensive command center designed to orchestrate AI agents through a unified web interface. It integrates with the vanilla hermes-agent to provide a zero-fork environment for managing chat, memory, and system operations. The platform features a Swarm Mode that utilizes tmux-backed workers for autonomous, role-based task dispatching and a Kanban board for tracking progress. Users can manage over 2,000 skills, browse MCP catalogs, and access a cross-platform PTY terminal from a single dashboard.
@@ -2093,7 +2093,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/plastic-labs/honcho
 GitHub: https://github.com/plastic-labs/honcho
 Category: Memory & Context
-Stars: 5,551
+Stars: 5,560
 Official: Yes (maintained by Nous Research)
 Memory library for building stateful agents — the upstream library that the elkimek/honcho-self-hosted Hermes wrapper builds on.
 
@@ -2111,7 +2111,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/builderz-labs/mission-control
 GitHub: https://github.com/builderz-labs/mission-control
 Category: Multi-Agent & Orchestration
-Stars: 5,422
+Stars: 5,428
 Self-hosted AI agent orchestration — dispatch tasks, run multi-agent workflows, monitor spend
 
 Mission Control is an open-source dashboard designed for the orchestration and management of AI agent fleets. It utilizes a local-first architecture powered by SQLite and a Next.js SPA to provide real-time telemetry and task dispatching without external dependencies. The platform supports multi-agent workflows with built-in quality gates and integrates with frameworks like CrewAI, LangGraph, and AutoGen. Users can manage recurring tasks via natural language scheduling and monitor security through trust scoring and secret detection.
@@ -2128,7 +2128,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/campfirein/byterover-cli
 GitHub: https://github.com/campfirein/byterover-cli
 Category: Memory & Context
-Stars: 4,878
+Stars: 4,882
 Memory as a git repo (formerly Cipher) — official Hermes Agent memory provider with 5-tier retrieval (4 tiers non-LLM, sub-100ms), brv vc commit/branch/merge versioning over plain markdown context tree. Elastic License 2.0.
 
 ByteRover CLI is a persistent, structured memory provider that gives AI coding agents a way to store and retrieve project knowledge. It organizes information into a context tree using a git-like version control system for branching, committing, and merging markdown-based context. The tool includes an interactive REPL, a web dashboard, and integration with over 20 LLM providers. It supports a wide range of AI coding agents including Cursor, Claude Code, and Windsurf via MCP integration.
@@ -2145,7 +2145,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/Agents365-ai/drawio-skill
 GitHub: https://github.com/Agents365-ai/drawio-skill
 Category: Skills & Skill Registries
-Stars: 4,695
+Stars: 4,722
 Generate draw.io diagrams from natural language descriptions
 
 The drawio-skill project is an agentic tool that converts natural language descriptions and source code into professional .drawio diagrams. It utilizes the native draw.io desktop CLI to generate XML and export files to formats like PNG, SVG, and PDF. The system includes specialized extractors for Python, JavaScript, Go, and Rust to automatically visualize codebase architectures and class hierarchies. It also features a self-correction loop that analyzes visual output to fix overlapping elements and clipped labels.
@@ -2162,7 +2162,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/alchaincyf/hermes-agent-orange-book
 GitHub: https://github.com/alchaincyf/hermes-agent-orange-book
 Category: Guides & Docs
-Stars: 4,548
+Stars: 4,549
 Hermes Agent practical guide — Orange Book series (Chinese language)
 
 The Hermes Agent Orange Book is a comprehensive practical guide designed to help users master the Hermes Agent open-source AI framework. It explains the framework's self-improving learning loop, three-layer memory system, and automatic skill evolution. The guide covers deployment, security models, and the use of the multi-agent Kanban platform. It provides detailed instructions for developers and power users across 21 sections, supporting both desktop and browser interfaces.
@@ -2179,7 +2179,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/NousResearch/hermes-agent-self-evolution
 GitHub: https://github.com/NousResearch/hermes-agent-self-evolution
 Category: Core & Official
-Stars: 4,348
+Stars: 4,354
 Official: Yes (maintained by Nous Research)
 Evolutionary self-improvement using DSPy + GEPA — optimizes skills, prompts, and code
 
@@ -2197,7 +2197,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/0xNyk/awesome-hermes-agent
 GitHub: https://github.com/0xNyk/awesome-hermes-agent
 Category: Guides & Docs
-Stars: 4,215
+Stars: 4,226
 Curated list of awesome skills, tools, integrations, and resources for Hermes Agent
 
 This repository is a curated directory of resources, skills, and integrations for the Hermes Agent ecosystem developed by Nous Research. It organizes community-contributed tools into categories such as deployment utilities, messaging bridges, and skill registries to help users extend the agent's autonomous capabilities. The list includes links to official documentation, specialized skill packs for programming or task management, and multi-platform interfaces for managing agent workflows. By tracking maturity levels from experimental to production, it provides a roadmap for developers to build on the agent's self-improving learning loop.
@@ -2214,7 +2214,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/junhoyeo/tokscale
 GitHub: https://github.com/junhoyeo/tokscale
 Category: Developer Tools
-Stars: 3,963
+Stars: 3,969
 CLI tool for tracking token usage from Claude Code, OpenClaw, Hermes, Codex, Gemini, and more
 
 Tokscale is a monitoring tool designed to track and analyze token consumption and costs across various AI coding agents. It works by scanning local data directories and database files from multiple AI clients to aggregate usage statistics. The tool provides a native Rust-based TUI for visualizing daily summaries and detailed stats. Users can also submit their usage data to a public leaderboard and create a personal profile.
@@ -2248,7 +2248,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/AMAP-ML/SkillClaw
 GitHub: https://github.com/AMAP-ML/SkillClaw
 Category: Skills & Skill Registries
-Stars: 2,024
+Stars: 2,026
 Let Skills Evolve Collectively with Agentic Evolver
 
 SkillClaw is a collective skill evolution framework that prevents AI agent skill libraries from becoming fragmented or outdated. It implements a post-task evolution loop that automatically digests, deduplicates, and improves skills in the background without interrupting the user's workflow. This allows skills to be unified across multiple agents, devices, and team members, ensuring that experience compounds across different contexts. It natively integrates with Hermes, OpenClaw, QwenPaw, and any OpenAI-compatible API.
@@ -2265,7 +2265,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/conorbronsdon/avoid-ai-writing
 GitHub: https://github.com/conorbronsdon/avoid-ai-writing
 Category: Skills & Skill Registries
-Stars: 2,011
+Stars: 2,016
 Audits and rewrites content to eliminate detectable AI writing patterns
 
 avoid-ai-writing is a portable writing skill designed to audit and remove detectable AI-generated patterns from text. It utilizes a structured two-pass detection system and a tiered word replacement table to identify and replace specific "AI-isms" with plainer alternatives. The tool supports distinct modes for rewriting, detecting, or editing files in place, and allows users to apply specific voice profiles. It is compatible with various agent frameworks including Hermes, Claude Code, OpenClaw, and Cursor.
@@ -2282,7 +2282,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/liaohch3/claude-tap
 GitHub: https://github.com/liaohch3/claude-tap
 Category: Developer Tools
-Stars: 2,006
+Stars: 2,011
 Local trace viewer for inspecting coding-agent API traffic from Hermes Agent, Claude Code, Codex, Gemini, Cursor, OpenCode, and others
 
 Claude-tap is a local proxy and trace viewer designed to inspect the API traffic of AI coding agents. It works by intercepting HTTP requests between the agent and the LLM provider, allowing developers to examine system prompts, tool calls, and streaming responses in real-time. The tool helps debug agent behavior by providing structured diffs between adjacent requests and redacting sensitive authentication headers for security. It supports a wide range of clients including Hermes Agent, Claude Code, Cursor, and Gemini CLI, exporting traces as portable HTML artifacts.
@@ -2299,7 +2299,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/dodo-reach/hermes-desktop
 GitHub: https://github.com/dodo-reach/hermes-desktop
 Category: Workspaces & GUIs
-Stars: 1,927
+Stars: 1,926
 A native Mac workspace for Hermes: real SSH, real terminal, real session data.
 
 Hermes Desktop is a native macOS companion app that provides a dedicated workbench for managing Hermes Agent without relying on browser wrappers or gateway APIs. It connects directly to a local or remote host via SSH to interact with the real machine-first workflow. The app allows users to manage sessions, Kanban boards, cron jobs, and skills while maintaining the host as the sole source of truth. It is designed to complement the official web dashboard by focusing on direct work and system repair via an embedded terminal.
@@ -2316,7 +2316,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/NousResearch/hermes-paperclip-adapter
 GitHub: https://github.com/NousResearch/hermes-paperclip-adapter
 Category: Core & Official
-Stars: 1,645
+Stars: 1,646
 Official: Yes (maintained by Nous Research)
 Run Hermes as a managed employee in Paperclip company systems
 
@@ -2334,7 +2334,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/jau123/MeiGen-AI-Design-MCP
 GitHub: https://github.com/jau123/MeiGen-AI-Design-MCP
 Category: Plugins & Extensions
-Stars: 1,491
+Stars: 1,493
 Supports GPT Image 2, Nanobanana & ComfyUI, with a 1,400+ prompt library, carefully crafted hooks and a multi-task orchestration system
 
 MeiGen AI Design MCP is an open-source MCP server that integrates professional image and video generation capabilities directly into AI coding tools. It functions as a bridge between MCP-compatible hosts and various backends, including the MeiGen cloud, OpenAI-compatible APIs, or local ComfyUI instances. The system utilizes a library of 1,446 curated prompts and a sub-agent orchestration system to handle parallel batch generation. It is compatible with tools such as Claude Code, Cursor, Windsurf, and Hermes Agent, and can also be operated as a standalone CLI.
@@ -2351,7 +2351,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/numtide/llm-agents.nix
 GitHub: https://github.com/numtide/llm-agents.nix
 Category: Deployment & Infra
-Stars: 1,474
+Stars: 1,475
 Nix packages for AI coding agents including Hermes
 
 llm-agents.nix is a collection of Nix packages that simplifies the installation and management of AI coding agents and development tools. It provides a centralized repository of Nix expressions to deploy various agentic CLIs from different providers. Users can instantly run these tools via the Nix CLI without manual setup. The collection includes a wide range of agents from providers like Google, OpenAI, and xAI, as well as open-source alternatives.
@@ -2368,7 +2368,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/wondelai/skills
 GitHub: https://github.com/wondelai/skills
 Category: Skills & Skill Registries
-Stars: 1,461
+Stars: 1,467
 Cross-platform skills library for Claude Code and agentskills.io-compatible agents
 
 Wondel.ai Skills is a cross-platform library that provides specialized knowledge frameworks for AI agents. It implements these skills as installable plugins based on established methodologies from industry-standard books and design guidelines. Users can integrate these capabilities into Claude Code or other agentskills.io-compatible agents to improve performance in domains like software architecture, UX design, and product strategy. The library organizes skills into thematic collections for streamlined installation via the Claude Code marketplace or skills.sh.
@@ -2385,7 +2385,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/NousResearch/Hermes-Function-Calling
 GitHub: https://github.com/NousResearch/Hermes-Function-Calling
 Category: Core & Official
-Stars: 1,404
+Stars: 1,405
 Official: Yes (maintained by Nous Research)
 Function calling examples and training data for Hermes LLM models
 
@@ -2421,7 +2421,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/AxDSan/mnemosyne
 GitHub: https://github.com/AxDSan/mnemosyne
 Category: Memory & Context
-Stars: 1,288
+Stars: 1,293
 The Zero-Dependency, Sub-Millisecond AI Memory System for Hermes Agents
 
 Mnemosyne is a universal memory layer designed to provide AI agents with persistent, long-term context. It utilizes a SQLite-backed architecture to store working memory, episodic memory, and temporal knowledge graphs in a single file. The system integrates via MCP, a Python SDK, or native plugins to support platforms like Cursor, Claude Code, and OpenWebUI. It enables efficient fact extraction, temporal recall, and bidirectional memory synchronization between instances.
@@ -2438,7 +2438,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/greyhaven-ai/autocontext
 GitHub: https://github.com/greyhaven-ai/autocontext
 Category: Memory & Context
-Stars: 1,224
+Stars: 1,225
 Recursive self-improving context harness — helps agents succeed on complex tasks
 
 autocontext is a recursive harness that helps agents solve complex tasks through iterative self-improvement. It operates by testing goals against real evaluations, retaining successful strategies while discarding failures to produce structured traces and playbooks. This process allows subsequent agent iterations to inherit accumulated knowledge, datasets, and optionally distilled local models. The system integrates with various providers including Anthropic, OpenAI, and Gemini, and supports MCP for tool-catalog protocol clients.
@@ -2455,7 +2455,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/NousResearch/autonovel
 GitHub: https://github.com/NousResearch/autonovel
 Category: Core & Official
-Stars: 1,202
+Stars: 1,205
 Official: Yes (maintained by Nous Research)
 Autonomous novel-writing pipeline generating 100k+ word manuscripts
 
@@ -2473,7 +2473,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/ksimback/hermes-ecosystem
 GitHub: https://github.com/ksimback/hermes-ecosystem
 Category: Guides & Docs
-Stars: 1,061
+Stars: 1,064
 Hermes Atlas — the community map of every tool, skill, and integration for Hermes Agent by Nous Research
 
 Hermes Atlas is a community-curated directory and ecosystem map for the Hermes Agent by Nous Research. It aggregates over 80 quality-filtered repositories, including skills, plugins, and deployment templates, using a vanilla JavaScript frontend and Vercel serverless functions. The platform features a RAG-powered chatbot that answers technical questions grounded in 27 research files using hybrid retrieval and OpenRouter LLMs. Users can search and filter the ecosystem while viewing live GitHub star counts and growth trends cached via Redis.
@@ -2507,7 +2507,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/xaspx/hermes-control-interface
 GitHub: https://github.com/xaspx/hermes-control-interface
 Category: Workspaces & GUIs
-Stars: 784
+Stars: 785
 A self-hosted web dashboard for the Hermes AI agent stack. Provides a browser-based terminal, file explorer, session overview, cron management, system metrics, and an agent status panel — all behind a
 
 Hermes Control Interface is a self-hosted web dashboard designed to centralize the management of the Hermes AI agent stack. It utilizes a Node.js and Express backend with a Vanilla JS frontend to provide a unified interface for agent orchestration and system monitoring. The platform integrates a swarm monitor for tracking agent health and task pipelines via a Kanban system, alongside tools for MCP server control and token analytics. Users can manage files, install skills, and interact with agents through a secure, password-protected web environment.
@@ -2558,7 +2558,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/Salomondiei08/oh-my-hermes
 GitHub: https://github.com/Salomondiei08/oh-my-hermes
 Category: Developer Tools
-Stars: 658
+Stars: 659
 Opinionated workflow layer for building, shipping, and operating apps with Hermes Agent
 
 Oh My Hermes is an opinionated workflow layer that transforms the Hermes Agent into a specialized autonomous developer and operator. It functions as a curated set of 23 skills and 5 workflows that allow Hermes to manage the entire software development lifecycle directly through chat interfaces like Telegram or Slack. The system orchestrates sub-agents for project management, development, security, and operations to handle tasks ranging from requirement clarification to automated deployment. It integrates with external tools like Vercel, Supabase, and GitHub to monitor issues, perform security scans, and manage production health checks.
@@ -2575,7 +2575,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/AaronWong1999/hermesclaw
 GitHub: https://github.com/AaronWong1999/hermesclaw
 Category: Integrations & Bridges
-Stars: 647
+Stars: 648
 Run Hermes Agent and OpenClaw on the same WeChat account
 
 HermesClaw is a lightweight Python proxy that allows users to run Hermes Agent, OpenClaw, and OpenCode on a single WeChat account. It resolves iLink connection conflicts by acting as the sole poller and routing messages to local proxy servers and an ACP bridge. This enables users to switch between different AI agents using specific commands or run multiple agents simultaneously. The integration also brings OpenCode's Vibe Coding capabilities to WeChat via voice message transcription.
@@ -2592,7 +2592,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/shannhk/hermes-agent-control-room
 GitHub: https://github.com/shannhk/hermes-agent-control-room
 Category: Multi-Agent & Orchestration
-Stars: 599
+Stars: 600
 Control Room-first template for scaling Hermes Agent from one VPS agent to specialist teams and automated workflows
 
 Hermes Agent Control Room is a template-based framework designed to organize and govern Hermes agents across VPS environments. It functions as a sidecar control plane that provides a structured system map, registry, and runbook library to manage agent operations. The architecture supports scaling from a single agent to specialized teams using a task bus pattern for delegation and synthesis. Users can interact with agents directly or through an optional orchestrator that serves as a central front door for automated workflows.
@@ -2643,7 +2643,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/Eynzof/hermes-agent-cn-desktop
 GitHub: https://github.com/Eynzof/hermes-agent-cn-desktop
 Category: Workspaces & GUIs
-Stars: 578
+Stars: 584
 Windows-first Chinese desktop app for Hermes Agent built with Tauri, TypeScript, and Rust
 
 Hermes Agent CN Desktop is a desktop client designed to provide a native user experience for the Hermes Agent, moving beyond the standard web dashboard. It is built using Tauri v2, Rust, React, and TypeScript, incorporating a modified Hermes Agent kernel specifically for the Chinese community. The application manages local processes and runtimes while offering a comprehensive UI for chat, memory management, and task control. It supports a wide range of cloud and local model providers, including Ollama and vLLM, and integrates with platforms like Feishu.
@@ -2711,7 +2711,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/joeynyc/hermes-skins
 GitHub: https://github.com/joeynyc/hermes-skins
 Category: Developer Tools
-Stars: 471
+Stars: 472
 Community CLI skins and themes for Hermes terminal UI
 
 Hermes Skins is a collection of visual themes for the Hermes CLI agent that allows users to customize the terminal user interface. It utilizes YAML configuration files to modify elements such as banner colors, ASCII art, spinner verbs, and branding text. These skins change only the visual presentation without affecting the agent's personality or behavior. Users can easily apply these themes via a session command or by updating their permanent configuration file.
@@ -2728,7 +2728,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/jwangkun/hermes-agent-guide
 GitHub: https://github.com/jwangkun/hermes-agent-guide
 Category: Guides & Docs
-Stars: 416
+Stars: 422
 A systematic Chinese-language guide to Hermes Agent — 16 books, 300K+ words, covering installation, advanced development, single- and multi-agent orchestration.
 
 This project is a comprehensive Chinese-language guide designed to provide a systematic learning path for the Hermes Agent framework. It organizes fragmented documentation into 16 volumes covering the system's five-layer architecture, memory systems, and skill ecosystems. The guide includes practical tutorials for installation, MCP protocol integration, and multi-agent orchestration. It also provides specific migration paths for OpenClaw users and strategies for commercial application.
@@ -2796,7 +2796,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/elkimek/honcho-self-hosted
 GitHub: https://github.com/elkimek/honcho-self-hosted
 Category: Memory & Context
-Stars: 328
+Stars: 329
 Self-hosted Honcho memory backend for cross-session persistence
 
 This project provides a configuration layer for self-hosting Plastic Labs' Honcho memory backend, enabling cross-session persistence for Hermes Agent without relying on third-party cloud storage. It deploys the full Honcho stack—including the API, PostgreSQL with pgvector, and Redis—on local hardware using Docker Compose. Users can route memory extraction and reasoning tasks through any OpenAI-compatible API or local inference servers like Ollama to maintain data sovereignty. This setup allows Hermes to build long-term user profiles and logical observations while keeping conversation data on the user's own infrastructure.
@@ -2830,7 +2830,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/robbyczgw-cla/hermes-web-search-plus
 GitHub: https://github.com/robbyczgw-cla/hermes-web-search-plus
 Category: Plugins & Extensions
-Stars: 316
+Stars: 315
 Multi-provider web search (Serper, Tavily, Exa, Querit, Perplexity) with auto-routing
 
 hermes-web-search-plus is a plugin for Hermes Agent that provides multi-provider web search and URL extraction. It utilizes a class-aware auto-routing system (Routing v2) to dynamically select the best available provider based on the user's configured API keys. The plugin ensures cost control by capping research mode work and offers a standalone setup wizard for managing provider priorities and capabilities.
@@ -2881,7 +2881,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/stainlu/hermes-labyrinth
 GitHub: https://github.com/stainlu/hermes-labyrinth
 Category: Plugins & Extensions
-Stars: 290
+Stars: 291
 Read-only observability plugin for Hermes Agent with journeys, crossings, guideposts, and reports
 
 Hermes Labyrinth is a read-only observability plugin for Hermes Agent that visualizes autonomous workflows as a structured map of events. It functions as a black-box recorder, reading local state to track prompts, tool calls, model transitions, and subagent activities without mutating session data. The tool provides deep diagnostic visibility through specialized views for skill overrides, scheduled cron tasks, and redacted journey reports. Users can export evidence in Markdown or JSON formats while relying on built-in redaction to protect sensitive credentials.
@@ -2898,7 +2898,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/amanning3390/hermeshub
 GitHub: https://github.com/amanning3390/hermeshub
 Category: Skills & Skill Registries
-Stars: 285
+Stars: 286
 Community skill browsing, search, and one-click installation hub
 
 HermesHub is an Agentic Resource Discovery (ARD) compatible marketplace that enables AI agents to find work and receive payment. It utilizes the Hermes Capability Taxonomy (HCT) to allow workers to declare machine-readable capabilities and submit Ed25519-signed bids. The platform supports both unattended agent-to-agent settlement via the Machine Payments Protocol and human-supervised flows through Stripe Connect. It further extends its reach by federating with other ARD registries like Hugging Face Discover and GitHub Agent Finder.
@@ -2915,7 +2915,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/ucsandman/DashClaw
 GitHub: https://github.com/ucsandman/DashClaw
 Category: Domain Applications
-Stars: 277
+Stars: 278
 Decision infrastructure with guard policies and risk assessment for agents
 
 DashClaw is a governance layer designed to manage and secure AI agents that interact with real-world systems. It intercepts agent intents to evaluate them against declarative policies, routing high-risk actions for human approval before execution. The system maintains a verifiable ledger of decisions and tracks terminal outcomes to prevent double-execution during retries. It integrates with various frameworks including LangChain, CrewAI, and AutoGen, as well as agents like Claude Code and Hermes Agent via SDKs or MCP.
@@ -2932,7 +2932,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/liftaris/herm
 GitHub: https://github.com/liftaris/herm
 Category: Workspaces & GUIs
-Stars: 260
+Stars: 261
 Alternative Hermes TUI and dashboard built with OpenTUI.
 
 Herm is an operator-focused terminal user interface (TUI) that centralizes the management of Hermes Agent into a single dashboard. Built with OpenTUI and Bun, it acts as a client for the Hermes Agent gateway rather than a standalone runtime. It allows users to chat with the agent, manage operational surfaces like cron jobs and memory, and track agentic work via an integrated kanban board. The tool also includes a system for discovering and installing Eikons, which are terminal avatars.
@@ -2966,7 +2966,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/42-evey/hermes-plugins
 GitHub: https://github.com/42-evey/hermes-plugins
 Category: Plugins & Extensions
-Stars: 246
+Stars: 247
 Goal management, inter-agent bridge, model selection, and cost control plugins
 
 Evey's Hermes Plugins is a collection of 23 custom extensions designed to enhance the autonomy, observability, and cost-efficiency of the Hermes Agent framework. The suite implements specialized logic for multi-model decision debates, smart task routing with fallback chains, and structured telemetry logging. These tools enable agents to manage their own goals, perform self-correction loops, and consolidate long-term memory into vector storage. Additionally, the project includes a bidirectional bridge for Claude Code and budget enforcement via Langfuse integration.
@@ -3068,7 +3068,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/Signet-AI/signetai
 GitHub: https://github.com/Signet-AI/signetai
 Category: Memory & Context
-Stars: 203
+Stars: 205
 Local-first identity, memory, and secrets layer for AI agents — portable state across Hermes Agent, Claude Code, Codex, OpenCode, OpenClaw, and MCP clients
 
 Signet AI is a local-first context layer that provides agents with durable identity, memory, and secrets management. It operates as a self-hosted daemon using SQLite and readable workspace files to ensure users maintain custody of their private context. This architecture allows for source-backed recall and the ability to manually inspect, edit, or delete memories via a dedicated dashboard. It integrates across multiple agent shells, including Hermes Agent, Claude Code, and MCP clients, to maintain consistent state across different tools.
@@ -3085,7 +3085,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/ReinaMacCredy/maestro
 GitHub: https://github.com/ReinaMacCredy/maestro
 Category: Skills & Skill Registries
-Stars: 201
+Stars: 202
 Harness for long-running AI agents — structured memory, cross-feature learning, plan-approve-execute
 
 maestro is a local-first harness that provides a durable state management system for long-running AI coding agents. It uses a card-based model stored as plain files in the repository to track features, tasks, decisions, and ideas without requiring a daemon or cloud service. Agents manage the project lifecycle via a CLI, ensuring that work is gated by proof and QA requirements before being closed. This approach prevents context loss and provides a reviewable audit trail of agent reasoning and execution.
@@ -3102,7 +3102,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/tlehman/litprog-skill
 GitHub: https://github.com/tlehman/litprog-skill
 Category: Skills & Skill Registries
-Stars: 192
+Stars: 194
 Literate programming skill — weave code and documentation across agents
 
 The litprog-skill is a Claude Code extension that implements Donald Knuth's literate programming paradigm by transforming codebases into human-readable narratives. It works by generating a .lit.md file that weaves together prose, Mermaid diagrams, and LaTeX math with the original source code. The tool includes a tangler to extract runnable files and a reverse-sync engine to ensure the documentation stays updated when source files are edited. This approach helps developers document architectural decisions and facilitates easier onboarding through structured, essay-like code explanations.
@@ -3221,7 +3221,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/indranilbanerjee/digital-marketing-pro
 GitHub: https://github.com/indranilbanerjee/digital-marketing-pro
 Category: Plugins & Extensions
-Stars: 162
+Stars: 163
 Open-source AI marketing plugin for agencies & in-house teams — 158 skills, 25 specialist agents, 12-Part Strategy Flow, Cowork team-persistent, EU AI Act Article 50 ready, 6-platform AEO/GEO incl. Go
 
 Digital Marketing Pro is an open-source AI marketing plugin designed to standardize strategy and execution for agencies and in-house teams managing multiple brands. It utilizes a 12-part strategy flow consisting of 61 explicit steps to ensure consistent output across different brand portfolios. The tool integrates with various AI interfaces including Claude Code, Cursor, and Hermes Agent, providing specialized agents for tasks ranging from funnel architecture to compliance auditing. It specifically supports multi-brand state management and regulatory adherence across 16 jurisdictions, including EU AI Act Article 50.
@@ -3238,7 +3238,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/1ilkhamov/opencode-hermes-multiagent
 GitHub: https://github.com/1ilkhamov/opencode-hermes-multiagent
 Category: Multi-Agent & Orchestration
-Stars: 152
+Stars: 153
 17 specialized agents for research, planning, implementation, quality, and infrastructure
 
 Hermes is a multi-agent orchestration system designed to automate complex software development workflows for OpenCode AI. It utilizes a master orchestrator to coordinate 17 specialized agents across research, planning, implementation, quality, and infrastructure categories. The system follows strict pipeline architectures that enforce mandatory quality gates, security audits, and revision loops for every code change. It integrates with MCP servers for external knowledge retrieval and supports custom model configurations for each agent role.
@@ -3403,6 +3403,16 @@ Highlights:
 
 ---
 
+## abundantbeing/hermes-browser-extension
+
+URL: https://hermesatlas.com/projects/abundantbeing/hermes-browser-extension
+GitHub: https://github.com/abundantbeing/hermes-browser-extension
+Category: Workspaces & GUIs
+Stars: 95
+Chromium side-panel extension that connects active browser context to a local or remote Hermes Agent runtime
+
+---
+
 ## 8bit64k/cronalytics
 
 URL: https://hermesatlas.com/projects/8bit64k/cronalytics
@@ -3561,7 +3571,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/yantrikos/yantrikdb-hermes-plugin
 GitHub: https://github.com/yantrikos/yantrikdb-hermes-plugin
 Category: Memory & Context
-Stars: 62
+Stars: 63
 Self-maintaining Hermes memory plugin with explainable retrieval — every recall comes back with a why_retrieved tag, plus canonicalization, contradiction tracking, and recency ranking. Embedded by default.
 
 yantrikdb-hermes-plugin is a memory provider for Hermes Agent designed to prevent the loss of important constraints during long sessions. It utilizes a temporal context graph and a maintenance pass to manage memory lifecycles through promotion, demotion, and supersession. The plugin features an embedded in-process backend by default, eliminating the need for a separate server or GPU. It also enables agents to author and track the outcomes of their own skills natively within the database.
@@ -3663,7 +3673,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/sheawinkler/hermes-agent-ultra
 GitHub: https://github.com/sheawinkler/hermes-agent-ultra
 Category: Forks & Derivatives
-Stars: 56
+Stars: 57
 Rust-based Hermes Agent Ultra derivative focused on performance and Hermes Agent feature parity
 
 Hermes Agent Ultra is a Rust-native autonomous agent runtime designed for high-performance execution and functional parity with the original Hermes Agent. It implements a deterministic core that manages agent loops, tool policies, and multi-provider inference routing without relying on a Python runtime. The project provides advanced operator controls such as session time-travel, runtime policy enforcement, and deep diagnostic snapshots for debugging complex local or gateway sessions. It supports a wide range of local backends including Ollama, llama.cpp, and vLLM, alongside integration with the Nous Portal for managed model access.
@@ -3709,6 +3719,23 @@ Highlights:
 
 ---
 
+## Christabel337/job-scout-agent
+
+URL: https://hermesatlas.com/projects/Christabel337/job-scout-agent
+GitHub: https://github.com/Christabel337/job-scout-agent
+Category: Domain Applications
+Stars: 48
+Autonomous job hunting — scans listings, writes cover letters, tracks applications
+
+Job Scout Agent is an automated job search tool designed to streamline the discovery and tracking of employment opportunities. The agent utilizes Hermes Agent capabilities to fetch live listings from job board APIs, score them against user-defined profiles, and perform company research. It organizes findings into structured local directories and maintains a CSV tracker for easy integration with Google Sheets. This system eliminates manual searching by providing a daily summary of relevant roles with direct application links.
+
+Highlights:
+- Fetches live job listings using browser-based API integration
+- Scores roles against skills, salary, and location preferences
+- Maintains an automated CSV tracker for application management
+
+---
+
 ## bigph00t/hermescraft
 
 URL: https://hermesatlas.com/projects/bigph00t/hermescraft
@@ -3726,29 +3753,12 @@ Highlights:
 
 ---
 
-## Christabel337/job-scout-agent
-
-URL: https://hermesatlas.com/projects/Christabel337/job-scout-agent
-GitHub: https://github.com/Christabel337/job-scout-agent
-Category: Domain Applications
-Stars: 47
-Autonomous job hunting — scans listings, writes cover letters, tracks applications
-
-Job Scout Agent is an automated job search tool designed to streamline the discovery and tracking of employment opportunities. The agent utilizes Hermes Agent capabilities to fetch live listings from job board APIs, score them against user-defined profiles, and perform company research. It organizes findings into structured local directories and maintains a CSV tracker for easy integration with Google Sheets. This system eliminates manual searching by providing a daily summary of relevant roles with direct application links.
-
-Highlights:
-- Fetches live job listings using browser-based API integration
-- Scores roles against skills, salary, and location preferences
-- Maintains an automated CSV tracker for application management
-
----
-
 ## 42-evey/evey-setup
 
 URL: https://hermesatlas.com/projects/42-evey/evey-setup
 GitHub: https://github.com/42-evey/evey-setup
 Category: Developer Tools
-Stars: 46
+Stars: 47
 Get a hermes-agent stack running in minutes — free models, 29 plugins, zero cost
 
 Evey Setup is a deployment toolkit designed to bootstrap a complete autonomous AI agent environment based on the Hermes Agent framework. It uses a multi-phase shell script to orchestrate a containerized stack including model routing via LiteLLM, local GPU inference through Ollama, and vector memory with Qdrant. The installer provides three service tiers—Base, Services, and Full—allowing users to scale from a minimal agent to a production-ready system with monitoring and workflow automation. It integrates 29 community plugins and pre-configures free model routing to enable zero-cost operation.
@@ -3757,6 +3767,23 @@ Highlights:
 - Deploys Hermes Agent with LiteLLM, Ollama, and Qdrant via Docker
 - Includes 29 community plugins for memory, social, and quality validation
 - Automates configuration for free model routing and local GPU inference
+
+---
+
+## ndesv21/socialclaw
+
+URL: https://hermesatlas.com/projects/ndesv21/socialclaw
+GitHub: https://github.com/ndesv21/socialclaw
+Category: Integrations & Bridges
+Stars: 47
+Social media scheduling CLI and OpenClaw skill for AI agents posting to X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, and Pinterest.
+
+SocialClaw is a social media scheduling tool designed to enable AI agents to publish content across multiple platforms. It provides an npm CLI and a Model Context Protocol (MCP) server that interfaces with a hosted workspace via API key authentication. The system supports campaign validation, asset uploads, and analytics tracking for platforms including X, LinkedIn, Instagram, and TikTok. It integrates directly with AI environments like Claude Code, Cursor, and OpenClaw to automate the publishing workflow.
+
+Highlights:
+- Multi-platform posting to X, LinkedIn, Instagram, and more
+- MCP server providing 17 validation-first publishing tools
+- CLI for schedule validation, asset management, and analytics
 
 ---
 
@@ -3828,23 +3855,6 @@ Highlights:
 
 ---
 
-## ndesv21/socialclaw
-
-URL: https://hermesatlas.com/projects/ndesv21/socialclaw
-GitHub: https://github.com/ndesv21/socialclaw
-Category: Integrations & Bridges
-Stars: 45
-Social media scheduling CLI and OpenClaw skill for AI agents posting to X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, and Pinterest.
-
-SocialClaw is a social media scheduling tool designed to enable AI agents to publish content across multiple platforms. It provides an npm CLI and a Model Context Protocol (MCP) server that interfaces with a hosted workspace via API key authentication. The system supports campaign validation, asset uploads, and analytics tracking for platforms including X, LinkedIn, Instagram, and TikTok. It integrates directly with AI environments like Claude Code, Cursor, and OpenClaw to automate the publishing workflow.
-
-Highlights:
-- Multi-platform posting to X, LinkedIn, Instagram, and more
-- MCP server providing 17 validation-first publishing tools
-- CLI for schedule validation, asset management, and analytics
-
----
-
 ## Rainhoole/hermes-agent-acp-skill
 
 URL: https://hermesatlas.com/projects/Rainhoole/hermes-agent-acp-skill
@@ -3867,7 +3877,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/yepyhun/Brainstack
 GitHub: https://github.com/yepyhun/Brainstack
 Category: Memory & Context
-Stars: 42
+Stars: 43
 Memory kernel stack for Hermes agent
 
 Brainstack is a local-first memory kernel designed to replace flat memory blobs in Hermes agents with a structured, multi-layered memory model. It integrates three distinct memory lines—Hindsight, Graphiti, and MemPalace—to handle session continuity, temporal graph relations, and large-corpus retrieval through a single memory owner. By categorizing information into specific "shelves" like profile, graph, and corpus, it prevents prompt stuffing and ensures Hermes receives only the most relevant, bounded evidence for each query. The system includes a dedicated installer and diagnostic tools to maintain stateful conversation continuity within the Hermes-Agent runtime.
@@ -4020,7 +4030,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/briancaffey/hermes-otel
 GitHub: https://github.com/briancaffey/hermes-otel
 Category: Plugins & Extensions
-Stars: 30
+Stars: 31
 OTel Plugin for Hermes Agent
 
 hermes-otel is an OpenTelemetry plugin for the Hermes Agent that provides observability for LLM workflows. It automatically captures and exports tool calls, model invocations, and API requests as OTel spans to any OTLP-compatible backend. The plugin supports complex parent-child nesting for sessions and provides detailed metrics, including token usage roll-ups and request latency. It is compatible with a wide range of observability platforms including Phoenix, Langfuse, SigNoz, and Honeycomb.
@@ -4046,6 +4056,23 @@ Highlights:
 - Crawls websites with depth controls and sitemap discovery support
 - Extracts structured JSON data using Workers AI and Llama 3.3
 - Converts fully rendered JavaScript-heavy pages into clean Markdown
+
+---
+
+## 0xrsydn/nix-hermes-agent
+
+URL: https://hermesatlas.com/projects/0xrsydn/nix-hermes-agent
+GitHub: https://github.com/0xrsydn/nix-hermes-agent
+Category: Deployment & Infra
+Stars: 26
+Nix package and NixOS module for reproducible Hermes deployment
+
+nix-hermes-agent provides a Nix package and NixOS module for the declarative deployment of Hermes Agent. It allows users to manage the entire agent lifecycle—including configuration, workspace documents, and systemd services—through a single Nix configuration file. The module ensures reproducibility by rendering settings into a structured CLI configuration while keeping sensitive API keys secure via external environment files. It supports both Nix-managed declarative skills and native Hermes CLI interactive skills, providing a stable foundation for production-ready agent infrastructure.
+
+Highlights:
+- Declarative management of agent config, documents, and systemd services
+- Secure secrets handling via systemd EnvironmentFiles and sops-nix integration
+- Hybrid skill support for both Nix-managed and interactive CLI installs
 
 ---
 
@@ -4080,23 +4107,6 @@ Highlights:
 - Reduces prompt token overhead via local BM25 tool ranking
 - Includes a dashboard for tracking estimated schema token savings
 - Compatible with Hermes Agent v0.14.0 and native tool search
-
----
-
-## 0xrsydn/nix-hermes-agent
-
-URL: https://hermesatlas.com/projects/0xrsydn/nix-hermes-agent
-GitHub: https://github.com/0xrsydn/nix-hermes-agent
-Category: Deployment & Infra
-Stars: 25
-Nix package and NixOS module for reproducible Hermes deployment
-
-nix-hermes-agent provides a Nix package and NixOS module for the declarative deployment of Hermes Agent. It allows users to manage the entire agent lifecycle—including configuration, workspace documents, and systemd services—through a single Nix configuration file. The module ensures reproducibility by rendering settings into a structured CLI configuration while keeping sensitive API keys secure via external environment files. It supports both Nix-managed declarative skills and native Hermes CLI interactive skills, providing a stable foundation for production-ready agent infrastructure.
-
-Highlights:
-- Declarative management of agent config, documents, and systemd services
-- Secure secrets handling via systemd EnvironmentFiles and sops-nix integration
-- Hybrid skill support for both Nix-managed and interactive CLI installs
 
 ---
 
@@ -4275,7 +4285,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/Context4GPTs/klodi-plugin
 GitHub: https://github.com/Context4GPTs/klodi-plugin
 Category: Plugins & Extensions
-Stars: 13
+Stars: 14
 The agent-to-agent marketplace, in your agent host. Your agent lists, haggles, and closes deals for you while you live your life.
 
 Klodi is an agent-to-agent marketplace plugin that enables AI agents to conduct peer-to-peer commerce on behalf of their users. The system functions by connecting buyer and seller agents through a marketplace that routes listings, offers, and private negotiation channels while keeping sensitive data like floor prices on the user's local disk. It allows users to delegate tasks such as listing items, haggling over prices, and scheduling logistics through plain markdown policy files. The project provides native adapters for multiple agent hosts including Hermes, OpenClaw, and Moltis, ensuring a consistent identity and rating across different platforms.
@@ -4284,6 +4294,23 @@ Highlights:
 - Automates listing, haggling, and closing deals via agent-to-agent negotiation.
 - Keeps floor prices and walk-away rules private on local storage.
 - Supports cross-platform identity across Hermes, OpenClaw, and Rust-based hosts.
+
+---
+
+## jpalmae/hermeshq
+
+URL: https://hermesatlas.com/projects/jpalmae/hermeshq
+GitHub: https://github.com/jpalmae/hermeshq
+Category: Deployment & Infra
+Stars: 13
+HermesHQ is a Docker-first control plane for running and operating multiple Hermes Agent instances from one web application.
+
+HermesHQ is a Docker-first control plane designed to orchestrate and manage multiple Hermes Agent instances from a single web application. It functions as an operational layer that wraps the Hermes execution engine, providing centralized task dispatching, scheduling, and a runtime ledger. The platform enables multi-agent delegation, RBAC-controlled user access, and per-agent communication channels for Telegram and WhatsApp. It also features an enterprise MCP bridge to expose specific agents to external AI clients like Claude Code and Codex.
+
+Highlights:
+- Orchestrates multiple Hermes Agent instances with separate workspaces and identities
+- Provides hierarchy-aware inter-agent delegation and task scheduling
+- Offers enterprise MCP access for external AI client integrations
 
 ---
 
@@ -4335,23 +4362,6 @@ Highlights:
 - Enforces human-in-the-loop approval for high-value USDC transfers
 - Supports Circle CCTP for cross-chain USDC routing and execution
 - Automates x402 micropayments below configurable policy thresholds
-
----
-
-## jpalmae/hermeshq
-
-URL: https://hermesatlas.com/projects/jpalmae/hermeshq
-GitHub: https://github.com/jpalmae/hermeshq
-Category: Deployment & Infra
-Stars: 12
-HermesHQ is a Docker-first control plane for running and operating multiple Hermes Agent instances from one web application.
-
-HermesHQ is a Docker-first control plane designed to orchestrate and manage multiple Hermes Agent instances from a single web application. It functions as an operational layer that wraps the Hermes execution engine, providing centralized task dispatching, scheduling, and a runtime ledger. The platform enables multi-agent delegation, RBAC-controlled user access, and per-agent communication channels for Telegram and WhatsApp. It also features an enterprise MCP bridge to expose specific agents to external AI clients like Claude Code and Codex.
-
-Highlights:
-- Orchestrates multiple Hermes Agent instances with separate workspaces and identities
-- Provides hierarchy-aware inter-agent delegation and task scheduling
-- Offers enterprise MCP access for external AI client integrations
 
 ---
 
@@ -4423,23 +4433,6 @@ Highlights:
 
 ---
 
-## nujovich/hermes-telemetry
-
-URL: https://hermesatlas.com/projects/nujovich/hermes-telemetry
-GitHub: https://github.com/nujovich/hermes-telemetry
-Category: Plugins & Extensions
-Stars: 11
-Budget enforcement + observability plugin for Hermes Agent. Stops runaway costs before they happen.
-
-hermes-telemetry is an observability and budget management plugin for Hermes Agent that prevents runaway API costs. It hooks directly into the agent's runtime to track token usage and costs in real time, allowing it to block LLM calls before they exceed defined spending limits. The plugin stores data in a SQLite database and provides cost analysis via slash commands and a local web dashboard.
-
-Highlights:
-- Enforces hard budget limits to stop overspending mid-session
-- Provides real-time cost analysis via /stats and /budget commands
-- Includes a local HTML dashboard for visual usage tracking
-
----
-
 ## bryercowan/hermes-embodied
 
 URL: https://hermesatlas.com/projects/bryercowan/hermes-embodied
@@ -4488,6 +4481,23 @@ Highlights:
 - Asset-first compositing keeps brand photos pixel-faithful during AI generation
 - C2PA signing for EU AI Act Article 50 provenance compliance
 - Cross-platform copy adaptation for seven major social media networks
+
+---
+
+## MukundaKatta/hermes-agentmemory
+
+URL: https://hermesatlas.com/projects/MukundaKatta/hermes-agentmemory
+GitHub: https://github.com/MukundaKatta/hermes-agentmemory
+Category: Memory & Context
+Stars: 7
+Pull-model episodic memory plugin for Hermes Agent with real deletion (no persistent summaries that haunt future recall) and a trace.jsonl audit log of every memory operation. Community fix for issue #6715. MIT.
+
+hermes-agentmemory is a standalone memory plugin for Hermes Agent that ensures data deletion is absolute and auditable. It utilizes a pull-model episodic memory approach where writes are synchronous and summaries are generated on-demand rather than in the background. This architecture prevents deleted events from persisting in derived summaries and provides a transparent audit trail of all memory operations. The plugin integrates via the Hermes user-plugins directory and uses Claude models for high-quality summarization.
+
+Highlights:
+- Immediate, complete deletion of events without leaving derived artifacts
+- Audit logs of every prefetch recorded in trace.jsonl
+- On-demand summarization using the Claude model family
 
 ---
 
@@ -4556,23 +4566,6 @@ Highlights:
 - Deploys Hermes agent with a ttyd web terminal interface
 - Integrates directly with Portainer as a Git Repository stack
 - Automates image builds using provided GitHub Action workflows
-
----
-
-## MukundaKatta/hermes-agentmemory
-
-URL: https://hermesatlas.com/projects/MukundaKatta/hermes-agentmemory
-GitHub: https://github.com/MukundaKatta/hermes-agentmemory
-Category: Memory & Context
-Stars: 6
-Pull-model episodic memory plugin for Hermes Agent with real deletion (no persistent summaries that haunt future recall) and a trace.jsonl audit log of every memory operation. Community fix for issue #6715. MIT.
-
-hermes-agentmemory is a standalone memory plugin for Hermes Agent that ensures data deletion is absolute and auditable. It utilizes a pull-model episodic memory approach where writes are synchronous and summaries are generated on-demand rather than in the background. This architecture prevents deleted events from persisting in derived summaries and provides a transparent audit trail of all memory operations. The plugin integrates via the Hermes user-plugins directory and uses Claude models for high-quality summarization.
-
-Highlights:
-- Immediate, complete deletion of events without leaving derived artifacts
-- Audit logs of every prefetch recorded in trace.jsonl
-- On-demand summarization using the Claude model family
 
 ---
 
@@ -4760,23 +4753,6 @@ Highlights:
 - Automates payments for HTTP 402 responses using USDC
 - Supports Pay Link, x402, MPP, and AP2 protocols
 - Compatible with OpenClaw, Hermes Agent, and agentskills.io standard
-
----
-
-## DIALLOUBE-RESEARCH/hypernatt-terminal
-
-URL: https://hermesatlas.com/projects/DIALLOUBE-RESEARCH/hypernatt-terminal
-GitHub: https://github.com/DIALLOUBE-RESEARCH/hypernatt-terminal
-Category: Integrations & Bridges
-Stars: 1
-BTC Decision Terminal for AI Agents — live vault-backed signals, on-chain proof, cross-chain swap. Verify in real time.
-
-HyperNatt Terminal is an MCP server that provides BTC/USDC decision context for AI agents based on a live Hyperliquid vault. It exposes nine read-only tools that deliver signals such as market maker trap states, hunt scores, and regime similarity. The system utilizes a pay-per-call x402 pricing model and integrates Li.Fi for cross-chain swap quotes. It is designed for non-custodial verification, allowing agents to access signed vault proofs and on-chain data without requiring key access.
-
-Highlights:
-- Read-only BTC/USDC signals from a live Hyperliquid vault
-- Non-custodial architecture with signed vault proofs for on-chain verification
-- Li.Fi integration for cross-chain swap quotes
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Hermes Atlas
 
-> The community-curated ecosystem map for Hermes Agent by Nous Research — 175+ tools, skills, plugins, and integrations with live GitHub data and AI-generated summaries. Updated daily. As of 2026-06-26.
+> The community-curated ecosystem map for Hermes Agent by Nous Research — 174+ tools, skills, plugins, and integrations with live GitHub data and AI-generated summaries. Updated daily. As of 2026-06-26.
 
 Hermes Atlas tracks every open-source project in the Hermes Agent ecosystem across 12 categories. Each project has a dedicated page with a prose summary, live star count, README, and category metadata. The full catalog is also available as JSON at https://hermesatlas.com/data/repos.json for programmatic access.
 
@@ -25,21 +25,21 @@ A hands-on developer tutorial for building on the Hermes Agent codebase, written
 - [Skill authoring template](https://hermesatlas.com/dev/skill-template): A copy-paste SKILL.md with annotated frontmatter.
 
 ## Top Projects
-- [NousResearch/hermes-agent](https://hermesatlas.com/projects/NousResearch/hermes-agent): The self-improving AI agent that grows with you — persistent memory, auto-generated skills, 14 platforms, 6 execution backends (203,319 stars, official)
-- [farion1231/cc-switch](https://hermesatlas.com/projects/farion1231/cc-switch): Cross-platform all-in-one manager for Claude Code, Codex, OpenCode, OpenClaw, Gemini CLI, and Hermes Agent (108,709 stars)
-- [nexu-io/open-design](https://hermesatlas.com/projects/nexu-io/open-design): Local-first open-source design/prototyping system with coding-agent CLI support including Hermes Agent (71,353 stars)
-- [mem0ai/mem0](https://hermesatlas.com/projects/mem0ai/mem0): Universal memory layer for AI Agents — official Hermes Agent memory provider, available as managed cloud or Apache-2.0 self-hosted OSS (59,479 stars)
-- [colbymchenry/codegraph](https://hermesatlas.com/projects/colbymchenry/codegraph): Local pre-indexed code knowledge graph for Hermes Agent and other coding agents to reduce token usage and tool calls (54,767 stars)
-- [iOfficeAI/AionUi](https://hermesatlas.com/projects/iOfficeAI/AionUi): Local open-source cowork app for OpenClaw, Hermes Agent, Claude Code, Codex, OpenCode, Gemini CLI, and other agent CLIs (28,886 stars)
-- [supermemoryai/supermemory](https://hermesatlas.com/projects/supermemoryai/supermemory): Memory engine and API — official Hermes Agent memory provider with sub-300ms recall sustained at 100B+ tokens/month, custom vector graph engine, context fencing, and byte-level dedupe with 100% prompt-cache discount. (27,600 stars)
-- [volcengine/OpenViking](https://hermesatlas.com/projects/volcengine/OpenViking): Open-source context database for AI agents — official Hermes Agent memory provider using viking:// URIs and tiered L0/L1/L2 loading; 91% token reduction and 43-49% task-completion gain over baseline on LoCoMo10. AGPL-3.0. (26,065 stars)
-- [garrytan/gbrain](https://hermesatlas.com/projects/garrytan/gbrain): Garry's Opinionated OpenClaw/Hermes Agent Brain (24,154 stars)
-- [mukul975/Anthropic-Cybersecurity-Skills](https://hermesatlas.com/projects/mukul975/Anthropic-Cybersecurity-Skills): 754 structured cybersecurity skills mapped to MITRE ATT&CK, NIST CSF 2.0, ATLAS, D3FEND & NIST AI RMF (21,479 stars)
-- [vectorize-io/hindsight](https://hermesatlas.com/projects/vectorize-io/hindsight): Agent memory that learns — long-term retain/recall/reflect workflows (17,588 stars, official)
-- [nesquena/hermes-webui](https://hermesatlas.com/projects/nesquena/hermes-webui): Hermes WebUI: The best way to use Hermes Agent from the web or from your phone! (15,041 stars)
-- [fathah/hermes-desktop](https://hermesatlas.com/projects/fathah/hermes-desktop): Desktop companion app for installing, configuring, and chatting with Hermes Agent (12,734 stars)
-- [EKKOLearnAI/hermes-web-ui](https://hermesatlas.com/projects/EKKOLearnAI/hermes-web-ui): Web dashboard for Hermes Agent — multi-platform AI chat, session management, scheduled jobs, usage analytics & channel configuration (Telegram, Discord, Slack, WhatsApp) (8,530 stars)
-- [outsourc-e/hermes-workspace](https://hermesatlas.com/projects/outsourc-e/hermes-workspace): Native web workspace — chat, terminal, memory browser, skills manager, and inspector panel (5,854 stars)
+- [NousResearch/hermes-agent](https://hermesatlas.com/projects/NousResearch/hermes-agent): The self-improving AI agent that grows with you — persistent memory, auto-generated skills, 14 platforms, 6 execution backends (203,579 stars, official)
+- [farion1231/cc-switch](https://hermesatlas.com/projects/farion1231/cc-switch): Cross-platform all-in-one manager for Claude Code, Codex, OpenCode, OpenClaw, Gemini CLI, and Hermes Agent (108,925 stars)
+- [nexu-io/open-design](https://hermesatlas.com/projects/nexu-io/open-design): Local-first open-source design/prototyping system with coding-agent CLI support including Hermes Agent (71,525 stars)
+- [mem0ai/mem0](https://hermesatlas.com/projects/mem0ai/mem0): Universal memory layer for AI Agents — official Hermes Agent memory provider, available as managed cloud or Apache-2.0 self-hosted OSS (59,502 stars)
+- [colbymchenry/codegraph](https://hermesatlas.com/projects/colbymchenry/codegraph): Local pre-indexed code knowledge graph for Hermes Agent and other coding agents to reduce token usage and tool calls (54,917 stars)
+- [iOfficeAI/AionUi](https://hermesatlas.com/projects/iOfficeAI/AionUi): Local open-source cowork app for OpenClaw, Hermes Agent, Claude Code, Codex, OpenCode, Gemini CLI, and other agent CLIs (28,906 stars)
+- [supermemoryai/supermemory](https://hermesatlas.com/projects/supermemoryai/supermemory): Memory engine and API — official Hermes Agent memory provider with sub-300ms recall sustained at 100B+ tokens/month, custom vector graph engine, context fencing, and byte-level dedupe with 100% prompt-cache discount. (27,627 stars)
+- [volcengine/OpenViking](https://hermesatlas.com/projects/volcengine/OpenViking): Open-source context database for AI agents — official Hermes Agent memory provider using viking:// URIs and tiered L0/L1/L2 loading; 91% token reduction and 43-49% task-completion gain over baseline on LoCoMo10. AGPL-3.0. (26,083 stars)
+- [garrytan/gbrain](https://hermesatlas.com/projects/garrytan/gbrain): Garry's Opinionated OpenClaw/Hermes Agent Brain (24,185 stars)
+- [mukul975/Anthropic-Cybersecurity-Skills](https://hermesatlas.com/projects/mukul975/Anthropic-Cybersecurity-Skills): 754 structured cybersecurity skills mapped to MITRE ATT&CK, NIST CSF 2.0, ATLAS, D3FEND & NIST AI RMF (21,659 stars)
+- [vectorize-io/hindsight](https://hermesatlas.com/projects/vectorize-io/hindsight): Agent memory that learns — long-term retain/recall/reflect workflows (17,611 stars, official)
+- [nesquena/hermes-webui](https://hermesatlas.com/projects/nesquena/hermes-webui): Hermes WebUI: The best way to use Hermes Agent from the web or from your phone! (15,060 stars)
+- [fathah/hermes-desktop](https://hermesatlas.com/projects/fathah/hermes-desktop): Desktop companion app for installing, configuring, and chatting with Hermes Agent (12,744 stars)
+- [EKKOLearnAI/hermes-web-ui](https://hermesatlas.com/projects/EKKOLearnAI/hermes-web-ui): Web dashboard for Hermes Agent — multi-platform AI chat, session management, scheduled jobs, usage analytics & channel configuration (Telegram, Discord, Slack, WhatsApp) (8,541 stars)
+- [outsourc-e/hermes-workspace](https://hermesatlas.com/projects/outsourc-e/hermes-workspace): Native web workspace — chat, terminal, memory browser, skills manager, and inspector panel (5,859 stars)
 
 ## Curated Lists
 - [Best Memory Providers for Hermes Agent](https://hermesatlas.com/lists/best-memory-providers): The top community-built memory and context management tools for Hermes Agent, ranked by GitHub stars. Memory is what makes Hermes self-improving — these tools extend its built-in r

--- a/projects/0xNyk/awesome-hermes-agent.html
+++ b/projects/0xNyk/awesome-hermes-agent.html
@@ -51,7 +51,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 4215
+    "userInteractionCount": 4226
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -79,7 +79,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>

--- a/projects/0xNyk/openclaw-to-hermes.html
+++ b/projects/0xNyk/openclaw-to-hermes.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -360,11 +360,11 @@ ruff check .
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/colbymchenry/codegraph">
-        <div class="stars">★ 54.8K</div>
+        <div class="stars">★ 54.9K</div>
         <div class="name"><span class="org">colbymchenry /</span> codegraph</div>
       </a>
       <a class="related-row" href="/projects/Salomondiei08/oh-my-hermes">
-        <div class="stars">★ 658</div>
+        <div class="stars">★ 659</div>
         <div class="name"><span class="org">Salomondiei08 /</span> oh-my-hermes</div>
       </a>
       <a class="related-row" href="/projects/liaohch3/claude-tap">
@@ -380,7 +380,7 @@ ruff check .
         <div class="name"><span class="org">junhoyeo /</span> tokscale</div>
       </a>
       <a class="related-row" href="/projects/joeynyc/hermes-skins">
-        <div class="stars">★ 471</div>
+        <div class="stars">★ 472</div>
         <div class="name"><span class="org">joeynyc /</span> hermes-skins</div>
       </a>
       <a class="related-row" href="/projects/AlexAI-MCP/hermes-CCC">

--- a/projects/0xrsydn/nix-hermes-agent.html
+++ b/projects/0xrsydn/nix-hermes-agent.html
@@ -52,7 +52,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 25
+    "userInteractionCount": 26
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -111,7 +111,7 @@
   <p class="project-desc">Nix package and NixOS module for Hermes Agent by Nous Research</p>
 
   <div class="meta-row">
-    <span class="stars">★ 25</span>
+    <span class="stars">★ 26</span>
     <span><span class="meta-label">lang</span>Nix</span>
     
     

--- a/projects/1ilkhamov/opencode-hermes-multiagent.html
+++ b/projects/1ilkhamov/opencode-hermes-multiagent.html
@@ -51,7 +51,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 152
+    "userInteractionCount": 153
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -79,7 +79,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -110,7 +110,7 @@
   <p class="project-desc">Hermes — a multi-agent system for OpenCode AI. 17 specialized agents for research, planning, implementation, quality, and infrastructure.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 152</span>
+    <span class="stars">★ 153</span>
     
     
     

--- a/projects/335234131/agent-browser-mcp.html
+++ b/projects/335234131/agent-browser-mcp.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -483,11 +483,11 @@ hermes mcp test agent_browser
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 316</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 246</div>
+        <div class="stars">★ 247</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -511,7 +511,7 @@ hermes mcp test agent_browser
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 290</div>
+        <div class="stars">★ 291</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
     </div>

--- a/projects/42-evey/evey-bridge-plugin.html
+++ b/projects/42-evey/evey-bridge-plugin.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -169,11 +169,11 @@
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 316</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 246</div>
+        <div class="stars">★ 247</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -193,7 +193,7 @@
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 290</div>
+        <div class="stars">★ 291</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
       <a class="related-row" href="/projects/clawshell/clawshell">

--- a/projects/42-evey/evey-setup.html
+++ b/projects/42-evey/evey-setup.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 46
+    "userInteractionCount": 47
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Get a hermes-agent stack running in minutes. Free models, 29 plugins, zero cost.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 46</span>
+    <span class="stars">★ 47</span>
     <span><span class="meta-label">lang</span>Shell</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -524,11 +524,11 @@ docker exec hermes-ollama ollama list               # list local models
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/colbymchenry/codegraph">
-        <div class="stars">★ 54.8K</div>
+        <div class="stars">★ 54.9K</div>
         <div class="name"><span class="org">colbymchenry /</span> codegraph</div>
       </a>
       <a class="related-row" href="/projects/Salomondiei08/oh-my-hermes">
-        <div class="stars">★ 658</div>
+        <div class="stars">★ 659</div>
         <div class="name"><span class="org">Salomondiei08 /</span> oh-my-hermes</div>
       </a>
       <a class="related-row" href="/projects/liaohch3/claude-tap">
@@ -544,7 +544,7 @@ docker exec hermes-ollama ollama list               # list local models
         <div class="name"><span class="org">junhoyeo /</span> tokscale</div>
       </a>
       <a class="related-row" href="/projects/joeynyc/hermes-skins">
-        <div class="stars">★ 471</div>
+        <div class="stars">★ 472</div>
         <div class="name"><span class="org">joeynyc /</span> hermes-skins</div>
       </a>
       <a class="related-row" href="/projects/AlexAI-MCP/hermes-CCC">

--- a/projects/42-evey/hermes-plugins.html
+++ b/projects/42-evey/hermes-plugins.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 246
+    "userInteractionCount": 247
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Custom plugins for hermes-agent — goal management, inter-agent bridge, model selection, cost control</p>
 
   <div class="meta-row">
-    <span class="stars">★ 246</span>
+    <span class="stars">★ 247</span>
     <span><span class="meta-label">lang</span>Python</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -327,7 +327,7 @@ cp hermes-plugins/evey_utils.py ~/.hermes/plugins/
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 316</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -351,7 +351,7 @@ cp hermes-plugins/evey_utils.py ~/.hermes/plugins/
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 290</div>
+        <div class="stars">★ 291</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
       <a class="related-row" href="/projects/clawshell/clawshell">

--- a/projects/8bit64k/cronalytics.html
+++ b/projects/8bit64k/cronalytics.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -528,11 +528,11 @@ provides_hooks:
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 316</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 246</div>
+        <div class="stars">★ 247</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -556,7 +556,7 @@ provides_hooks:
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 290</div>
+        <div class="stars">★ 291</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
     </div>

--- a/projects/AMAP-ML/SkillClaw.html
+++ b/projects/AMAP-ML/SkillClaw.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 2024
+    "userInteractionCount": 2026
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -575,7 +575,7 @@ skillclaw skills list-remote   # browse shared skills
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills">
-        <div class="stars">★ 21.5K</div>
+        <div class="stars">★ 21.7K</div>
         <div class="name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</div>
       </a>
       <a class="related-row" href="/projects/conorbronsdon/avoid-ai-writing">
@@ -599,7 +599,7 @@ skillclaw skills list-remote   # browse shared skills
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 192</div>
+        <div class="stars">★ 194</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/AaronWong1999/hermesclaw.html
+++ b/projects/AaronWong1999/hermesclaw.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 647
+    "userInteractionCount": 648
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Run Hermes Agent and OpenClaw on the same WeChat account</p>
 
   <div class="meta-row">
-    <span class="stars">★ 647</span>
+    <span class="stars">★ 648</span>
     <span><span class="meta-label">lang</span>Python</span>
     <span><span class="meta-label">license</span>MIT</span>
     

--- a/projects/Abruptive/Ankh.md.html
+++ b/projects/Abruptive/Ankh.md.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -346,11 +346,11 @@
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/colbymchenry/codegraph">
-        <div class="stars">★ 54.8K</div>
+        <div class="stars">★ 54.9K</div>
         <div class="name"><span class="org">colbymchenry /</span> codegraph</div>
       </a>
       <a class="related-row" href="/projects/Salomondiei08/oh-my-hermes">
-        <div class="stars">★ 658</div>
+        <div class="stars">★ 659</div>
         <div class="name"><span class="org">Salomondiei08 /</span> oh-my-hermes</div>
       </a>
       <a class="related-row" href="/projects/liaohch3/claude-tap">
@@ -366,7 +366,7 @@
         <div class="name"><span class="org">junhoyeo /</span> tokscale</div>
       </a>
       <a class="related-row" href="/projects/joeynyc/hermes-skins">
-        <div class="stars">★ 471</div>
+        <div class="stars">★ 472</div>
         <div class="name"><span class="org">joeynyc /</span> hermes-skins</div>
       </a>
       <a class="related-row" href="/projects/AlexAI-MCP/hermes-CCC">

--- a/projects/AbuZar-Ansarii/Hermes-Agent-On-Android.html
+++ b/projects/AbuZar-Ansarii/Hermes-Agent-On-Android.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -345,7 +345,7 @@ ollama serve
         <div class="name"><span class="org">TheAiSingularity /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/0xrsydn/nix-hermes-agent">
-        <div class="stars">★ 25</div>
+        <div class="stars">★ 26</div>
         <div class="name"><span class="org">0xrsydn /</span> nix-hermes-agent</div>
       </a>
       <a class="related-row" href="/projects/rookiemann/portable-hermes-agent">

--- a/projects/Agent-3-7/minions.html
+++ b/projects/Agent-3-7/minions.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -222,7 +222,7 @@ Not yet. The adapter interface exists, but launch is Hermes-only. OpenClaw is ne
         <div class="name"><span class="org">runtimenoteslabs /</span> gladiator</div>
       </a>
       <a class="related-row" href="/projects/1ilkhamov/opencode-hermes-multiagent">
-        <div class="stars">★ 152</div>
+        <div class="stars">★ 153</div>
         <div class="name"><span class="org">1ilkhamov /</span> opencode-hermes-multiagent</div>
       </a>
       <a class="related-row" href="/projects/Rainhoole/hermes-agent-acp-skill">

--- a/projects/Agents365-ai/drawio-skill.html
+++ b/projects/Agents365-ai/drawio-skill.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 4695
+    "userInteractionCount": 4722
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -642,7 +642,7 @@ python3 scripts/aiicons.py &quot;openai&quot; --embed     # self-contained data 
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills">
-        <div class="stars">★ 21.5K</div>
+        <div class="stars">★ 21.7K</div>
         <div class="name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</div>
       </a>
       <a class="related-row" href="/projects/conorbronsdon/avoid-ai-writing">
@@ -662,7 +662,7 @@ python3 scripts/aiicons.py &quot;openai&quot; --embed     # self-contained data 
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 192</div>
+        <div class="stars">★ 194</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/AkoliteZA/hermes-agent-idea-workflow.html
+++ b/projects/AkoliteZA/hermes-agent-idea-workflow.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -312,7 +312,7 @@ idea-to-implementation-doc/
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills">
-        <div class="stars">★ 21.5K</div>
+        <div class="stars">★ 21.7K</div>
         <div class="name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</div>
       </a>
       <a class="related-row" href="/projects/conorbronsdon/avoid-ai-writing">
@@ -336,7 +336,7 @@ idea-to-implementation-doc/
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 192</div>
+        <div class="stars">★ 194</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/AlexAI-MCP/hermes-CCC.html
+++ b/projects/AlexAI-MCP/hermes-CCC.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -608,11 +608,11 @@ cd hermes-CCC
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/colbymchenry/codegraph">
-        <div class="stars">★ 54.8K</div>
+        <div class="stars">★ 54.9K</div>
         <div class="name"><span class="org">colbymchenry /</span> codegraph</div>
       </a>
       <a class="related-row" href="/projects/Salomondiei08/oh-my-hermes">
-        <div class="stars">★ 658</div>
+        <div class="stars">★ 659</div>
         <div class="name"><span class="org">Salomondiei08 /</span> oh-my-hermes</div>
       </a>
       <a class="related-row" href="/projects/liaohch3/claude-tap">
@@ -628,7 +628,7 @@ cd hermes-CCC
         <div class="name"><span class="org">junhoyeo /</span> tokscale</div>
       </a>
       <a class="related-row" href="/projects/joeynyc/hermes-skins">
-        <div class="stars">★ 471</div>
+        <div class="stars">★ 472</div>
         <div class="name"><span class="org">joeynyc /</span> hermes-skins</div>
       </a>
       <a class="related-row" href="/projects/unmodeled-tyler/vessel-browser">

--- a/projects/AxDSan/mnemosyne.html
+++ b/projects/AxDSan/mnemosyne.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 1288
+    "userInteractionCount": 1293
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -882,7 +882,7 @@ mnemosyne sync status --remote https://my-vps:8765
         <div class="name"><span class="org">greyhaven-ai /</span> autocontext</div>
       </a>
       <a class="related-row" href="/projects/elkimek/honcho-self-hosted">
-        <div class="stars">★ 328</div>
+        <div class="stars">★ 329</div>
         <div class="name"><span class="org">elkimek /</span> honcho-self-hosted</div>
       </a>
       <a class="related-row" href="/projects/yoloshii/ClawMem">
@@ -890,7 +890,7 @@ mnemosyne sync status --remote https://my-vps:8765
         <div class="name"><span class="org">yoloshii /</span> ClawMem</div>
       </a>
       <a class="related-row" href="/projects/Signet-AI/signetai">
-        <div class="stars">★ 203</div>
+        <div class="stars">★ 205</div>
         <div class="name"><span class="org">Signet-AI /</span> signetai</div>
       </a>
       <a class="related-row" href="/projects/plur-ai/plur">

--- a/projects/BORT-AGENTS/hermes-bort.html
+++ b/projects/BORT-AGENTS/hermes-bort.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -572,7 +572,7 @@ VPM v2 forwarder, and KR v2 delegated writes.</p>
         <div class="name"><span class="org">kevinmarmstrong /</span> hermes-claude-code-rc</div>
       </a>
       <a class="related-row" href="/projects/AaronWong1999/hermesclaw">
-        <div class="stars">★ 647</div>
+        <div class="stars">★ 648</div>
         <div class="name"><span class="org">AaronWong1999 /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/Codename-11/hermes-relay">

--- a/projects/Christabel337/job-scout-agent.html
+++ b/projects/Christabel337/job-scout-agent.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 47
+    "userInteractionCount": 48
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Autonomous job hunting agent built with Hermes Agent</p>
 
   <div class="meta-row">
-    <span class="stars">★ 47</span>
+    <span class="stars">★ 48</span>
     <span><span class="meta-label">lang</span>Python</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -245,7 +245,7 @@
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/ucsandman/DashClaw">
-        <div class="stars">★ 277</div>
+        <div class="stars">★ 278</div>
         <div class="name"><span class="org">ucsandman /</span> DashClaw</div>
       </a>
       <a class="related-row" href="/projects/Lethe044/hermes-incident-commander">

--- a/projects/Codename-11/hermes-relay.html
+++ b/projects/Codename-11/hermes-relay.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -541,7 +541,7 @@ ln -s &quot;$PWD/plugin&quot; ~/.hermes/plugins/hermes-relay
         <div class="name"><span class="org">kevinmarmstrong /</span> hermes-claude-code-rc</div>
       </a>
       <a class="related-row" href="/projects/AaronWong1999/hermesclaw">
-        <div class="stars">★ 647</div>
+        <div class="stars">★ 648</div>
         <div class="name"><span class="org">AaronWong1999 /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/kfa-ai/hermes-timetree-sync">

--- a/projects/Context4GPTs/klodi-plugin.html
+++ b/projects/Context4GPTs/klodi-plugin.html
@@ -47,13 +47,13 @@
     "name": "Context4GPTs",
     "url": "https://github.com/Context4GPTs"
   },
-  "dateModified": "2026-06-26T07:20:45.000Z",
+  "dateModified": "2026-06-26T14:33:03.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 13
+    "userInteractionCount": 14
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">The agent-to-agent marketplace, in your agent host. Your agent lists, haggles, and closes deals for you while you live your life.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 13</span>
+    <span class="stars">★ 14</span>
     <span><span class="meta-label">lang</span>TypeScript</span>
     <span><span class="meta-label">license</span>Apache-2.0</span>
     
@@ -391,11 +391,11 @@ your policies                                     your policies
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 316</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 246</div>
+        <div class="stars">★ 247</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -419,7 +419,7 @@ your policies                                     your policies
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 290</div>
+        <div class="stars">★ 291</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
     </div>

--- a/projects/Cranot/super-hermes.html
+++ b/projects/Cranot/super-hermes.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -417,7 +417,7 @@ impact under load, integer overflow on failure_count.
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills">
-        <div class="stars">★ 21.5K</div>
+        <div class="stars">★ 21.7K</div>
         <div class="name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</div>
       </a>
       <a class="related-row" href="/projects/conorbronsdon/avoid-ai-writing">
@@ -441,7 +441,7 @@ impact under load, integer overflow on failure_count.
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 192</div>
+        <div class="stars">★ 194</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/CryptoDmitry/hermes-agent-control-room.html
+++ b/projects/CryptoDmitry/hermes-agent-control-room.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -475,7 +475,7 @@ ls skills/
         <div class="name"><span class="org">runtimenoteslabs /</span> gladiator</div>
       </a>
       <a class="related-row" href="/projects/1ilkhamov/opencode-hermes-multiagent">
-        <div class="stars">★ 152</div>
+        <div class="stars">★ 153</div>
         <div class="name"><span class="org">1ilkhamov /</span> opencode-hermes-multiagent</div>
       </a>
       <a class="related-row" href="/projects/Rainhoole/hermes-agent-acp-skill">

--- a/projects/DIALLOUBE-RESEARCH/hypernatt-terminal.html
+++ b/projects/DIALLOUBE-RESEARCH/hypernatt-terminal.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -213,7 +213,7 @@ curl -s https://hypernatt.com/api/m2m/proof-of-edge       # live vault data; edg
         <div class="name"><span class="org">kevinmarmstrong /</span> hermes-claude-code-rc</div>
       </a>
       <a class="related-row" href="/projects/AaronWong1999/hermesclaw">
-        <div class="stars">★ 647</div>
+        <div class="stars">★ 648</div>
         <div class="name"><span class="org">AaronWong1999 /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/Codename-11/hermes-relay">

--- a/projects/DougTrajano/pydantic-ai-skills.html
+++ b/projects/DougTrajano/pydantic-ai-skills.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -404,7 +404,7 @@ result = await run_skill_script(
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills">
-        <div class="stars">★ 21.5K</div>
+        <div class="stars">★ 21.7K</div>
         <div class="name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</div>
       </a>
       <a class="related-row" href="/projects/conorbronsdon/avoid-ai-writing">
@@ -424,7 +424,7 @@ result = await run_skill_script(
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 192</div>
+        <div class="stars">★ 194</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/EKKOLearnAI/hermes-web-ui.html
+++ b/projects/EKKOLearnAI/hermes-web-ui.html
@@ -52,7 +52,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 8530
+    "userInteractionCount": 8541
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -869,8 +869,12 @@ artifacts, documentation, and associated files in this repository.</p>
         <div class="stars">★ 85</div>
         <div class="name"><span class="org">Euraika-Labs /</span> pan-ui</div>
       </a>
+      <a class="related-row" href="/projects/abundantbeing/hermes-browser-extension">
+        <div class="stars">★ 95</div>
+        <div class="name"><span class="org">abundantbeing /</span> hermes-browser-extension</div>
+      </a>
       <a class="related-row" href="/projects/Eynzof/hermes-agent-cn-desktop">
-        <div class="stars">★ 578</div>
+        <div class="stars">★ 584</div>
         <div class="name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       </a>
       <a class="related-row" href="/projects/Felix-Forever/hermes-agent-desktop">
@@ -880,10 +884,6 @@ artifacts, documentation, and associated files in this repository.</p>
       <a class="related-row" href="/projects/jazzyalex/agent-sessions">
         <div class="stars">★ 661</div>
         <div class="name"><span class="org">jazzyalex /</span> agent-sessions</div>
-      </a>
-      <a class="related-row" href="/projects/nickvasilescu/hermes-desktop-os1">
-        <div class="stars">★ 479</div>
-        <div class="name"><span class="org">nickvasilescu /</span> hermes-desktop-os1</div>
       </a>
     </div>
     <p class="list-link"><a href="/lists/workspaces-and-guis">see all workspaces &amp; guis →</a></p>

--- a/projects/EfficientContext/ContextPilot.html
+++ b/projects/EfficientContext/ContextPilot.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -479,7 +479,7 @@ for resp, idx in zip(asyncio.run(generate_all()), order):
         <div class="name"><span class="org">greyhaven-ai /</span> autocontext</div>
       </a>
       <a class="related-row" href="/projects/elkimek/honcho-self-hosted">
-        <div class="stars">★ 328</div>
+        <div class="stars">★ 329</div>
         <div class="name"><span class="org">elkimek /</span> honcho-self-hosted</div>
       </a>
       <a class="related-row" href="/projects/yoloshii/ClawMem">
@@ -487,7 +487,7 @@ for resp, idx in zip(asyncio.run(generate_all()), order):
         <div class="name"><span class="org">yoloshii /</span> ClawMem</div>
       </a>
       <a class="related-row" href="/projects/Signet-AI/signetai">
-        <div class="stars">★ 203</div>
+        <div class="stars">★ 205</div>
         <div class="name"><span class="org">Signet-AI /</span> signetai</div>
       </a>
       <a class="related-row" href="/projects/plur-ai/plur">

--- a/projects/Euraika-Labs/pan-ui.html
+++ b/projects/Euraika-Labs/pan-ui.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -567,8 +567,12 @@ npm run dev
         <div class="stars">★ 108</div>
         <div class="name"><span class="org">sanchomuzax /</span> hermes-webui</div>
       </a>
+      <a class="related-row" href="/projects/abundantbeing/hermes-browser-extension">
+        <div class="stars">★ 95</div>
+        <div class="name"><span class="org">abundantbeing /</span> hermes-browser-extension</div>
+      </a>
       <a class="related-row" href="/projects/Eynzof/hermes-agent-cn-desktop">
-        <div class="stars">★ 578</div>
+        <div class="stars">★ 584</div>
         <div class="name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       </a>
       <a class="related-row" href="/projects/Felix-Forever/hermes-agent-desktop">
@@ -582,10 +586,6 @@ npm run dev
       <a class="related-row" href="/projects/nickvasilescu/hermes-desktop-os1">
         <div class="stars">★ 479</div>
         <div class="name"><span class="org">nickvasilescu /</span> hermes-desktop-os1</div>
-      </a>
-      <a class="related-row" href="/projects/farion1231/cc-switch">
-        <div class="stars">★ 108.7K</div>
-        <div class="name"><span class="org">farion1231 /</span> cc-switch</div>
       </a>
     </div>
     <p class="list-link"><a href="/lists/workspaces-and-guis">see all workspaces &amp; guis →</a></p>

--- a/projects/Eynzof/hermes-agent-cn-desktop.html
+++ b/projects/Eynzof/hermes-agent-cn-desktop.html
@@ -52,7 +52,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 578
+    "userInteractionCount": 584
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -111,7 +111,7 @@
   <p class="project-desc">Hermes Agent CN desktop app, Windows-First, built with Tauri, Typescript and Rust. Isolated Hermes Agent core insides. </p>
 
   <div class="meta-row">
-    <span class="stars">★ 578</span>
+    <span class="stars">★ 584</span>
     <span><span class="meta-label">lang</span>TypeScript</span>
     
     
@@ -439,6 +439,10 @@ v0.1.1
         <div class="stars">★ 85</div>
         <div class="name"><span class="org">Euraika-Labs /</span> pan-ui</div>
       </a>
+      <a class="related-row" href="/projects/abundantbeing/hermes-browser-extension">
+        <div class="stars">★ 95</div>
+        <div class="name"><span class="org">abundantbeing /</span> hermes-browser-extension</div>
+      </a>
       <a class="related-row" href="/projects/Felix-Forever/hermes-agent-desktop">
         <div class="stars">★ 57</div>
         <div class="name"><span class="org">Felix-Forever /</span> hermes-agent-desktop</div>
@@ -450,10 +454,6 @@ v0.1.1
       <a class="related-row" href="/projects/nickvasilescu/hermes-desktop-os1">
         <div class="stars">★ 479</div>
         <div class="name"><span class="org">nickvasilescu /</span> hermes-desktop-os1</div>
-      </a>
-      <a class="related-row" href="/projects/farion1231/cc-switch">
-        <div class="stars">★ 108.7K</div>
-        <div class="name"><span class="org">farion1231 /</span> cc-switch</div>
       </a>
     </div>
     <p class="list-link"><a href="/lists/workspaces-and-guis">see all workspaces &amp; guis →</a></p>

--- a/projects/FahrenheitResearch/hermes-weather-plugin.html
+++ b/projects/FahrenheitResearch/hermes-weather-plugin.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -365,11 +365,11 @@ $env:ECAPE_RS_RUNNER = &#39;C:\path\to\run_case.exe&#39;
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 316</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 246</div>
+        <div class="stars">★ 247</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/42-evey/evey-bridge-plugin">
@@ -389,7 +389,7 @@ $env:ECAPE_RS_RUNNER = &#39;C:\path\to\run_case.exe&#39;
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 290</div>
+        <div class="stars">★ 291</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
       <a class="related-row" href="/projects/clawshell/clawshell">

--- a/projects/Felix-Forever/hermes-agent-desktop.html
+++ b/projects/Felix-Forever/hermes-agent-desktop.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -539,8 +539,12 @@ python -c &quot;import re; open(&#39;/tmp/c.js&#39;,&#39;w&#39;).write(re.search
         <div class="stars">★ 85</div>
         <div class="name"><span class="org">Euraika-Labs /</span> pan-ui</div>
       </a>
+      <a class="related-row" href="/projects/abundantbeing/hermes-browser-extension">
+        <div class="stars">★ 95</div>
+        <div class="name"><span class="org">abundantbeing /</span> hermes-browser-extension</div>
+      </a>
       <a class="related-row" href="/projects/Eynzof/hermes-agent-cn-desktop">
-        <div class="stars">★ 578</div>
+        <div class="stars">★ 584</div>
         <div class="name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       </a>
       <a class="related-row" href="/projects/jazzyalex/agent-sessions">
@@ -550,10 +554,6 @@ python -c &quot;import re; open(&#39;/tmp/c.js&#39;,&#39;w&#39;).write(re.search
       <a class="related-row" href="/projects/nickvasilescu/hermes-desktop-os1">
         <div class="stars">★ 479</div>
         <div class="name"><span class="org">nickvasilescu /</span> hermes-desktop-os1</div>
-      </a>
-      <a class="related-row" href="/projects/farion1231/cc-switch">
-        <div class="stars">★ 108.7K</div>
-        <div class="name"><span class="org">farion1231 /</span> cc-switch</div>
       </a>
     </div>
     <p class="list-link"><a href="/lists/workspaces-and-guis">see all workspaces &amp; guis →</a></p>

--- a/projects/JackTheGit/hermes-ai-infrastructure-monitoring-toolkit.html
+++ b/projects/JackTheGit/hermes-ai-infrastructure-monitoring-toolkit.html
@@ -79,7 +79,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -384,7 +384,7 @@ TOTAL KEYWORDS ANALYZED       44       100%
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/ucsandman/DashClaw">
-        <div class="stars">★ 277</div>
+        <div class="stars">★ 278</div>
         <div class="name"><span class="org">ucsandman /</span> DashClaw</div>
       </a>
       <a class="related-row" href="/projects/Lethe044/hermes-incident-commander">
@@ -392,7 +392,7 @@ TOTAL KEYWORDS ANALYZED       44       100%
         <div class="name"><span class="org">Lethe044 /</span> hermes-incident-commander</div>
       </a>
       <a class="related-row" href="/projects/Christabel337/job-scout-agent">
-        <div class="stars">★ 47</div>
+        <div class="stars">★ 48</div>
         <div class="name"><span class="org">Christabel337 /</span> job-scout-agent</div>
       </a>
       <a class="related-row" href="/projects/rodmarkun/anihermes">

--- a/projects/JackTheGit/hermes-autonomous-server.html
+++ b/projects/JackTheGit/hermes-autonomous-server.html
@@ -79,7 +79,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -393,7 +393,7 @@ hermes uninstall
         <div class="name"><span class="org">TheAiSingularity /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/0xrsydn/nix-hermes-agent">
-        <div class="stars">★ 25</div>
+        <div class="stars">★ 26</div>
         <div class="name"><span class="org">0xrsydn /</span> nix-hermes-agent</div>
       </a>
       <a class="related-row" href="/projects/rookiemann/portable-hermes-agent">

--- a/projects/Ladybug-Memory/hermes-memory-plugin.html
+++ b/projects/Ladybug-Memory/hermes-memory-plugin.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -277,7 +277,7 @@ hermes memory setup
         <div class="name"><span class="org">greyhaven-ai /</span> autocontext</div>
       </a>
       <a class="related-row" href="/projects/elkimek/honcho-self-hosted">
-        <div class="stars">★ 328</div>
+        <div class="stars">★ 329</div>
         <div class="name"><span class="org">elkimek /</span> honcho-self-hosted</div>
       </a>
       <a class="related-row" href="/projects/yoloshii/ClawMem">
@@ -285,7 +285,7 @@ hermes memory setup
         <div class="name"><span class="org">yoloshii /</span> ClawMem</div>
       </a>
       <a class="related-row" href="/projects/Signet-AI/signetai">
-        <div class="stars">★ 203</div>
+        <div class="stars">★ 205</div>
         <div class="name"><span class="org">Signet-AI /</span> signetai</div>
       </a>
       <a class="related-row" href="/projects/plur-ai/plur">

--- a/projects/Lethe044/hermes-incident-commander.html
+++ b/projects/Lethe044/hermes-incident-commander.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -425,11 +425,11 @@ pytest tests/test_incident_env.py::TestSkillFile -v
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/ucsandman/DashClaw">
-        <div class="stars">★ 277</div>
+        <div class="stars">★ 278</div>
         <div class="name"><span class="org">ucsandman /</span> DashClaw</div>
       </a>
       <a class="related-row" href="/projects/Christabel337/job-scout-agent">
-        <div class="stars">★ 47</div>
+        <div class="stars">★ 48</div>
         <div class="name"><span class="org">Christabel337 /</span> job-scout-agent</div>
       </a>
       <a class="related-row" href="/projects/rodmarkun/anihermes">

--- a/projects/MnrGreg/hermes-venice-web.html
+++ b/projects/MnrGreg/hermes-venice-web.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -258,11 +258,11 @@ Star this repo if it helps you!</p>
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 316</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 246</div>
+        <div class="stars">★ 247</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -286,7 +286,7 @@ Star this repo if it helps you!</p>
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 290</div>
+        <div class="stars">★ 291</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
     </div>

--- a/projects/MukundaKatta/hermes-agentmemory.html
+++ b/projects/MukundaKatta/hermes-agentmemory.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 6
+    "userInteractionCount": 7
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Pull-model episodic memory plugin for Hermes Agent. Real deletes, audit trace, BYO Claude. MIT.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 6</span>
+    <span class="stars">★ 7</span>
     <span><span class="meta-label">lang</span>Python</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -259,7 +259,7 @@ export ANTHROPIC_API_KEY=...
         <div class="name"><span class="org">greyhaven-ai /</span> autocontext</div>
       </a>
       <a class="related-row" href="/projects/elkimek/honcho-self-hosted">
-        <div class="stars">★ 328</div>
+        <div class="stars">★ 329</div>
         <div class="name"><span class="org">elkimek /</span> honcho-self-hosted</div>
       </a>
       <a class="related-row" href="/projects/yoloshii/ClawMem">
@@ -267,7 +267,7 @@ export ANTHROPIC_API_KEY=...
         <div class="name"><span class="org">yoloshii /</span> ClawMem</div>
       </a>
       <a class="related-row" href="/projects/Signet-AI/signetai">
-        <div class="stars">★ 203</div>
+        <div class="stars">★ 205</div>
         <div class="name"><span class="org">Signet-AI /</span> signetai</div>
       </a>
       <a class="related-row" href="/projects/plur-ai/plur">

--- a/projects/NousResearch/Hermes-Function-Calling.html
+++ b/projects/NousResearch/Hermes-Function-Calling.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 1404
+    "userInteractionCount": 1405
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -382,7 +382,7 @@ You are a helpful assistant that answers in JSON. Here&#39;s the json schema you
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/NousResearch/hermes-agent">
-        <div class="stars">★ 203.3K</div>
+        <div class="stars">★ 203.6K</div>
         <div class="name"><span class="org">NousResearch /</span> hermes-agent</div>
       </a>
       <a class="related-row" href="/projects/NousResearch/atropos">
@@ -390,7 +390,7 @@ You are a helpful assistant that answers in JSON. Here&#39;s the json schema you
         <div class="name"><span class="org">NousResearch /</span> atropos</div>
       </a>
       <a class="related-row" href="/projects/NousResearch/hermes-agent-self-evolution">
-        <div class="stars">★ 4.3K</div>
+        <div class="stars">★ 4.4K</div>
         <div class="name"><span class="org">NousResearch /</span> hermes-agent-self-evolution</div>
       </a>
       <a class="related-row" href="/projects/NousResearch/hermes-paperclip-adapter">

--- a/projects/NousResearch/atropos.html
+++ b/projects/NousResearch/atropos.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -668,7 +668,7 @@ Please follow the <a href="https://github.com/NousResearch/atropos/blob/main/COD
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/NousResearch/hermes-agent">
-        <div class="stars">★ 203.3K</div>
+        <div class="stars">★ 203.6K</div>
         <div class="name"><span class="org">NousResearch /</span> hermes-agent</div>
       </a>
       <a class="related-row" href="/projects/NousResearch/Hermes-Function-Calling">
@@ -676,7 +676,7 @@ Please follow the <a href="https://github.com/NousResearch/atropos/blob/main/COD
         <div class="name"><span class="org">NousResearch /</span> Hermes-Function-Calling</div>
       </a>
       <a class="related-row" href="/projects/NousResearch/hermes-agent-self-evolution">
-        <div class="stars">★ 4.3K</div>
+        <div class="stars">★ 4.4K</div>
         <div class="name"><span class="org">NousResearch /</span> hermes-agent-self-evolution</div>
       </a>
       <a class="related-row" href="/projects/NousResearch/hermes-paperclip-adapter">

--- a/projects/NousResearch/autonovel.html
+++ b/projects/NousResearch/autonovel.html
@@ -52,7 +52,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 1202
+    "userInteractionCount": 1205
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -483,7 +483,7 @@ through this pipeline:</p>
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/NousResearch/hermes-agent">
-        <div class="stars">★ 203.3K</div>
+        <div class="stars">★ 203.6K</div>
         <div class="name"><span class="org">NousResearch /</span> hermes-agent</div>
       </a>
       <a class="related-row" href="/projects/NousResearch/Hermes-Function-Calling">
@@ -495,7 +495,7 @@ through this pipeline:</p>
         <div class="name"><span class="org">NousResearch /</span> atropos</div>
       </a>
       <a class="related-row" href="/projects/NousResearch/hermes-agent-self-evolution">
-        <div class="stars">★ 4.3K</div>
+        <div class="stars">★ 4.4K</div>
         <div class="name"><span class="org">NousResearch /</span> hermes-agent-self-evolution</div>
       </a>
       <a class="related-row" href="/projects/NousResearch/hermes-paperclip-adapter">

--- a/projects/NousResearch/hermes-agent-self-evolution.html
+++ b/projects/NousResearch/hermes-agent-self-evolution.html
@@ -52,7 +52,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 4348
+    "userInteractionCount": 4354
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -111,7 +111,7 @@
   <p class="project-desc">⚒ Evolutionary self-improvement for Hermes Agent — optimize skills, prompts, and code using DSPy + GEPA</p>
 
   <div class="meta-row">
-    <span class="stars">★ 4.3K</span>
+    <span class="stars">★ 4.4K</span>
     <span><span class="meta-label">lang</span>Python</span>
     
     <span><span class="meta-label">maintainer</span>Nous Research</span>
@@ -268,7 +268,7 @@ python -m evolution.skills.evolve_skill \
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/NousResearch/hermes-agent">
-        <div class="stars">★ 203.3K</div>
+        <div class="stars">★ 203.6K</div>
         <div class="name"><span class="org">NousResearch /</span> hermes-agent</div>
       </a>
       <a class="related-row" href="/projects/NousResearch/Hermes-Function-Calling">

--- a/projects/NousResearch/hermes-agent.html
+++ b/projects/NousResearch/hermes-agent.html
@@ -47,13 +47,13 @@
     "name": "NousResearch",
     "url": "https://github.com/NousResearch"
   },
-  "dateModified": "2026-06-26T07:50:47.000Z",
+  "dateModified": "2026-06-26T14:40:20.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 203319
+    "userInteractionCount": 203579
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">The agent that grows with you</p>
 
   <div class="meta-row">
-    <span class="stars">★ 203.3K</span>
+    <span class="stars">★ 203.6K</span>
     <span><span class="meta-label">lang</span>Python</span>
     <span><span class="meta-label">license</span>MIT</span>
     <span><span class="meta-label">maintainer</span>Nous Research</span>
@@ -457,7 +457,7 @@ scripts/run_tests.sh
         <div class="name"><span class="org">NousResearch /</span> atropos</div>
       </a>
       <a class="related-row" href="/projects/NousResearch/hermes-agent-self-evolution">
-        <div class="stars">★ 4.3K</div>
+        <div class="stars">★ 4.4K</div>
         <div class="name"><span class="org">NousResearch /</span> hermes-agent-self-evolution</div>
       </a>
       <a class="related-row" href="/projects/NousResearch/hermes-paperclip-adapter">

--- a/projects/NousResearch/hermes-paperclip-adapter.html
+++ b/projects/NousResearch/hermes-paperclip-adapter.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 1645
+    "userInteractionCount": 1646
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -538,7 +538,7 @@ npm run build
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/NousResearch/hermes-agent">
-        <div class="stars">★ 203.3K</div>
+        <div class="stars">★ 203.6K</div>
         <div class="name"><span class="org">NousResearch /</span> hermes-agent</div>
       </a>
       <a class="related-row" href="/projects/NousResearch/Hermes-Function-Calling">
@@ -550,7 +550,7 @@ npm run build
         <div class="name"><span class="org">NousResearch /</span> atropos</div>
       </a>
       <a class="related-row" href="/projects/NousResearch/hermes-agent-self-evolution">
-        <div class="stars">★ 4.3K</div>
+        <div class="stars">★ 4.4K</div>
         <div class="name"><span class="org">NousResearch /</span> hermes-agent-self-evolution</div>
       </a>
       <a class="related-row" href="/projects/NousResearch/autonovel">

--- a/projects/OnlyTerp/hermes-optimization-guide.html
+++ b/projects/OnlyTerp/hermes-optimization-guide.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>

--- a/projects/PederHP/skillsdotnet.html
+++ b/projects/PederHP/skillsdotnet.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -444,7 +444,7 @@ Instructions for the agent go here.
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills">
-        <div class="stars">★ 21.5K</div>
+        <div class="stars">★ 21.7K</div>
         <div class="name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</div>
       </a>
       <a class="related-row" href="/projects/conorbronsdon/avoid-ai-writing">
@@ -468,7 +468,7 @@ Instructions for the agent go here.
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 192</div>
+        <div class="stars">★ 194</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/Rainhoole/hermes-agent-acp-skill.html
+++ b/projects/Rainhoole/hermes-agent-acp-skill.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -208,7 +208,7 @@
         <div class="name"><span class="org">runtimenoteslabs /</span> gladiator</div>
       </a>
       <a class="related-row" href="/projects/1ilkhamov/opencode-hermes-multiagent">
-        <div class="stars">★ 152</div>
+        <div class="stars">★ 153</div>
         <div class="name"><span class="org">1ilkhamov /</span> opencode-hermes-multiagent</div>
       </a>
       <a class="related-row" href="/projects/linke-ai/hermes-agent-team">

--- a/projects/ReinaMacCredy/maestro.html
+++ b/projects/ReinaMacCredy/maestro.html
@@ -47,13 +47,13 @@
     "name": "ReinaMacCredy",
     "url": "https://github.com/ReinaMacCredy"
   },
-  "dateModified": "2026-06-26T04:43:41.000Z",
+  "dateModified": "2026-06-26T10:51:34.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 201
+    "userInteractionCount": 202
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Agent harness for codebases. Gives Claude Code, Codex, and CI a shared task system, verdict ledger, and state store so agent work is traceable and auditable.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 201</span>
+    <span class="stars">★ 202</span>
     <span><span class="meta-label">lang</span>Rust</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -166,80 +166,115 @@ maestro fixes that by making the work itself durable, queryable, and gated:</p>
 </ul>
 <p>Everything is repo-local and reviewable in a diff.</p>
 <h3>Card model</h3>
-<p>maestro&#39;s durable unit is a <strong>card</strong>. Features, tasks, bugs, chores, ideas, and
-decisions all live under <code>.maestro/cards/&lt;id&gt;/</code>; <code>card.yaml</code> carries the typed
-state, parent, dependencies, claim, and timestamps, while sidecars such as
-<code>spec.md</code>, <code>qa.md</code>, and <code>notes.md</code> carry the human-readable contract and evidence.</p>
+<p>maestro uses a three-level work model:</p>
+<pre><code class="language-text">High = card
+Mid  = CardKind / workflow kind
+Low  = task
+</code></pre>
+<p>A <strong>card</strong> owns identity, container/lifecycle state, and governance. A <strong>task</strong>
+is the atomic executable progress unit. A <strong>facet</strong> is an optional sidecar that
+describes or proves a card.</p>
+<p>Cards live under <code>.maestro/cards/&lt;id&gt;/</code>; <code>card.yaml</code> carries identity, type,
+state, parent, ownership, links, and timestamps. Feature, Bug, Chore, Custom,
+Decision, Idea, and Progress are CardKinds / workflow kinds on cards, not
+separate high-level objects. Progress is the lightweight CardKind for small
+work: its <code>progress.yml</code> stores many Low Tasks compactly without requiring the
+full feature pipeline. Facets such as <code>spec.md</code>, <code>qa.md</code>, and <code>notes.md</code> are
+optional sidecars for any card type that needs contract, evidence, or history.</p>
 <p><img src="https://raw.githubusercontent.com/ReinaMacCredy/maestro/main/docs/readme/maestro-card-model.png" alt="Maestro card model"></p>
-<p>Feature cards are the containers. Workable cards (<code>task</code>, <code>bug</code>, <code>chore</code>) dock
-under a feature through <code>parent</code>, enter <code>maestro ready</code> when their blocking
-dependencies are closed, and can be claimed by an agent session. Ideas and
-decisions are cards too, but they keep their own typed lifecycle verbs through
-the harness and decision flows.</p>
-<p>The flat query verbs give agents a Beads-style operating surface:
-<code>maestro ready</code>, <code>maestro list</code>, <code>maestro show</code>, <code>maestro claim</code>,
-<code>maestro note</code>, <code>maestro dep</code>, and <code>maestro archive</code>. When several sessions are
-working at once, <code>maestro active</code>, <code>maestro link</code>, and <code>maestro msg</code> add the
-cross-agent coordination layer on top of the same cards.</p>
+<p>Tasks are not CardTypes. They live inside card-backed task records for
+legacy/gated work or inside a Progress card&#39;s <code>progress.yml</code> for low-ceremony
+small work. New low-ceremony work uses <code>maestro task add/start/done/list</code>;
+legacy workable cards (<code>task</code>, <code>bug</code>, <code>chore</code>) remain readable and claimable for
+compatibility. Tasks carry <code>card_id</code> ownership and dependency/blocker metadata,
+and they use Task lifecycle semantics for claim, blocking, handoff, proof, and
+done/verified state. When several sessions are working at once, <code>maestro active</code>, <code>maestro link</code>, and <code>maestro msg</code> add the cross-agent coordination
+layer on top of the same card and task records.</p>
 <h3>How It Works</h3>
-<p>Everything durable is a card. The agent uses flat card queries to find and claim work, then
-uses typed lifecycle verbs only where gates matter: feature contract gates, task proof gates,
-decision locks, and harness measurement.</p>
+<p>Cards are durable planning/governance records; Tasks are durable executable
+progress records. The agent orients around Cards, uses flat card queries for
+card context, and uses <code>maestro task ...</code> for Low-level executable work. Typed
+lifecycle verbs still gate feature contracts, decision locks, proof, QA, and
+harness measurement.</p>
 <pre><code class="language-mermaid">flowchart LR
     A[Human request] --&gt; B[feature card]
     B --&gt; C[spec.md + qa.md]
     C --&gt; D[feature accept]
     D --&gt; E[feature prepare]
-    E --&gt; F[work cards]
-    F --&gt; G[maestro ready]
-    G --&gt; H[maestro claim]
-    H --&gt; I[task complete with proof]
-    I --&gt; J[task verify]
-    J --&gt; K[feature verify + close]
-    K --&gt; L[archive card tree]
+    E --&gt; F[progress / bug / chore / custom card]
+    F --&gt; G[progress.yml or owned task storage]
+    G --&gt; H[maestro task list]
+    H --&gt; I[maestro task start]
+    I --&gt; J[maestro task done or proof]
+    J --&gt; K[task verify when gated]
+    K --&gt; L[feature verify + close]
+    L --&gt; M[archive card tree]
 
-    R[run events + hooks] --&gt; I
+    R[run events + hooks] --&gt; J
 
     subgraph Harness loop
-        M[friction recurs] --&gt; N[idea card]
-        N --&gt; O[harness apply]
-        O --&gt; P[work card]
-        P --&gt; Q[harness measure]
+        N[friction recurs] --&gt; O[idea card]
+        O --&gt; P[harness apply]
+        P --&gt; Q[progress-backed tasks]
+        Q --&gt; S[harness measure]
     end
 </code></pre>
-<p>The card type controls which verbs are valid:</p>
+<p>The card type controls which lifecycle verbs are valid:</p>
 <table>
 <thead>
 <tr>
 <th>Type</th>
+<th>Level</th>
 <th>Role</th>
 <th>Main verbs</th>
 </tr>
 </thead>
 <tbody><tr>
 <td><code>feature</code></td>
+<td>CardKind</td>
 <td>Product contract and parent container</td>
 <td><code>feature accept</code>, <code>feature prepare</code>, <code>feature verify</code>, <code>feature close</code>, <code>archive</code></td>
 </tr>
 <tr>
-<td><code>task</code> / <code>bug</code> / <code>chore</code></td>
-<td>Workable implementation cards</td>
+<td><code>bug</code> / <code>chore</code> / <code>custom</code></td>
+<td>CardKind</td>
+<td>Workflow cards with their own lifecycle and optional facets</td>
+<td>card/task lifecycle verbs, proof and close flows when gated</td>
+</tr>
+<tr>
+<td><code>progress</code></td>
+<td>CardKind</td>
+<td>Lightweight container for compact Low Tasks in <code>progress.yml</code></td>
+<td><code>task add</code>, <code>task list</code>, <code>task start</code>, <code>task done</code> over Progress-backed tasks</td>
+</tr>
+<tr>
+<td>legacy <code>task</code> cards</td>
+<td>Compatibility</td>
+<td>Compatibility implementation cards</td>
 <td><code>ready</code>, <code>claim</code>, <code>task complete</code>, <code>task verify</code>, <code>close</code></td>
 </tr>
 <tr>
 <td><code>idea</code></td>
+<td>CardKind</td>
 <td>Harness/self-improvement proposal</td>
 <td><code>harness list</code>, <code>harness apply</code>, <code>harness dismiss</code>, <code>harness measure</code></td>
 </tr>
 <tr>
 <td><code>decision</code></td>
+<td>CardKind</td>
 <td>Durable reasoning record</td>
 <td><code>decision new</code>, <code>decision lock</code>, <code>decision show</code></td>
 </tr>
+<tr>
+<td>Low Task</td>
+<td>Task</td>
+<td>Executable unit with <code>card_id</code> and blocker metadata</td>
+<td>task list/start/done, verify/proof when required</td>
+</tr>
 </tbody></table>
-<p><code>parent</code> is hierarchy, not a blocker. A card appears in <code>ready</code> only when it is workable
-and every <code>blocks</code> dependency is closed. <code>related</code> carries context without blocking the
-board and also gates linked-card messaging; <code>supersedes</code> records replacement history.</p>
+<p><code>parent</code> is hierarchy, not an execution blocker. Task readiness is computed from
+Task status and resolved blocker metadata. <code>related</code> carries context without
+blocking the board, and <code>supersedes</code> records replacement history.</p>
 <h3>Install</h3>
 <p>From source (always works):</p>
 <pre><code>git clone https://github.com/ReinaMacCredy/maestro
@@ -356,7 +391,9 @@ or touch a card before sending. <code>msg send</code> confirms the route as
 <code>sent to &lt;their-card&gt; (from &lt;your-card&gt;)</code>. <code>msg read [card]</code> prints recent seen context plus unread
 partner messages and advances this card&#39;s cursor. <code>msg list [card]</code> shows either a channel overview
 (<code>your unread</code>, peer read-through when known, and last-message direction) or one partner&#39;s full
-timeline.</p>
+timeline. <code>msg read</code> and scoped <code>msg list &lt;card&gt;</code> also remind agents that inbox messages are
+advisory only: they can suggest cross-card Task order, but execution is gated only by explicit Task
+blockers such as <code>maestro task block &lt;dependent-task&gt; --by &lt;blocking-task&gt;</code>.</p>
 <p>Channels live under <code>.maestro/channels/</code> as gitignored machine-local state: a JSONL file per linked
 pair plus per-card cursor files. If your current card has unread messages on still-linked channels,
 maestro prints a best-effort inbox hint on stderr before ordinary commands, keeping JSON stdout
@@ -565,12 +602,17 @@ editable design state; <code>accept</code> freezes the contract into <code>ready
 <code>close</code> requires no live child work plus QA coverage and a passing contract sweep. Each feature is a
 card under <code>.maestro/cards/&lt;id&gt;/</code>: <code>card.yaml</code> holds typed state, <code>qa.md</code> holds the behavior baseline
 and slices block, <code>spec.md</code> is the design write-up, and <code>notes.md</code> accumulates the running design log.</p>
-<h4>Work Cards Gated by Proof</h4>
-<p><code>task</code>, <code>bug</code>, and <code>chore</code> are the workable card types. They can be discovered with <code>maestro ready</code>,
-claimed with <code>maestro claim &lt;id&gt;</code>, blocked with <code>maestro dep add &lt;child&gt; &lt;blocker&gt;</code>, and closed with
-the proof-gated task flow. Typed task verbs still own proof: <code>task complete</code> records the summary,
-claim, and observed proof, then <code>task verify</code> checks that evidence before the card counts as done.
-The result is that &quot;done&quot; is always backed by evidence you can open.</p>
+<h4>Tasks and Work Cards Gated by Proof</h4>
+<p>Low-level Tasks are the executable units. For small work, <code>maestro task add</code>
+creates a ready Task inside a Progress card&#39;s <code>progress.yml</code>; <code>task start</code>
+claims it, and <code>task done</code> verifies simple completion when no explicit gate is
+attached. For gated or card-owned work, <code>task complete</code> records the summary,
+claim, and observed proof, then <code>task verify</code> checks that evidence before the
+Task counts as done.</p>
+<p>Legacy <code>task</code>, <code>bug</code>, and <code>chore</code> cards remain workable card types. They can be
+discovered with <code>maestro ready</code>, claimed with <code>maestro claim &lt;id&gt;</code>, blocked with
+<code>maestro dep add &lt;child&gt; &lt;blocker&gt;</code>, and closed after their proof-gated work is
+done. The result is that &quot;done&quot; is always backed by evidence you can open.</p>
 <h4>QA: baseline and slices</h4>
 <p>QA lives in one file per feature, <code>.maestro/cards/&lt;id&gt;/qa.md</code>: the behavior baseline (markdown with
 an <code>amend_log_position</code> frontmatter and <code>[bl-NNN]</code> scenario lines) plus a fenced yaml <code>slices:</code>
@@ -892,7 +934,7 @@ embedded/    shipped harness, hook, shell, and skill resources
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills">
-        <div class="stars">★ 21.5K</div>
+        <div class="stars">★ 21.7K</div>
         <div class="name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</div>
       </a>
       <a class="related-row" href="/projects/conorbronsdon/avoid-ai-writing">
@@ -916,7 +958,7 @@ embedded/    shipped harness, hook, shell, and skill resources
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 192</div>
+        <div class="stars">★ 194</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/Ridwannurudeen/hermes-council.html
+++ b/projects/Ridwannurudeen/hermes-council.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -657,7 +657,7 @@ endorsing one community server over others. Install standalone via the
         <div class="name"><span class="org">kevinmarmstrong /</span> hermes-claude-code-rc</div>
       </a>
       <a class="related-row" href="/projects/AaronWong1999/hermesclaw">
-        <div class="stars">★ 647</div>
+        <div class="stars">★ 648</div>
         <div class="name"><span class="org">AaronWong1999 /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/Codename-11/hermes-relay">

--- a/projects/Romanescu11/hermes-skill-factory.html
+++ b/projects/Romanescu11/hermes-skill-factory.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -322,7 +322,7 @@ tags: [python, venv, testing]
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills">
-        <div class="stars">★ 21.5K</div>
+        <div class="stars">★ 21.7K</div>
         <div class="name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</div>
       </a>
       <a class="related-row" href="/projects/conorbronsdon/avoid-ai-writing">
@@ -346,7 +346,7 @@ tags: [python, venv, testing]
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 192</div>
+        <div class="stars">★ 194</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/Sahil-SS9/MrHermagi-tutorbot.html
+++ b/projects/Sahil-SS9/MrHermagi-tutorbot.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -306,7 +306,7 @@ smaller model as a fallback to stay resilient and cheap.</p>
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/ucsandman/DashClaw">
-        <div class="stars">★ 277</div>
+        <div class="stars">★ 278</div>
         <div class="name"><span class="org">ucsandman /</span> DashClaw</div>
       </a>
       <a class="related-row" href="/projects/Lethe044/hermes-incident-commander">
@@ -314,7 +314,7 @@ smaller model as a fallback to stay resilient and cheap.</p>
         <div class="name"><span class="org">Lethe044 /</span> hermes-incident-commander</div>
       </a>
       <a class="related-row" href="/projects/Christabel337/job-scout-agent">
-        <div class="stars">★ 47</div>
+        <div class="stars">★ 48</div>
         <div class="name"><span class="org">Christabel337 /</span> job-scout-agent</div>
       </a>
       <a class="related-row" href="/projects/rodmarkun/anihermes">

--- a/projects/Sahil-SS9/Toolaria.html
+++ b/projects/Sahil-SS9/Toolaria.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -579,11 +579,11 @@ handle. Swept-blob guidance is scoped to the owning session.</li>
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 316</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 246</div>
+        <div class="stars">★ 247</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -607,7 +607,7 @@ handle. Swept-blob guidance is scoped to the owning session.</li>
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 290</div>
+        <div class="stars">★ 291</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
     </div>

--- a/projects/Sahil-SS9/hermaguard.html
+++ b/projects/Sahil-SS9/hermaguard.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -276,7 +276,7 @@ sudo ln -sf $(pwd)/tools/hermaguard-prescan/hermaguard-prescan.py /usr/local/bin
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills">
-        <div class="stars">★ 21.5K</div>
+        <div class="stars">★ 21.7K</div>
         <div class="name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</div>
       </a>
       <a class="related-row" href="/projects/conorbronsdon/avoid-ai-writing">
@@ -300,7 +300,7 @@ sudo ln -sf $(pwd)/tools/hermaguard-prescan/hermaguard-prescan.py /usr/local/bin
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 192</div>
+        <div class="stars">★ 194</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/Sahil-SS9/hermes-Custom-CLI-Themes.html
+++ b/projects/Sahil-SS9/hermes-Custom-CLI-Themes.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -261,11 +261,11 @@ curl -fsSL https://raw.githubusercontent.com/Sahil-SS9/hermes-Custom-CLI-Themes/
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 316</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 246</div>
+        <div class="stars">★ 247</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -289,7 +289,7 @@ curl -fsSL https://raw.githubusercontent.com/Sahil-SS9/hermes-Custom-CLI-Themes/
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 290</div>
+        <div class="stars">★ 291</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
     </div>

--- a/projects/Sahil-SS9/hermes-memlock.html
+++ b/projects/Sahil-SS9/hermes-memlock.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -475,11 +475,11 @@ downloads the embedding model on first use.</li>
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 316</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 246</div>
+        <div class="stars">★ 247</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -503,7 +503,7 @@ downloads the embedding model on first use.</li>
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 290</div>
+        <div class="stars">★ 291</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
     </div>

--- a/projects/Sahil-SS9/hermes-multichannel-prompt-optimizer.html
+++ b/projects/Sahil-SS9/hermes-multichannel-prompt-optimizer.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -507,7 +507,7 @@ venv/bin/pytest tests/plugins/test_prompt_optimizer_plugin.py -v
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills">
-        <div class="stars">★ 21.5K</div>
+        <div class="stars">★ 21.7K</div>
         <div class="name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</div>
       </a>
       <a class="related-row" href="/projects/conorbronsdon/avoid-ai-writing">
@@ -531,7 +531,7 @@ venv/bin/pytest tests/plugins/test_prompt_optimizer_plugin.py -v
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 192</div>
+        <div class="stars">★ 194</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/Sahil-SS9/hermes-simplify-swarm.html
+++ b/projects/Sahil-SS9/hermes-simplify-swarm.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -215,7 +215,7 @@ git clone https://github.com/Sahil-SS9/hermes-simplify-swarm.git simplify-swarm
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills">
-        <div class="stars">★ 21.5K</div>
+        <div class="stars">★ 21.7K</div>
         <div class="name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</div>
       </a>
       <a class="related-row" href="/projects/conorbronsdon/avoid-ai-writing">
@@ -239,7 +239,7 @@ git clone https://github.com/Sahil-SS9/hermes-simplify-swarm.git simplify-swarm
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 192</div>
+        <div class="stars">★ 194</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/Salomondiei08/oh-my-hermes.html
+++ b/projects/Salomondiei08/oh-my-hermes.html
@@ -52,7 +52,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 658
+    "userInteractionCount": 659
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -111,7 +111,7 @@
   <p class="project-desc">An opinionated workflow layer for building, shipping, and operating apps with Hermes Agent</p>
 
   <div class="meta-row">
-    <span class="stars">★ 658</span>
+    <span class="stars">★ 659</span>
     <span><span class="meta-label">lang</span>Shell</span>
     
     
@@ -705,7 +705,7 @@ Multi-service orchestration, more example apps, hosted setup wizard.</p>
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/colbymchenry/codegraph">
-        <div class="stars">★ 54.8K</div>
+        <div class="stars">★ 54.9K</div>
         <div class="name"><span class="org">colbymchenry /</span> codegraph</div>
       </a>
       <a class="related-row" href="/projects/liaohch3/claude-tap">
@@ -721,7 +721,7 @@ Multi-service orchestration, more example apps, hosted setup wizard.</p>
         <div class="name"><span class="org">junhoyeo /</span> tokscale</div>
       </a>
       <a class="related-row" href="/projects/joeynyc/hermes-skins">
-        <div class="stars">★ 471</div>
+        <div class="stars">★ 472</div>
         <div class="name"><span class="org">joeynyc /</span> hermes-skins</div>
       </a>
       <a class="related-row" href="/projects/AlexAI-MCP/hermes-CCC">

--- a/projects/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server.html
+++ b/projects/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -748,11 +748,11 @@ Create <code>.vscode/mcp.json</code>:</p>
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 316</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 246</div>
+        <div class="stars">★ 247</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -772,7 +772,7 @@ Create <code>.vscode/mcp.json</code>:</p>
         <div class="name"><span class="org">raulvidis /</span> hermes-cloudflare</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 290</div>
+        <div class="stars">★ 291</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
       <a class="related-row" href="/projects/clawshell/clawshell">

--- a/projects/Signet-AI/signetai.html
+++ b/projects/Signet-AI/signetai.html
@@ -52,7 +52,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 203
+    "userInteractionCount": 205
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -111,7 +111,7 @@
   <p class="project-desc">Local-first identity, memory, and secrets for AI agents. Portable state across models and harnesses.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 203</span>
+    <span class="stars">★ 205</span>
     <span><span class="meta-label">lang</span>TypeScript</span>
     
     
@@ -637,7 +637,7 @@ contributing significant features. Read the
         <div class="name"><span class="org">greyhaven-ai /</span> autocontext</div>
       </a>
       <a class="related-row" href="/projects/elkimek/honcho-self-hosted">
-        <div class="stars">★ 328</div>
+        <div class="stars">★ 329</div>
         <div class="name"><span class="org">elkimek /</span> honcho-self-hosted</div>
       </a>
       <a class="related-row" href="/projects/yoloshii/ClawMem">

--- a/projects/TheAiSingularity/hermesclaw.html
+++ b/projects/TheAiSingularity/hermesclaw.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -642,7 +642,7 @@ shellcheck scripts/hermesclaw  # lint before submitting
         <div class="name"><span class="org">numtide /</span> llm-agents.nix</div>
       </a>
       <a class="related-row" href="/projects/0xrsydn/nix-hermes-agent">
-        <div class="stars">★ 25</div>
+        <div class="stars">★ 26</div>
         <div class="name"><span class="org">0xrsydn /</span> nix-hermes-agent</div>
       </a>
       <a class="related-row" href="/projects/rookiemann/portable-hermes-agent">

--- a/projects/Xquik-dev/hermes-tweet.html
+++ b/projects/Xquik-dev/hermes-tweet.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -515,11 +515,11 @@ Python plugin. Both use the same Xquik API contract.</p>
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 316</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 246</div>
+        <div class="stars">★ 247</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -543,7 +543,7 @@ Python plugin. Both use the same Xquik API contract.</p>
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 290</div>
+        <div class="stars">★ 291</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
     </div>

--- a/projects/ZeroPointRepo/youtube-skills.html
+++ b/projects/ZeroPointRepo/youtube-skills.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -533,7 +533,7 @@ npx skills add ZeroPointRepo/youtube-skills --skill transcript --skill youtube-s
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills">
-        <div class="stars">★ 21.5K</div>
+        <div class="stars">★ 21.7K</div>
         <div class="name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</div>
       </a>
       <a class="related-row" href="/projects/conorbronsdon/avoid-ai-writing">
@@ -557,7 +557,7 @@ npx skills add ZeroPointRepo/youtube-skills --skill transcript --skill youtube-s
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 192</div>
+        <div class="stars">★ 194</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/abundantbeing/hermes-browser-extension.html
+++ b/projects/abundantbeing/hermes-browser-extension.html
@@ -1,0 +1,436 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>hermes-browser-extension — Hermes Agent Workspaces &amp; GUIs | Hermes Atlas</title>
+<meta name="description" content="Browser-native side panel for Hermes Agent — connect web context to your local Hermes runtime.">
+<link rel="canonical" href="https://hermesatlas.com/projects/abundantbeing/hermes-browser-extension">
+<meta property="og:title" content="hermes-browser-extension — Hermes Atlas">
+<meta property="og:description" content="Browser-native side panel for Hermes Agent — connect web context to your local Hermes runtime.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://hermesatlas.com/projects/abundantbeing/hermes-browser-extension">
+<meta property="og:site_name" content="Hermes Atlas">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-browser-extension&amp;subtitle=Browser-native+side+panel+for+Hermes+Agent+%E2%80%94+connect+web+context+to+your+local+Hermes+runtime.&amp;kind=project+%C2%B7+workspaces">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="hermes-browser-extension — Hermes Atlas">
+<meta name="twitter:description" content="Browser-native side panel for Hermes Agent — connect web context to your local Hermes runtime.">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-browser-extension&amp;subtitle=Browser-native+side+panel+for+Hermes+Agent+%E2%80%94+connect+web+context+to+your+local+Hermes+runtime.&amp;kind=project+%C2%B7+workspaces">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "map", "item": "https://hermesatlas.com/" },
+    { "@type": "ListItem", "position": 2, "name": "workspaces &amp; guis", "item": "https://hermesatlas.com/lists/workspaces-and-guis" },
+    { "@type": "ListItem", "position": 3, "name": "hermes-browser-extension" }
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "@id": "https://hermesatlas.com/projects/abundantbeing/hermes-browser-extension#software",
+  "name": "hermes-browser-extension",
+  "description": "Browser-native side panel for Hermes Agent — connect web context to your local Hermes runtime.",
+  "url": "https://hermesatlas.com/projects/abundantbeing/hermes-browser-extension",
+  "codeRepository": "https://github.com/abundantbeing/hermes-browser-extension",
+  "applicationCategory": "DesktopEnhancementApplication",
+  "operatingSystem": "Cross-platform",
+  "programmingLanguage": "JavaScript",
+  "license": "https://spdx.org/licenses/MIT.html",
+  "author": {
+    "@type": "Organization",
+    "name": "abundantbeing",
+    "url": "https://github.com/abundantbeing"
+  },
+  "dateModified": "2026-06-26T08:01:23.000Z",
+  "interactionStatistic": {
+    "@type": "InteractionCounter",
+    "interactionType": {
+      "@type": "LikeAction"
+    },
+    "userInteractionCount": 95
+  },
+  "isPartOf": {
+    "@id": "https://hermesatlas.com/#website"
+  }
+}
+</script>
+<link rel="alternate" type="application/rss+xml" title="Hermes Atlas — new projects" href="/rss.xml">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+<link rel="apple-touch-icon" href="/apple-touch-icon.png">
+<link rel="manifest" href="/site.webmanifest">
+<script>(function(){try{var s=localStorage.getItem('theme');var o=window.matchMedia&&window.matchMedia('(prefers-color-scheme: light)').matches;var t=s||(o?'light':'dark');document.documentElement.setAttribute('data-theme',t)}catch(e){document.documentElement.setAttribute('data-theme','dark')}})();</script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap">
+<link rel="stylesheet" href="/assets/css/tokens.css">
+<link rel="stylesheet" href="/assets/css/base.css">
+<link rel="stylesheet" href="/assets/css/page.css">
+</head>
+<body>
+
+<a class="skip-link" href="#main">Skip to content</a>
+
+<header class="masthead">
+  <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
+  <div class="mast-meta" aria-label="Site metadata">
+    <span id="meta-count">174·repos</span>
+    <span id="meta-version">hermes·v0.15.2</span>
+    <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
+  </div>
+  <nav class="mast-nav" aria-label="Primary">
+    <a href="/" class="active">map</a>
+    <a href="/#curated-lists">lists</a>
+    <a href="/guide/">handbook</a>
+    <a href="/dev/">dev</a>
+    <a href="/reports/">reports</a>
+    <a href="/#newsletter">newsletter</a>
+    <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
+  </nav>
+  <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
+    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+  </button>
+</header>
+
+<div class="breadcrumb" aria-label="Breadcrumb">
+  <a href="/">map</a><span class="sep">/</span><a href="/lists/workspaces-and-guis">workspaces &amp; guis</a><span class="sep">/</span>hermes-browser-extension
+</div>
+
+<main id="main">
+
+<section class="project">
+  <h1 class="project-name">
+    <span class="org">abundantbeing</span><span class="slash">/</span>hermes-browser-extension
+  </h1>
+  <p class="project-desc">Browser-native side panel for Hermes Agent — connect web context to your local Hermes runtime.</p>
+
+  <div class="meta-row">
+    <span class="stars">★ 95</span>
+    <span><span class="meta-label">lang</span>JavaScript</span>
+    <span><span class="meta-label">license</span>MIT</span>
+    
+    <span><span class="meta-label">updated</span>2026-06-26</span>
+  </div>
+
+  <div class="actions">
+    <a href="https://github.com/abundantbeing/hermes-browser-extension" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
+    
+  </div>
+</section>
+
+
+
+
+
+<details class="readme-details" open>
+  <summary class="readme-toggle">readme</summary>
+  <section class="readme" data-nosnippet>
+    <h2>Hermes Browser Extension</h2>
+<p>Browser-native side panel for <a href="https://hermes-agent.nousresearch.com/docs">Hermes Agent</a> — connect active web context to your local or remote Hermes runtime.</p>
+<blockquote>
+<p>Created by <strong>Jon Komet</strong> (<code>@abundantbeing</code>). Community extension for Hermes Agent by Nous Research.</p>
+</blockquote>
+<p align="center">
+  <img src="https://raw.githubusercontent.com/abundantbeing/hermes-browser-extension/main/assets/readme/hermes-browser-demo.gif" alt="Hermes Browser Extension demo showing the side panel reading browser context and composing a Hermes prompt" width="100%" />
+</p>
+
+<p align="center">
+  <strong>Public alpha · Load unpacked · Local/remote Hermes API · Read-only browser context</strong><br />
+  Not on the Chrome Web Store yet.
+</p>
+
+<h3>What it is</h3>
+<p>Hermes Browser Extension is not a browser chatbot. It is a Chrome/Edge/Chromium side panel for the real Hermes Agent runtime. It talks to your Hermes Gateway/API server — local by default, remote when you configure a reachable URL — so it can use the models, tools, skills, sessions, memory, and MCP servers already configured in Hermes.</p>
+<p>This repo is specifically for the <strong>extension</strong>. A future standalone <strong>Hermes Browser</strong> may become a separate native macOS/Linux/Windows app built on the groundwork from this extension.</p>
+<h3>Visual tour</h3>
+<table>
+<thead>
+<tr>
+<th>Side panel</th>
+<th>Theme settings</th>
+<th>Local agents</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><img src="https://raw.githubusercontent.com/abundantbeing/hermes-browser-extension/main/assets/readme/hermes-browser-sidepanel.png" alt="Hermes Browser Extension side panel in Mono theme" width="300" /></td>
+<td><img src="https://raw.githubusercontent.com/abundantbeing/hermes-browser-extension/main/assets/readme/hermes-browser-theme-settings.png" alt="Hermes Browser Extension appearance settings with color mode and theme picker" width="300" /></td>
+<td><img src="https://raw.githubusercontent.com/abundantbeing/hermes-browser-extension/main/assets/readme/hermes-browser-settings-agent-picker.png" alt="Hermes Browser Extension settings with connected local agent picker" width="300" /></td>
+</tr>
+</tbody></table>
+<h3>Highlights</h3>
+<ul>
+<li>Chrome/Edge/Chromium MV3 side panel powered by the Side Panel API.</li>
+<li>Connects to a configurable local or remote Hermes API server. Default: <code>http://127.0.0.1:8642</code>.</li>
+<li>Supports dashboard WebSocket mode when you have a signed-in remote Hermes dashboard tab and no API key.</li>
+<li>Auto-syncs connected Hermes providers/models, profiles, skills, sessions, and capabilities.</li>
+<li>Sends active tab/browser context into a persisted Hermes session.</li>
+<li>Captures active tab title/URL, open tabs, selected text, readable page text, metadata, headings, forms, links, and buttons where available.</li>
+<li>Supports voice dictation through the local Hermes audio transcription API, with a visible extension voice-tab fallback for Chromium side-panel microphone blocks.</li>
+<li>Wraps webpage text as untrusted context before sending it to Hermes.</li>
+<li>Streams Hermes responses and falls back to non-streaming chat when needed.</li>
+<li>Includes Desktop-style appearance settings: Light/Dark/System mode plus Nous, Midnight, Ember, Mono, Cyberpunk, and Slate themes.</li>
+<li>Includes a localhost agent picker for switching between trusted local Hermes API gateway ports.</li>
+<li>No <code>debugger</code>, <code>nativeMessaging</code>, click/type/form-submit, cookies, history, bookmarks, downloads, or browser-control permissions in v0.1.</li>
+</ul>
+<h3>Requirements</h3>
+<ul>
+<li>Hermes Agent installed and working.</li>
+<li>Hermes Gateway/API server enabled locally or on a reachable remote machine.</li>
+<li>Node.js 20+.</li>
+<li>Chrome, Edge, Brave, Comet, or another Chromium browser with Side Panel API support (Chrome 114+ baseline).</li>
+</ul>
+<h3>Quick start</h3>
+<h4>1. Clone and build</h4>
+<pre><code class="language-bash">git clone https://github.com/abundantbeing/hermes-browser-extension.git
+cd hermes-browser-extension
+npm install
+npm run build
+</code></pre>
+<p>The loadable extension is generated at:</p>
+<pre><code class="language-text">dist/
+</code></pre>
+<h4>2. Load unpacked in Chrome/Edge</h4>
+<ol>
+<li>Open <code>chrome://extensions</code> or <code>edge://extensions</code>.</li>
+<li>Enable <strong>Developer mode</strong>.</li>
+<li>Click <strong>Load unpacked</strong>.</li>
+<li>Select this repo&#39;s <code>dist/</code> folder — not the repo root and not <code>extension/</code>.</li>
+<li>Pin/click the Hermes extension icon to open the side panel.</li>
+</ol>
+<p>After code updates, run <code>npm run build</code> again and click <strong>Reload</strong> on the Hermes Browser Extension card in the browser extensions page.</p>
+<h3>Connect to Hermes</h3>
+<h4>Local API server</h4>
+<p>Local-only is the safest default. Put this in <code>~/.hermes/.env</code> on the machine running Hermes:</p>
+<pre><code class="language-bash">API_SERVER_ENABLED=true
+API_SERVER_HOST=127.0.0.1
+API_SERVER_PORT=8642
+API_SERVER_KEY=&lt;strong-local-secret&gt;
+API_SERVER_CORS_ORIGINS=chrome-extension://&lt;your-extension-id&gt;
+</code></pre>
+<p>Start or restart the gateway:</p>
+<pre><code class="language-bash">hermes gateway run
+</code></pre>
+<p>Verify the API server:</p>
+<pre><code class="language-bash">HERMES_GATEWAY_URL=http://127.0.0.1:8642
+HERMES_API_TOKEN=&#39;&lt;your-api-server-key-or-browser-token&gt;&#39;
+curl &quot;$HERMES_GATEWAY_URL/health&quot;
+curl -H &quot;Authorization: Bearer $HERMES_API_TOKEN&quot; &quot;$HERMES_GATEWAY_URL/v1/models&quot;
+</code></pre>
+<p>Then in the extension side panel:</p>
+<ol>
+<li>Click <strong>Connect to Hermes</strong> and approve locally if your Hermes Desktop/gateway supports the approval flow.</li>
+<li>If approval is not available yet, click <strong>Manual setup</strong>.</li>
+<li>Choose <strong>Local gateway</strong>.</li>
+<li>Use Gateway URL <code>http://127.0.0.1:8642</code>.</li>
+<li>Paste your scoped browser token or <code>API_SERVER_KEY</code>.</li>
+<li>Click <strong>Test connection</strong>, then <strong>Save settings</strong>.</li>
+<li>Open a normal <code>https://</code> page and ask: <code>Summarize this page in one sentence.</code></li>
+</ol>
+<h4>Remote API server</h4>
+<p>For a remote Hermes machine, bind the API server to a reachable trusted interface and keep CORS narrow:</p>
+<pre><code class="language-bash">API_SERVER_ENABLED=true
+API_SERVER_HOST=0.0.0.0
+API_SERVER_PORT=8642
+API_SERVER_KEY=&lt;strong-remote-secret&gt;
+API_SERVER_CORS_ORIGINS=chrome-extension://&lt;your-extension-id&gt;
+</code></pre>
+<p>Use Tailscale/VPN/reverse proxy + HTTPS where possible. Do <strong>not</strong> expose the Hermes API server naked to the public internet. The Hermes API server can access the real Hermes runtime and tools.</p>
+<h4>Remote dashboard mode, no API server</h4>
+<p>If you run Hermes elsewhere and only expose the OAuth-gated dashboard, select <strong>Remote</strong>, enter the dashboard&#39;s <code>https://</code> URL, and leave the API key blank. With no key, the extension connects over the dashboard&#39;s <code>/api/ws</code> socket instead of the REST API server.</p>
+<p>Auth uses a single-use WebSocket ticket minted from a signed-in dashboard tab:</p>
+<ul>
+<li>Open the dashboard URL in a normal browser tab and sign in, and keep that tab around.</li>
+<li>The extension mints the ticket first-party from that tab, then opens the socket.</li>
+<li><strong>Test connection</strong> opens the socket and loads models, which confirms the whole path.</li>
+</ul>
+<p>Limitations in this mode: image attachments are inline-only, and the skills/profiles lists are unavailable because those are REST-only and the dashboard&#39;s REST surface is not reachable cross-origin.</p>
+<h3>What syncs after connection</h3>
+<p>After connection, the side panel loads from the connected Hermes gateway:</p>
+<ul>
+<li><code>/v1/models</code> — all providers/models Hermes can enumerate, including provider-qualified IDs.</li>
+<li><code>/api/sessions</code> — recent Hermes sessions grouped by source.</li>
+<li><code>/v1/skills</code> — slash-command skill suggestions in the composer.</li>
+<li><code>/v1/profiles</code> — profile picker when the gateway exposes profile metadata.</li>
+<li><code>/v1/capabilities</code> — feature flags such as audio transcription and Browser upload support.</li>
+</ul>
+<p>The DOM/context chip should show a non-zero page-context count on normal readable pages. Browser internal pages such as <code>chrome://extensions</code> are intentionally restricted.</p>
+<h3>Install with Hermes / Computer Use</h3>
+<p>You can ask Hermes to help install it:</p>
+<pre><code class="language-text">Install Hermes Browser Extension from https://github.com/abundantbeing/hermes-browser-extension. Clone it, run npm install, run npm run build, then use computer use to open chrome://extensions, enable Developer mode, load the dist folder unpacked, and help me connect it to my local or remote Hermes Gateway API server. Do not reveal, print, screenshot, or commit my API key.
+</code></pre>
+<h3>Security model</h3>
+<p>Hermes Browser Extension is intentionally conservative in v0.1:</p>
+<ul>
+<li>Local API server by default; remote API server support requires an explicit URL, token, and CORS allowlist.</li>
+<li>Strong bearer/API key required for API access.</li>
+<li>Page content is wrapped as untrusted context before it reaches Hermes.</li>
+<li>Read-only browser context capture: no click, type, form-submit, checkout, download, or browser-control behavior.</li>
+<li>No <code>debugger</code>, <code>nativeMessaging</code>, <code>cookies</code>, <code>history</code>, <code>downloads</code>, or <code>bookmarks</code> permissions.</li>
+<li>Restricted pages include browser internals, extension pages, and obvious banking/crypto/password/payment/health/government-tax categories.</li>
+</ul>
+<p>See <a href="https://github.com/abundantbeing/hermes-browser-extension/blob/main/SECURITY.md"><code>SECURITY.md</code></a> for details.</p>
+<h3>Troubleshooting</h3>
+<h4>I loaded the extension but nothing works</h4>
+<p>Make sure you loaded <code>dist/</code>, not the repo root. The selected folder must contain <code>manifest.json</code> directly.</p>
+<h4>The side panel says it cannot connect</h4>
+<p>Check that Hermes Gateway/API server is running and reachable from the browser:</p>
+<pre><code class="language-bash">curl http://127.0.0.1:8642/health
+# or, for remote mode:
+curl http://&lt;trusted-remote-host&gt;:8642/health
+</code></pre>
+<p>If <code>/v1/models</code> fails, check <code>API_SERVER_KEY</code>, the extension&#39;s stored API key/browser token, and <code>API_SERVER_CORS_ORIGINS</code>. For remote mode, the browser extension origin (<code>chrome-extension://&lt;id&gt;</code>) must be allowlisted on the Hermes machine.</p>
+<h4>The DOM chip says <code>0 chars</code></h4>
+<p>Open a normal <code>https://</code> page and refresh context. Browser internal pages (<code>chrome://</code>, <code>edge://</code>, extension pages, devtools, etc.) are restricted by design.</p>
+<h4>Microphone says blocked or voice dictation does not start</h4>
+<p>Chromium side panels can suppress microphone permission prompts. Hermes Browser Extension handles this with a visible extension voice page:</p>
+<ol>
+<li>Click the mic button in the side panel.</li>
+<li>If the side panel cannot capture the mic, a <strong>Hermes Voice Dictation</strong> tab opens.</li>
+<li>In that tab, click <strong>Start dictation</strong>. This click is the permission gesture Chromium expects.</li>
+<li>Speak, then click <strong>Stop + transcribe</strong>.</li>
+<li>The transcript is sent back to the side panel composer automatically.</li>
+</ol>
+<p>If Chromium still says the mic is blocked, click <strong>Open microphone settings</strong> in the voice tab and set Microphone to <strong>Allow</strong> for <code>chrome-extension://&lt;the Hermes extension id&gt;/</code>, then return to the voice tab and try again.</p>
+<h4>The first-run Connect flow is unavailable</h4>
+<p>Use <strong>Manual setup</strong> with your local/remote Gateway URL and API key. The native Desktop approval flow is still evolving during alpha.</p>
+<h3>GitHub PR/Issue auto-review</h3>
+<p>This repo includes two Hermes review runners:</p>
+<ul>
+<li><code>npm run review:watch</code> — local poller for open PRs/issues. This works now from a machine that can reach Hermes and is authenticated with <code>gh</code>.</li>
+<li><code>npm run review:event</code> — GitHub-event runner for future GitHub Actions/webhook wiring. It expects <code>GITHUB_EVENT_NAME</code>, <code>GITHUB_EVENT_PATH</code>, and <code>GITHUB_REPOSITORY</code>.</li>
+</ul>
+<p>The local poller checks open PRs and issues, computes a stable signature from PR head SHA or issue title/body, and only reviews changed targets. It upserts one bot comment per PR/issue with a stable marker. PR diffs and issue bodies are treated as untrusted input.</p>
+<p>Local setup:</p>
+<pre><code class="language-bash"># Uses gh auth token, local API_SERVER_KEY from ~/.hermes/.env,
+# and http://127.0.0.1:8642 by default.
+npm run review:watch
+</code></pre>
+<p>Optional overrides:</p>
+<pre><code class="language-bash">HERMES_REVIEW_REPO=abundantbeing/hermes-browser-extension
+HERMES_REVIEW_GATEWAY_URL=http://127.0.0.1:8642
+HERMES_REVIEW_API_KEY=&lt;api-server-key-or-scoped-token&gt;
+HERMES_REVIEW_MAX_TARGETS=3
+HERMES_REVIEW_STATE_FILE=~/.hermes/hermes-browser-review-state.json
+</code></pre>
+<p>For a GitHub-hosted Actions runner later, <code>HERMES_REVIEW_GATEWAY_URL</code> must be reachable from GitHub. A runner cannot reach <code>http://127.0.0.1:8642</code> on your personal machine; use a remote Hermes API server behind Tailscale/VPN/HTTPS or a self-hosted GitHub runner on the same network. Pushing <code>.github/workflows/*</code> also requires a GitHub token with <code>workflow</code> scope.</p>
+<p>Dry-runs:</p>
+<pre><code class="language-bash">npm run review:watch:dry-run
+
+GITHUB_EVENT_NAME=pull_request_target \
+GITHUB_EVENT_PATH=./event.json \
+GITHUB_REPOSITORY=abundantbeing/hermes-browser-extension \
+GITHUB_TOKEN=&lt;github-token&gt; \
+npm run review:event:dry-run
+</code></pre>
+<h3>Development</h3>
+<pre><code class="language-bash">npm test
+npm run check:js
+npm run check:manifest
+npm run verify
+npm run build
+npm run package
+</code></pre>
+<p>Project layout:</p>
+<pre><code class="language-text">extension/
+  manifest.json       MV3 extension manifest
+  background.js       side panel behavior
+  content.js          page context collector
+  sidepanel.html      side panel UI
+  sidepanel.css       side panel styling
+  sidepanel.js        Hermes API client + UI state
+  voice-dictation.*   visible extension voice recorder fallback for blocked side-panel mic capture
+  request-permissions.* visible extension mic-permission helper page
+  sidepanel-preview.html static visual QA preview
+  assets/             local Hermes fonts, icons, and imagery
+  lib/common.mjs      shared prompt/context/security utilities
+scripts/
+  build.mjs           copies extension/ to dist/
+  check-manifest.mjs  validates required manifest assets/permissions
+  hermes-review-github-event.mjs PR/issue event runner for GitHub Actions/webhooks
+  hermes-review-watch.mjs local PR/issue review poller
+  package.mjs         creates artifacts/hermes-browser-extension.tar.gz
+tests/
+  common.test.mjs     utility behavior tests
+</code></pre>
+<h3>Relationship to Hermes Agent</h3>
+<p><a href="https://github.com/NousResearch/hermes-agent">Hermes Agent</a> is an open-source project by Nous Research. Hermes Browser Extension is a community extension by Jon Komet that connects to a local or remote Hermes API server. It is designed to live at the edge of the ecosystem without adding core tool-schema footprint.</p>
+<p>Useful links:</p>
+<ul>
+<li>Hermes docs: <a href="https://hermes-agent.nousresearch.com/docs">https://hermes-agent.nousresearch.com/docs</a></li>
+<li>Hermes API server docs: <a href="https://hermes-agent.nousresearch.com/docs/user-guide/features/api-server">https://hermes-agent.nousresearch.com/docs/user-guide/features/api-server</a></li>
+<li>Hermes upstream repo: <a href="https://github.com/NousResearch/hermes-agent">https://github.com/NousResearch/hermes-agent</a></li>
+</ul>
+<h3>Author</h3>
+<p>Built by <strong>Jon Komet</strong> (<code>@abundantbeing</code>).</p>
+<h3>License</h3>
+<p>MIT. See <a href="LICENSE"><code>LICENSE</code></a>.</p>
+
+  </section>
+</details>
+
+<aside class="related" aria-label="Related repos">
+  <div>
+    <div class="section-label">more in workspaces &amp; guis</div>
+    <div class="section-sub">other repos in this category, ranked by stars.</div>
+  </div>
+  <div>
+    <div class="related-list">
+      <a class="related-row" href="/projects/outsourc-e/hermes-workspace">
+        <div class="stars">★ 5.9K</div>
+        <div class="name"><span class="org">outsourc-e /</span> hermes-workspace</div>
+      </a>
+      <a class="related-row" href="/projects/fathah/hermes-desktop">
+        <div class="stars">★ 12.7K</div>
+        <div class="name"><span class="org">fathah /</span> hermes-desktop</div>
+      </a>
+      <a class="related-row" href="/projects/sanchomuzax/hermes-webui">
+        <div class="stars">★ 108</div>
+        <div class="name"><span class="org">sanchomuzax /</span> hermes-webui</div>
+      </a>
+      <a class="related-row" href="/projects/Euraika-Labs/pan-ui">
+        <div class="stars">★ 85</div>
+        <div class="name"><span class="org">Euraika-Labs /</span> pan-ui</div>
+      </a>
+      <a class="related-row" href="/projects/Eynzof/hermes-agent-cn-desktop">
+        <div class="stars">★ 584</div>
+        <div class="name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
+      </a>
+      <a class="related-row" href="/projects/Felix-Forever/hermes-agent-desktop">
+        <div class="stars">★ 57</div>
+        <div class="name"><span class="org">Felix-Forever /</span> hermes-agent-desktop</div>
+      </a>
+      <a class="related-row" href="/projects/jazzyalex/agent-sessions">
+        <div class="stars">★ 661</div>
+        <div class="name"><span class="org">jazzyalex /</span> agent-sessions</div>
+      </a>
+      <a class="related-row" href="/projects/nickvasilescu/hermes-desktop-os1">
+        <div class="stars">★ 479</div>
+        <div class="name"><span class="org">nickvasilescu /</span> hermes-desktop-os1</div>
+      </a>
+    </div>
+    <p class="list-link"><a href="/lists/workspaces-and-guis">see all workspaces &amp; guis →</a></p>
+  </div>
+</aside>
+
+</main>
+
+<footer class="page-footer">
+  <div class="fn-left">hermes atlas · curated by <a href="https://github.com/ksimback">ksimback</a> · <a href="https://github.com/ksimback/hermes-ecosystem/issues">suggest a repo</a> · <a href="/privacy">privacy</a></div>
+  <div>v2 · 2026.04</div>
+</footer>
+
+<script>(function(){var t=document.getElementById('theme-toggle');if(!t)return;function render(){var c=document.documentElement.getAttribute('data-theme');t.querySelector('.tt-light').classList.toggle('tt-active',c==='light');t.querySelector('.tt-dark').classList.toggle('tt-active',c!=='light');}render();t.addEventListener('click',function(){var c=document.documentElement.getAttribute('data-theme');var n=c==='light'?'dark':'light';document.documentElement.setAttribute('data-theme',n);try{localStorage.setItem('theme',n)}catch(e){}render();});})();</script>
+<script src="/assets/js/masthead-fetch.js" defer></script>
+<!-- Cloudflare Web Analytics -->
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js"
+        data-cf-beacon='{"token": "fe0d4d79280b4386b6b0cd99b2d94dbc"}'></script>
+<!-- End Cloudflare Web Analytics -->
+</body>
+</html>

--- a/projects/adityahimaone/hermes-agent-rtk-caveman.html
+++ b/projects/adityahimaone/hermes-agent-rtk-caveman.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -465,11 +465,11 @@ ls -la ~/templates/
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/colbymchenry/codegraph">
-        <div class="stars">★ 54.8K</div>
+        <div class="stars">★ 54.9K</div>
         <div class="name"><span class="org">colbymchenry /</span> codegraph</div>
       </a>
       <a class="related-row" href="/projects/Salomondiei08/oh-my-hermes">
-        <div class="stars">★ 658</div>
+        <div class="stars">★ 659</div>
         <div class="name"><span class="org">Salomondiei08 /</span> oh-my-hermes</div>
       </a>
       <a class="related-row" href="/projects/liaohch3/claude-tap">
@@ -481,7 +481,7 @@ ls -la ~/templates/
         <div class="name"><span class="org">junhoyeo /</span> tokscale</div>
       </a>
       <a class="related-row" href="/projects/joeynyc/hermes-skins">
-        <div class="stars">★ 471</div>
+        <div class="stars">★ 472</div>
         <div class="name"><span class="org">joeynyc /</span> hermes-skins</div>
       </a>
       <a class="related-row" href="/projects/AlexAI-MCP/hermes-CCC">

--- a/projects/adnw-vinc/hermes-nextcloud.html
+++ b/projects/adnw-vinc/hermes-nextcloud.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -320,7 +320,7 @@ $NC contacts export --uid &lt;contact-uid&gt; --local ./contact.vcf
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills">
-        <div class="stars">★ 21.5K</div>
+        <div class="stars">★ 21.7K</div>
         <div class="name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</div>
       </a>
       <a class="related-row" href="/projects/conorbronsdon/avoid-ai-writing">
@@ -344,7 +344,7 @@ $NC contacts export --uid &lt;contact-uid&gt; --local ./contact.vcf
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 192</div>
+        <div class="stars">★ 194</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/agent-of-empires/agent-of-empires.html
+++ b/projects/agent-of-empires/agent-of-empires.html
@@ -47,7 +47,7 @@
     "name": "agent-of-empires",
     "url": "https://github.com/agent-of-empires"
   },
-  "dateModified": "2026-06-26T05:51:47.000Z",
+  "dateModified": "2026-06-26T14:43:15.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -342,7 +342,7 @@ unchanged.</p>
         <div class="name"><span class="org">runtimenoteslabs /</span> gladiator</div>
       </a>
       <a class="related-row" href="/projects/1ilkhamov/opencode-hermes-multiagent">
-        <div class="stars">★ 152</div>
+        <div class="stars">★ 153</div>
         <div class="name"><span class="org">1ilkhamov /</span> opencode-hermes-multiagent</div>
       </a>
       <a class="related-row" href="/projects/Rainhoole/hermes-agent-acp-skill">

--- a/projects/aivrar/portable-hermes-agent.html
+++ b/projects/aivrar/portable-hermes-agent.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -359,8 +359,12 @@ AIAgent (run_agent.py)
         <div class="stars">★ 85</div>
         <div class="name"><span class="org">Euraika-Labs /</span> pan-ui</div>
       </a>
+      <a class="related-row" href="/projects/abundantbeing/hermes-browser-extension">
+        <div class="stars">★ 95</div>
+        <div class="name"><span class="org">abundantbeing /</span> hermes-browser-extension</div>
+      </a>
       <a class="related-row" href="/projects/Eynzof/hermes-agent-cn-desktop">
-        <div class="stars">★ 578</div>
+        <div class="stars">★ 584</div>
         <div class="name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       </a>
       <a class="related-row" href="/projects/Felix-Forever/hermes-agent-desktop">
@@ -370,10 +374,6 @@ AIAgent (run_agent.py)
       <a class="related-row" href="/projects/jazzyalex/agent-sessions">
         <div class="stars">★ 661</div>
         <div class="name"><span class="org">jazzyalex /</span> agent-sessions</div>
-      </a>
-      <a class="related-row" href="/projects/nickvasilescu/hermes-desktop-os1">
-        <div class="stars">★ 479</div>
-        <div class="name"><span class="org">nickvasilescu /</span> hermes-desktop-os1</div>
       </a>
     </div>
     <p class="list-link"><a href="/lists/workspaces-and-guis">see all workspaces &amp; guis →</a></p>

--- a/projects/alchaincyf/hermes-agent-orange-book.html
+++ b/projects/alchaincyf/hermes-agent-orange-book.html
@@ -51,7 +51,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 4548
+    "userInteractionCount": 4549
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -79,7 +79,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>

--- a/projects/alias8818/hermes-tool-slimmer.html
+++ b/projects/alias8818/hermes-tool-slimmer.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -400,7 +400,7 @@ python -m build
         <div class="name"><span class="org">greyhaven-ai /</span> autocontext</div>
       </a>
       <a class="related-row" href="/projects/elkimek/honcho-self-hosted">
-        <div class="stars">★ 328</div>
+        <div class="stars">★ 329</div>
         <div class="name"><span class="org">elkimek /</span> honcho-self-hosted</div>
       </a>
       <a class="related-row" href="/projects/yoloshii/ClawMem">
@@ -408,7 +408,7 @@ python -m build
         <div class="name"><span class="org">yoloshii /</span> ClawMem</div>
       </a>
       <a class="related-row" href="/projects/Signet-AI/signetai">
-        <div class="stars">★ 203</div>
+        <div class="stars">★ 205</div>
         <div class="name"><span class="org">Signet-AI /</span> signetai</div>
       </a>
       <a class="related-row" href="/projects/plur-ai/plur">

--- a/projects/amanning3390/flowstate-qmd.html
+++ b/projects/amanning3390/flowstate-qmd.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -442,7 +442,7 @@ bun bench/tool-calls.ts    # MCP tool round-trip simulation
         <div class="name"><span class="org">greyhaven-ai /</span> autocontext</div>
       </a>
       <a class="related-row" href="/projects/elkimek/honcho-self-hosted">
-        <div class="stars">★ 328</div>
+        <div class="stars">★ 329</div>
         <div class="name"><span class="org">elkimek /</span> honcho-self-hosted</div>
       </a>
       <a class="related-row" href="/projects/yoloshii/ClawMem">
@@ -450,7 +450,7 @@ bun bench/tool-calls.ts    # MCP tool round-trip simulation
         <div class="name"><span class="org">yoloshii /</span> ClawMem</div>
       </a>
       <a class="related-row" href="/projects/Signet-AI/signetai">
-        <div class="stars">★ 203</div>
+        <div class="stars">★ 205</div>
         <div class="name"><span class="org">Signet-AI /</span> signetai</div>
       </a>
       <a class="related-row" href="/projects/plur-ai/plur">

--- a/projects/amanning3390/hermeshub.html
+++ b/projects/amanning3390/hermeshub.html
@@ -52,7 +52,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 285
+    "userInteractionCount": 286
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -111,7 +111,7 @@
   <p class="project-desc">HermesHub - The Skills Hub for Hermes Agent by Nous Research. Browse, share, and install community skills.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 285</span>
+    <span class="stars">★ 286</span>
     <span><span class="meta-label">lang</span>TypeScript</span>
     
     
@@ -349,7 +349,7 @@ Includes the CLI (<code>init</code>, <code>validate</code>, <code>publish</code>
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills">
-        <div class="stars">★ 21.5K</div>
+        <div class="stars">★ 21.7K</div>
         <div class="name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</div>
       </a>
       <a class="related-row" href="/projects/conorbronsdon/avoid-ai-writing">
@@ -373,7 +373,7 @@ Includes the CLI (<code>init</code>, <code>validate</code>, <code>publish</code>
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 192</div>
+        <div class="stars">★ 194</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/anneheartrecord/hermes-agent-anatomy.html
+++ b/projects/anneheartrecord/hermes-agent-anatomy.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>

--- a/projects/armelhbobdad/bmad-module-skill-forge.html
+++ b/projects/armelhbobdad/bmad-module-skill-forge.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -386,7 +386,7 @@ results = await cognee.search(
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills">
-        <div class="stars">★ 21.5K</div>
+        <div class="stars">★ 21.7K</div>
         <div class="name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</div>
       </a>
       <a class="related-row" href="/projects/conorbronsdon/avoid-ai-writing">
@@ -410,7 +410,7 @@ results = await cognee.search(
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 192</div>
+        <div class="stars">★ 194</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/basilisk-labs/agentplane-hermes-plugin.html
+++ b/projects/basilisk-labs/agentplane-hermes-plugin.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -243,11 +243,11 @@ or CLI surfaces.</p>
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 316</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 246</div>
+        <div class="stars">★ 247</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -271,7 +271,7 @@ or CLI surfaces.</p>
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 290</div>
+        <div class="stars">★ 291</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
     </div>

--- a/projects/beardthelion/hermes-skill-distillation.html
+++ b/projects/beardthelion/hermes-skill-distillation.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -276,7 +276,7 @@ demo/
         <div class="name"><span class="org">carterwayneskhizeine /</span> hermes-agent-windows-R</div>
       </a>
       <a class="related-row" href="/projects/sheawinkler/hermes-agent-ultra">
-        <div class="stars">★ 56</div>
+        <div class="stars">★ 57</div>
         <div class="name"><span class="org">sheawinkler /</span> hermes-agent-ultra</div>
       </a>
       <a class="related-row" href="/projects/pengchengxia75-arch/hermes-agent-windows">

--- a/projects/bigph00t/hermescraft.html
+++ b/projects/bigph00t/hermescraft.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -461,7 +461,7 @@ bash -n scripts/run-landfolk-bots.sh
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/ucsandman/DashClaw">
-        <div class="stars">★ 277</div>
+        <div class="stars">★ 278</div>
         <div class="name"><span class="org">ucsandman /</span> DashClaw</div>
       </a>
       <a class="related-row" href="/projects/Lethe044/hermes-incident-commander">
@@ -469,7 +469,7 @@ bash -n scripts/run-landfolk-bots.sh
         <div class="name"><span class="org">Lethe044 /</span> hermes-incident-commander</div>
       </a>
       <a class="related-row" href="/projects/Christabel337/job-scout-agent">
-        <div class="stars">★ 47</div>
+        <div class="stars">★ 48</div>
         <div class="name"><span class="org">Christabel337 /</span> job-scout-agent</div>
       </a>
       <a class="related-row" href="/projects/rodmarkun/anihermes">

--- a/projects/black-forest-labs/skills.html
+++ b/projects/black-forest-labs/skills.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -279,7 +279,7 @@ while True:
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills">
-        <div class="stars">★ 21.5K</div>
+        <div class="stars">★ 21.7K</div>
         <div class="name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</div>
       </a>
       <a class="related-row" href="/projects/conorbronsdon/avoid-ai-writing">
@@ -303,7 +303,7 @@ while True:
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 192</div>
+        <div class="stars">★ 194</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/briancaffey/hermes-otel.html
+++ b/projects/briancaffey/hermes-otel.html
@@ -47,13 +47,13 @@
     "name": "briancaffey",
     "url": "https://github.com/briancaffey"
   },
-  "dateModified": "2026-06-26T04:46:46.000Z",
+  "dateModified": "2026-06-26T14:14:46.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 30
+    "userInteractionCount": 31
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">OTel Plugin for Hermes Agent</p>
 
   <div class="meta-row">
-    <span class="stars">★ 30</span>
+    <span class="stars">★ 31</span>
     <span><span class="meta-label">lang</span>Python</span>
     <span><span class="meta-label">license</span>Apache-2.0</span>
     
@@ -628,10 +628,12 @@ headers:                        # merged onto outgoing OTLP requests
 <h3>How it works</h3>
 <p>Hermes fires lifecycle hooks. This plugin maps them to OTel spans:</p>
 <pre><code>Turn 1:
-  session.{platform} / cron (root, when session hooks are available)
+  agent / cron (root, when session hooks are available)
   └── LLM span
       └── API span (first call → stop or tool_calls)
           └── Tool span(s) (if tools called)
+      ├── subagent.{role} span (when delegate_task is used)
+      │   └── agent (child run rejoins the trace) → its own LLM/API/tool spans
       └── API span (second call → final response)
 </code></pre>
 <h4>Span hierarchy</h4>
@@ -644,9 +646,9 @@ headers:                        # merged onto outgoing OTLP requests
 </tr>
 </thead>
 <tbody><tr>
-<td><code>session.{platform}</code> / <code>cron</code></td>
-<td>GENERAL</td>
-<td>Session metadata, completion/interruption status</td>
+<td><code>agent</code> / <code>cron</code></td>
+<td>AGENT</td>
+<td>Session metadata, completion/interruption status, turn summary</td>
 </tr>
 <tr>
 <td><code>llm.{model}</code></td>
@@ -656,14 +658,21 @@ headers:                        # merged onto outgoing OTLP requests
 <tr>
 <td><code>api.{model}</code></td>
 <td>LLM</td>
-<td>Token counts (prompt + completion), duration, finish reason, cache tokens</td>
+<td>Token counts (prompt + completion), duration, finish reason, cache tokens. On failure: <code>ERROR</code> status + recorded exception + retry metadata</td>
 </tr>
 <tr>
 <td><code>tool.{name}</code></td>
 <td>TOOL</td>
 <td>Tool name, arguments (input), result (output), error status</td>
 </tr>
+<tr>
+<td><code>subagent.{role}</code></td>
+<td>AGENT</td>
+<td>Delegated child agent — role, goal, status, duration, summary; the child&#39;s own run nests beneath it so a multi-agent run is <strong>one connected trace</strong></td>
+</tr>
 </tbody></table>
+<p><strong>Sub-agent delegation:</strong> when the agent calls <code>delegate_task</code>, the plugin opens a <code>subagent.{role}</code> span in the parent trace (via the <code>subagent_start</code> / <code>subagent_stop</code> hooks) and rejoins the delegated child&#39;s own root span underneath it. Without this, child agents export as dozens of disconnected traces. See <a href="https://github.com/briancaffey/hermes-otel/blob/main/website/docs/architecture/span-hierarchy.md">Span hierarchy → <code>subagent.*</code></a> and the <code>hermes.subagent.count</code> / <code>hermes.subagent.duration</code> metrics.</p>
+<p><strong>API errors &amp; retries:</strong> failed provider requests (rate limits, timeouts, 5xx, network errors) close the <code>api.{model}</code> span as <code>ERROR</code> with an <code>exception</code> event and retry metadata (<code>error.type</code>, status code, <code>hermes.retry.count</code>, <code>hermes.retryable</code>), via the <code>api_request_error</code> hook — previously these ended <code>OK</code> and were invisible. Emits <code>hermes.api.error.count{error_type,status_class,retryable}</code> and <code>hermes.retry.count</code>.</p>
 <h4>Attribute conventions</h4>
 <p>The plugin emits <strong>dual-convention</strong> attributes so both backends work:</p>
 <table>
@@ -722,7 +731,7 @@ traceparent = get_current_traceparent(session_id)   # &quot;00-&lt;trace&gt;-&lt
 </tr>
 <tr>
 <td><code>__init__.py</code></td>
-<td>Entry point — initializes tracer, registers core hooks (+ session hooks when supported)</td>
+<td>Entry point — initializes tracer, registers core hooks (+ session and sub-agent hooks when supported)</td>
 </tr>
 <tr>
 <td><code>tracer.py</code></td>
@@ -892,11 +901,11 @@ traceparent = get_current_traceparent(session_id)   # &quot;00-&lt;trace&gt;-&lt
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 316</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 246</div>
+        <div class="stars">★ 247</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -920,7 +929,7 @@ traceparent = get_current_traceparent(session_id)   # &quot;00-&lt;trace&gt;-&lt
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 290</div>
+        <div class="stars">★ 291</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
     </div>

--- a/projects/bryercowan/hermes-embodied.html
+++ b/projects/bryercowan/hermes-embodied.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -315,7 +315,7 @@
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/ucsandman/DashClaw">
-        <div class="stars">★ 277</div>
+        <div class="stars">★ 278</div>
         <div class="name"><span class="org">ucsandman /</span> DashClaw</div>
       </a>
       <a class="related-row" href="/projects/Lethe044/hermes-incident-commander">
@@ -323,7 +323,7 @@
         <div class="name"><span class="org">Lethe044 /</span> hermes-incident-commander</div>
       </a>
       <a class="related-row" href="/projects/Christabel337/job-scout-agent">
-        <div class="stars">★ 47</div>
+        <div class="stars">★ 48</div>
         <div class="name"><span class="org">Christabel337 /</span> job-scout-agent</div>
       </a>
       <a class="related-row" href="/projects/rodmarkun/anihermes">

--- a/projects/builderz-labs/mission-control.html
+++ b/projects/builderz-labs/mission-control.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 5422
+    "userInteractionCount": 5428
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -854,7 +854,7 @@ pnpm dev                    # http://localhost:3000/setup
         <div class="name"><span class="org">runtimenoteslabs /</span> gladiator</div>
       </a>
       <a class="related-row" href="/projects/1ilkhamov/opencode-hermes-multiagent">
-        <div class="stars">★ 152</div>
+        <div class="stars">★ 153</div>
         <div class="name"><span class="org">1ilkhamov /</span> opencode-hermes-multiagent</div>
       </a>
       <a class="related-row" href="/projects/Rainhoole/hermes-agent-acp-skill">

--- a/projects/cablate/Agentic-MCP-Skill.html
+++ b/projects/cablate/Agentic-MCP-Skill.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -453,7 +453,7 @@ agentic-mcp call playwright browser_click --params &#39;{&quot;element&quot;: &q
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills">
-        <div class="stars">★ 21.5K</div>
+        <div class="stars">★ 21.7K</div>
         <div class="name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</div>
       </a>
       <a class="related-row" href="/projects/conorbronsdon/avoid-ai-writing">
@@ -477,7 +477,7 @@ agentic-mcp call playwright browser_click --params &#39;{&quot;element&quot;: &q
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 192</div>
+        <div class="stars">★ 194</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/campfirein/byterover-cli.html
+++ b/projects/campfirein/byterover-cli.html
@@ -52,7 +52,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 4878
+    "userInteractionCount": 4882
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -590,7 +590,7 @@ brv debug            # Debug mode
         <div class="name"><span class="org">greyhaven-ai /</span> autocontext</div>
       </a>
       <a class="related-row" href="/projects/elkimek/honcho-self-hosted">
-        <div class="stars">★ 328</div>
+        <div class="stars">★ 329</div>
         <div class="name"><span class="org">elkimek /</span> honcho-self-hosted</div>
       </a>
       <a class="related-row" href="/projects/yoloshii/ClawMem">
@@ -598,7 +598,7 @@ brv debug            # Debug mode
         <div class="name"><span class="org">yoloshii /</span> ClawMem</div>
       </a>
       <a class="related-row" href="/projects/Signet-AI/signetai">
-        <div class="stars">★ 203</div>
+        <div class="stars">★ 205</div>
         <div class="name"><span class="org">Signet-AI /</span> signetai</div>
       </a>
       <a class="related-row" href="/projects/plur-ai/plur">

--- a/projects/carterwayneskhizeine/hermes-agent-windows-R.html
+++ b/projects/carterwayneskhizeine/hermes-agent-windows-R.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -244,7 +244,7 @@ cd ..
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/sheawinkler/hermes-agent-ultra">
-        <div class="stars">★ 56</div>
+        <div class="stars">★ 57</div>
         <div class="name"><span class="org">sheawinkler /</span> hermes-agent-ultra</div>
       </a>
       <a class="related-row" href="/projects/pengchengxia75-arch/hermes-agent-windows">

--- a/projects/chigwell/skilldock.io.html
+++ b/projects/chigwell/skilldock.io.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -405,7 +405,7 @@ The exact details are derived from the OpenAPI <code>securitySchemes</code> when
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills">
-        <div class="stars">★ 21.5K</div>
+        <div class="stars">★ 21.7K</div>
         <div class="name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</div>
       </a>
       <a class="related-row" href="/projects/conorbronsdon/avoid-ai-writing">
@@ -429,7 +429,7 @@ The exact details are derived from the OpenAPI <code>securitySchemes</code> when
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 192</div>
+        <div class="stars">★ 194</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/clawshell/clawshell.html
+++ b/projects/clawshell/clawshell.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -469,11 +469,11 @@ hermes config set model.api_key  &lt;your-clawshell-virtual-key&gt;
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 316</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 246</div>
+        <div class="stars">★ 247</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -497,7 +497,7 @@ hermes config set model.api_key  &lt;your-clawshell-virtual-key&gt;
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 290</div>
+        <div class="stars">★ 291</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
     </div>

--- a/projects/clawvader-tech/hermes-telegram-miniapp.html
+++ b/projects/clawvader-tech/hermes-telegram-miniapp.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -571,8 +571,12 @@ Optional Local Models (CPU)
         <div class="stars">★ 85</div>
         <div class="name"><span class="org">Euraika-Labs /</span> pan-ui</div>
       </a>
+      <a class="related-row" href="/projects/abundantbeing/hermes-browser-extension">
+        <div class="stars">★ 95</div>
+        <div class="name"><span class="org">abundantbeing /</span> hermes-browser-extension</div>
+      </a>
       <a class="related-row" href="/projects/Eynzof/hermes-agent-cn-desktop">
-        <div class="stars">★ 578</div>
+        <div class="stars">★ 584</div>
         <div class="name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       </a>
       <a class="related-row" href="/projects/Felix-Forever/hermes-agent-desktop">
@@ -582,10 +586,6 @@ Optional Local Models (CPU)
       <a class="related-row" href="/projects/jazzyalex/agent-sessions">
         <div class="stars">★ 661</div>
         <div class="name"><span class="org">jazzyalex /</span> agent-sessions</div>
-      </a>
-      <a class="related-row" href="/projects/nickvasilescu/hermes-desktop-os1">
-        <div class="stars">★ 479</div>
-        <div class="name"><span class="org">nickvasilescu /</span> hermes-desktop-os1</div>
       </a>
     </div>
     <p class="list-link"><a href="/lists/workspaces-and-guis">see all workspaces &amp; guis →</a></p>

--- a/projects/colbymchenry/codegraph.html
+++ b/projects/colbymchenry/codegraph.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 54767
+    "userInteractionCount": 54917
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Pre-indexed code knowledge graph, auto syncs on code changes, for Claude Code, Codex, Gemini, Cursor, OpenCode, AntiGravity, Kiro, and Hermes Agent — fewer tokens, fewer tool calls, 100% local</p>
 
   <div class="meta-row">
-    <span class="stars">★ 54.8K</span>
+    <span class="stars">★ 54.9K</span>
     <span><span class="meta-label">lang</span>TypeScript</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -1579,7 +1579,7 @@ is written):</p>
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/Salomondiei08/oh-my-hermes">
-        <div class="stars">★ 658</div>
+        <div class="stars">★ 659</div>
         <div class="name"><span class="org">Salomondiei08 /</span> oh-my-hermes</div>
       </a>
       <a class="related-row" href="/projects/liaohch3/claude-tap">
@@ -1595,7 +1595,7 @@ is written):</p>
         <div class="name"><span class="org">junhoyeo /</span> tokscale</div>
       </a>
       <a class="related-row" href="/projects/joeynyc/hermes-skins">
-        <div class="stars">★ 471</div>
+        <div class="stars">★ 472</div>
         <div class="name"><span class="org">joeynyc /</span> hermes-skins</div>
       </a>
       <a class="related-row" href="/projects/AlexAI-MCP/hermes-CCC">

--- a/projects/conorbronsdon/avoid-ai-writing.html
+++ b/projects/conorbronsdon/avoid-ai-writing.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 2011
+    "userInteractionCount": 2016
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -749,7 +749,7 @@ map that keeps <code>SKILL.md</code> and the engine in sync.</p>
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills">
-        <div class="stars">★ 21.5K</div>
+        <div class="stars">★ 21.7K</div>
         <div class="name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</div>
       </a>
       <a class="related-row" href="/projects/wondelai/skills">
@@ -769,7 +769,7 @@ map that keeps <code>SKILL.md</code> and the engine in sync.</p>
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 192</div>
+        <div class="stars">★ 194</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/dodo-reach/hermes-desktop.html
+++ b/projects/dodo-reach/hermes-desktop.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 1927
+    "userInteractionCount": 1926
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -562,8 +562,12 @@ because it is technically possible.</p>
         <div class="stars">★ 85</div>
         <div class="name"><span class="org">Euraika-Labs /</span> pan-ui</div>
       </a>
+      <a class="related-row" href="/projects/abundantbeing/hermes-browser-extension">
+        <div class="stars">★ 95</div>
+        <div class="name"><span class="org">abundantbeing /</span> hermes-browser-extension</div>
+      </a>
       <a class="related-row" href="/projects/Eynzof/hermes-agent-cn-desktop">
-        <div class="stars">★ 578</div>
+        <div class="stars">★ 584</div>
         <div class="name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       </a>
       <a class="related-row" href="/projects/Felix-Forever/hermes-agent-desktop">
@@ -573,10 +577,6 @@ because it is technically possible.</p>
       <a class="related-row" href="/projects/jazzyalex/agent-sessions">
         <div class="stars">★ 661</div>
         <div class="name"><span class="org">jazzyalex /</span> agent-sessions</div>
-      </a>
-      <a class="related-row" href="/projects/nickvasilescu/hermes-desktop-os1">
-        <div class="stars">★ 479</div>
-        <div class="name"><span class="org">nickvasilescu /</span> hermes-desktop-os1</div>
       </a>
     </div>
     <p class="list-link"><a href="/lists/workspaces-and-guis">see all workspaces &amp; guis →</a></p>

--- a/projects/elkimek/honcho-self-hosted.html
+++ b/projects/elkimek/honcho-self-hosted.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 328
+    "userInteractionCount": 329
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Self-host Honcho memory layer for Hermes Agent — OpenRouter + Venice, no code changes</p>
 
   <div class="meta-row">
-    <span class="stars">★ 328</span>
+    <span class="stars">★ 329</span>
     <span><span class="meta-label">lang</span>Shell</span>
     <span><span class="meta-label">license</span>GPL-3.0</span>
     
@@ -604,7 +604,7 @@ sudo systemctl restart honcho-mcp
         <div class="name"><span class="org">yoloshii /</span> ClawMem</div>
       </a>
       <a class="related-row" href="/projects/Signet-AI/signetai">
-        <div class="stars">★ 203</div>
+        <div class="stars">★ 205</div>
         <div class="name"><span class="org">Signet-AI /</span> signetai</div>
       </a>
       <a class="related-row" href="/projects/plur-ai/plur">

--- a/projects/ellickjohnson/portainer-stack-hermes.html
+++ b/projects/ellickjohnson/portainer-stack-hermes.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -187,7 +187,7 @@
         <div class="name"><span class="org">TheAiSingularity /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/0xrsydn/nix-hermes-agent">
-        <div class="stars">★ 25</div>
+        <div class="stars">★ 26</div>
         <div class="name"><span class="org">0xrsydn /</span> nix-hermes-agent</div>
       </a>
       <a class="related-row" href="/projects/rookiemann/portable-hermes-agent">

--- a/projects/esaradev/icarus-plugin.html
+++ b/projects/esaradev/icarus-plugin.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -522,7 +522,7 @@ scripts/
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills">
-        <div class="stars">★ 21.5K</div>
+        <div class="stars">★ 21.7K</div>
         <div class="name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</div>
       </a>
       <a class="related-row" href="/projects/conorbronsdon/avoid-ai-writing">
@@ -546,7 +546,7 @@ scripts/
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 192</div>
+        <div class="stars">★ 194</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/chigwell/skilldock.io">

--- a/projects/farion1231/cc-switch.html
+++ b/projects/farion1231/cc-switch.html
@@ -47,13 +47,13 @@
     "name": "farion1231",
     "url": "https://github.com/farion1231"
   },
-  "dateModified": "2026-06-26T03:27:04.000Z",
+  "dateModified": "2026-06-26T08:04:24.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 108709
+    "userInteractionCount": 108925
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">A cross-platform desktop All-in-One assistant for Claude Code, Codex, OpenCode, OpenClaw, Gemini CLI &amp; Hermes Agent. Only official website: ccswitch.io</p>
 
   <div class="meta-row">
-    <span class="stars">★ 108.7K</span>
+    <span class="stars">★ 108.9K</span>
     <span><span class="meta-label">lang</span>Rust</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -164,8 +164,8 @@
 <details open>
 <summary>Click to collapse</summary>
 
-<p><a href="https://platform.moonshot.cn/console?aff=cc-switch"><img src="https://raw.githubusercontent.com/farion1231/cc-switch/main/assets/partners/banners/kimi-banner-en.png" alt="Kimi K2.6"></a></p>
-<p>Kimi K2.6 is an open-source, native multimodal agentic model from Moonshot AI, built for long-horizon coding, coding-driven design, and swarm-based task orchestration. It is designed to handle complex end-to-end engineering work across front-end, DevOps, performance optimization, and full-stack workflows, while coordinating large groups of specialized agents to plan, implement, test, and iterate on real coding tasks. <strong><a href="https://platform.moonshot.cn/console?aff=cc-switch">Click here to start using Kimi</a></strong></p>
+<p><a href="https://platform.moonshot.cn/console?aff=cc-switch"><img src="https://raw.githubusercontent.com/farion1231/cc-switch/main/assets/partners/banners/kimi-banner-en.png" alt="Kimi K2.7 Code"></a></p>
+<p>Kimi K2.7 Code is an open-source, coding-focused agentic model developed by Moonshot AI. It delivers stronger coding and agent performance, with substantial improvements in real-world long-horizon coding tasks. These gains translate into higher end-to-end task success rates across complex software engineering workflows. K2.7 Code also improves reasoning efficiency, reducing thinking-token usage by approximately 30% compared with K2.6. <strong><a href="https://platform.moonshot.cn/console?aff=cc-switch">Click here to start using Kimi</a></strong></p>
 <hr>
 <table>
 <tr>
@@ -655,8 +655,12 @@ pnpm test:unit --coverage
         <div class="stars">★ 85</div>
         <div class="name"><span class="org">Euraika-Labs /</span> pan-ui</div>
       </a>
+      <a class="related-row" href="/projects/abundantbeing/hermes-browser-extension">
+        <div class="stars">★ 95</div>
+        <div class="name"><span class="org">abundantbeing /</span> hermes-browser-extension</div>
+      </a>
       <a class="related-row" href="/projects/Eynzof/hermes-agent-cn-desktop">
-        <div class="stars">★ 578</div>
+        <div class="stars">★ 584</div>
         <div class="name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       </a>
       <a class="related-row" href="/projects/Felix-Forever/hermes-agent-desktop">
@@ -666,10 +670,6 @@ pnpm test:unit --coverage
       <a class="related-row" href="/projects/jazzyalex/agent-sessions">
         <div class="stars">★ 661</div>
         <div class="name"><span class="org">jazzyalex /</span> agent-sessions</div>
-      </a>
-      <a class="related-row" href="/projects/nickvasilescu/hermes-desktop-os1">
-        <div class="stars">★ 479</div>
-        <div class="name"><span class="org">nickvasilescu /</span> hermes-desktop-os1</div>
       </a>
     </div>
     <p class="list-link"><a href="/lists/workspaces-and-guis">see all workspaces &amp; guis →</a></p>

--- a/projects/fathah/hermes-desktop.html
+++ b/projects/fathah/hermes-desktop.html
@@ -47,13 +47,13 @@
     "name": "fathah",
     "url": "https://github.com/fathah"
   },
-  "dateModified": "2026-06-26T05:52:18.000Z",
+  "dateModified": "2026-06-26T13:22:00.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 12734
+    "userInteractionCount": 12744
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -183,12 +183,13 @@
  </a>
 </p>
 
-<p><a href="https://ko-fi.com/D1D41ZEKFO"><img src="https://ko-fi.com/img/githubbutton_sm.svg" alt="ko-fi"></a></p>
+
 <blockquote>
 <p><strong>This project is in active development.</strong> Features may change, and some things might break. If you run into a problem or have an idea, <a href="https://github.com/fathah/hermes-desktop/issues">open an issue</a>. Contributions are welcome!</p>
 </blockquote>
 <p>Hermes One is a community maintained native desktop app for installing, configuring, and chatting with <a href="https://github.com/NousResearch/hermes-agent">Hermes Agent</a> — a self-improving AI assistant with tool use, multi-platform messaging, and a closed learning loop.</p>
 <p>Instead of managing the CLI by hand, the app walks through install, provider setup, and day-to-day usage in one place. It uses the official Hermes install script, stores Hermes in <code>~/.hermes</code>, and gives you a GUI for chat, sessions, profiles, memory, skills, tools, scheduling, messaging gateways, and more.</p>
+<p><a href="https://ko-fi.com/D1D41ZEKFO"><img src="https://ko-fi.com/img/githubbutton_sm.svg" alt="ko-fi"></a></p>
 <h3>Sponsors</h3>
 <blockquote>
 <p><a href="mailto:fathah@hermesone.org">Want to appear here?</a></p>
@@ -565,8 +566,12 @@ helper loop.</li>
         <div class="stars">★ 85</div>
         <div class="name"><span class="org">Euraika-Labs /</span> pan-ui</div>
       </a>
+      <a class="related-row" href="/projects/abundantbeing/hermes-browser-extension">
+        <div class="stars">★ 95</div>
+        <div class="name"><span class="org">abundantbeing /</span> hermes-browser-extension</div>
+      </a>
       <a class="related-row" href="/projects/Eynzof/hermes-agent-cn-desktop">
-        <div class="stars">★ 578</div>
+        <div class="stars">★ 584</div>
         <div class="name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       </a>
       <a class="related-row" href="/projects/Felix-Forever/hermes-agent-desktop">
@@ -580,10 +585,6 @@ helper loop.</li>
       <a class="related-row" href="/projects/nickvasilescu/hermes-desktop-os1">
         <div class="stars">★ 479</div>
         <div class="name"><span class="org">nickvasilescu /</span> hermes-desktop-os1</div>
-      </a>
-      <a class="related-row" href="/projects/farion1231/cc-switch">
-        <div class="stars">★ 108.7K</div>
-        <div class="name"><span class="org">farion1231 /</span> cc-switch</div>
       </a>
     </div>
     <p class="list-link"><a href="/lists/workspaces-and-guis">see all workspaces &amp; guis →</a></p>

--- a/projects/futurebrowser/hermes-exabase-plugin.html
+++ b/projects/futurebrowser/hermes-exabase-plugin.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -252,7 +252,7 @@ memory extraction.</p>
         <div class="name"><span class="org">greyhaven-ai /</span> autocontext</div>
       </a>
       <a class="related-row" href="/projects/elkimek/honcho-self-hosted">
-        <div class="stars">★ 328</div>
+        <div class="stars">★ 329</div>
         <div class="name"><span class="org">elkimek /</span> honcho-self-hosted</div>
       </a>
       <a class="related-row" href="/projects/yoloshii/ClawMem">
@@ -260,7 +260,7 @@ memory extraction.</p>
         <div class="name"><span class="org">yoloshii /</span> ClawMem</div>
       </a>
       <a class="related-row" href="/projects/Signet-AI/signetai">
-        <div class="stars">★ 203</div>
+        <div class="stars">★ 205</div>
         <div class="name"><span class="org">Signet-AI /</span> signetai</div>
       </a>
       <a class="related-row" href="/projects/plur-ai/plur">

--- a/projects/garrytan/gbrain.html
+++ b/projects/garrytan/gbrain.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 24154
+    "userInteractionCount": 24185
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -489,7 +489,7 @@ completes in ~1-2 seconds. (Closes #1605, #1581.)</p>
         <div class="name"><span class="org">greyhaven-ai /</span> autocontext</div>
       </a>
       <a class="related-row" href="/projects/elkimek/honcho-self-hosted">
-        <div class="stars">★ 328</div>
+        <div class="stars">★ 329</div>
         <div class="name"><span class="org">elkimek /</span> honcho-self-hosted</div>
       </a>
       <a class="related-row" href="/projects/yoloshii/ClawMem">
@@ -497,7 +497,7 @@ completes in ~1-2 seconds. (Closes #1605, #1581.)</p>
         <div class="name"><span class="org">yoloshii /</span> ClawMem</div>
       </a>
       <a class="related-row" href="/projects/Signet-AI/signetai">
-        <div class="stars">★ 203</div>
+        <div class="stars">★ 205</div>
         <div class="name"><span class="org">Signet-AI /</span> signetai</div>
       </a>
       <a class="related-row" href="/projects/plur-ai/plur">

--- a/projects/gizdusum/hermes-blockchain-oracle.html
+++ b/projects/gizdusum/hermes-blockchain-oracle.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -480,7 +480,7 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
         <div class="name"><span class="org">kevinmarmstrong /</span> hermes-claude-code-rc</div>
       </a>
       <a class="related-row" href="/projects/AaronWong1999/hermesclaw">
-        <div class="stars">★ 647</div>
+        <div class="stars">★ 648</div>
         <div class="name"><span class="org">AaronWong1999 /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/Codename-11/hermes-relay">

--- a/projects/greyhaven-ai/autocontext.html
+++ b/projects/greyhaven-ai/autocontext.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 1224
+    "userInteractionCount": 1225
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -568,7 +568,7 @@ Yes. Wire <code>autoctx mcp-serve</code> (or <code>bunx autoctx mcp-serve</code>
         <div class="name"><span class="org">vectorize-io /</span> hindsight</div>
       </a>
       <a class="related-row" href="/projects/elkimek/honcho-self-hosted">
-        <div class="stars">★ 328</div>
+        <div class="stars">★ 329</div>
         <div class="name"><span class="org">elkimek /</span> honcho-self-hosted</div>
       </a>
       <a class="related-row" href="/projects/yoloshii/ClawMem">
@@ -576,7 +576,7 @@ Yes. Wire <code>autoctx mcp-serve</code> (or <code>bunx autoctx mcp-serve</code>
         <div class="name"><span class="org">yoloshii /</span> ClawMem</div>
       </a>
       <a class="related-row" href="/projects/Signet-AI/signetai">
-        <div class="stars">★ 203</div>
+        <div class="stars">★ 205</div>
         <div class="name"><span class="org">Signet-AI /</span> signetai</div>
       </a>
       <a class="related-row" href="/projects/plur-ai/plur">

--- a/projects/hlothaire/hermes-trace.html
+++ b/projects/hlothaire/hermes-trace.html
@@ -74,7 +74,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -400,11 +400,11 @@ development.</p>
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 316</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 246</div>
+        <div class="stars">★ 247</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -428,7 +428,7 @@ development.</p>
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 290</div>
+        <div class="stars">★ 291</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
     </div>

--- a/projects/howdymary/hermes-agent-metaharness.html
+++ b/projects/howdymary/hermes-agent-metaharness.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -353,7 +353,7 @@ and how they map onto this repo&#39;s next steps.</p>
         <div class="name"><span class="org">runtimenoteslabs /</span> gladiator</div>
       </a>
       <a class="related-row" href="/projects/1ilkhamov/opencode-hermes-multiagent">
-        <div class="stars">★ 152</div>
+        <div class="stars">★ 153</div>
         <div class="name"><span class="org">1ilkhamov /</span> opencode-hermes-multiagent</div>
       </a>
       <a class="related-row" href="/projects/Rainhoole/hermes-agent-acp-skill">

--- a/projects/hxsteric/mercury.html
+++ b/projects/hxsteric/mercury.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -301,7 +301,7 @@ python3 scripts/dashboard_server.py \
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/ucsandman/DashClaw">
-        <div class="stars">★ 277</div>
+        <div class="stars">★ 278</div>
         <div class="name"><span class="org">ucsandman /</span> DashClaw</div>
       </a>
       <a class="related-row" href="/projects/Lethe044/hermes-incident-commander">
@@ -309,7 +309,7 @@ python3 scripts/dashboard_server.py \
         <div class="name"><span class="org">Lethe044 /</span> hermes-incident-commander</div>
       </a>
       <a class="related-row" href="/projects/Christabel337/job-scout-agent">
-        <div class="stars">★ 47</div>
+        <div class="stars">★ 48</div>
         <div class="name"><span class="org">Christabel337 /</span> job-scout-agent</div>
       </a>
       <a class="related-row" href="/projects/rodmarkun/anihermes">

--- a/projects/iOfficeAI/AionUi.html
+++ b/projects/iOfficeAI/AionUi.html
@@ -47,13 +47,13 @@
     "name": "iOfficeAI",
     "url": "https://github.com/iOfficeAI"
   },
-  "dateModified": "2026-06-26T07:50:17.000Z",
+  "dateModified": "2026-06-26T14:18:14.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 28886
+    "userInteractionCount": 28906
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -921,8 +921,12 @@ bun run test       # run unit tests
         <div class="stars">★ 85</div>
         <div class="name"><span class="org">Euraika-Labs /</span> pan-ui</div>
       </a>
+      <a class="related-row" href="/projects/abundantbeing/hermes-browser-extension">
+        <div class="stars">★ 95</div>
+        <div class="name"><span class="org">abundantbeing /</span> hermes-browser-extension</div>
+      </a>
       <a class="related-row" href="/projects/Eynzof/hermes-agent-cn-desktop">
-        <div class="stars">★ 578</div>
+        <div class="stars">★ 584</div>
         <div class="name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       </a>
       <a class="related-row" href="/projects/Felix-Forever/hermes-agent-desktop">
@@ -932,10 +936,6 @@ bun run test       # run unit tests
       <a class="related-row" href="/projects/jazzyalex/agent-sessions">
         <div class="stars">★ 661</div>
         <div class="name"><span class="org">jazzyalex /</span> agent-sessions</div>
-      </a>
-      <a class="related-row" href="/projects/nickvasilescu/hermes-desktop-os1">
-        <div class="stars">★ 479</div>
-        <div class="name"><span class="org">nickvasilescu /</span> hermes-desktop-os1</div>
       </a>
     </div>
     <p class="list-link"><a href="/lists/workspaces-and-guis">see all workspaces &amp; guis →</a></p>

--- a/projects/indranilbanerjee/digital-marketing-pro.html
+++ b/projects/indranilbanerjee/digital-marketing-pro.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 162
+    "userInteractionCount": 163
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Open-source AI marketing plugin for agencies &amp; in-house teams — 158 skills, 25 specialist agents, 12-Part Strategy Flow, Cowork team-persistent, EU AI Act Article 50 ready, 6-platform AEO/GEO incl. Google AI Mode. Installs on Claude Code, Cowork, Codex, Cursor, Copilot CLI, Antigravity. MIT-licensed.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 162</span>
+    <span class="stars">★ 163</span>
     <span><span class="meta-label">lang</span>Python</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -1039,11 +1039,11 @@ Removed the v3.6 / v3.7 era invented manifests for OpenAI Codex (<code>.codex-pl
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 316</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 246</div>
+        <div class="stars">★ 247</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -1067,7 +1067,7 @@ Removed the v3.6 / v3.7 era invented manifests for OpenAI Codex (<code>.codex-pl
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 290</div>
+        <div class="stars">★ 291</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
     </div>

--- a/projects/indranilbanerjee/socialforge.html
+++ b/projects/indranilbanerjee/socialforge.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -641,11 +641,11 @@ claude plugin install socialforge@neels-plugins
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 316</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 246</div>
+        <div class="stars">★ 247</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -669,7 +669,7 @@ claude plugin install socialforge@neels-plugins
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 290</div>
+        <div class="stars">★ 291</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
     </div>

--- a/projects/jau123/MeiGen-AI-Design-MCP.html
+++ b/projects/jau123/MeiGen-AI-Design-MCP.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 1491
+    "userInteractionCount": 1493
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -563,11 +563,11 @@ Response: { &quot;success&quot;: true, &quot;presignedUrl&quot;: &quot;https://.
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 316</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 246</div>
+        <div class="stars">★ 247</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -591,7 +591,7 @@ Response: { &quot;success&quot;: true, &quot;presignedUrl&quot;: &quot;https://.
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 290</div>
+        <div class="stars">★ 291</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
     </div>

--- a/projects/jazzyalex/agent-sessions.html
+++ b/projects/jazzyalex/agent-sessions.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -369,8 +369,12 @@ open &quot;/Applications/Agent Sessions.app&quot;
         <div class="stars">★ 85</div>
         <div class="name"><span class="org">Euraika-Labs /</span> pan-ui</div>
       </a>
+      <a class="related-row" href="/projects/abundantbeing/hermes-browser-extension">
+        <div class="stars">★ 95</div>
+        <div class="name"><span class="org">abundantbeing /</span> hermes-browser-extension</div>
+      </a>
       <a class="related-row" href="/projects/Eynzof/hermes-agent-cn-desktop">
-        <div class="stars">★ 578</div>
+        <div class="stars">★ 584</div>
         <div class="name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       </a>
       <a class="related-row" href="/projects/Felix-Forever/hermes-agent-desktop">
@@ -380,10 +384,6 @@ open &quot;/Applications/Agent Sessions.app&quot;
       <a class="related-row" href="/projects/nickvasilescu/hermes-desktop-os1">
         <div class="stars">★ 479</div>
         <div class="name"><span class="org">nickvasilescu /</span> hermes-desktop-os1</div>
-      </a>
-      <a class="related-row" href="/projects/farion1231/cc-switch">
-        <div class="stars">★ 108.7K</div>
-        <div class="name"><span class="org">farion1231 /</span> cc-switch</div>
       </a>
     </div>
     <p class="list-link"><a href="/lists/workspaces-and-guis">see all workspaces &amp; guis →</a></p>

--- a/projects/jefferyjob/awesome-hermes-agent-zh.html
+++ b/projects/jefferyjob/awesome-hermes-agent-zh.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>

--- a/projects/joeynyc/hermes-skins.html
+++ b/projects/joeynyc/hermes-skins.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 471
+    "userInteractionCount": 472
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Custom skins (visual themes) for the Hermes CLI agent</p>
 
   <div class="meta-row">
-    <span class="stars">★ 471</span>
+    <span class="stars">★ 472</span>
     <span><span class="meta-label">lang</span>Python</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -320,11 +320,11 @@ branding:
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/colbymchenry/codegraph">
-        <div class="stars">★ 54.8K</div>
+        <div class="stars">★ 54.9K</div>
         <div class="name"><span class="org">colbymchenry /</span> codegraph</div>
       </a>
       <a class="related-row" href="/projects/Salomondiei08/oh-my-hermes">
-        <div class="stars">★ 658</div>
+        <div class="stars">★ 659</div>
         <div class="name"><span class="org">Salomondiei08 /</span> oh-my-hermes</div>
       </a>
       <a class="related-row" href="/projects/liaohch3/claude-tap">

--- a/projects/jpalmae/hermeshq.html
+++ b/projects/jpalmae/hermeshq.html
@@ -52,7 +52,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 12
+    "userInteractionCount": 13
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -111,7 +111,7 @@
   <p class="project-desc">HermesHQ is a Docker-first control plane for running and operating multiple Hermes Agent instances from one web application.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 12</span>
+    <span class="stars">★ 13</span>
     <span><span class="meta-label">lang</span>Python</span>
     
     
@@ -609,7 +609,7 @@ tts:
         <div class="name"><span class="org">TheAiSingularity /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/0xrsydn/nix-hermes-agent">
-        <div class="stars">★ 25</div>
+        <div class="stars">★ 26</div>
         <div class="name"><span class="org">0xrsydn /</span> nix-hermes-agent</div>
       </a>
       <a class="related-row" href="/projects/rookiemann/portable-hermes-agent">

--- a/projects/junhoyeo/tokscale.html
+++ b/projects/junhoyeo/tokscale.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 3963
+    "userInteractionCount": 3969
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -1392,11 +1392,11 @@ tokscale codex status --name personal --json
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/colbymchenry/codegraph">
-        <div class="stars">★ 54.8K</div>
+        <div class="stars">★ 54.9K</div>
         <div class="name"><span class="org">colbymchenry /</span> codegraph</div>
       </a>
       <a class="related-row" href="/projects/Salomondiei08/oh-my-hermes">
-        <div class="stars">★ 658</div>
+        <div class="stars">★ 659</div>
         <div class="name"><span class="org">Salomondiei08 /</span> oh-my-hermes</div>
       </a>
       <a class="related-row" href="/projects/liaohch3/claude-tap">
@@ -1408,7 +1408,7 @@ tokscale codex status --name personal --json
         <div class="name"><span class="org">adityahimaone /</span> hermes-agent-rtk-caveman</div>
       </a>
       <a class="related-row" href="/projects/joeynyc/hermes-skins">
-        <div class="stars">★ 471</div>
+        <div class="stars">★ 472</div>
         <div class="name"><span class="org">joeynyc /</span> hermes-skins</div>
       </a>
       <a class="related-row" href="/projects/AlexAI-MCP/hermes-CCC">

--- a/projects/jwangkun/hermes-agent-guide.html
+++ b/projects/jwangkun/hermes-agent-guide.html
@@ -52,7 +52,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 416
+    "userInteractionCount": 422
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -111,7 +111,7 @@
   <p class="project-desc">Hermes Agent 是目前开源社区最具潜力的 AI Agent 框架之一。它继承了 OpenClaw 的优秀基因，在架构设计、记忆系统、技能生态和自动化能力上实现全面升级。但 Hermes 的文档分散在多个仓库和平台，缺乏一本系统性的中文指南。  本书填补的正是这个空白。全书 16 册、30 万+ 字，覆盖从安装部署到高阶开发、从个人玩赚到企业服务、从单 Agent 操控到多 Agent 编排的完整知识图谱。</p>
 
   <div class="meta-row">
-    <span class="stars">★ 416</span>
+    <span class="stars">★ 422</span>
     <span><span class="meta-label">lang</span>Python</span>
     
     

--- a/projects/kaminocorp/hermes-alpha.html
+++ b/projects/kaminocorp/hermes-alpha.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -437,7 +437,7 @@ SLACK_BOT_TOKEN=...
         <div class="name"><span class="org">carterwayneskhizeine /</span> hermes-agent-windows-R</div>
       </a>
       <a class="related-row" href="/projects/sheawinkler/hermes-agent-ultra">
-        <div class="stars">★ 56</div>
+        <div class="stars">★ 57</div>
         <div class="name"><span class="org">sheawinkler /</span> hermes-agent-ultra</div>
       </a>
       <a class="related-row" href="/projects/pengchengxia75-arch/hermes-agent-windows">

--- a/projects/keepnotes-ai/keep.html
+++ b/projects/keepnotes-ai/keep.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -364,7 +364,7 @@ versions = kp.list_versions(&quot;doc:1&quot;)
         <div class="name"><span class="org">greyhaven-ai /</span> autocontext</div>
       </a>
       <a class="related-row" href="/projects/elkimek/honcho-self-hosted">
-        <div class="stars">★ 328</div>
+        <div class="stars">★ 329</div>
         <div class="name"><span class="org">elkimek /</span> honcho-self-hosted</div>
       </a>
       <a class="related-row" href="/projects/yoloshii/ClawMem">
@@ -372,7 +372,7 @@ versions = kp.list_versions(&quot;doc:1&quot;)
         <div class="name"><span class="org">yoloshii /</span> ClawMem</div>
       </a>
       <a class="related-row" href="/projects/Signet-AI/signetai">
-        <div class="stars">★ 203</div>
+        <div class="stars">★ 205</div>
         <div class="name"><span class="org">Signet-AI /</span> signetai</div>
       </a>
       <a class="related-row" href="/projects/plur-ai/plur">

--- a/projects/kevinmarmstrong/hermes-claude-code-rc.html
+++ b/projects/kevinmarmstrong/hermes-claude-code-rc.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -400,7 +400,7 @@ Phone (Claude app) &lt;-- claude.ai session URL &lt;-- stdout scan
         <div class="name"><span class="org">gizdusum /</span> hermes-blockchain-oracle</div>
       </a>
       <a class="related-row" href="/projects/AaronWong1999/hermesclaw">
-        <div class="stars">★ 647</div>
+        <div class="stars">★ 648</div>
         <div class="name"><span class="org">AaronWong1999 /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/Codename-11/hermes-relay">

--- a/projects/kfa-ai/hermes-timetree-sync.html
+++ b/projects/kfa-ai/hermes-timetree-sync.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -325,7 +325,7 @@ TIMETREE_PASSWORD=...
         <div class="name"><span class="org">kevinmarmstrong /</span> hermes-claude-code-rc</div>
       </a>
       <a class="related-row" href="/projects/AaronWong1999/hermesclaw">
-        <div class="stars">★ 647</div>
+        <div class="stars">★ 648</div>
         <div class="name"><span class="org">AaronWong1999 /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/Codename-11/hermes-relay">

--- a/projects/ksimback/hermes-ecosystem.html
+++ b/projects/ksimback/hermes-ecosystem.html
@@ -46,13 +46,13 @@
     "name": "ksimback",
     "url": "https://github.com/ksimback"
   },
-  "dateModified": "2026-06-25T08:22:00.000Z",
+  "dateModified": "2026-06-26T07:53:32.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 1061
+    "userInteractionCount": 1064
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -115,7 +115,7 @@
     <span><span class="meta-label">lang</span>HTML</span>
     
     
-    <span><span class="meta-label">updated</span>2026-06-25</span>
+    <span><span class="meta-label">updated</span>2026-06-26</span>
   </div>
 
   <div class="actions">

--- a/projects/liaohch3/claude-tap.html
+++ b/projects/liaohch3/claude-tap.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 2006
+    "userInteractionCount": 2011
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -739,11 +739,11 @@ claude-tap --tap-no-open
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/colbymchenry/codegraph">
-        <div class="stars">★ 54.8K</div>
+        <div class="stars">★ 54.9K</div>
         <div class="name"><span class="org">colbymchenry /</span> codegraph</div>
       </a>
       <a class="related-row" href="/projects/Salomondiei08/oh-my-hermes">
-        <div class="stars">★ 658</div>
+        <div class="stars">★ 659</div>
         <div class="name"><span class="org">Salomondiei08 /</span> oh-my-hermes</div>
       </a>
       <a class="related-row" href="/projects/adityahimaone/hermes-agent-rtk-caveman">
@@ -755,7 +755,7 @@ claude-tap --tap-no-open
         <div class="name"><span class="org">junhoyeo /</span> tokscale</div>
       </a>
       <a class="related-row" href="/projects/joeynyc/hermes-skins">
-        <div class="stars">★ 471</div>
+        <div class="stars">★ 472</div>
         <div class="name"><span class="org">joeynyc /</span> hermes-skins</div>
       </a>
       <a class="related-row" href="/projects/AlexAI-MCP/hermes-CCC">

--- a/projects/liftaris/herm.html
+++ b/projects/liftaris/herm.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 260
+    "userInteractionCount": 261
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">The Hermes TUI built with OpenTUI</p>
 
   <div class="meta-row">
-    <span class="stars">★ 260</span>
+    <span class="stars">★ 261</span>
     <span><span class="meta-label">lang</span>TypeScript</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -329,8 +329,12 @@ runtime Herm operates</li>
         <div class="stars">★ 85</div>
         <div class="name"><span class="org">Euraika-Labs /</span> pan-ui</div>
       </a>
+      <a class="related-row" href="/projects/abundantbeing/hermes-browser-extension">
+        <div class="stars">★ 95</div>
+        <div class="name"><span class="org">abundantbeing /</span> hermes-browser-extension</div>
+      </a>
       <a class="related-row" href="/projects/Eynzof/hermes-agent-cn-desktop">
-        <div class="stars">★ 578</div>
+        <div class="stars">★ 584</div>
         <div class="name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       </a>
       <a class="related-row" href="/projects/Felix-Forever/hermes-agent-desktop">
@@ -340,10 +344,6 @@ runtime Herm operates</li>
       <a class="related-row" href="/projects/jazzyalex/agent-sessions">
         <div class="stars">★ 661</div>
         <div class="name"><span class="org">jazzyalex /</span> agent-sessions</div>
-      </a>
-      <a class="related-row" href="/projects/nickvasilescu/hermes-desktop-os1">
-        <div class="stars">★ 479</div>
-        <div class="name"><span class="org">nickvasilescu /</span> hermes-desktop-os1</div>
       </a>
     </div>
     <p class="list-link"><a href="/lists/workspaces-and-guis">see all workspaces &amp; guis →</a></p>

--- a/projects/linke-ai/hermes-agent-team.html
+++ b/projects/linke-ai/hermes-agent-team.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -359,7 +359,7 @@ pip install -r requirements.txt
         <div class="name"><span class="org">runtimenoteslabs /</span> gladiator</div>
       </a>
       <a class="related-row" href="/projects/1ilkhamov/opencode-hermes-multiagent">
-        <div class="stars">★ 152</div>
+        <div class="stars">★ 153</div>
         <div class="name"><span class="org">1ilkhamov /</span> opencode-hermes-multiagent</div>
       </a>
       <a class="related-row" href="/projects/Rainhoole/hermes-agent-acp-skill">

--- a/projects/longyunfeigu/learn-hermes-agent.html
+++ b/projects/longyunfeigu/learn-hermes-agent.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>

--- a/projects/mag3nt-com/openclaw-skill.html
+++ b/projects/mag3nt-com/openclaw-skill.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -322,7 +322,7 @@ Agent: Calling the market feed API...
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills">
-        <div class="stars">★ 21.5K</div>
+        <div class="stars">★ 21.7K</div>
         <div class="name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</div>
       </a>
       <a class="related-row" href="/projects/conorbronsdon/avoid-ai-writing">
@@ -346,7 +346,7 @@ Agent: Calling the market feed API...
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 192</div>
+        <div class="stars">★ 194</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/marshallrichards/ClawPhone.html
+++ b/projects/marshallrichards/ClawPhone.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -217,7 +217,7 @@ export TEMP=&quot;$TMPDIR&quot;
         <div class="name"><span class="org">TheAiSingularity /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/0xrsydn/nix-hermes-agent">
-        <div class="stars">★ 25</div>
+        <div class="stars">★ 26</div>
         <div class="name"><span class="org">0xrsydn /</span> nix-hermes-agent</div>
       </a>
       <a class="related-row" href="/projects/rookiemann/portable-hermes-agent">

--- a/projects/martymcenroe/HermesWiki.html
+++ b/projects/martymcenroe/HermesWiki.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>

--- a/projects/mem0ai/mem0.html
+++ b/projects/mem0ai/mem0.html
@@ -47,13 +47,13 @@
     "name": "mem0ai",
     "url": "https://github.com/mem0ai"
   },
-  "dateModified": "2026-06-26T07:36:11.000Z",
+  "dateModified": "2026-06-26T14:41:50.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 59479
+    "userInteractionCount": 59502
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -449,7 +449,7 @@ if __name__ == &quot;__main__&quot;:
         <div class="name"><span class="org">greyhaven-ai /</span> autocontext</div>
       </a>
       <a class="related-row" href="/projects/elkimek/honcho-self-hosted">
-        <div class="stars">★ 328</div>
+        <div class="stars">★ 329</div>
         <div class="name"><span class="org">elkimek /</span> honcho-self-hosted</div>
       </a>
       <a class="related-row" href="/projects/yoloshii/ClawMem">
@@ -457,7 +457,7 @@ if __name__ == &quot;__main__&quot;:
         <div class="name"><span class="org">yoloshii /</span> ClawMem</div>
       </a>
       <a class="related-row" href="/projects/Signet-AI/signetai">
-        <div class="stars">★ 203</div>
+        <div class="stars">★ 205</div>
         <div class="name"><span class="org">Signet-AI /</span> signetai</div>
       </a>
       <a class="related-row" href="/projects/plur-ai/plur">

--- a/projects/metantonio/hermes-wsl-ubuntu.html
+++ b/projects/metantonio/hermes-wsl-ubuntu.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>

--- a/projects/mudrii/hermes-agent-docs.html
+++ b/projects/mudrii/hermes-agent-docs.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>

--- a/projects/mukul975/Anthropic-Cybersecurity-Skills.html
+++ b/projects/mukul975/Anthropic-Cybersecurity-Skills.html
@@ -47,13 +47,13 @@
     "name": "mukul975",
     "url": "https://github.com/mukul975"
   },
-  "dateModified": "2026-06-22T17:11:47.000Z",
+  "dateModified": "2026-06-26T14:37:50.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 21479
+    "userInteractionCount": 21659
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,11 +112,11 @@
   <p class="project-desc">817 structured cybersecurity skills for AI agents · Mapped to 6 frameworks: MITRE ATT&amp;CK, NIST CSF 2.0, MITRE ATLAS, D3FEND, NIST AI RMF &amp; MITRE F3 (Fight Fraud) · agentskills.io standard · Works with Claude Code, GitHub Copilot, Codex CLI, Cursor, Gemini CLI &amp; 20+ platforms · 29 security domains · Apache 2.0</p>
 
   <div class="meta-row">
-    <span class="stars">★ 21.5K</span>
+    <span class="stars">★ 21.7K</span>
     <span><span class="meta-label">lang</span>Python</span>
     <span><span class="meta-label">license</span>Apache-2.0</span>
     
-    <span><span class="meta-label">updated</span>2026-06-22</span>
+    <span><span class="meta-label">updated</span>2026-06-26</span>
   </div>
 
   <div class="actions">
@@ -171,7 +171,8 @@
 
 <hr>
 <blockquote>
-<p>⚠️ <strong>Community Project</strong> — This is an independent, community-created project. Not affiliated with Anthropic PBC. </p>
+<p>⚠️ <strong>Community Project</strong> — This is an independent, community-created project. Not affiliated with Anthropic PBC.</p>
+<p>🔐 <strong>Authorized &amp; lawful use only.</strong> This library includes offensive and dual-use techniques (e.g. red-team C2, phishing simulation, exploitation) intended for <strong>authorized penetration testing, security research, defense, and education</strong>. Only use them against systems you own or have <strong>explicit written permission</strong> to test, and comply with all applicable laws and rules of engagement. You are solely responsible for how you use these skills. See <a href="https://github.com/mukul975/Anthropic-Cybersecurity-Skills/blob/main/SECURITY.md">SECURITY.md</a> and <a href="https://github.com/mukul975/Anthropic-Cybersecurity-Skills/blob/main/CODE_OF_CONDUCT.md">CODE_OF_CONDUCT.md</a>.</p>
 </blockquote>
 <h3>Give any AI agent the security skills of a senior analyst</h3>
 <p>A junior analyst knows which Volatility3 plugin to run on a suspicious memory dump, which Sigma rules catch Kerberoasting, and how to scope a cloud breach across three providers. <strong>Your AI agent doesn&#39;t — unless you give it these skills.</strong></p>
@@ -919,7 +920,7 @@ LangChain · CrewAI · AutoGen · Semantic Kernel · Haystack · Vercel AI SDK �
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 192</div>
+        <div class="stars">★ 194</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/nativ3ai/hermes-agent-camel.html
+++ b/projects/nativ3ai/hermes-agent-camel.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -403,7 +403,7 @@ scripts/run_tests.sh
         <div class="name"><span class="org">carterwayneskhizeine /</span> hermes-agent-windows-R</div>
       </a>
       <a class="related-row" href="/projects/sheawinkler/hermes-agent-ultra">
-        <div class="stars">★ 56</div>
+        <div class="stars">★ 57</div>
         <div class="name"><span class="org">sheawinkler /</span> hermes-agent-ultra</div>
       </a>
       <a class="related-row" href="/projects/pengchengxia75-arch/hermes-agent-windows">

--- a/projects/nativ3ai/hermes-payguard.html
+++ b/projects/nativ3ai/hermes-payguard.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -326,11 +326,11 @@ pytest -q
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 316</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 246</div>
+        <div class="stars">★ 247</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -350,7 +350,7 @@ pytest -q
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 290</div>
+        <div class="stars">★ 291</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
       <a class="related-row" href="/projects/clawshell/clawshell">

--- a/projects/ndesv21/socialclaw.html
+++ b/projects/ndesv21/socialclaw.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 45
+    "userInteractionCount": 47
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Social media scheduling CLI and OpenClaw skill for AI agents posting to X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, and Pinterest.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 45</span>
+    <span class="stars">★ 47</span>
     <span><span class="meta-label">lang</span>JavaScript</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -399,7 +399,7 @@ npm publish --access public
         <div class="name"><span class="org">kevinmarmstrong /</span> hermes-claude-code-rc</div>
       </a>
       <a class="related-row" href="/projects/AaronWong1999/hermesclaw">
-        <div class="stars">★ 647</div>
+        <div class="stars">★ 648</div>
         <div class="name"><span class="org">AaronWong1999 /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/Codename-11/hermes-relay">

--- a/projects/nesquena/hermes-webui.html
+++ b/projects/nesquena/hermes-webui.html
@@ -47,13 +47,13 @@
     "name": "nesquena",
     "url": "https://github.com/nesquena"
   },
-  "dateModified": "2026-06-26T07:13:19.000Z",
+  "dateModified": "2026-06-26T13:47:46.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 15041
+    "userInteractionCount": 15060
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Hermes WebUI: The best way to use Hermes Agent from the web or from your phone!</p>
 
   <div class="meta-row">
-    <span class="stars">★ 15.0K</span>
+    <span class="stars">★ 15.1K</span>
     <span><span class="meta-label">lang</span>Python</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -1043,8 +1043,12 @@ Added the Profiles entry to the mobile na</p>
         <div class="stars">★ 85</div>
         <div class="name"><span class="org">Euraika-Labs /</span> pan-ui</div>
       </a>
+      <a class="related-row" href="/projects/abundantbeing/hermes-browser-extension">
+        <div class="stars">★ 95</div>
+        <div class="name"><span class="org">abundantbeing /</span> hermes-browser-extension</div>
+      </a>
       <a class="related-row" href="/projects/Eynzof/hermes-agent-cn-desktop">
-        <div class="stars">★ 578</div>
+        <div class="stars">★ 584</div>
         <div class="name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       </a>
       <a class="related-row" href="/projects/Felix-Forever/hermes-agent-desktop">
@@ -1054,10 +1058,6 @@ Added the Profiles entry to the mobile na</p>
       <a class="related-row" href="/projects/jazzyalex/agent-sessions">
         <div class="stars">★ 661</div>
         <div class="name"><span class="org">jazzyalex /</span> agent-sessions</div>
-      </a>
-      <a class="related-row" href="/projects/nickvasilescu/hermes-desktop-os1">
-        <div class="stars">★ 479</div>
-        <div class="name"><span class="org">nickvasilescu /</span> hermes-desktop-os1</div>
       </a>
     </div>
     <p class="list-link"><a href="/lists/workspaces-and-guis">see all workspaces &amp; guis →</a></p>

--- a/projects/nexu-io/open-design.html
+++ b/projects/nexu-io/open-design.html
@@ -47,13 +47,13 @@
     "name": "nexu-io",
     "url": "https://github.com/nexu-io"
   },
-  "dateModified": "2026-06-26T07:39:28.000Z",
+  "dateModified": "2026-06-26T14:39:40.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 71353
+    "userInteractionCount": 71525
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">🎨 Local-first, open-source Claude Design alternative. 🖥️ Native desktop app. ⚡ 259+ Skills · ✨ 142+ Design Systems 🖼️ Web · desktop · mobile prototypes · slides · images · videos · HyperFrames 📦 Sandboxed preview · HTML/PDF/PPTX/MP4 export 🤖 Claude Code / OpenClaw / Codex / Cursor / OpenCode / Qwen / Copilot / Hermes / Kimi &amp; 17+ CLIs.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 71.4K</span>
+    <span class="stars">★ 71.5K</span>
     <span><span class="meta-label">lang</span>TypeScript</span>
     <span><span class="meta-label">license</span>Apache-2.0</span>
     
@@ -1018,7 +1018,7 @@ gh pr create --fill
 <h3>Contributors</h3>
 <p>Thanks to everyone who has taken part — code, docs, feedback, a sharp issue, a new skill, a new design system.</p>
 <a href="https://github.com/nexu-io/open-design/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=nexu-io/open-design&max=500&columns=20&anon=1&cache_bust=2026-06-23" alt="Open Design contributors" />
+  <img src="https://contrib.rocks/image?repo=nexu-io/open-design&max=500&columns=20&anon=1&cache_bust=2026-06-26" alt="Open Design contributors" />
 </a>
 
 <hr>
@@ -1037,9 +1037,9 @@ gh pr create --fill
 <p>If this saved you thirty minutes, give it a ★. Stars don&#39;t pay rent — but they tell the next designer, agent, and contributor that this experiment is worth their attention. One click, three seconds, a real signal.</p>
 <a href="https://star-history.com/#nexu-io/open-design&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=nexu-io/open-design&type=Date&theme=dark&cache_bust=2026-06-23" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=nexu-io/open-design&type=Date&cache_bust=2026-06-23" />
-    <img alt="Open Design star history" src="https://api.star-history.com/svg?repos=nexu-io/open-design&type=Date&cache_bust=2026-06-23" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=nexu-io/open-design&type=Date&theme=dark&cache_bust=2026-06-26" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=nexu-io/open-design&type=Date&cache_bust=2026-06-26" />
+    <img alt="Open Design star history" src="https://api.star-history.com/svg?repos=nexu-io/open-design&type=Date&cache_bust=2026-06-26" />
   </picture>
 </a>
 
@@ -1079,7 +1079,7 @@ gh pr create --fill
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills">
-        <div class="stars">★ 21.5K</div>
+        <div class="stars">★ 21.7K</div>
         <div class="name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</div>
       </a>
       <a class="related-row" href="/projects/conorbronsdon/avoid-ai-writing">
@@ -1103,7 +1103,7 @@ gh pr create --fill
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 192</div>
+        <div class="stars">★ 194</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/nickvasilescu/hermes-desktop-os1.html
+++ b/projects/nickvasilescu/hermes-desktop-os1.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -342,8 +342,12 @@ for bugs and feature requests.</p>
         <div class="stars">★ 85</div>
         <div class="name"><span class="org">Euraika-Labs /</span> pan-ui</div>
       </a>
+      <a class="related-row" href="/projects/abundantbeing/hermes-browser-extension">
+        <div class="stars">★ 95</div>
+        <div class="name"><span class="org">abundantbeing /</span> hermes-browser-extension</div>
+      </a>
       <a class="related-row" href="/projects/Eynzof/hermes-agent-cn-desktop">
-        <div class="stars">★ 578</div>
+        <div class="stars">★ 584</div>
         <div class="name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       </a>
       <a class="related-row" href="/projects/Felix-Forever/hermes-agent-desktop">
@@ -353,10 +357,6 @@ for bugs and feature requests.</p>
       <a class="related-row" href="/projects/jazzyalex/agent-sessions">
         <div class="stars">★ 661</div>
         <div class="name"><span class="org">jazzyalex /</span> agent-sessions</div>
-      </a>
-      <a class="related-row" href="/projects/farion1231/cc-switch">
-        <div class="stars">★ 108.7K</div>
-        <div class="name"><span class="org">farion1231 /</span> cc-switch</div>
       </a>
     </div>
     <p class="list-link"><a href="/lists/workspaces-and-guis">see all workspaces &amp; guis →</a></p>

--- a/projects/nujovich/hermes-telemetry.html
+++ b/projects/nujovich/hermes-telemetry.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -1289,11 +1289,11 @@ pre_tool_call             Hard budget enforcement (tool-gate)
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 316</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 246</div>
+        <div class="stars">★ 247</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -1317,7 +1317,7 @@ pre_tool_call             Hard budget enforcement (tool-gate)
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 290</div>
+        <div class="stars">★ 291</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
     </div>

--- a/projects/numtide/llm-agents.nix.html
+++ b/projects/numtide/llm-agents.nix.html
@@ -47,13 +47,13 @@
     "name": "numtide",
     "url": "https://github.com/numtide"
   },
-  "dateModified": "2026-06-26T07:19:46.000Z",
+  "dateModified": "2026-06-26T10:13:53.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 1474
+    "userInteractionCount": 1475
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -1615,7 +1615,7 @@ nix run github:numtide/llm-agents.nix#qwen-code
         <div class="name"><span class="org">TheAiSingularity /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/0xrsydn/nix-hermes-agent">
-        <div class="stars">★ 25</div>
+        <div class="stars">★ 26</div>
         <div class="name"><span class="org">0xrsydn /</span> nix-hermes-agent</div>
       </a>
       <a class="related-row" href="/projects/rookiemann/portable-hermes-agent">

--- a/projects/outsourc-e/hermes-workspace.html
+++ b/projects/outsourc-e/hermes-workspace.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 5854
+    "userInteractionCount": 5859
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -990,8 +990,12 @@ hermes dashboard      # dashboard plugin on :9119 (sessions/skills/jobs/config)
         <div class="stars">★ 85</div>
         <div class="name"><span class="org">Euraika-Labs /</span> pan-ui</div>
       </a>
+      <a class="related-row" href="/projects/abundantbeing/hermes-browser-extension">
+        <div class="stars">★ 95</div>
+        <div class="name"><span class="org">abundantbeing /</span> hermes-browser-extension</div>
+      </a>
       <a class="related-row" href="/projects/Eynzof/hermes-agent-cn-desktop">
-        <div class="stars">★ 578</div>
+        <div class="stars">★ 584</div>
         <div class="name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       </a>
       <a class="related-row" href="/projects/Felix-Forever/hermes-agent-desktop">
@@ -1005,10 +1009,6 @@ hermes dashboard      # dashboard plugin on :9119 (sessions/skills/jobs/config)
       <a class="related-row" href="/projects/nickvasilescu/hermes-desktop-os1">
         <div class="stars">★ 479</div>
         <div class="name"><span class="org">nickvasilescu /</span> hermes-desktop-os1</div>
-      </a>
-      <a class="related-row" href="/projects/farion1231/cc-switch">
-        <div class="stars">★ 108.7K</div>
-        <div class="name"><span class="org">farion1231 /</span> cc-switch</div>
       </a>
     </div>
     <p class="list-link"><a href="/lists/workspaces-and-guis">see all workspaces &amp; guis →</a></p>

--- a/projects/pengchengxia75-arch/hermes-agent-windows.html
+++ b/projects/pengchengxia75-arch/hermes-agent-windows.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -254,7 +254,7 @@ hermes            # 启动命令行对话
         <div class="name"><span class="org">carterwayneskhizeine /</span> hermes-agent-windows-R</div>
       </a>
       <a class="related-row" href="/projects/sheawinkler/hermes-agent-ultra">
-        <div class="stars">★ 56</div>
+        <div class="stars">★ 57</div>
         <div class="name"><span class="org">sheawinkler /</span> hermes-agent-ultra</div>
       </a>
       <a class="related-row" href="/projects/nativ3ai/hermes-agent-camel">

--- a/projects/plastic-labs/honcho.html
+++ b/projects/plastic-labs/honcho.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 5551
+    "userInteractionCount": 5560
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -768,7 +768,7 @@ the results.</p>
         <div class="name"><span class="org">greyhaven-ai /</span> autocontext</div>
       </a>
       <a class="related-row" href="/projects/elkimek/honcho-self-hosted">
-        <div class="stars">★ 328</div>
+        <div class="stars">★ 329</div>
         <div class="name"><span class="org">elkimek /</span> honcho-self-hosted</div>
       </a>
       <a class="related-row" href="/projects/yoloshii/ClawMem">
@@ -776,7 +776,7 @@ the results.</p>
         <div class="name"><span class="org">yoloshii /</span> ClawMem</div>
       </a>
       <a class="related-row" href="/projects/Signet-AI/signetai">
-        <div class="stars">★ 203</div>
+        <div class="stars">★ 205</div>
         <div class="name"><span class="org">Signet-AI /</span> signetai</div>
       </a>
       <a class="related-row" href="/projects/plur-ai/plur">

--- a/projects/plur-ai/plur.html
+++ b/projects/plur-ai/plur.html
@@ -47,7 +47,7 @@
     "name": "plur-ai",
     "url": "https://github.com/plur-ai"
   },
-  "dateModified": "2026-06-26T07:36:26.000Z",
+  "dateModified": "2026-06-26T12:52:07.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -519,7 +519,7 @@ pnpm install &amp;&amp; pnpm build &amp;&amp; pnpm test
         <div class="name"><span class="org">greyhaven-ai /</span> autocontext</div>
       </a>
       <a class="related-row" href="/projects/elkimek/honcho-self-hosted">
-        <div class="stars">★ 328</div>
+        <div class="stars">★ 329</div>
         <div class="name"><span class="org">elkimek /</span> honcho-self-hosted</div>
       </a>
       <a class="related-row" href="/projects/yoloshii/ClawMem">
@@ -527,7 +527,7 @@ pnpm install &amp;&amp; pnpm build &amp;&amp; pnpm test
         <div class="name"><span class="org">yoloshii /</span> ClawMem</div>
       </a>
       <a class="related-row" href="/projects/Signet-AI/signetai">
-        <div class="stars">★ 203</div>
+        <div class="stars">★ 205</div>
         <div class="name"><span class="org">Signet-AI /</span> signetai</div>
       </a>
       <a class="related-row" href="/projects/amanning3390/flowstate-qmd">

--- a/projects/pyrate-llama/hermes-ui.html
+++ b/projects/pyrate-llama/hermes-ui.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -772,8 +772,12 @@ tailscale up
         <div class="stars">★ 85</div>
         <div class="name"><span class="org">Euraika-Labs /</span> pan-ui</div>
       </a>
+      <a class="related-row" href="/projects/abundantbeing/hermes-browser-extension">
+        <div class="stars">★ 95</div>
+        <div class="name"><span class="org">abundantbeing /</span> hermes-browser-extension</div>
+      </a>
       <a class="related-row" href="/projects/Eynzof/hermes-agent-cn-desktop">
-        <div class="stars">★ 578</div>
+        <div class="stars">★ 584</div>
         <div class="name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       </a>
       <a class="related-row" href="/projects/Felix-Forever/hermes-agent-desktop">
@@ -783,10 +787,6 @@ tailscale up
       <a class="related-row" href="/projects/jazzyalex/agent-sessions">
         <div class="stars">★ 661</div>
         <div class="name"><span class="org">jazzyalex /</span> agent-sessions</div>
-      </a>
-      <a class="related-row" href="/projects/nickvasilescu/hermes-desktop-os1">
-        <div class="stars">★ 479</div>
-        <div class="name"><span class="org">nickvasilescu /</span> hermes-desktop-os1</div>
       </a>
     </div>
     <p class="list-link"><a href="/lists/workspaces-and-guis">see all workspaces &amp; guis →</a></p>

--- a/projects/raulvidis/hermes-android.html
+++ b/projects/raulvidis/hermes-android.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -591,7 +591,7 @@ cd hermes-android-bridge
         <div class="name"><span class="org">kevinmarmstrong /</span> hermes-claude-code-rc</div>
       </a>
       <a class="related-row" href="/projects/AaronWong1999/hermesclaw">
-        <div class="stars">★ 647</div>
+        <div class="stars">★ 648</div>
         <div class="name"><span class="org">AaronWong1999 /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/Codename-11/hermes-relay">

--- a/projects/raulvidis/hermes-cloudflare.html
+++ b/projects/raulvidis/hermes-cloudflare.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -249,11 +249,11 @@ export CLOUDFLARE_ACCOUNT_ID=&quot;your-account-id&quot;
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 316</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 246</div>
+        <div class="stars">★ 247</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -273,7 +273,7 @@ export CLOUDFLARE_ACCOUNT_ID=&quot;your-account-id&quot;
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 290</div>
+        <div class="stars">★ 291</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
       <a class="related-row" href="/projects/clawshell/clawshell">

--- a/projects/robbyczgw-cla/hermes-web-search-plus.html
+++ b/projects/robbyczgw-cla/hermes-web-search-plus.html
@@ -47,13 +47,13 @@
     "name": "robbyczgw-cla",
     "url": "https://github.com/robbyczgw-cla"
   },
-  "dateModified": "2026-06-25T15:52:31.000Z",
+  "dateModified": "2026-06-26T11:29:10.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 316
+    "userInteractionCount": 315
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,11 +112,11 @@
   <p class="project-desc">Hermes Agent flagship plugin for multi-provider web search and extraction with intelligent routing, quality reports, and research mode.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 316</span>
+    <span class="stars">★ 315</span>
     <span><span class="meta-label">lang</span>Python</span>
     <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-06-25</span>
+    <span><span class="meta-label">updated</span>2026-06-26</span>
   </div>
 
   <div class="actions">
@@ -267,6 +267,16 @@ python ~/.hermes/plugins/web-search-plus/setup.py config set-default you --dry-r
 <li><code>setup.py --config-path /path/to/config.json</code> points the helper at a custom config; <code>WEB_SEARCH_PLUS_CONFIG=/path/to/config.json</code> points <code>search.py</code> at the same file.</li>
 <li><code>config reset --yes</code> backs up the existing file before writing fresh defaults.</li>
 </ul>
+<h4>GroktoCrawl / local Firecrawl-compatible backends</h4>
+<p>The Firecrawl provider can target a local Firecrawl-v2-compatible backend by overriding its search and scrape URLs in <code>config.json</code>. For example, a local <a href="https://github.com/groktopus/groktocrawl">GroktoCrawl</a> instance listening on <code>127.0.0.1:8080</code> can be used without adding a separate provider:</p>
+<pre><code class="language-json">{
+  &quot;firecrawl&quot;: {
+    &quot;api_url&quot;: &quot;http://127.0.0.1:8080/v2/search&quot;,
+    &quot;scrape_url&quot;: &quot;http://127.0.0.1:8080/v2/scrape&quot;
+  }
+}
+</code></pre>
+<p>Keep <code>FIRECRAWL_API_KEY</code> configured if your backend enforces bearer authentication; local development instances may ignore the header. This recipe has been smoke-tested for Firecrawl-style search and URL scrape responses, including GitHub repository extraction through GroktoCrawl&#39;s adapter layer. It does not make GroktoCrawl the default, and it does not claim coverage for every Firecrawl endpoint, pagination edge case, or provider-specific error shape.</p>
 <hr>
 <h3>Capability model</h3>
 <table>
@@ -280,12 +290,12 @@ python ~/.hermes/plugins/web-search-plus/setup.py config set-default you --dry-r
 <tbody><tr>
 <td>Search</td>
 <td><code>web_search_plus</code></td>
-<td>Brave, Serper, Tavily, Exa, Linkup, Firecrawl, Parallel, Perplexity, Kilo Perplexity, You.com, SearXNG, SerpBase, or Querit</td>
+<td>Brave, Serper, Tavily, Exa, Linkup, Firecrawl, Parallel, Perplexity, Kilo Perplexity, You.com, SearXNG, SerpBase, Querit, or Keenable</td>
 </tr>
 <tr>
 <td>Extraction</td>
 <td><code>web_extract_plus</code></td>
-<td>Linkup, Firecrawl, Tavily, Exa, Parallel, or You.com</td>
+<td>Linkup, Firecrawl, Tavily, Exa, Parallel, You.com, or Keenable</td>
 </tr>
 <tr>
 <td>Best starter</td>
@@ -336,7 +346,7 @@ web_search_plus(query=&quot;best bookshelf speakers under 1000&quot;, quality_re
 <td><code>provider</code></td>
 <td>string</td>
 <td><code>&quot;auto&quot;</code></td>
-<td><code>auto</code>, <code>serper</code>, <code>brave</code>, <code>tavily</code>, <code>exa</code>, <code>linkup</code>, <code>firecrawl</code>, <code>parallel</code>, <code>perplexity</code>, <code>kilo-perplexity</code>, <code>you</code>, <code>searxng</code>, <code>serpbase</code>, <code>querit</code></td>
+<td><code>auto</code>, <code>serper</code>, <code>brave</code>, <code>tavily</code>, <code>exa</code>, <code>linkup</code>, <code>firecrawl</code>, <code>parallel</code>, <code>perplexity</code>, <code>kilo-perplexity</code>, <code>you</code>, <code>searxng</code>, <code>serpbase</code>, <code>querit</code>, <code>keenable</code></td>
 </tr>
 <tr>
 <td><code>depth</code></td>
@@ -395,7 +405,7 @@ web_search_plus(query=&quot;best bookshelf speakers under 1000&quot;, quality_re
 web_extract_plus(urls=[&quot;https://docs.linkup.so&quot;], provider=&quot;linkup&quot;, render_js=False)
 # → Linkup fetch endpoint
 </code></pre>
-<p>Auto extraction currently tries Tavily, then Exa, Linkup, Parallel, Firecrawl, and You.com when keys are available. Tavily is the fast reliable default; Exa is the fast docs/academic backup; Linkup stays the clean long-form/RAG fallback; Parallel is the excerpt-heavy LLM-ready backup; Firecrawl remains the robust scraper safety net; You.com is the final fallback.</p>
+<p>Auto extraction currently tries Tavily, then Exa, Linkup, Parallel, Firecrawl, and You.com when keys are available, then Keenable as the last resort <strong>only if it is configured</strong> (a <code>KEENABLE_API_KEY</code>, or the opted-in keyless public endpoint). Tavily is the fast reliable default; Exa is the fast docs/academic backup; Linkup stays the clean long-form/RAG fallback; Parallel is the excerpt-heavy LLM-ready backup; Firecrawl remains the robust scraper safety net; You.com is a fallback; Keenable is the lowest-priority fallback. The keyless public tier is off by default — see <a href="#keenable-keyless-public-access">Keenable keyless public access</a> — so <code>web_extract_plus</code> is available only when at least one extraction provider is configured.</p>
 <p>Parameters:</p>
 <table>
 <thead>
@@ -515,6 +525,12 @@ web_extract_plus(urls=[&quot;https://docs.linkup.so&quot;], provider=&quot;linku
 <td>Privacy-focused self-hosted metasearch</td>
 </tr>
 <tr>
+<td>Keenable</td>
+<td align="right">✅</td>
+<td align="right">✅</td>
+<td>Independent web index; key via <code>KEENABLE_API_KEY</code>, or opt-in keyless public tier (off by default); lowest-priority fallback</td>
+</tr>
+<tr>
 <td>SerpBase</td>
 <td align="right">✅</td>
 <td align="right">—</td>
@@ -547,6 +563,7 @@ FIRECRAWL_API_KEY=***     # https://firecrawl.dev — search + extraction
 PERPLEXITY_API_KEY=***    # https://perplexity.ai/settings/api
 YOU_API_KEY=***           # https://api.you.com — search + extraction
 SEARXNG_INSTANCE_URL=https://your-instance.example.com
+KEENABLE_API_KEY=***      # https://keenable.ai — search + extraction (or opt into the keyless public tier, off by default)
 SERPBASE_API_KEY=***      # https://www.serpbase.dev — explicit/fallback-only Google-like SERP search
 PARALLEL_API_KEY=***      # https://platform.parallel.ai — explicit/guarded LLM-ready search + extraction
 QUERIT_API_KEY=***        # https://querit.ai — explicit/fallback-only by default
@@ -554,6 +571,13 @@ QUERIT_API_KEY=***        # https://querit.ai — explicit/fallback-only by defa
 # Kilo gateway alternate provider (`provider=&quot;kilo-perplexity&quot;`)
 KILOCODE_API_KEY=***
 </code></pre>
+<h4>Keenable keyless public access</h4>
+<p>Keenable also exposes keyless <code>/public</code> endpoints, but they are <strong>opt-in and off by default</strong>. With a <code>KEENABLE_API_KEY</code> set, requests always use the authenticated endpoints. Without a key, Keenable is treated as unconfigured (it won&#39;t auto-route, fall back, or enable <code>web_extract_plus</code>) unless you explicitly enable the public tier:</p>
+<pre><code class="language-json">// config.json
+{ &quot;keenable&quot;: { &quot;allow_public&quot;: true } }
+</code></pre>
+<p>or via environment: <code>KEENABLE_ALLOW_PUBLIC=1</code>.</p>
+<p>When enabled, queries and fetched URLs are sent to an <strong>unauthenticated</strong> public service. The limits are <strong>per IP</strong> with <strong>no SLA</strong> — roughly <strong>1,000 requests/hour</strong> and <strong>10 requests/second</strong> — so treat the public tier as a best-effort last resort, not a dependable provider. The first request that uses the public endpoint logs a one-time warning so the egress is visible. <code>web-search-plus doctor</code> reports keyless providers as <code>key=no</code> with a separate <code>keyless=on/off</code> badge so key status stays truthful.</p>
 <hr>
 <h3>Result quality and adaptive routing</h3>
 <ul>
@@ -617,7 +641,7 @@ LICENSE          MIT license
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 246</div>
+        <div class="stars">★ 247</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">
@@ -641,7 +665,7 @@ LICENSE          MIT license
         <div class="name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
       </a>
       <a class="related-row" href="/projects/stainlu/hermes-labyrinth">
-        <div class="stars">★ 290</div>
+        <div class="stars">★ 291</div>
         <div class="name"><span class="org">stainlu /</span> hermes-labyrinth</div>
       </a>
       <a class="related-row" href="/projects/clawshell/clawshell">

--- a/projects/rodmarkun/anihermes.html
+++ b/projects/rodmarkun/anihermes.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -336,7 +336,7 @@ python3 ~/.hermes/scripts/anihermes_add_torrent.py --series &quot;Frieren&quot; 
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/ucsandman/DashClaw">
-        <div class="stars">★ 277</div>
+        <div class="stars">★ 278</div>
         <div class="name"><span class="org">ucsandman /</span> DashClaw</div>
       </a>
       <a class="related-row" href="/projects/Lethe044/hermes-incident-commander">
@@ -344,7 +344,7 @@ python3 ~/.hermes/scripts/anihermes_add_torrent.py --series &quot;Frieren&quot; 
         <div class="name"><span class="org">Lethe044 /</span> hermes-incident-commander</div>
       </a>
       <a class="related-row" href="/projects/Christabel337/job-scout-agent">
-        <div class="stars">★ 47</div>
+        <div class="stars">★ 48</div>
         <div class="name"><span class="org">Christabel337 /</span> job-scout-agent</div>
       </a>
       <a class="related-row" href="/projects/JackTheGit/hermes-ai-infrastructure-monitoring-toolkit">

--- a/projects/roli-lpci/lintlang.html
+++ b/projects/roli-lpci/lintlang.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -484,11 +484,11 @@ pytest
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/colbymchenry/codegraph">
-        <div class="stars">★ 54.8K</div>
+        <div class="stars">★ 54.9K</div>
         <div class="name"><span class="org">colbymchenry /</span> codegraph</div>
       </a>
       <a class="related-row" href="/projects/Salomondiei08/oh-my-hermes">
-        <div class="stars">★ 658</div>
+        <div class="stars">★ 659</div>
         <div class="name"><span class="org">Salomondiei08 /</span> oh-my-hermes</div>
       </a>
       <a class="related-row" href="/projects/liaohch3/claude-tap">
@@ -504,7 +504,7 @@ pytest
         <div class="name"><span class="org">junhoyeo /</span> tokscale</div>
       </a>
       <a class="related-row" href="/projects/joeynyc/hermes-skins">
-        <div class="stars">★ 471</div>
+        <div class="stars">★ 472</div>
         <div class="name"><span class="org">joeynyc /</span> hermes-skins</div>
       </a>
       <a class="related-row" href="/projects/AlexAI-MCP/hermes-CCC">

--- a/projects/rookiemann/portable-hermes-agent.html
+++ b/projects/rookiemann/portable-hermes-agent.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -364,7 +364,7 @@ AIAgent (run_agent.py)
         <div class="name"><span class="org">TheAiSingularity /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/0xrsydn/nix-hermes-agent">
-        <div class="stars">★ 25</div>
+        <div class="stars">★ 26</div>
         <div class="name"><span class="org">0xrsydn /</span> nix-hermes-agent</div>
       </a>
       <a class="related-row" href="/projects/xmbshwll/hermes-agent-docker">

--- a/projects/runtimenoteslabs/gladiator.html
+++ b/projects/runtimenoteslabs/gladiator.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -646,7 +646,7 @@ sudo service postgresql start
         <div class="name"><span class="org">howdymary /</span> hermes-agent-metaharness</div>
       </a>
       <a class="related-row" href="/projects/1ilkhamov/opencode-hermes-multiagent">
-        <div class="stars">★ 152</div>
+        <div class="stars">★ 153</div>
         <div class="name"><span class="org">1ilkhamov /</span> opencode-hermes-multiagent</div>
       </a>
       <a class="related-row" href="/projects/Rainhoole/hermes-agent-acp-skill">

--- a/projects/sanchomuzax/hermes-webui.html
+++ b/projects/sanchomuzax/hermes-webui.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -402,8 +402,12 @@ journalctl -u hermes-webui -f
         <div class="stars">★ 85</div>
         <div class="name"><span class="org">Euraika-Labs /</span> pan-ui</div>
       </a>
+      <a class="related-row" href="/projects/abundantbeing/hermes-browser-extension">
+        <div class="stars">★ 95</div>
+        <div class="name"><span class="org">abundantbeing /</span> hermes-browser-extension</div>
+      </a>
       <a class="related-row" href="/projects/Eynzof/hermes-agent-cn-desktop">
-        <div class="stars">★ 578</div>
+        <div class="stars">★ 584</div>
         <div class="name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       </a>
       <a class="related-row" href="/projects/Felix-Forever/hermes-agent-desktop">
@@ -417,10 +421,6 @@ journalctl -u hermes-webui -f
       <a class="related-row" href="/projects/nickvasilescu/hermes-desktop-os1">
         <div class="stars">★ 479</div>
         <div class="name"><span class="org">nickvasilescu /</span> hermes-desktop-os1</div>
-      </a>
-      <a class="related-row" href="/projects/farion1231/cc-switch">
-        <div class="stars">★ 108.7K</div>
-        <div class="name"><span class="org">farion1231 /</span> cc-switch</div>
       </a>
     </div>
     <p class="list-link"><a href="/lists/workspaces-and-guis">see all workspaces &amp; guis →</a></p>

--- a/projects/shannhk/hermes-agent-control-room.html
+++ b/projects/shannhk/hermes-agent-control-room.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 599
+    "userInteractionCount": 600
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Control Room-first template for managing Hermes agents from one VPS agent to specialist teams and orchestrated workflows</p>
 
   <div class="meta-row">
-    <span class="stars">★ 599</span>
+    <span class="stars">★ 600</span>
     <span><span class="meta-label">lang</span>Shell</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -473,7 +473,7 @@ ls skills/
         <div class="name"><span class="org">runtimenoteslabs /</span> gladiator</div>
       </a>
       <a class="related-row" href="/projects/1ilkhamov/opencode-hermes-multiagent">
-        <div class="stars">★ 152</div>
+        <div class="stars">★ 153</div>
         <div class="name"><span class="org">1ilkhamov /</span> opencode-hermes-multiagent</div>
       </a>
       <a class="related-row" href="/projects/Rainhoole/hermes-agent-acp-skill">

--- a/projects/sheawinkler/hermes-agent-ultra.html
+++ b/projects/sheawinkler/hermes-agent-ultra.html
@@ -46,13 +46,13 @@
     "name": "sheawinkler",
     "url": "https://github.com/sheawinkler"
   },
-  "dateModified": "2026-06-26T06:44:10.000Z",
+  "dateModified": "2026-06-26T14:10:38.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 56
+    "userInteractionCount": 57
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -111,7 +111,7 @@
   <p class="project-desc">Hermes Agent Ultra (built from hermes-agent-rs core by lumioresearch, @oxterrybit). Hermes-agent feature parity at commit level. Rust Performance</p>
 
   <div class="meta-row">
-    <span class="stars">★ 56</span>
+    <span class="stars">★ 57</span>
     <span><span class="meta-label">lang</span>Rust</span>
     
     

--- a/projects/smartcontractkit/chainlink-agent-skills.html
+++ b/projects/smartcontractkit/chainlink-agent-skills.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -224,7 +224,7 @@ Any questions before you start?
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills">
-        <div class="stars">★ 21.5K</div>
+        <div class="stars">★ 21.7K</div>
         <div class="name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</div>
       </a>
       <a class="related-row" href="/projects/conorbronsdon/avoid-ai-writing">
@@ -244,7 +244,7 @@ Any questions before you start?
         <div class="name"><span class="org">Agents365-ai /</span> drawio-skill</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 192</div>
+        <div class="stars">★ 194</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/stainlu/hermes-labyrinth.html
+++ b/projects/stainlu/hermes-labyrinth.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 290
+    "userInteractionCount": 291
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">Read-only observability plugin for Hermes Agent: journeys, crossings, guideposts, and reports.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 290</span>
+    <span class="stars">★ 291</span>
     <span><span class="meta-label">lang</span>HTML</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -340,11 +340,11 @@ roadmap.</p>
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/robbyczgw-cla/hermes-web-search-plus">
-        <div class="stars">★ 316</div>
+        <div class="stars">★ 315</div>
         <div class="name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
       </a>
       <a class="related-row" href="/projects/42-evey/hermes-plugins">
-        <div class="stars">★ 246</div>
+        <div class="stars">★ 247</div>
         <div class="name"><span class="org">42-evey /</span> hermes-plugins</div>
       </a>
       <a class="related-row" href="/projects/FahrenheitResearch/hermes-weather-plugin">

--- a/projects/stephenschoettler/hermes-lcm.html
+++ b/projects/stephenschoettler/hermes-lcm.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -957,7 +957,7 @@ for changelogs.</p>
         <div class="name"><span class="org">greyhaven-ai /</span> autocontext</div>
       </a>
       <a class="related-row" href="/projects/elkimek/honcho-self-hosted">
-        <div class="stars">★ 328</div>
+        <div class="stars">★ 329</div>
         <div class="name"><span class="org">elkimek /</span> honcho-self-hosted</div>
       </a>
       <a class="related-row" href="/projects/yoloshii/ClawMem">
@@ -965,7 +965,7 @@ for changelogs.</p>
         <div class="name"><span class="org">yoloshii /</span> ClawMem</div>
       </a>
       <a class="related-row" href="/projects/Signet-AI/signetai">
-        <div class="stars">★ 203</div>
+        <div class="stars">★ 205</div>
         <div class="name"><span class="org">Signet-AI /</span> signetai</div>
       </a>
       <a class="related-row" href="/projects/plur-ai/plur">

--- a/projects/supermemoryai/supermemory.html
+++ b/projects/supermemoryai/supermemory.html
@@ -47,13 +47,13 @@
     "name": "supermemoryai",
     "url": "https://github.com/supermemoryai"
   },
-  "dateModified": "2026-06-25T20:35:23.000Z",
+  "dateModified": "2026-06-26T14:34:42.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 27600
+    "userInteractionCount": 27627
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -116,7 +116,7 @@
     <span><span class="meta-label">lang</span>TypeScript</span>
     <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-06-25</span>
+    <span><span class="meta-label">updated</span>2026-06-26</span>
   </div>
 
   <div class="actions">
@@ -554,7 +554,7 @@ npx supermemory local
         <div class="name"><span class="org">greyhaven-ai /</span> autocontext</div>
       </a>
       <a class="related-row" href="/projects/elkimek/honcho-self-hosted">
-        <div class="stars">★ 328</div>
+        <div class="stars">★ 329</div>
         <div class="name"><span class="org">elkimek /</span> honcho-self-hosted</div>
       </a>
       <a class="related-row" href="/projects/yoloshii/ClawMem">
@@ -562,7 +562,7 @@ npx supermemory local
         <div class="name"><span class="org">yoloshii /</span> ClawMem</div>
       </a>
       <a class="related-row" href="/projects/Signet-AI/signetai">
-        <div class="stars">★ 203</div>
+        <div class="stars">★ 205</div>
         <div class="name"><span class="org">Signet-AI /</span> signetai</div>
       </a>
       <a class="related-row" href="/projects/plur-ai/plur">

--- a/projects/swarmclawai/swarmclaw.html
+++ b/projects/swarmclawai/swarmclaw.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -808,7 +808,7 @@ OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer your-token
         <div class="name"><span class="org">runtimenoteslabs /</span> gladiator</div>
       </a>
       <a class="related-row" href="/projects/1ilkhamov/opencode-hermes-multiagent">
-        <div class="stars">★ 152</div>
+        <div class="stars">★ 153</div>
         <div class="name"><span class="org">1ilkhamov /</span> opencode-hermes-multiagent</div>
       </a>
       <a class="related-row" href="/projects/Rainhoole/hermes-agent-acp-skill">

--- a/projects/teknium1/hermes-miniverse.html
+++ b/projects/teknium1/hermes-miniverse.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -279,7 +279,7 @@ python bridge.py --agent hermes-researcher --name &quot;Hermes (Research)&quot; 
         <div class="name"><span class="org">kevinmarmstrong /</span> hermes-claude-code-rc</div>
       </a>
       <a class="related-row" href="/projects/AaronWong1999/hermesclaw">
-        <div class="stars">★ 647</div>
+        <div class="stars">★ 648</div>
         <div class="name"><span class="org">AaronWong1999 /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/Codename-11/hermes-relay">

--- a/projects/tiann/execplan-skill.html
+++ b/projects/tiann/execplan-skill.html
@@ -79,7 +79,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -179,7 +179,7 @@
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills">
-        <div class="stars">★ 21.5K</div>
+        <div class="stars">★ 21.7K</div>
         <div class="name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</div>
       </a>
       <a class="related-row" href="/projects/conorbronsdon/avoid-ai-writing">
@@ -203,7 +203,7 @@
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 192</div>
+        <div class="stars">★ 194</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/tlehman/litprog-skill.html
+++ b/projects/tlehman/litprog-skill.html
@@ -52,7 +52,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 192
+    "userInteractionCount": 194
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -111,7 +111,7 @@
   <p class="project-desc">Literate programming skill for agent harnesses like Claude Code, OpenCode and Hermes Agent</p>
 
   <div class="meta-row">
-    <span class="stars">★ 192</span>
+    <span class="stars">★ 194</span>
     <span><span class="meta-label">lang</span>TypeScript</span>
     
     
@@ -215,7 +215,7 @@ cp litprog-skill/SKILL.md your-project/.claude/skills/literate-programming.md
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills">
-        <div class="stars">★ 21.5K</div>
+        <div class="stars">★ 21.7K</div>
         <div class="name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</div>
       </a>
       <a class="related-row" href="/projects/conorbronsdon/avoid-ai-writing">

--- a/projects/ucsandman/DashClaw.html
+++ b/projects/ucsandman/DashClaw.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 277
+    "userInteractionCount": 278
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">🛡️The governance runtime for AI agents. Intercept actions, enforce guard policies, require approvals, and produce audit-ready decision trails.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 277</span>
+    <span class="stars">★ 278</span>
     <span><span class="meta-label">lang</span>TypeScript</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -667,7 +667,7 @@ await claw.createAction({ /* ... */, idempotency_key: key });
         <div class="name"><span class="org">Lethe044 /</span> hermes-incident-commander</div>
       </a>
       <a class="related-row" href="/projects/Christabel337/job-scout-agent">
-        <div class="stars">★ 47</div>
+        <div class="stars">★ 48</div>
         <div class="name"><span class="org">Christabel337 /</span> job-scout-agent</div>
       </a>
       <a class="related-row" href="/projects/rodmarkun/anihermes">

--- a/projects/ultraworkers/hermes-agent-helm-chart.html
+++ b/projects/ultraworkers/hermes-agent-helm-chart.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -470,7 +470,7 @@ bash ci/verify.sh
         <div class="name"><span class="org">TheAiSingularity /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/0xrsydn/nix-hermes-agent">
-        <div class="stars">★ 25</div>
+        <div class="stars">★ 26</div>
         <div class="name"><span class="org">0xrsydn /</span> nix-hermes-agent</div>
       </a>
       <a class="related-row" href="/projects/rookiemann/portable-hermes-agent">

--- a/projects/unmodeled-tyler/vessel-browser.html
+++ b/projects/unmodeled-tyler/vessel-browser.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -729,11 +729,11 @@ vessel-browser-launch --dry-run
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/colbymchenry/codegraph">
-        <div class="stars">★ 54.8K</div>
+        <div class="stars">★ 54.9K</div>
         <div class="name"><span class="org">colbymchenry /</span> codegraph</div>
       </a>
       <a class="related-row" href="/projects/Salomondiei08/oh-my-hermes">
-        <div class="stars">★ 658</div>
+        <div class="stars">★ 659</div>
         <div class="name"><span class="org">Salomondiei08 /</span> oh-my-hermes</div>
       </a>
       <a class="related-row" href="/projects/liaohch3/claude-tap">
@@ -749,7 +749,7 @@ vessel-browser-launch --dry-run
         <div class="name"><span class="org">junhoyeo /</span> tokscale</div>
       </a>
       <a class="related-row" href="/projects/joeynyc/hermes-skins">
-        <div class="stars">★ 471</div>
+        <div class="stars">★ 472</div>
         <div class="name"><span class="org">joeynyc /</span> hermes-skins</div>
       </a>
       <a class="related-row" href="/projects/AlexAI-MCP/hermes-CCC">

--- a/projects/vectorize-io/hindsight.html
+++ b/projects/vectorize-io/hindsight.html
@@ -47,13 +47,13 @@
     "name": "vectorize-io",
     "url": "https://github.com/vectorize-io"
   },
-  "dateModified": "2026-06-26T06:41:07.000Z",
+  "dateModified": "2026-06-26T14:29:17.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 17588
+    "userInteractionCount": 17611
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -432,7 +432,7 @@ client.reflect(bank_id=&quot;my-bank&quot;, query=&quot;What should I know about
         <div class="name"><span class="org">greyhaven-ai /</span> autocontext</div>
       </a>
       <a class="related-row" href="/projects/elkimek/honcho-self-hosted">
-        <div class="stars">★ 328</div>
+        <div class="stars">★ 329</div>
         <div class="name"><span class="org">elkimek /</span> honcho-self-hosted</div>
       </a>
       <a class="related-row" href="/projects/yoloshii/ClawMem">
@@ -440,7 +440,7 @@ client.reflect(bank_id=&quot;my-bank&quot;, query=&quot;What should I know about
         <div class="name"><span class="org">yoloshii /</span> ClawMem</div>
       </a>
       <a class="related-row" href="/projects/Signet-AI/signetai">
-        <div class="stars">★ 203</div>
+        <div class="stars">★ 205</div>
         <div class="name"><span class="org">Signet-AI /</span> signetai</div>
       </a>
       <a class="related-row" href="/projects/plur-ai/plur">

--- a/projects/vectrocomputers/Hermes-Agent-Action-Plan.html
+++ b/projects/vectrocomputers/Hermes-Agent-Action-Plan.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>

--- a/projects/volcengine/OpenViking.html
+++ b/projects/volcengine/OpenViking.html
@@ -47,13 +47,13 @@
     "name": "volcengine",
     "url": "https://github.com/volcengine"
   },
-  "dateModified": "2026-06-26T07:36:36.000Z",
+  "dateModified": "2026-06-26T14:29:21.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 26065
+    "userInteractionCount": 26083
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -629,6 +629,7 @@ ov tree viking://resources/volcengine -L 2
 ov find &quot;what is openviking&quot;
 ov grep &quot;openviking&quot; --uri viking://resources/volcengine/OpenViking/docs/zh
 </code></pre>
+<p>To rebuild existing indexes, <code>ov reindex &lt;uri&gt; --mode vectors_only</code> refreshes vectors only. Use <code>--mode semantic_and_vectors</code> when semantic artifacts (<code>.abstract.md</code> and <code>.overview.md</code>) must be regenerated before vectors; there is no <code>semantic</code> or <code>full</code> mode alias.</p>
 <p>Congratulations! You have successfully run OpenViking 🎉</p>
 <h4>Commercial Access</h4>
 <p>OpenViking Personal is now officially available. Compared with the open-source edition, the Service version is officially hosted and ready to use, scales far beyond local hardware with VikingDB, and comes with richer integrations plus professional support. It includes a free trial for up to 50 files, and existing open-source users can move over smoothly with our migration tool.</p>
@@ -1013,7 +1014,7 @@ For vulnerability reporting and supported versions, see <a href="https://github.
         <div class="name"><span class="org">greyhaven-ai /</span> autocontext</div>
       </a>
       <a class="related-row" href="/projects/elkimek/honcho-self-hosted">
-        <div class="stars">★ 328</div>
+        <div class="stars">★ 329</div>
         <div class="name"><span class="org">elkimek /</span> honcho-self-hosted</div>
       </a>
       <a class="related-row" href="/projects/yoloshii/ClawMem">
@@ -1021,7 +1022,7 @@ For vulnerability reporting and supported versions, see <a href="https://github.
         <div class="name"><span class="org">yoloshii /</span> ClawMem</div>
       </a>
       <a class="related-row" href="/projects/Signet-AI/signetai">
-        <div class="stars">★ 203</div>
+        <div class="stars">★ 205</div>
         <div class="name"><span class="org">Signet-AI /</span> signetai</div>
       </a>
       <a class="related-row" href="/projects/plur-ai/plur">

--- a/projects/willingning-coder/eagle-eye.html
+++ b/projects/willingning-coder/eagle-eye.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -373,7 +373,7 @@ python scripts/generate_config.py --scan-only
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills">
-        <div class="stars">★ 21.5K</div>
+        <div class="stars">★ 21.7K</div>
         <div class="name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</div>
       </a>
       <a class="related-row" href="/projects/conorbronsdon/avoid-ai-writing">
@@ -397,7 +397,7 @@ python scripts/generate_config.py --scan-only
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 192</div>
+        <div class="stars">★ 194</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/wondelai/skills.html
+++ b/projects/wondelai/skills.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 1461
+    "userInteractionCount": 1467
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -856,7 +856,7 @@ npx skills add wondelai/skills/lean-analytics
   <div>
     <div class="related-list">
       <a class="related-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills">
-        <div class="stars">★ 21.5K</div>
+        <div class="stars">★ 21.7K</div>
         <div class="name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</div>
       </a>
       <a class="related-row" href="/projects/conorbronsdon/avoid-ai-writing">
@@ -876,7 +876,7 @@ npx skills add wondelai/skills/lean-analytics
         <div class="name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
       </a>
       <a class="related-row" href="/projects/tlehman/litprog-skill">
-        <div class="stars">★ 192</div>
+        <div class="stars">★ 194</div>
         <div class="name"><span class="org">tlehman /</span> litprog-skill</div>
       </a>
       <a class="related-row" href="/projects/esaradev/icarus-plugin">

--- a/projects/xaspx/hermes-control-interface.html
+++ b/projects/xaspx/hermes-control-interface.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 784
+    "userInteractionCount": 785
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">A self-hosted web dashboard for the Hermes AI agent stack. Provides a browser-based terminal, file explorer, session overview, cron management, system metrics, and an agent status panel — all behind a single password gate.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 784</span>
+    <span class="stars">★ 785</span>
     <span><span class="meta-label">lang</span>JavaScript</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -824,8 +824,12 @@ systemctl restart hci-staging
         <div class="stars">★ 85</div>
         <div class="name"><span class="org">Euraika-Labs /</span> pan-ui</div>
       </a>
+      <a class="related-row" href="/projects/abundantbeing/hermes-browser-extension">
+        <div class="stars">★ 95</div>
+        <div class="name"><span class="org">abundantbeing /</span> hermes-browser-extension</div>
+      </a>
       <a class="related-row" href="/projects/Eynzof/hermes-agent-cn-desktop">
-        <div class="stars">★ 578</div>
+        <div class="stars">★ 584</div>
         <div class="name"><span class="org">Eynzof /</span> hermes-agent-cn-desktop</div>
       </a>
       <a class="related-row" href="/projects/Felix-Forever/hermes-agent-desktop">
@@ -835,10 +839,6 @@ systemctl restart hci-staging
       <a class="related-row" href="/projects/jazzyalex/agent-sessions">
         <div class="stars">★ 661</div>
         <div class="name"><span class="org">jazzyalex /</span> agent-sessions</div>
-      </a>
-      <a class="related-row" href="/projects/nickvasilescu/hermes-desktop-os1">
-        <div class="stars">★ 479</div>
-        <div class="name"><span class="org">nickvasilescu /</span> hermes-desktop-os1</div>
       </a>
     </div>
     <p class="list-link"><a href="/lists/workspaces-and-guis">see all workspaces &amp; guis →</a></p>

--- a/projects/xiaonancs/hermes-agent-study.html
+++ b/projects/xiaonancs/hermes-agent-study.html
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>

--- a/projects/xmbshwll/hermes-agent-docker.html
+++ b/projects/xmbshwll/hermes-agent-docker.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -220,7 +220,7 @@
         <div class="name"><span class="org">TheAiSingularity /</span> hermesclaw</div>
       </a>
       <a class="related-row" href="/projects/0xrsydn/nix-hermes-agent">
-        <div class="stars">★ 25</div>
+        <div class="stars">★ 26</div>
         <div class="name"><span class="org">0xrsydn /</span> nix-hermes-agent</div>
       </a>
       <a class="related-row" href="/projects/rookiemann/portable-hermes-agent">

--- a/projects/yantrikos/yantrikdb-hermes-plugin.html
+++ b/projects/yantrikos/yantrikdb-hermes-plugin.html
@@ -53,7 +53,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 62
+    "userInteractionCount": 63
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -112,7 +112,7 @@
   <p class="project-desc">YantrikDB memory provider for NousResearch/hermes-agent — self-maintaining memory with benchmarked recall, self-tuning ranking, contradiction tracking, proactive hygiene, and explainable recall.</p>
 
   <div class="meta-row">
-    <span class="stars">★ 62</span>
+    <span class="stars">★ 63</span>
     <span><span class="meta-label">lang</span>Python</span>
     <span><span class="meta-label">license</span>MIT</span>
     
@@ -728,7 +728,7 @@ YANTRIKDB_INTEGRATION_TOKEN=ydb_... \
         <div class="name"><span class="org">greyhaven-ai /</span> autocontext</div>
       </a>
       <a class="related-row" href="/projects/elkimek/honcho-self-hosted">
-        <div class="stars">★ 328</div>
+        <div class="stars">★ 329</div>
         <div class="name"><span class="org">elkimek /</span> honcho-self-hosted</div>
       </a>
       <a class="related-row" href="/projects/yoloshii/ClawMem">
@@ -736,7 +736,7 @@ YANTRIKDB_INTEGRATION_TOKEN=ydb_... \
         <div class="name"><span class="org">yoloshii /</span> ClawMem</div>
       </a>
       <a class="related-row" href="/projects/Signet-AI/signetai">
-        <div class="stars">★ 203</div>
+        <div class="stars">★ 205</div>
         <div class="name"><span class="org">Signet-AI /</span> signetai</div>
       </a>
       <a class="related-row" href="/projects/plur-ai/plur">

--- a/projects/yepyhun/Brainstack.html
+++ b/projects/yepyhun/Brainstack.html
@@ -52,7 +52,7 @@
     "interactionType": {
       "@type": "LikeAction"
     },
-    "userInteractionCount": 42
+    "userInteractionCount": 43
   },
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
@@ -80,7 +80,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -111,7 +111,7 @@
   <p class="project-desc">Memory kernel stack for Hermes agent</p>
 
   <div class="meta-row">
-    <span class="stars">★ 42</span>
+    <span class="stars">★ 43</span>
     <span><span class="meta-label">lang</span>Python</span>
     
     
@@ -594,7 +594,7 @@ target Hermes config to accept upstream or installer defaults for those blocks.<
         <div class="name"><span class="org">greyhaven-ai /</span> autocontext</div>
       </a>
       <a class="related-row" href="/projects/elkimek/honcho-self-hosted">
-        <div class="stars">★ 328</div>
+        <div class="stars">★ 329</div>
         <div class="name"><span class="org">elkimek /</span> honcho-self-hosted</div>
       </a>
       <a class="related-row" href="/projects/yoloshii/ClawMem">
@@ -602,7 +602,7 @@ target Hermes config to accept upstream or installer defaults for those blocks.<
         <div class="name"><span class="org">yoloshii /</span> ClawMem</div>
       </a>
       <a class="related-row" href="/projects/Signet-AI/signetai">
-        <div class="stars">★ 203</div>
+        <div class="stars">★ 205</div>
         <div class="name"><span class="org">Signet-AI /</span> signetai</div>
       </a>
       <a class="related-row" href="/projects/plur-ai/plur">

--- a/projects/yoloshii/ClawMem.html
+++ b/projects/yoloshii/ClawMem.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -1073,11 +1073,11 @@ clawmem status                                  Quick index status
         <div class="name"><span class="org">greyhaven-ai /</span> autocontext</div>
       </a>
       <a class="related-row" href="/projects/elkimek/honcho-self-hosted">
-        <div class="stars">★ 328</div>
+        <div class="stars">★ 329</div>
         <div class="name"><span class="org">elkimek /</span> honcho-self-hosted</div>
       </a>
       <a class="related-row" href="/projects/Signet-AI/signetai">
-        <div class="stars">★ 203</div>
+        <div class="stars">★ 205</div>
         <div class="name"><span class="org">Signet-AI /</span> signetai</div>
       </a>
       <a class="related-row" href="/projects/plur-ai/plur">

--- a/projects/yonro/hermes-xmemo-plugin.html
+++ b/projects/yonro/hermes-xmemo-plugin.html
@@ -81,7 +81,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -575,7 +575,7 @@ Wiping the outbox will permanently delete any pending or held write operations t
         <div class="name"><span class="org">greyhaven-ai /</span> autocontext</div>
       </a>
       <a class="related-row" href="/projects/elkimek/honcho-self-hosted">
-        <div class="stars">★ 328</div>
+        <div class="stars">★ 329</div>
         <div class="name"><span class="org">elkimek /</span> honcho-self-hosted</div>
       </a>
       <a class="related-row" href="/projects/yoloshii/ClawMem">
@@ -583,7 +583,7 @@ Wiping the outbox will permanently delete any pending or held write operations t
         <div class="name"><span class="org">yoloshii /</span> ClawMem</div>
       </a>
       <a class="related-row" href="/projects/Signet-AI/signetai">
-        <div class="stars">★ 203</div>
+        <div class="stars">★ 205</div>
         <div class="name"><span class="org">Signet-AI /</span> signetai</div>
       </a>
       <a class="related-row" href="/projects/plur-ai/plur">

--- a/reports/index.html
+++ b/reports/index.html
@@ -89,7 +89,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">175·repos</span>
+    <span id="meta-count">174·repos</span>
     <span id="meta-version">hermes·v0.15.2</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>

--- a/rss.xml
+++ b/rss.xml
@@ -6,21 +6,13 @@
     <atom:link href="https://hermesatlas.com/rss.xml" rel="self" type="application/rss+xml" />
     <description>Newly added community-built tools, skills, plugins, and integrations for Nous Research's Hermes Agent. Updated daily.</description>
     <language>en</language>
-    <lastBuildDate>Fri, 26 Jun 2026 07:53:30 GMT</lastBuildDate>
+    <lastBuildDate>Fri, 26 Jun 2026 14:45:18 GMT</lastBuildDate>
     <generator>hermesatlas.com/scripts/build-pages.js</generator>
     <item>
       <title>hypernatt-terminal (Integrations &amp; Bridges)</title>
       <link>https://hermesatlas.com/projects/DIALLOUBE-RESEARCH/hypernatt-terminal</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/DIALLOUBE-RESEARCH/hypernatt-terminal</guid>
-      <pubDate>Thu, 25 Jun 2026 08:22:00 GMT</pubDate>
-      <category>Integrations &amp; Bridges</category>
-      <description>HyperNatt Terminal is an MCP server that provides BTC/USDC decision context for AI agents based on a live Hyperliquid vault. It exposes nine read-only tools that deliver signals such as market maker trap states, hunt scores, and regime similarity. The system utilizes a pay-per-call x402 pricing model and integrates Li.Fi for cross-chain swap quotes. It is designed for non-custodial verification, allowing agents to access signed vault proofs and on-chain data without requiring key access.</description>
-    </item>
-    <item>
-      <title>hypernatt-terminal (Integrations &amp; Bridges)</title>
-      <link>https://hermesatlas.com/projects/DIALLOUBE-RESEARCH/hypernatt-terminal</link>
-      <guid isPermaLink="true">https://hermesatlas.com/projects/DIALLOUBE-RESEARCH/hypernatt-terminal</guid>
-      <pubDate>Thu, 25 Jun 2026 08:22:00 GMT</pubDate>
+      <pubDate>Thu, 25 Jun 2026 08:21:07 GMT</pubDate>
       <category>Integrations &amp; Bridges</category>
       <description>HyperNatt Terminal is an MCP server that provides BTC/USDC decision context for AI agents based on a live Hyperliquid vault. It exposes nine read-only tools that deliver signals such as market maker trap states, hunt scores, and regime similarity. The system utilizes a pay-per-call x402 pricing model and integrates Li.Fi for cross-chain swap quotes. It is designed for non-custodial verification, allowing agents to access signed vault proofs and on-chain data without requiring key access.</description>
     </item>
@@ -28,7 +20,7 @@
       <title>hermes-xmemo-plugin (Memory &amp; Context)</title>
       <link>https://hermesatlas.com/projects/yonro/hermes-xmemo-plugin</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/yonro/hermes-xmemo-plugin</guid>
-      <pubDate>Thu, 25 Jun 2026 08:22:00 GMT</pubDate>
+      <pubDate>Tue, 23 Jun 2026 11:14:56 GMT</pubDate>
       <category>Memory &amp; Context</category>
       <description>The hermes-xmemo-plugin is a native memory provider that gives Hermes Agent durable, cross-session memory. It connects the agent to a user-owned XMemo account to store and retrieve facts, preferences, and working states via semantic search and background prefetching. This allows Hermes to access context saved from other agents, including memories authorized through a ChatGPT bridge. The plugin integrates directly into the Hermes memory lifecycle, supporting native memory mirroring and session sn</description>
     </item>
@@ -36,7 +28,7 @@
       <title>hermes-venice-web (Plugins &amp; Extensions)</title>
       <link>https://hermesatlas.com/projects/MnrGreg/hermes-venice-web</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/MnrGreg/hermes-venice-web</guid>
-      <pubDate>Thu, 25 Jun 2026 08:22:00 GMT</pubDate>
+      <pubDate>Sun, 21 Jun 2026 01:13:16 GMT</pubDate>
       <category>Plugins &amp; Extensions</category>
       <description>This plugin serves as a privacy-focused replacement for the built-in web search and extraction tools in Hermes Agent. It integrates Venice AI's /augment/search and /augment/scrape endpoints to provide the agent with explicit control over when to fetch web data. Because it uses standalone endpoints, these tools can be paired with any AI provider, including local models or other cloud APIs. The implementation ensures zero data retention and provides structured, LLM-friendly output.</description>
     </item>
@@ -44,15 +36,7 @@
       <title>hermes-telemetry (Plugins &amp; Extensions)</title>
       <link>https://hermesatlas.com/projects/nujovich/hermes-telemetry</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/nujovich/hermes-telemetry</guid>
-      <pubDate>Thu, 25 Jun 2026 08:22:00 GMT</pubDate>
-      <category>Plugins &amp; Extensions</category>
-      <description>hermes-telemetry is an observability and budget management plugin for Hermes Agent that prevents runaway API costs. It hooks directly into the agent's runtime to track token usage and costs in real time, allowing it to block LLM calls before they exceed defined spending limits. The plugin stores data in a SQLite database and provides cost analysis via slash commands and a local web dashboard.</description>
-    </item>
-    <item>
-      <title>hermes-telemetry (Plugins &amp; Extensions)</title>
-      <link>https://hermesatlas.com/projects/nujovich/hermes-telemetry</link>
-      <guid isPermaLink="true">https://hermesatlas.com/projects/nujovich/hermes-telemetry</guid>
-      <pubDate>Thu, 25 Jun 2026 08:22:00 GMT</pubDate>
+      <pubDate>Fri, 19 Jun 2026 10:35:32 GMT</pubDate>
       <category>Plugins &amp; Extensions</category>
       <description>hermes-telemetry is an observability and budget management plugin for Hermes Agent that prevents runaway API costs. It hooks directly into the agent's runtime to track token usage and costs in real time, allowing it to block LLM calls before they exceed defined spending limits. The plugin stores data in a SQLite database and provides cost analysis via slash commands and a local web dashboard.</description>
     </item>
@@ -60,7 +44,7 @@
       <title>hermes-trace (Plugins &amp; Extensions)</title>
       <link>https://hermesatlas.com/projects/hlothaire/hermes-trace</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/hlothaire/hermes-trace</guid>
-      <pubDate>Thu, 25 Jun 2026 08:22:00 GMT</pubDate>
+      <pubDate>Tue, 16 Jun 2026 12:07:30 GMT</pubDate>
       <category>Plugins &amp; Extensions</category>
       <description>Hermes Trace is a plugin that provides visibility into agent execution by building structured trace graphs of session activity. It utilizes 18 lifecycle hooks to automatically capture LLM calls, tool usage, subagent spawns, and approval requests. Users can analyze these traces via a dedicated CLI or an in-session slash command to identify bottlenecks and track token usage. The system ensures reliability by wrapping all hooks in error-handling blocks and requires no runtime dependencies beyond th</description>
     </item>
@@ -68,7 +52,7 @@
       <title>socialclaw (Integrations &amp; Bridges)</title>
       <link>https://hermesatlas.com/projects/ndesv21/socialclaw</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/ndesv21/socialclaw</guid>
-      <pubDate>Thu, 25 Jun 2026 08:22:00 GMT</pubDate>
+      <pubDate>Mon, 15 Jun 2026 13:24:17 GMT</pubDate>
       <category>Integrations &amp; Bridges</category>
       <description>SocialClaw is a social media scheduling tool designed to enable AI agents to publish content across multiple platforms. It provides an npm CLI and a Model Context Protocol (MCP) server that interfaces with a hosted workspace via API key authentication. The system supports campaign validation, asset uploads, and analytics tracking for platforms including X, LinkedIn, Instagram, and TikTok. It integrates directly with AI environments like Claude Code, Cursor, and OpenClaw to automate the publishin</description>
     </item>
@@ -76,7 +60,7 @@
       <title>Toolaria (Plugins &amp; Extensions)</title>
       <link>https://hermesatlas.com/projects/Sahil-SS9/Toolaria</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/Sahil-SS9/Toolaria</guid>
-      <pubDate>Thu, 25 Jun 2026 08:22:00 GMT</pubDate>
+      <pubDate>Thu, 11 Jun 2026 19:07:54 GMT</pubDate>
       <category>Plugins &amp; Extensions</category>
       <description>Toolaria is a zero-config plugin for Hermes Agent that prevents large tool outputs from flooding the model's context window. It implements a spill-to-disk pattern by storing oversized results in a SHA256-addressed blob store and providing the model with a compact excerpt and a fetch handle. The model can then retrieve specific slices of data via semantic search or structural outlines. It also supports pass-by-reference, allowing large results to be passed between tools without ever entering the </description>
     </item>
@@ -84,7 +68,7 @@
       <title>hermes-memlock (Plugins &amp; Extensions)</title>
       <link>https://hermesatlas.com/projects/Sahil-SS9/hermes-memlock</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/Sahil-SS9/hermes-memlock</guid>
-      <pubDate>Thu, 25 Jun 2026 08:22:00 GMT</pubDate>
+      <pubDate>Thu, 11 Jun 2026 15:00:34 GMT</pubDate>
       <category>Plugins &amp; Extensions</category>
       <description>MemLock is a plugin for Hermes Agent that prevents standing instructions from being ignored after context compaction. It uses a pre_llm_call hook to audit the active conversation region for pinned anchors, re-injecting only those that have drifted into the summary region. Users can manage these anchors via the guard_pin tool or static configuration to maintain behavioral consistency over long dialogues. The system supports both keyword-based and semantic detection to balance token costs with ins</description>
     </item>
@@ -92,7 +76,7 @@
       <title>hermes-simplify-swarm (Skills &amp; Skill Registries)</title>
       <link>https://hermesatlas.com/projects/Sahil-SS9/hermes-simplify-swarm</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/Sahil-SS9/hermes-simplify-swarm</guid>
-      <pubDate>Thu, 25 Jun 2026 08:22:00 GMT</pubDate>
+      <pubDate>Tue, 09 Jun 2026 07:43:52 GMT</pubDate>
       <category>Skills &amp; Skill Registries</category>
       <description>Simplify Swarm is a multi-agent code refinement skill for Hermes Agent designed to automate deep code cleaning and technical debt reduction. It utilizes three specialized sub-agents—Hygiene, Clarity, and Correctness—to analyze codebases for dead code, structural bloat, and complex bugs like N+1 queries or memory leaks. Findings are triaged into a risk-tiered system that separates safe automated fixes from risky architectural changes requiring human review. The tool supports TypeScript, JavaScrip</description>
     </item>
@@ -100,7 +84,7 @@
       <title>hermaguard (Skills &amp; Skill Registries)</title>
       <link>https://hermesatlas.com/projects/Sahil-SS9/hermaguard</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/Sahil-SS9/hermaguard</guid>
-      <pubDate>Thu, 25 Jun 2026 08:22:00 GMT</pubDate>
+      <pubDate>Tue, 09 Jun 2026 07:41:22 GMT</pubDate>
       <category>Skills &amp; Skill Registries</category>
       <description>HermaGuard is an adversarial code review skill for AI agents designed to identify vulnerabilities and logic bugs without modifying source code. It utilizes a deterministic pre-scan layer featuring tools like Semgrep and Bandit followed by three parallel subagents that analyze edge cases, exploitability, and integration blast radius. Findings are merged by a consolidator into structured Markdown and JSON reports for triage. The system includes a feedback MCP server to track fix rates and a benchm</description>
     </item>
@@ -108,7 +92,7 @@
       <title>socialforge (Plugins &amp; Extensions)</title>
       <link>https://hermesatlas.com/projects/indranilbanerjee/socialforge</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/indranilbanerjee/socialforge</guid>
-      <pubDate>Thu, 25 Jun 2026 08:22:00 GMT</pubDate>
+      <pubDate>Tue, 09 Jun 2026 06:27:11 GMT</pubDate>
       <category>Plugins &amp; Extensions</category>
       <description>SocialForge is an open-source social media production engine designed to automate the creation of monthly content calendars for agencies and in-house teams. It uses asset-first compositing to generate AI backgrounds and scenes around existing brand photos to ensure visual fidelity. The system handles copy adaptation across seven platforms and integrates C2PA signing for EU AI Act compliance. It is compatible with Hermes Agent, Claude Code, and over 35 other Agent Skills platforms.</description>
     </item>
@@ -116,7 +100,7 @@
       <title>digital-marketing-pro (Plugins &amp; Extensions)</title>
       <link>https://hermesatlas.com/projects/indranilbanerjee/digital-marketing-pro</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/indranilbanerjee/digital-marketing-pro</guid>
-      <pubDate>Thu, 25 Jun 2026 08:22:00 GMT</pubDate>
+      <pubDate>Tue, 09 Jun 2026 06:26:21 GMT</pubDate>
       <category>Plugins &amp; Extensions</category>
       <description>Digital Marketing Pro is an open-source AI marketing plugin designed to standardize strategy and execution for agencies and in-house teams managing multiple brands. It utilizes a 12-part strategy flow consisting of 61 explicit steps to ensure consistent output across different brand portfolios. The tool integrates with various AI interfaces including Claude Code, Cursor, and Hermes Agent, providing specialized agents for tasks ranging from funnel architecture to compliance auditing. It specifica</description>
     </item>
@@ -124,7 +108,7 @@
       <title>openclaw-skill (Skills &amp; Skill Registries)</title>
       <link>https://hermesatlas.com/projects/mag3nt-com/openclaw-skill</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/mag3nt-com/openclaw-skill</guid>
-      <pubDate>Thu, 25 Jun 2026 08:22:00 GMT</pubDate>
+      <pubDate>Sun, 07 Jun 2026 04:18:33 GMT</pubDate>
       <category>Skills &amp; Skill Registries</category>
       <description>mag3nt-pay is an agent payment skill that enables AI agents to autonomously pay for APIs that return HTTP 402 Payment Required errors. It works by detecting payment protocols from response headers, decoding the payment challenge, and settling the transaction using USDC via Mag3nt virtual cards. The skill supports Base, Solana, and most EVM networks, allowing agents to handle micropayments and subscriptions without human intervention. It is compatible with OpenClaw, Hermes Agent, and any framewor</description>
     </item>
@@ -132,7 +116,7 @@
       <title>hermes-Custom-CLI-Themes (Plugins &amp; Extensions)</title>
       <link>https://hermesatlas.com/projects/Sahil-SS9/hermes-Custom-CLI-Themes</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/Sahil-SS9/hermes-Custom-CLI-Themes</guid>
-      <pubDate>Thu, 25 Jun 2026 08:22:00 GMT</pubDate>
+      <pubDate>Tue, 02 Jun 2026 15:56:01 GMT</pubDate>
       <category>Plugins &amp; Extensions</category>
       <description>Hermes Custom CLI Themes is a collection of visual skins designed to personalize the Hermes Agent terminal interface. Each theme is defined in a single YAML file that configures color palettes, spinners, branding, and ASCII banner art. Users can apply these skins by placing them in a specific local directory and updating their configuration or using an in-app command. The project includes a variety of themed presets ranging from tactical and sci-fi aesthetics to minimalist investigator styles.</description>
     </item>
@@ -140,7 +124,7 @@
       <title>MrHermagi-tutorbot (Domain Applications)</title>
       <link>https://hermesatlas.com/projects/Sahil-SS9/MrHermagi-tutorbot</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/Sahil-SS9/MrHermagi-tutorbot</guid>
-      <pubDate>Thu, 25 Jun 2026 08:22:00 GMT</pubDate>
+      <pubDate>Tue, 02 Jun 2026 15:56:01 GMT</pubDate>
       <category>Domain Applications</category>
       <description>MrHermagi-tutorbot is a Discord-based AI educational assistant that automates the delivery of structured learning paths using Hermes Agent profiles. The bot utilizes YAML-defined curricula to generate daily lessons consisting of Discord summaries, dark-mode HTML deep-dives, and TTS audio for mobile listening. It features a Socratic teacher persona that delivers content to forum channels and provides interactive Q&amp;A support in dedicated text channels. Users can swap subjects by updating a configu</description>
     </item>
@@ -148,7 +132,7 @@
       <title>hermes-multichannel-prompt-optimizer (Skills &amp; Skill Registries)</title>
       <link>https://hermesatlas.com/projects/Sahil-SS9/hermes-multichannel-prompt-optimizer</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/Sahil-SS9/hermes-multichannel-prompt-optimizer</guid>
-      <pubDate>Thu, 25 Jun 2026 08:22:00 GMT</pubDate>
+      <pubDate>Tue, 02 Jun 2026 15:56:01 GMT</pubDate>
       <category>Skills &amp; Skill Registries</category>
       <description>This Hermes Agent plugin optimizes user prompts by rewriting them for clarity and efficiency before they reach the LLM. It intercepts messages across CLI, TUI, and gateway platforms, tailoring the rewrite based on the target model's vendor family and reasoning capabilities. The system supports multi-language detection to preserve original languages and records all interactions in a local SQLite database for longitudinal analysis. Users can monitor performance through dedicated slash commands for</description>
     </item>
@@ -156,7 +140,7 @@
       <title>cronalytics (Plugins &amp; Extensions)</title>
       <link>https://hermesatlas.com/projects/8bit64k/cronalytics</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/8bit64k/cronalytics</guid>
-      <pubDate>Thu, 25 Jun 2026 08:22:00 GMT</pubDate>
+      <pubDate>Tue, 02 Jun 2026 15:56:01 GMT</pubDate>
       <category>Plugins &amp; Extensions</category>
       <description>Cronalytics is a plugin for Hermes Agent that provides observability and cost attribution for scheduled cron jobs. It utilizes the on_session_end hook to capture usage data and store it in a local SQLite fact database. Users can monitor job health and expenses through a visual dashboard, a programmatic CLI, and a specialized agent skill for automated diagnostics. This allows developers to identify failure patterns and optimize the economics of their agentic automations.</description>
     </item>
@@ -164,7 +148,7 @@
       <title>agentplane-hermes-plugin (Plugins &amp; Extensions)</title>
       <link>https://hermesatlas.com/projects/basilisk-labs/agentplane-hermes-plugin</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/basilisk-labs/agentplane-hermes-plugin</guid>
-      <pubDate>Thu, 25 Jun 2026 08:22:00 GMT</pubDate>
+      <pubDate>Tue, 02 Jun 2026 15:56:01 GMT</pubDate>
       <category>Plugins &amp; Extensions</category>
       <description>This plugin integrates AgentPlane into the Hermes ecosystem by enabling external Kanban worker lanes. It functions by intercepting Kanban assignees matching specific patterns and resolving them to an external supervisor command rather than a standard Hermes profile. The integration maintains strict boundaries by requiring AgentPlane to manage task lifecycles through official APIs instead of direct database mutations. It supports path allowlisting for secure workspace management and includes a di</description>
     </item>
@@ -172,7 +156,7 @@
       <title>herm (Workspaces &amp; GUIs)</title>
       <link>https://hermesatlas.com/projects/liftaris/herm</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/liftaris/herm</guid>
-      <pubDate>Thu, 25 Jun 2026 08:22:00 GMT</pubDate>
+      <pubDate>Tue, 02 Jun 2026 15:56:01 GMT</pubDate>
       <category>Workspaces &amp; GUIs</category>
       <description>Herm is an operator-focused terminal user interface (TUI) that centralizes the management of Hermes Agent into a single dashboard. Built with OpenTUI and Bun, it acts as a client for the Hermes Agent gateway rather than a standalone runtime. It allows users to chat with the agent, manage operational surfaces like cron jobs and memory, and track agentic work via an integrated kanban board. The tool also includes a system for discovering and installing Eikons, which are terminal avatars.</description>
     </item>
@@ -180,7 +164,7 @@
       <title>eagle-eye (Skills &amp; Skill Registries)</title>
       <link>https://hermesatlas.com/projects/willingning-coder/eagle-eye</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/willingning-coder/eagle-eye</guid>
-      <pubDate>Thu, 25 Jun 2026 08:22:00 GMT</pubDate>
+      <pubDate>Tue, 02 Jun 2026 15:56:01 GMT</pubDate>
       <category>Skills &amp; Skill Registries</category>
       <description>Eagle Eye is a zero-invasive plugin for Hermes Agent that prevents token waste and LLM confusion by filtering large skill libraries. It uses a five-layer retrieval system to narrow down 100+ skills to the top five most relevant candidates before an API call. The system combines deterministic hard triggers with probabilistic methods like FTS5, synonyms, and dense embeddings via RRF fusion. This approach provides lightweight hints to the LLM while allowing the model to retain final decision author</description>
     </item>
@@ -188,65 +172,81 @@
       <title>hermes-exabase-plugin (Memory &amp; Context)</title>
       <link>https://hermesatlas.com/projects/futurebrowser/hermes-exabase-plugin</link>
       <guid isPermaLink="true">https://hermesatlas.com/projects/futurebrowser/hermes-exabase-plugin</guid>
-      <pubDate>Thu, 25 Jun 2026 08:22:00 GMT</pubDate>
+      <pubDate>Tue, 02 Jun 2026 15:56:01 GMT</pubDate>
       <category>Memory &amp; Context</category>
       <description>This plugin integrates the Exabase M-1 memory engine into Hermes Agent to provide persistent, long-term context for AI interactions. It functions by storing conversation turns and inferred memories in a self-organizing knowledge graph that resolves contradictions and evolves over time. Users can configure retrieval precision, enable query expansion, and utilize result reranking to fine-tune how the agent accesses stored facts and preferences. The integration includes dedicated tools for manual m</description>
     </item>
     <item>
-      <title>hermes-bort (Integrations &amp; Bridges)</title>
-      <link>https://hermesatlas.com/projects/BORT-AGENTS/hermes-bort</link>
-      <guid isPermaLink="true">https://hermesatlas.com/projects/BORT-AGENTS/hermes-bort</guid>
-      <pubDate>Thu, 25 Jun 2026 08:22:00 GMT</pubDate>
-      <category>Integrations &amp; Bridges</category>
-      <description>hermes-bort is a plugin for Hermes Agent that enables interaction with BORT (BAP-578) agent NFTs on the BSC mainnet. It allows Hermes processes to read on-chain agent states, execute actions via operator-signed writes, and manage portable session memory anchored to IPFS. The plugin integrates with the hermes-agent-self-evolution optimizer to commit verifiable on-chain learning records and evolved skills directly to an agent's knowledge registry.</description>
+      <title>AionUi (Workspaces &amp; GUIs)</title>
+      <link>https://hermesatlas.com/projects/iOfficeAI/AionUi</link>
+      <guid isPermaLink="true">https://hermesatlas.com/projects/iOfficeAI/AionUi</guid>
+      <pubDate>Thu, 28 May 2026 12:08:49 GMT</pubDate>
+      <category>Workspaces &amp; GUIs</category>
+      <description>AionUi is a cross-platform cowork application that provides a unified graphical interface for managing and interacting with multiple AI agents. It integrates a built-in agent engine with file system access and web search capabilities, eliminating the need for separate CLI installations. The platform supports a wide range of external agents like Claude Code and Hermes Agent, while offering specialized assistants for generating editable Office documents via OfficeCLI. Users can manage these agents</description>
     </item>
     <item>
-      <title>hermes-agentmemory (Memory &amp; Context)</title>
-      <link>https://hermesatlas.com/projects/MukundaKatta/hermes-agentmemory</link>
-      <guid isPermaLink="true">https://hermesatlas.com/projects/MukundaKatta/hermes-agentmemory</guid>
-      <pubDate>Thu, 25 Jun 2026 08:22:00 GMT</pubDate>
-      <category>Memory &amp; Context</category>
-      <description>hermes-agentmemory is a standalone memory plugin for Hermes Agent that ensures data deletion is absolute and auditable. It utilizes a pull-model episodic memory approach where writes are synchronous and summaries are generated on-demand rather than in the background. This architecture prevents deleted events from persisting in derived summaries and provides a transparent audit trail of all memory operations. The plugin integrates via the Hermes user-plugins directory and uses Claude models for h</description>
+      <title>cc-switch (Workspaces &amp; GUIs)</title>
+      <link>https://hermesatlas.com/projects/farion1231/cc-switch</link>
+      <guid isPermaLink="true">https://hermesatlas.com/projects/farion1231/cc-switch</guid>
+      <pubDate>Thu, 28 May 2026 12:08:49 GMT</pubDate>
+      <category>Workspaces &amp; GUIs</category>
+      <description>CC Switch is a cross-platform management tool designed to centralize the administration of various AI coding agents and CLI tools. It is built using the Tauri 2 framework to provide a native desktop experience across different operating systems. The application allows users to manage tools including Claude Code, Claude Desktop, Codex, Gemini CLI, OpenCode, OpenClaw, and Hermes Agent from a single interface.</description>
     </item>
     <item>
-      <title>hermes-memory-plugin (Memory &amp; Context)</title>
-      <link>https://hermesatlas.com/projects/Ladybug-Memory/hermes-memory-plugin</link>
-      <guid isPermaLink="true">https://hermesatlas.com/projects/Ladybug-Memory/hermes-memory-plugin</guid>
-      <pubDate>Thu, 25 Jun 2026 08:22:00 GMT</pubDate>
-      <category>Memory &amp; Context</category>
-      <description>Hermes Ladybug Memory is a local-first memory provider plugin that enables Hermes agents to store and retrieve information without relying on cloud services or external APIs. It utilizes a columnar embedded graph database to manage typed memory entries, named relationships, and importance-weighted recall. The system prioritizes high-value information using a 1-10 importance scale and supports BM25 keyword search for precise retrieval. Users can also enable optional entity extraction via GLiNER2 </description>
+      <title>open-design (Skills &amp; Skill Registries)</title>
+      <link>https://hermesatlas.com/projects/nexu-io/open-design</link>
+      <guid isPermaLink="true">https://hermesatlas.com/projects/nexu-io/open-design</guid>
+      <pubDate>Thu, 28 May 2026 12:08:49 GMT</pubDate>
+      <category>Skills &amp; Skill Registries</category>
+      <description>Open Design is a local-first, open-source design and prototyping system that serves as an agent-native alternative to Claude Design. It transforms the design process into a filesystem of skills, plugins, and design systems that can be read and remixed by coding agents. The system enables the generation of web, desktop, and mobile prototypes, motion graphics, and pitch decks using real CSS and components. It integrates with various local CLIs, including Hermes Agent, and supports OpenAI-compatibl</description>
     </item>
     <item>
-      <title>yantrikdb-hermes-plugin (Memory &amp; Context)</title>
-      <link>https://hermesatlas.com/projects/yantrikos/yantrikdb-hermes-plugin</link>
-      <guid isPermaLink="true">https://hermesatlas.com/projects/yantrikos/yantrikdb-hermes-plugin</guid>
-      <pubDate>Thu, 25 Jun 2026 08:22:00 GMT</pubDate>
-      <category>Memory &amp; Context</category>
-      <description>yantrikdb-hermes-plugin is a memory provider for Hermes Agent designed to prevent the loss of important constraints during long sessions. It utilizes a temporal context graph and a maintenance pass to manage memory lifecycles through promotion, demotion, and supersession. The plugin features an embedded in-process backend by default, eliminating the need for a separate server or GPU. It also enables agents to author and track the outcomes of their own skills natively within the database.</description>
+      <title>agent-of-empires (Multi-Agent &amp; Orchestration)</title>
+      <link>https://hermesatlas.com/projects/agent-of-empires/agent-of-empires</link>
+      <guid isPermaLink="true">https://hermesatlas.com/projects/agent-of-empires/agent-of-empires</guid>
+      <pubDate>Thu, 28 May 2026 12:08:49 GMT</pubDate>
+      <category>Multi-Agent &amp; Orchestration</category>
+      <description>Agent of Empires is a session manager for AI coding agents on Linux and macOS that simplifies the coordination of multiple parallel agents. It leverages tmux to ensure sessions persist independently of the terminal, allowing users to monitor agent status via a TUI or a web-based dashboard. The system supports isolated environments through Docker sandboxing and git worktrees for managing different branches. It integrates with various agents including Hermes, Claude Code, and Gemini, providing too</description>
     </item>
     <item>
-      <title>byterover-cli (Memory &amp; Context)</title>
-      <link>https://hermesatlas.com/projects/campfirein/byterover-cli</link>
-      <guid isPermaLink="true">https://hermesatlas.com/projects/campfirein/byterover-cli</guid>
-      <pubDate>Thu, 25 Jun 2026 08:22:00 GMT</pubDate>
-      <category>Memory &amp; Context</category>
-      <description>ByteRover CLI is a persistent, structured memory provider that gives AI coding agents a way to store and retrieve project knowledge. It organizes information into a context tree using a git-like version control system for branching, committing, and merging markdown-based context. The tool includes an interactive REPL, a web dashboard, and integration with over 20 LLM providers. It supports a wide range of AI coding agents including Cursor, Claude Code, and Windsurf via MCP integration.</description>
+      <title>ClawPhone (Deployment &amp; Infra)</title>
+      <link>https://hermesatlas.com/projects/marshallrichards/ClawPhone</link>
+      <guid isPermaLink="true">https://hermesatlas.com/projects/marshallrichards/ClawPhone</guid>
+      <pubDate>Thu, 28 May 2026 12:08:49 GMT</pubDate>
+      <category>Deployment &amp; Infra</category>
+      <description>ClawPhone provides scripts and configuration guides for deploying agent CLIs on Android devices. It leverages Termux to run these agents natively, utilizing proot or compatibility layers only when necessary. The project includes a streamlined installer for Google's Antigravity CLI and detailed implementation notes for running OpenClaw. This setup allows agents to operate in the background with potential access to phone hardware via Termux:API and Termux:GUI.</description>
     </item>
     <item>
-      <title>supermemory (Memory &amp; Context)</title>
-      <link>https://hermesatlas.com/projects/supermemoryai/supermemory</link>
-      <guid isPermaLink="true">https://hermesatlas.com/projects/supermemoryai/supermemory</guid>
-      <pubDate>Thu, 25 Jun 2026 08:22:00 GMT</pubDate>
-      <category>Memory &amp; Context</category>
-      <description>Supermemory is a memory and context engine that provides AI agents with persistent memory across conversations. It automatically extracts facts, maintains user profiles, and manages knowledge updates to prevent AI forgetfulness. The system integrates RAG, multi-modal extractors, and third-party connectors into a single API for developers or a standalone app for users. It supports various clients via an MCP server and provides dedicated plugins for tools like Claude Code and Hermes.</description>
+      <title>hermes-labyrinth (Plugins &amp; Extensions)</title>
+      <link>https://hermesatlas.com/projects/stainlu/hermes-labyrinth</link>
+      <guid isPermaLink="true">https://hermesatlas.com/projects/stainlu/hermes-labyrinth</guid>
+      <pubDate>Thu, 28 May 2026 12:08:49 GMT</pubDate>
+      <category>Plugins &amp; Extensions</category>
+      <description>Hermes Labyrinth is a read-only observability plugin for Hermes Agent that visualizes autonomous workflows as a structured map of events. It functions as a black-box recorder, reading local state to track prompts, tool calls, model transitions, and subagent activities without mutating session data. The tool provides deep diagnostic visibility through specialized views for skill overrides, scheduled cron tasks, and redacted journey reports. Users can export evidence in Markdown or JSON formats wh</description>
     </item>
     <item>
-      <title>OpenViking (Memory &amp; Context)</title>
-      <link>https://hermesatlas.com/projects/volcengine/OpenViking</link>
-      <guid isPermaLink="true">https://hermesatlas.com/projects/volcengine/OpenViking</guid>
-      <pubDate>Thu, 25 Jun 2026 08:22:00 GMT</pubDate>
-      <category>Memory &amp; Context</category>
-      <description>OpenViking is an open-source context database that simplifies context management for AI agents. It replaces traditional flat vector storage with a filesystem paradigm to unify the organization of memories, resources, and skills. The system utilizes a three-tier loading structure (L0/L1/L2) to reduce token consumption and supports recursive directory retrieval for precise context acquisition. It also provides visualized retrieval trajectories to make the retrieval process observable and debuggabl</description>
+      <title>youtube-skills (Skills &amp; Skill Registries)</title>
+      <link>https://hermesatlas.com/projects/ZeroPointRepo/youtube-skills</link>
+      <guid isPermaLink="true">https://hermesatlas.com/projects/ZeroPointRepo/youtube-skills</guid>
+      <pubDate>Thu, 28 May 2026 12:08:49 GMT</pubDate>
+      <category>Skills &amp; Skill Registries</category>
+      <description>YouTube Skills is a collection of tools that enables AI agents to interact with YouTube content without relying on browser automation or local binaries. It utilizes the TranscriptAPI backend to bypass cloud IP blocks, providing agents with direct access to video transcripts, search results, and channel metadata. The project integrates with Hermes Agent, OpenClaw, and Claude Code using the Agent Skills format. Users can perform tasks like summarizing videos, extracting playlist contents, and sear</description>
+    </item>
+    <item>
+      <title>hermes-agent-helm-chart (Deployment &amp; Infra)</title>
+      <link>https://hermesatlas.com/projects/ultraworkers/hermes-agent-helm-chart</link>
+      <guid isPermaLink="true">https://hermesatlas.com/projects/ultraworkers/hermes-agent-helm-chart</guid>
+      <pubDate>Thu, 28 May 2026 12:08:49 GMT</pubDate>
+      <category>Deployment &amp; Infra</category>
+      <description>This unofficial community Helm chart facilitates the deployment of Nous Research's Hermes Agent on Kubernetes clusters. It provides a structured configuration model that enforces state-safety guardrails, such as single-replica constraints and specific update strategies, to prevent data corruption in persistent environments. The chart supports both direct workload management and an operator-ready mode for platform teams using custom resource definitions. It is optimized for multi-tenant isolation</description>
+    </item>
+    <item>
+      <title>hermes-agent-windows (Forks &amp; Derivatives)</title>
+      <link>https://hermesatlas.com/projects/pengchengxia75-arch/hermes-agent-windows</link>
+      <guid isPermaLink="true">https://hermesatlas.com/projects/pengchengxia75-arch/hermes-agent-windows</guid>
+      <pubDate>Thu, 28 May 2026 12:08:49 GMT</pubDate>
+      <category>Forks &amp; Derivatives</category>
+      <description>This project is a Windows-native adaptation of the Hermes Agent that eliminates the need for WSL2 or Linux environments. It utilizes a PowerShell-based installer to deploy the agent directly into the Windows ecosystem while resolving platform-specific issues like process signal handling. The fork introduces a dedicated Web UI management panel for real-time chat, session history, and visual configuration of skills and API keys.</description>
     </item>
   </channel>
 </rss>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -30,6 +30,7 @@
   <url><loc>https://hermesatlas.com/projects/fathah/hermes-desktop</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-06-26</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/sanchomuzax/hermes-webui</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-06-26</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/Euraika-Labs/pan-ui</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-06-26</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/abundantbeing/hermes-browser-extension</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-06-26</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/mukul975/Anthropic-Cybersecurity-Skills</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-06-26</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/conorbronsdon/avoid-ai-writing</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-06-26</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/wondelai/skills</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-06-26</lastmod></url>
@@ -190,10 +191,8 @@
   <url><loc>https://hermesatlas.com/projects/ndesv21/socialclaw</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-06-26</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/hlothaire/hermes-trace</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-06-26</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/nujovich/hermes-telemetry</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-06-26</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/nujovich/hermes-telemetry</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-06-26</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/MnrGreg/hermes-venice-web</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-06-26</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/yonro/hermes-xmemo-plugin</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-06-26</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/DIALLOUBE-RESEARCH/hypernatt-terminal</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-06-26</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/DIALLOUBE-RESEARCH/hypernatt-terminal</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-06-26</lastmod></url>
   <url><loc>https://hermesatlas.com/lists/best-memory-providers</loc><changefreq>weekly</changefreq><priority>0.6</priority><lastmod>2026-06-26</lastmod></url>
   <url><loc>https://hermesatlas.com/lists/top-skills</loc><changefreq>weekly</changefreq><priority>0.6</priority><lastmod>2026-06-26</lastmod></url>


### PR DESCRIPTION
## Summary
- add abundantbeing/hermes-browser-extension to Workspaces & GUIs
- generate the project page and updated Atlas artifacts
- remove two pre-existing duplicate repo rows so repos.json validation passes

## Filter / review results
- Scope: PASS — Chromium side-panel extension for Hermes Agent gateway/runtime
- Quality: PASS — public repo, 95 stars, MIT license, active release v0.1.4, tests present
- Security: PASS with note — read-only browser context design, no debugger/nativeMessaging/cookies/history/bookmarks/downloads permissions; broad host permissions are documented and used for page-context capture
- Build: PASS — upstream npm verify and build pass

## Validation
- Upstream repo: npm install --ignore-scripts; npm run verify; npm run build
- Atlas: node scripts/validate-repos-json.js
- Atlas: node --test tests/*.test.js