### PR TITLE
add aidevelopers2/remoteopenclaw-mcp (2 stars) to Skills & Skill Registries

### DIFF
--- a/data/repos.json
+++ b/data/repos.json
@@ -1838,5 +1838,15 @@
     "url": "https://github.com/penfieldlabs/hermes-penfield",
     "official": false,
     "category": "Memory & Context"
+  },
+  {
+    "owner": "aidevelopers2",
+    "repo": "remoteopenclaw-mcp",
+    "name": "remoteopenclaw-mcp",
+    "description": "CLI + MCP server to search remoteopenclaw.com, a directory of 13,870+ MCP servers and 4,384+ agent skills for Hermes, OpenClaw, Claude Code, and Codex",
+    "stars": 2,
+    "url": "https://github.com/aidevelopers2/remoteopenclaw-mcp",
+    "official": false,
+    "category": "Skills & Skill Registries"
   }
 ]


### PR DESCRIPTION
adds [aidevelopers2/remoteopenclaw-mcp](https://github.com/aidevelopers2/remoteopenclaw-mcp) to the ecosystem map.

**Stars:** 2
**Category:** Skills & Skill Registries
**Description:** CLI + MCP server to search remoteopenclaw.com, a directory of 13,870+ MCP servers and 4,384+ agent skills for Hermes, OpenClaw, Claude Code, and Codex

it's the open source (MIT, TypeScript) search client for [remoteopenclaw.com](https://remoteopenclaw.com), which includes a dedicated Hermes skills directory at [remoteopenclaw.com/skills/hermes](https://www.remoteopenclaw.com/skills/hermes). works from the terminal (`npx remoteopenclaw search <query>`) or as a stdio MCP server, no API key needed. disclosure: I maintain it.

this PR only updates repos.json, following the same pattern as the automation PRs. happy to add the HTML chip too if you'd prefer that in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)