### PR TITLE
Frontend polish: word-boundary meta truncation, lazy README images, headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Live ecosystem map for Hermes Agent by Nous Research",
   "private": true,
   "type": "module",
+  "scripts": {
+    "test": "node --test tests/*.test.js"
+  },
   "dependencies": {
     "@vercel/og": "^0.11.1",
     "dompurify": "^3.4.11",

--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -104,7 +104,9 @@ renderer.image = function ({ href, title, text }) {
     src = currentRawBase + cleanRelativePath(src);
   }
   const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
-  return `<img src="${escapeHtml(src)}" alt="${escapeHtml(text || "")}"${titleAttr}>`;
+  // README images sit below the fold on project pages — lazy-load + async-decode
+  // to cut initial payload and avoid layout jank.
+  return `<img src="${escapeHtml(src)}" alt="${escapeHtml(text || "")}"${titleAttr} loading="lazy" decoding="async">`;
 };
 
 // Demote README heading levels so each page has a single <h1> (DESIGN.md §11).
@@ -133,6 +135,17 @@ function sanitizeReadmeHtml(html) {
 // string (repo description, summary) can't break out of the block. ──
 function ldJson(node) {
   return `<script type="application/ld+json">\n${JSON.stringify(node, null, 2).replace(/</g, "\\u003c")}\n</script>`;
+}
+
+// Truncate at a word boundary + ellipsis so meta descriptions and feed blurbs
+// don't cut off mid-word ("...these tools e"). Null-safe; returns unchanged if
+// already within the limit.
+function truncate(str, max) {
+  const s = String(str || "");
+  if (s.length <= max) return s;
+  const cut = s.slice(0, max);
+  const lastSpace = cut.lastIndexOf(" ");
+  return (lastSpace > max * 0.6 ? cut.slice(0, lastSpace) : cut).trimEnd() + "…";
 }
 
 // ── Load data ──
@@ -636,9 +649,7 @@ This file is the companion to ${SITE_URL}/llms.txt (the concise index).`);
 // ── Project page template ──
 function renderProjectPage(repo, meta, readmeHtml, relatedRepos, summary, handbookMention) {
   const title = `${repo.name} — Hermes Agent ${repo.category} | Hermes Atlas`;
-  const desc = escapeHtml(
-    (meta.description || repo.description).slice(0, 160)
-  );
+  const desc = escapeHtml(truncate(meta.description || repo.description, 160));
   const canonicalUrl = `${SITE_URL}/projects/${repo.owner}/${repo.repo}`;
   const stars = meta.stars || repo.stars;
   const listSlug = categoryToListSlug[repo.category];
@@ -786,7 +797,7 @@ ${PAGE_FOOTER}
 // ── List page template ──
 function renderListPage(list, matchedRepos, listSummaryEntries) {
   const title = `${list.title} | Hermes Atlas`;
-  const desc = escapeHtml(list.description.slice(0, 160));
+  const desc = escapeHtml(truncate(list.description, 160));
   const canonicalUrl = `${SITE_URL}/lists/${list.slug}`;
 
   const sorted = matchedRepos.slice().sort((a, b) => (b.meta?.stars || b.stars) - (a.meta?.stars || a.stars));

--- a/vercel.json
+++ b/vercel.json
@@ -34,6 +34,8 @@
       "headers": [
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Content-Security-Policy", "value": "object-src 'none'; base-uri 'self'; frame-ancestors 'none'" },
         { "key": "Cache-Control", "value": "public, max-age=3600, s-maxage=86400" }
       ]
     }


### PR DESCRIPTION
## Changes
- **Truncation (C5/C13)**: `truncate()` cuts meta descriptions at a word boundary + ellipsis instead of mid-word (`"...these tools e"`); applied to project + list `<meta name="description">`. Null-safe — also fixes a latent crash when both description fields were empty.
- **Lazy images (C11)**: README images render `loading="lazy" decoding="async"` (they're below the fold) — cuts initial payload and layout jank.
- **npm test (C13)**: added `"test"` script so `npm test` runs the suite instead of silently failing.
- **Headers**: `Referrer-Policy: strict-origin-when-cross-origin` + a conservative CSP (`object-src 'none'; base-uri 'self'; frame-ancestors 'none'`) on page responses. Deliberately scoped to directives that **cannot** break resource loading — verified the site uses no `<object>`/`<embed>`/`<base>` and no cross-origin forms. A full `script-src`/`style-src`/`img-src` CSP needs real browser QA (gstack browse is down on this machine) and is flagged for follow-up.

## Verification
`npm test` 16/16; JSON valid; `truncate` unit-checked (word boundary, short-unchanged, null-safe); marked renderer emits the lazy attrs; offline build clean (183 pages, 0 errors). Pages regenerate with the new truncation/lazy attrs on merge via `build-pages.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)