### PR TITLE
Add chainbase-labs/Agentkey to Integrations & Bridges

### DIFF
--- a/data/repos.json
+++ b/data/repos.json
@@ -1778,5 +1778,15 @@
     "url": "https://github.com/DanielLi202/hermes-tag",
     "official": false,
     "category": "Integrations & Bridges  *(also fits \"Memory & Context\" — recategorize as you see fit)*"
+  },
+  {
+    "owner": "chainbase-labs",
+    "repo": "Agentkey",
+    "name": "Agentkey",
+    "description": "Give Hermes agents live web reach — one key for web search, scraping, social platforms, and crypto/on-chain data across 26+ services. One plugin, zero extra config.",
+    "stars": 175,
+    "url": "https://github.com/chainbase-labs/Agentkey",
+    "official": false,
+    "category": "Integrations & Bridges"
   }
 ]

--- a/index.html
+++ b/index.html
@@ -1390,7 +1390,7 @@
     <div class="cat-num">§08</div>
     <h2 class="cat-title">Integrations &amp; bridges</h2>
     <p class="cat-desc">Connect Hermes to other agents, platforms, and specialized systems.</p>
-    <div class="cat-count"><span class="cat-count-n">12</span> repos</div>
+    <div class="cat-count"><span class="cat-count-n">13</span> repos</div>
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/AaronWong1999/hermesclaw" data-github="https://github.com/AaronWong1999/hermesclaw" data-desc="Run Hermes Agent and OpenClaw on the same WeChat account">
@@ -1406,6 +1406,14 @@
       <div class="repo-body">
         <div class="repo-name"><span class="org">raulvidis /</span> hermes-android</div>
         <div class="repo-desc">Android device control — bridge app + Python toolset for mobile automation.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/chainbase-labs/Agentkey" data-github="https://github.com/chainbase-labs/Agentkey" data-desc="Give Hermes agents live web reach — one key for web search, scraping, social platforms, and crypto/on-chain data across 26+ services. One plugin, zero extra config.">
+      <div class="repo-stars">★ 175</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">chainbase-labs /</span> Agentkey</div>
+        <div class="repo-desc">Give Hermes agents live web reach — one key for web search, scraping, social platforms, and crypto/on-chain data across 26+ services. One plugin, zero extra config.</div>
       </div>
       <div class="repo-delta">— / wk</div>
     </a>


### PR DESCRIPTION
## Suggest a Repo

Adds **[chainbase-labs/Agentkey](https://github.com/chainbase-labs/Agentkey)** to the **Integrations & Bridges** category.

Following the "Adding a repo directly" path in [CONTRIBUTING.md](https://github.com/ksimback/hermes-ecosystem/blob/main/CONTRIBUTING.md). Same spirit as #423 (AgentLine) — a service that plugs an external capability into Hermes agents via a single integration.

### What it is
AgentKey gives a Hermes agent **live web reach through one API key**: web search, scraping, social platforms, and crypto / on-chain data across **26+ services**, exposed as a single plugin / MCP server with zero extra config. The agent gets one key and one credit balance instead of wiring up and rotating a dozen provider keys.

**What Hermes agents can do with it:**
- Web search (Tavily, Brave, Perplexity, Serper) and URL → markdown scraping (Firecrawl, Jina Reader)
- Read social platforms (X, Reddit, YouTube, LinkedIn, TikTok, Threads, Instagram, and CN sources)
- Pull crypto / on-chain & market data (CoinMarketCap, CoinGecko, DexScreener, Chainbase)
- Automatic provider failover and pay-as-you-go billing — no per-provider key management

### Why it fits the criteria
| Check | Status |
|---|---|
| Built for / integrates with Hermes Agent | ✅ Single plugin / MCP server an agent drops in |
| Created after Hermes launch (2025-07-22) | ✅ 2026-04-23 |
| Genuine effort, adds value | ✅ Unified access layer across 26+ providers |
| ≥ 1 GitHub star | ✅ 175 |
| Security review | ✅ Apache-2.0, no obfuscated code; hosted gateway, keys never exposed to the agent |

### Changes
- `data/repos.json` — new entry (`Integrations & Bridges`)
- `index.html` — card in the Integrations & Bridges section, count 12 → 13

The project page under `projects/` is generated by `build-pages.js` after merge, so it isn't included here.

> Note: the `Validate repos.json` check currently fails on two **pre-existing** entries on `main` (`observeco` with a non-canonical `Monitoring & Observability` category, and `DanielLi202/hermes-tag` with an annotated category string). This PR does not touch them; the entry added here passes the validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
