### PR TITLE
Fix data drift: dedup repos, prune dead/dup homepage rows, per-item RSS dates

### DIFF
--- a/.github/workflows/build-pages.yml
+++ b/.github/workflows/build-pages.yml
@@ -27,6 +27,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Full history so computeAddedDates() in build-pages.js can walk the
+          # git log of data/repos.json for per-repo first-seen dates. A shallow
+          # clone (default depth 1) collapses every RSS <pubDate> to the latest
+          # commit time.
+          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/data/repos.json
+++ b/data/repos.json
@@ -1767,7 +1767,7 @@
     "stars": 2,
     "url": "https://github.com/observeco/observeco",
     "official": false,
-    "category": "Monitoring & Observability"
+    "category": "Developer Tools"
   },
   {
     "owner": "DanielLi202",
@@ -1777,7 +1777,7 @@
     "stars": 3,
     "url": "https://github.com/DanielLi202/hermes-tag",
     "official": false,
-    "category": "Integrations & Bridges  *(also fits \"Memory & Context\" — recategorize as you see fit)*"
+    "category": "Integrations & Bridges"
   },
   {
     "owner": "Cyber-Yichen",

--- a/data/repos.json
+++ b/data/repos.json
@@ -1810,26 +1810,6 @@
     "category": "Developer Tools"
   },
   {
-    "owner": "bergside",
-    "repo": "typeui",
-    "name": "typeui",
-    "description": "Build better UI with AI",
-    "stars": 1409,
-    "url": "https://github.com/bergside/typeui",
-    "official": false,
-    "category": "Developer Tools"
-  },
-  {
-    "owner": "penfieldlabs",
-    "repo": "hermes-penfield",
-    "name": "hermes-penfield",
-    "description": "🧠 Penfield memory providers for Hermes agent",
-    "stars": 1,
-    "url": "https://github.com/penfieldlabs/hermes-penfield",
-    "official": false,
-    "category": "Memory & Context"
-  },
-  {
     "owner": "penfieldlabs",
     "repo": "hermes-penfield",
     "name": "hermes-penfield",

--- a/index.html
+++ b/index.html
@@ -3,11 +3,11 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Hermes Atlas — community map of Hermes Agent (100+ tools)</title>
-<meta name="description" content="Hermes Atlas is the community map of Hermes Agent by Nous Research — 100+ open-source tools, skills, plugins, and integrations with live GitHub data and AI-powered search.">
+<title>Hermes Atlas — community map of Hermes Agent (180+ tools)</title>
+<meta name="description" content="Hermes Atlas is the community map of Hermes Agent by Nous Research — 180+ open-source tools, skills, plugins, and integrations with live GitHub data and AI-powered search.">
 <link rel="canonical" href="https://hermesatlas.com/">
 <meta property="og:title" content="Hermes Atlas — community map of Hermes Agent">
-<meta property="og:description" content="Hermes Atlas is the community map of Hermes Agent by Nous Research — 100+ open-source tools, skills, plugins &amp; integrations with live GitHub data.">
+<meta property="og:description" content="Hermes Atlas is the community map of Hermes Agent by Nous Research — 180+ open-source tools, skills, plugins &amp; integrations with live GitHub data.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://hermesatlas.com/">
 <meta property="og:site_name" content="Hermes Atlas">
@@ -21,7 +21,7 @@
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Hermes Atlas — community map of Hermes Agent">
-<meta name="twitter:description" content="Hermes Atlas is the community map of Hermes Agent by Nous Research — 100+ open-source tools, skills, plugins &amp; integrations with live GitHub data.">
+<meta name="twitter:description" content="Hermes Atlas is the community map of Hermes Agent by Nous Research — 180+ open-source tools, skills, plugins &amp; integrations with live GitHub data.">
 <meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Hermes+Agent&amp;subtitle=The+Community+Ecosystem+Map+-+100%2B+tools%2C+skills%2C+plugins&amp;v=20260425">
 <meta name="twitter:url" content="https://hermesatlas.com/">
 <link rel="alternate" type="application/rss+xml" title="Hermes Atlas — new projects" href="/rss.xml">
@@ -40,7 +40,7 @@
       "url": "https://hermesatlas.com/",
       "name": "Hermes Atlas",
       "alternateName": "Hermes Agent Ecosystem Map",
-      "description": "Hermes Atlas is the community map of Hermes Agent by Nous Research — 100+ open-source tools, skills, plugins, and integrations with live GitHub data and AI-powered search.",
+      "description": "Hermes Atlas is the community map of Hermes Agent by Nous Research — 180+ open-source tools, skills, plugins, and integrations with live GitHub data and AI-powered search.",
       "inLanguage": "en",
       "publisher": { "@id": "https://hermesatlas.com/#organization" }
     },
@@ -59,7 +59,7 @@
       "@type": "Dataset",
       "@id": "https://hermesatlas.com/#catalog",
       "name": "Hermes Agent Ecosystem Catalog",
