### PR TITLE
Harden API request paths: role whitelist, disconnect abort, error hygiene

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -266,7 +266,19 @@ export default async function handler(req, res) {
     if (!m || typeof m.content !== "string" || m.content.length > 2000) {
       return res.status(400).json({ error: "Invalid history message" });
     }
+    // Whitelist roles. Without this a client can inject {role:"system"}
+    // messages that append attacker instructions after the real system prompt
+    // and hijack the bot's behavior under Hermes Atlas branding.
+    if (m.role !== "user" && m.role !== "assistant") {
+      return res.status(400).json({ error: "Invalid history message role" });
+    }
   }
+
+  // Abort the upstream LLM call (and query-rewrite call) if the client
+  // disconnects mid-stream. Otherwise the full completion keeps running and
+  // billing tokens nobody will read, up to the function's maxDuration.
+  const ac = new AbortController();
+  res.on("close", () => ac.abort());
 
   // Rate limiting — per-IP (hour + day) and global (hour + day).
   // Use x-real-ip (set by Vercel's edge, not client-spoofable). Fall back
@@ -331,7 +343,7 @@ export default async function handler(req, res) {
     // 2. Rewrite query using conversation history (if history exists)
     // This transforms "how do I install it?" → "how do I install Hermes Agent?"
     const searchQuery = history.length > 0
-      ? await rewriteQuery(message, history)
+      ? await rewriteQuery(message, history, ac.signal)
       : message;
 
     console.log(`[RAG] Original: "${message}" → Search: "${searchQuery}"`);
@@ -461,6 +473,7 @@ ${retrievedContext}${repoMetadataBlock}`;
         "HTTP-Referer": "https://hermesatlas.com",
         "X-Title": "Hermes Atlas",
       },
+      signal: ac.signal,
       body: JSON.stringify({
         // OpenRouter native fallback — pass ONLY `models` array (no `model` field)
         // It will try each in order until one succeeds
@@ -482,9 +495,9 @@ ${retrievedContext}${repoMetadataBlock}`;
         const parsed = JSON.parse(err);
         if (parsed.error?.code === 429) {
           userMsg = "All available AI models are rate-limited right now. Please try again in a minute.";
-        } else if (parsed.error?.message) {
-          userMsg = parsed.error.message;
         }
+        // Do not echo parsed.error.message — never forward an upstream provider's
+        // error text to the client; the full error is logged server-side above.
       } catch {}
       res.write(userMsg);
       return res.end();
@@ -551,6 +564,12 @@ ${retrievedContext}${repoMetadataBlock}`;
 
     res.end();
   } catch (err) {
+    // Client disconnected mid-stream — expected, not an error worth logging or
+    // writing (the socket is already gone).
+    if (ac.signal.aborted || err?.name === "AbortError") {
+      try { res.end(); } catch {}
+      return;
+    }
     console.error("Chat error:", err);
     // Headers are already sent, write error inline and end
     try {
@@ -562,7 +581,7 @@ ${retrievedContext}${repoMetadataBlock}`;
 
 // Rewrite a follow-up question as a standalone query using conversation history.
 // Uses few-shot examples for reliable pronoun resolution and context expansion.
