### PR TITLE
Escalate silent workflow failures + pass dispatch inputs via env

### DIFF
--- a/.github/workflows/build-pages.yml
+++ b/.github/workflows/build-pages.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      issues: write
 
     steps:
       - name: Checkout
@@ -108,3 +109,29 @@ jobs:
       - name: Ping IndexNow with changed URLs
         if: steps.diff.outputs.changed == 'true'
         run: node scripts/indexnow-ping.js
+
+      # Escalate silent failures. This workflow runs daily and gates what is live
+      # on hermesatlas.com; without this a failed run was only a red X in the
+      # Actions tab. Opens (or comments on a deduped) workflow-issue.
+      - name: Escalate on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const wf = 'build-pages';
+            const title = `[Workflow] ${wf} failed`;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = `The **${wf}** workflow failed — it gates what is live on hermesatlas.com.\n\n**Run:** ${runUrl}\n\nCheck the run log (npm install, generator error, OpenRouter/GitHub API, or the push-retry loop).`;
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner, repo: context.repo.repo, state: 'open', labels: 'workflow-issue'
+            });
+            const match = existing.data.find(i => i.title === title);
+            if (match) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo, issue_number: match.number, body
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner, repo: context.repo.repo, title, body, labels: ['workflow-issue']
+              });
+            }

--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -108,10 +108,15 @@ jobs:
 
       - name: Run smoke test
         id: smoke
+        # Pass dispatch inputs via env, never interpolated straight into the
+        # shell command (a crafted `base`/`sample` could otherwise inject shell).
+        env:
+          SMOKE_BASE: ${{ inputs.base || 'https://hermesatlas.com' }}
+          SMOKE_SAMPLE: ${{ inputs.sample || '25' }}
         run: |
           node scripts/smoke-test-prod.js \
-            --base "${{ inputs.base || 'https://hermesatlas.com' }}" \
-            --sample "${{ inputs.sample || '25' }}" \
+            --base "$SMOKE_BASE" \
+            --sample "$SMOKE_SAMPLE" \
             --continue \
             | tee smoke-output.txt
 

--- a/.github/workflows/rebuild-chunks.yml
+++ b/.github/workflows/rebuild-chunks.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      issues: write
 
     steps:
       - name: Checkout
@@ -86,3 +87,28 @@ jobs:
           done
           echo "Push failed after 3 attempts"
           exit 1
+
+      # Escalate silent failures — this workflow rebuilds the RAG knowledge base
+      # that Ask the Atlas answers from; a failed run was previously only a red X.
+      - name: Escalate on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const wf = 'rebuild-chunks';
+            const title = `[Workflow] ${wf} failed`;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = `The **${wf}** workflow failed — it rebuilds the Ask-the-Atlas knowledge base.\n\n**Run:** ${runUrl}\n\nCheck the run log (OpenRouter embeddings, chunks.json size, or the push-retry loop).`;
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner, repo: context.repo.repo, state: 'open', labels: 'workflow-issue'
+            });
+            const match = existing.data.find(i => i.title === title);
+            if (match) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo, issue_number: match.number, body
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner, repo: context.repo.repo, title, body, labels: ['workflow-issue']
+              });
+            }

--- a/.github/workflows/refresh-docs.yml
+++ b/.github/workflows/refresh-docs.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      issues: write
 
     steps:
       - name: Checkout
@@ -71,3 +72,28 @@ jobs:
           done
           echo "Push failed after 3 attempts"
           exit 1
+
+      # Escalate silent failures — this workflow mirrors the official Hermes docs
+      # into the KB; a failed run was previously only a red X in the Actions tab.
+      - name: Escalate on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const wf = 'refresh-docs';
+            const title = `[Workflow] ${wf} failed`;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = `The **${wf}** workflow failed — it mirrors the official Hermes docs into the KB.\n\n**Run:** ${runUrl}\n\nCheck the run log (scrape/network error or the push-retry loop).`;
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner, repo: context.repo.repo, state: 'open', labels: 'workflow-issue'
+            });
+            const match = existing.data.find(i => i.title === title);
+            if (match) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo, issue_number: match.number, body
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner, repo: context.repo.repo, title, body, labels: ['workflow-issue']
+              });
+            }

--- a/.github/workflows/smoke-test-pr.yml
+++ b/.github/workflows/smoke-test-pr.yml
@@ -97,9 +97,13 @@ jobs:
 
       - name: Run smoke test against preview
         id: smoke
+        # Pass the preview URL via env, never interpolated straight into the
+        # shell command.
+        env:
+          SMOKE_BASE: ${{ steps.vercel.outputs.base_url }}
         run: |
           node scripts/smoke-test-prod.js \
-            --base "${{ steps.vercel.outputs.base_url }}" \
+            --base "$SMOKE_BASE" \
             --sample "25" \
             --continue \
             | tee smoke-output.txt


### PR DESCRIPTION
## B4 — silent-failure escalation
`build-pages`, `rebuild-chunks`, and `refresh-docs` run daily and gate what's live on hermesatlas.com + the Ask-the-Atlas KB, but a failed run was only a red X in the Actions tab. Added an `if: failure()` step to each that opens (or comments on a deduped) `workflow-issue` tracking issue, plus `issues: write` permission.

## B5 — dispatch-input hygiene
`post-deploy-smoke` and `smoke-test-pr` spliced `${{ inputs.base }}` / `${{ inputs.sample }}` / `${{ steps.vercel.outputs.base_url }}` straight into the `run:` shell. Routed through `env:` (`SMOKE_BASE`/`SMOKE_SAMPLE`), matching the codebase's no-interpolation-into-shell discipline.

## Verification
All 5 workflow YAMLs parse; 3/3 escalation steps present; 0 raw `--base "${{` interpolations remain. Escalation fires on the next real failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)