-      "description": "Machine-readable catalog of community-built tools, skills, plugins, workspaces, and integrations for Nous Research's Hermes Agent. 100+ projects across 12 categories with live GitHub metadata and AI-generated summaries.",
+      "description": "Machine-readable catalog of community-built tools, skills, plugins, workspaces, and integrations for Nous Research's Hermes Agent. 180+ projects across 12 categories with live GitHub metadata and AI-generated summaries.",
       "url": "https://hermesatlas.com/",
       "keywords": "Hermes Agent, Nous Research, AI agents, LLM tools, agent skills, MCP servers, agent plugins",
       "license": "https://creativecommons.org/publicdomain/zero/1.0/",

--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -1119,6 +1119,35 @@ function syncHomepageRepos(repos) {
   let html = fs.readFileSync(indexPath, "utf-8");
   const NL = html.includes("\r\n") ? "\r\n" : "\n";
 
+  // Prune stale repo-rows before syncing. The append-only add logic below never
+  // removes rows, so entries pruned from data/repos.json (dead/renamed repos)
+  // and any duplicate rows left behind by double-submission linger as broken
+  // links. Drop any repo-row whose owner/repo is not in repos.json, and collapse
+  // duplicate rows to the first occurrence. Only touches <a class="repo-row">
+  // anchors — the hand-curated featured hero uses different markup.
+  const validKeys = new Set(repos.map((r) => `${r.owner}/${r.repo}`));
+  const seenRows = new Set();
+  let removedInvalid = 0;
+  let removedDup = 0;
+  html = html.replace(
+    /\n[ \t]*<a class="repo-row" href="\/projects\/([^"]+)"[\s\S]*?<\/a>/g,
+    (block, key) => {
+      if (!validKeys.has(key)) {
+        removedInvalid++;
+        return "";
+      }
+      if (seenRows.has(key)) {
+        removedDup++;
+        return "";
+      }
+      seenRows.add(key);
+      return block;
+    }
+  );
+  if (removedInvalid || removedDup) {
+    console.log(`  Pruned ${removedInvalid} dead + ${removedDup} duplicate repo-rows`);
+  }
+
   const onPage = new Set(
     [...html.matchAll(/href="\/projects\/([^"]+)"/g)].map((m) => m[1])
   );

--- a/scripts/generate-summaries.js
+++ b/scripts/generate-summaries.js
@@ -239,6 +239,20 @@ async function main() {
     await sleep(DELAY_MS);
   }
 
+  // Prune orphaned summaries for repos no longer in the catalog. Without this
+  // the file accumulates dead entries (removed/renamed repos), which then leak
+  // into llms-full.txt (built by bundling summary content). Removal-only — no
+  // generated content, so no hallucination risk.
+  const validKeys = new Set(repos.map((r) => `${r.owner}/${r.repo}`));
+  let pruned = 0;
+  for (const key of Object.keys(summaries)) {
+    if (!validKeys.has(key)) {
+      delete summaries[key];
+      pruned++;
+    }
+  }
+  if (pruned) console.log(`Pruned ${pruned} orphaned summaries (not in repos.json)`);
+
   // Write summaries
   fs.writeFileSync(summariesPath, JSON.stringify(summaries, null, 2) + "\n", "utf-8");
   console.log(

--- a/scripts/validate-repos-json.js
+++ b/scripts/validate-repos-json.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import fs from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 export const CANONICAL_CATEGORIES = [
   "Core & Official",
@@ -159,6 +159,9 @@ function main() {
   console.log(`data/repos.json validation passed (${parsed.length} repos)`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+// Windows-safe entry check: `file://${argv[1]}` mismatches import.meta.url on
+// Windows (drive letters + backslashes), silently no-op'ing the validator
+// locally so bad data only surfaces in CI. pathToFileURL normalizes both.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main();
 }


### PR DESCRIPTION
## Problems (all confirmed live)
- **repos.json duplicates**: `bergside/typeui`, `penfieldlabs/hermes-penfield` merged twice → 2 exact-dup entries.
- **Homepage drift**: `syncHomepageRepos()` is append-only, so 3 dead links (`supermodeltools/bigiron`, `MorvaniLabs/cordn8`, `marlandoj/zouroboros`) + 5 duplicate rows lingered.
- **Orphan summaries** leaking into `llms-full.txt`.
- **RSS dates collapsed**: all 30 `<pubDate>` identical because CI checkout was shallow → `computeAddedDates()` saw 1 commit.
- **Stale copy**: "100+" vs 183 actual.

## Fixes
- Dedup `repos.json` (185→183; dropped == kept byte-for-byte).
- Prune pass in `syncHomepageRepos()`: drop rows not in repos.json + collapse dups (only `<a class="repo-row">`; hero untouched).
- Orphan-prune in `generate-summaries.js` (removal-only).
- `fetch-depth: 0` on `build-pages.yml` checkout.
- "100+" → "180+" in homepage title/meta.

## Verification (offline build)
- Prune log: **3 dead + 5 duplicate repo-rows removed**; dead rows gone from index.html.
- RSS: **1 → 24 distinct pubDates**.
- `node --test` 16/16. Pages/artifacts regenerate + summaries prune on merge via `build-pages.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)