-async function rewriteQuery(message, history) {
+async function rewriteQuery(message, history, signal) {
   try {
     // Build a minimal history for the rewriter
     const historyText = history
@@ -626,6 +645,7 @@ Rewritten:`;
 
     const res = await fetch("https://openrouter.ai/api/v1/chat/completions", {
       method: "POST",
+      signal,
       headers: {
         Authorization: `Bearer ${OPENROUTER_KEY}`,
         "Content-Type": "application/json",

--- a/api/og.js
+++ b/api/og.js
@@ -1,6 +1,7 @@
 import { ImageResponse } from "@vercel/og";
 import fs from "node:fs";
 import path from "node:path";
+import { rateLimit } from "../lib/redis.js";
 
 const MAX_TITLE = 120;
 const MAX_SUBTITLE = 180;
@@ -20,6 +21,23 @@ function loadFonts() {
 }
 
 export default async function handler(req, res) {
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  // Satori rendering is CPU-heavy and the immutable CDN cache is keyed by the
+  // full query string, so ?title=<random> bypasses the cache on every request
+  // — a cheap compute-burn vector. Rate-limit per IP (fails open if Redis is
+  // down; OG cards are non-critical).
+  const ip =
+    req.headers["x-real-ip"]?.trim() ||
+    req.headers["x-forwarded-for"]?.split(",")[0]?.trim() ||
+    "unknown";
+  const { allowed } = await rateLimit(`og:ip:${ip}`, 60, 60);
+  if (!allowed) {
+    return res.status(429).json({ error: "Too many requests" });
+  }
+
   try {
     const url = new URL(req.url, `http://${req.headers.host || "localhost"}`);
     const title = (url.searchParams.get("title") || "Hermes Atlas").slice(0, MAX_TITLE);

--- a/api/stars-history.js
+++ b/api/stars-history.js
@@ -49,6 +49,9 @@ export default async function handler(req, res) {
     });
   } catch (err) {
     console.error("Stars history error:", err);
-    return res.status(200).json({ days: 0, history: [], error: err.message });
+    // Don't cache the error response (vercel.json /api/(.*) sets s-maxage=3600)
+    // and don't leak err.message to the client.
+    res.setHeader("Cache-Control", "no-store");
+    return res.status(200).json({ days: 0, history: [] });
   }
 }

--- a/api/stars.js
+++ b/api/stars.js
@@ -148,7 +148,9 @@ export default async function handler(req, res) {
     const snapshot = Object.fromEntries(
       starData.map(r => [`${r.owner}/${r.repo}`, r.stars])
     );
-    await kvSet(historyKey, snapshot);
+    // 366-day TTL: stars-history only ever reads back 365 days, so without an
+    // expiry these daily keys accumulate in Redis forever.
+    await kvSet(historyKey, snapshot, { ex: 366 * 86400 });
 
     return res.status(200).json(response);
   } catch (err) {
@@ -161,7 +163,12 @@ export default async function handler(req, res) {
       stars: r.stars,
       updatedAt: null
     })));
-    return res.status(200).json({ ...fallback, error: err.message });
+    // Serve the static fallback but never let this error response get cached
+    // by the CDN (the /api/(.*) rule in vercel.json sets s-maxage=3600, which
+    // would pin a transient GitHub/Redis failure as the "good" answer for an
+    // hour). Do not leak err.message to the client — it's logged above.
+    res.setHeader("Cache-Control", "no-store");
+    return res.status(200).json(fallback);
   }
 }
 


### PR DESCRIPTION
Follow-on API hardening after #394 (chat.js was out of scope there).

- **chat.js role whitelist (A1)**: history messages must be `user`/`assistant`; blocks `{role:"system"}` injection that hijacks the bot's rules under Atlas branding.
- **chat.js disconnect abort (A2)**: `AbortController` tied to `res` `close` aborts the streaming completion + query-rewrite when the client leaves mid-stream — stops paying for unread tokens (up to `maxDuration`). Abort treated as clean end.
- **chat.js error hygiene (A4)**: no longer echoes OpenRouter's `error.message`; keeps 429 case, generic otherwise.
- **stars.js / stars-history.js (A3)**: error responses set `Cache-Control: no-store` (the `/api/(.*)` rule caches `s-maxage=3600`, which would pin a transient failure for an hour) and drop `err.message`.
- **stars.js (A5)**: 366-day TTL on `stars:history:<date>` keys (were never expiring).
- **og.js (A6)**: method gate + fail-open per-IP rate limit — satori render is CPU-heavy and `?title=<random>` bypasses the query-keyed immutable cache.

## Verification
`node --check` on all 4 files; `node --test` 16/16. Endpoint behavior verified against the Vercel preview (see below).

🤖 Generated with [Claude Code](https://claude.com/claude-code)