### PR TITLE
Sync catalog: add 2 stranded repos, prune ECOSYSTEM drift, guard recurrence

### DIFF
--- a/ECOSYSTEM.md
+++ b/ECOSYSTEM.md
@@ -107,7 +107,6 @@ Plugins extend Hermes with new tools, data sources, or behaviors at the framewor
 | [FahrenheitResearch/hermes-weather-plugin](https://github.com/FahrenheitResearch/hermes-weather-plugin) | Professional weather data with NWS imagery and forecasts | — | Beta |
 | [nativ3ai/hermes-payguard](https://github.com/nativ3ai/hermes-payguard) | Safe USDC and x402 payment handling for agents | — | Experimental |
 | [raulvidis/hermes-cloudflare](https://github.com/raulvidis/hermes-cloudflare) | Headless browsing via Cloudflare Workers | — | Experimental |
-| [anpicasso/hermes-plugin-chrome-profiles](https://github.com/anpicasso/hermes-plugin-chrome-profiles) | Multi-account Chrome profile switching for browser tool | — | Experimental |
 
 ---
 
@@ -134,7 +133,6 @@ Frameworks for running multiple Hermes agents or coordinating agent swarms.
 |:-----------|:------------|------:|:---------|
 | [builderz-labs/mission-control](https://github.com/builderz-labs/mission-control) | Self-hosted AI agent orchestration — dispatch tasks, run multi-agent workflows, monitor spend | 3,875 | Beta |
 | [swarmclawai/swarmclaw](https://github.com/swarmclawai/swarmclaw) | Build autonomous AI agent swarms with orchestration, skills, and multiple model providers | 285 | Beta |
-| [supermodeltools/bigiron](https://github.com/supermodeltools/bigiron) | AI-native SDLC — Hermes Agent + Supermodel code graph, graph-gated at every phase | 7 | Experimental |
 | [1ilkhamov/opencode-hermes-multiagent](https://github.com/1ilkhamov/opencode-hermes-multiagent) | 17 specialized agents with structured communication protocols | — | Beta |
 | [Rainhoole/hermes-agent-acp-skill](https://github.com/Rainhoole/hermes-agent-acp-skill) | Multi-agent delegation routing via ACP | — | Beta |
 | [Abruptive/Ankh.md](https://github.com/Abruptive/Ankh.md) | TAW Agent × Hermes swarm framework for multi-agent collaboration | 25 | Experimental |
@@ -148,7 +146,6 @@ Docker images, deployment templates, and infrastructure tooling for running Herm
 
 | Repository | Description | Stars | Maturity |
 |:-----------|:------------|------:|:---------|
-| [Crustocean/hermes-agent-template](https://github.com/Crustocean/hermes-agent-template) | Production-ready Docker template for cloud deployment | — | Beta |
 | [xmbshwll/hermes-agent-docker](https://github.com/xmbshwll/hermes-agent-docker) | Minimal Docker sandbox image for Hermes | — | Beta |
 | [0xrsydn/nix-hermes-agent](https://github.com/0xrsydn/nix-hermes-agent) | Nix package and NixOS module for reproducible Hermes deployment | — | Beta |
 | [numtide/llm-agents.nix](https://github.com/numtide/llm-agents.nix) | Nix packages for AI coding agents including Hermes | 967 | Production |
@@ -168,8 +165,6 @@ Connect Hermes to external platforms, services, and ecosystems.
 | [raulvidis/hermes-android](https://github.com/raulvidis/hermes-android) | Android device bridge with Python toolset for mobile automation | — | Beta |
 | [gizdusum/hermes-blockchain-oracle](https://github.com/gizdusum/hermes-blockchain-oracle) | Solana on-chain analytics MCP server for Hermes | — | Experimental |
 | [Ridwannurudeen/hermes-council](https://github.com/Ridwannurudeen/hermes-council) | Adversarial multi-perspective MCP server for decision-making | — | Experimental |
-| [Hmbown/NemoHermes](https://github.com/Hmbown/NemoHermes) | NVIDIA capability registry and GPU routing for Hermes | — | Experimental |
-| [marlandoj/zouroboros-swarm-executors](https://github.com/marlandoj/zouroboros-swarm-executors) | Claude Code ↔ Hermes task handoff and swarm execution | — | Experimental |
 
 ---
 
@@ -205,8 +200,6 @@ Purpose-built agents and workflows powered by Hermes for specific use cases.
 | [hxsteric/mercury](https://github.com/hxsteric/mercury) | Multi-chain blockchain cash flow analyzer | — | Beta |
 | [Lethe044/hermes-incident-commander](https://github.com/Lethe044/hermes-incident-commander) | Production incident detection and self-healing workflows | — | Beta |
 | [bryercowan/hermes-embodied](https://github.com/bryercowan/hermes-embodied) | Self-improving robotics via VLA model fine-tuning | — | Experimental |
-| [Lethe044/hermes-legal](https://github.com/Lethe044/hermes-legal) | Contract risk analysis and legal document review | — | Experimental |
-| [Snehal707/Hermes-mars-rover](https://github.com/Snehal707/Hermes-mars-rover) | Mars rover simulator with ROS2 and Gazebo integration | — | Experimental |
 
 ---
 
@@ -265,7 +258,6 @@ Notable forks that add significant functionality beyond the base Hermes agent.
 |:-----------|:------------|------:|:---------|
 | [nativ3ai/hermes-agent-camel](https://github.com/nativ3ai/hermes-agent-camel) | Hermes with integrated CaMeL trust boundaries for safer autonomous execution | 12 | Beta |
 | [kaminocorp/hermes-alpha](https://github.com/kaminocorp/hermes-alpha) | Cloud-deployed Hermes with pre-configured templates and managed infrastructure | — | Beta |
-| [jasperan/orahermes-agent](https://github.com/jasperan/orahermes-agent) | Oracle Cloud (OCI) GenAI and Oracle 26ai database integration | — | Experimental |
 | [beardthelion/hermes-skill-distillation](https://github.com/beardthelion/hermes-skill-distillation) | Fine-tuning trajectory generation from Hermes skill executions | — | Experimental |
 
 ---

--- a/data/repos.json
+++ b/data/repos.json
@@ -1828,5 +1828,25 @@
     "url": "https://github.com/aidevelopers2/remoteopenclaw-mcp",
     "official": false,
     "category": "Skills & Skill Registries"
+  },
+  {
+    "owner": "chainbase-labs",
+    "repo": "Agentkey",
+    "name": "Agentkey",
+    "description": "Connect your AI agent to the world — Web search, Social media, Crypto & On-chain data. One plugin, zero extra config.",
+    "stars": 180,
+    "url": "https://github.com/chainbase-labs/Agentkey",
+    "official": false,
+    "category": "Integrations & Bridges"
+  },
+  {
+    "owner": "teixeirazeus",
+    "repo": "fablize-for-hermes",
+    "name": "fablize-for-hermes",
+    "description": "This project adapts fablize's verified procedures — verification grounding, multi-story evidence gating, investigation protocol, and early-stop prevention.",
+    "stars": 5,
+    "url": "https://github.com/teixeirazeus/fablize-for-hermes",
+    "official": false,
+    "category": "Skills & Skill Registries"
   }
 ]

--- a/scripts/check-dead-repos.js
+++ b/scripts/check-dead-repos.js
@@ -68,6 +68,28 @@ for (const err of data.errors || []) {
 
 console.log(`Checked ${repos.length} repos: ${dead.length} dead`);
 
+// ECOSYSTEM.md drift: it mirrors the catalog and is bundled into llms-full.txt
+// + the RAG chunks, so repo rows left behind after a catalog removal quietly
+// pollute LLM retrieval. Flag any ECOSYSTEM.md repo link not in data/repos.json.
+let ecoDrift = [];
+try {
+  const eco = await fs.readFile("ECOSYSTEM.md", "utf8");
+  const inCatalog = new Set(repos.map((r) => `${r.owner}/${r.repo}`.toLowerCase()));
+  const linked = [
+    ...new Set(
+      [...eco.matchAll(/github\.com\/([\w.-]+\/[\w.-]+)/g)].map((m) =>
+        m[1].replace(/\.git$/, "").toLowerCase()
+      )
+    ),
+  ];
+  ecoDrift = linked.filter(
+    (k) => !inCatalog.has(k) && !k.startsWith("nousresearch/hermes-agent")
+  );
+  console.log(`ECOSYSTEM.md: ${ecoDrift.length} repo rows not in catalog`);
+} catch (e) {
+  console.warn(`Could not read ECOSYSTEM.md for drift check: ${e.message}`);
+}
+
 let body = "";
 if (dead.length > 0) {
   body =
@@ -81,8 +103,22 @@ if (dead.length > 0) {
   }
   body +=
     `\n## Fix\n\nRemove each entry from \`data/repos.json\` and merge. ` +
-    `See PR #148 (Web3CZ removal) and a4e906e (iamagenius00/hermes-a2a removal) for prior examples.\n\n` +
-    `_Auto-detected by \`scripts/check-dead-repos.js\` via \`audit-summaries.yml\`. This issue updates in place; it auto-closes when the list goes empty._\n`;
+    `See PR #148 (Web3CZ removal) and a4e906e (iamagenius00/hermes-a2a removal) for prior examples.\n\n`;
+}
+
+if (ecoDrift.length > 0) {
+  body +=
+    `## ECOSYSTEM.md drift (${ecoDrift.length})\n\n` +
+    `These repos are linked in \`ECOSYSTEM.md\` but are no longer in \`data/repos.json\`. ` +
+    `\`ECOSYSTEM.md\` is bundled into \`llms-full.txt\` and the RAG chunks, so these stale rows ` +
+    `pollute LLM retrieval.\n\n`;
+  for (const k of ecoDrift) body += `- \`${k}\`\n`;
+  body += `\n**Fix**: remove each stale row from \`ECOSYSTEM.md\` (or re-add the repo to the catalog).\n\n`;
+}
+
+if (body) {
+  body +=
+    `_Auto-detected by \`scripts/check-dead-repos.js\` via \`audit-summaries.yml\`. This issue updates in place; it auto-closes when the lists go empty._\n`;
 }
 
 await fs.writeFile("dead-repos.md", body);


### PR DESCRIPTION
## What
- **Add 2 stranded repos**: `chainbase-labs/Agentkey` (Integrations, 180★), `teixeirazeus/fablize-for-hermes` (Skills, 5★). Both passed the validator when submitted; their PRs (#436/#387) were left DIRTY by the pre-fix auto-merge bug. Verified both still resolve on GitHub and aren't archived.
- **Prune 8 stale ECOSYSTEM.md rows** for repos no longer in the catalog — `ECOSYSTEM.md` is bundled into `llms-full.txt` + RAG chunks, so these polluted retrieval.
- **Extend `check-dead-repos.js`** to flag ECOSYSTEM↔catalog drift in the audit issue, preventing silent recurrence.

## Verification
`validate-repos-json` passes (185 repos); ECOSYSTEM drift now 0; diffs are +2 repos / −8 stale rows only; `npm test` 16/16.

Closes #436, #387.

🤖 Generated with [Claude Code](https://claude.com/claude-code)