### PR TITLE
Automate weekly featured-pick rotation (on-brand pool) + un-stale

### DIFF
--- a/.github/workflows/rotate-featured.yml
+++ b/.github/workflows/rotate-featured.yml
@@ -1,0 +1,80 @@
+name: Rotate featured pick
+
+# Weekly auto-rotation of the homepage "Featured this week" community pick.
+# scripts/rotate-featured.js --auto cycles through Hermes-native community tools
+# (see the picker's star-band + name filter). Kevin can override any week by
+# running `node scripts/rotate-featured.js <owner>/<repo>` locally, or curate by
+# adjusting the picker's band.
+
+concurrency:
+  group: main-bot-push
+  cancel-in-progress: false
+
+on:
+  schedule:
+    - cron: '0 10 * * 1' # Mondays 10:00 UTC (after the daily + Monday-audit cluster)
+  workflow_dispatch: {}
+
+jobs:
+  rotate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Rotate featured pick
+        run: node scripts/rotate-featured.js --auto
+
+      - name: Commit + push if changed
+        run: |
+          git config user.name "Hermes Atlas Bot"
+          git config user.email "bot@hermesatlas.com"
+          git add index.html data/featured.json
+          if git diff --cached --quiet; then
+            echo "No featured change to commit"
+            exit 0
+          fi
+          git commit -m "Rotate featured community pick"
+          # main can move during the run (other bot workflows); mirror the
+          # rebase-retry pattern used by the other pushing workflows.
+          for attempt in 1 2 3; do
+            if git push; then
+              echo "Pushed on attempt $attempt"
+              exit 0
+            fi
+            echo "Push rejected (attempt $attempt) — pulling --rebase and retrying"
+            git pull --rebase origin main || { echo "Rebase failed — aborting"; exit 1; }
+          done
+          echo "Push failed after 3 attempts"
+          exit 1
+
+      - name: Escalate on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const wf = 'rotate-featured';
+            const title = `[Workflow] ${wf} failed`;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = `The **${wf}** workflow failed.\n\n**Run:** ${runUrl}\n\nCheck the run log (picker found no eligible repo, or the push-retry loop).`;
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner, repo: context.repo.repo, state: 'open', labels: 'workflow-issue'
+            });
+            const match = existing.data.find(i => i.title === title);
+            if (match) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo, issue_number: match.number, body
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner, repo: context.repo.repo, title, body, labels: ['workflow-issue']
+              });
+            }

--- a/data/featured.json
+++ b/data/featured.json
@@ -1,5 +1,10 @@
 [
   {
+    "slug": "dodo-reach/hermes-desktop",
+    "weekStart": "2026-06-29",
+    "addedAt": "2026-07-03T17:59:44.093Z"
+  },
+  {
     "slug": "garrytan/gbrain",
     "weekStart": "2026-05-25",
     "addedAt": "2026-05-25T11:55:30.574Z"

--- a/index.html
+++ b/index.html
@@ -172,16 +172,16 @@
 <section class="featured-week" aria-label="Featured project this week">
   <div class="featured-week-meta">
     <div class="featured-label">featured · this week</div>
-    <span class="featured-week-date">may 25, 2026</span>
+    <span class="featured-week-date">jun 29, 2026</span>
   </div>
-  <a class="featured-week-name" href="/projects/garrytan/gbrain">
-    <span class="org">garrytan</span><span class="slash">/</span>gbrain
+  <a class="featured-week-name" href="/projects/dodo-reach/hermes-desktop">
+    <span class="org">dodo-reach</span><span class="slash">/</span>hermes-desktop
   </a>
-  <p class="featured-week-desc">GBrain is an autonomous memory and synthesis layer designed to serve as the institutional or personal knowledge base for AI agents. It combines a self-wiring knowledge graph with a synthesis engine to provide cited prose answers and gap analysis rather than…</p>
+  <p class="featured-week-desc">Hermes Desktop is a native macOS companion app that provides a dedicated workbench for managing Hermes Agent without relying on browser wrappers or gateway APIs. It connects directly to a local or remote host via SSH to interact with the real machine-first…</p>
   <div class="featured-week-foot">
-    <span class="featured-week-tag featured-week-tag--star">★ 18.8K</span>
-    <span class="featured-week-tag">memory &amp; context</span>
-    <a class="featured-week-link" href="/projects/garrytan/gbrain">read the full breakdown →</a>
+    <span class="featured-week-tag featured-week-tag--star">★ 1.9K</span>
+    <span class="featured-week-tag">workspaces &amp; guis</span>
+    <a class="featured-week-link" href="/projects/dodo-reach/hermes-desktop">read the full breakdown →</a>
   </div>
 </section>
 <!-- END featured-week -->

--- a/scripts/rotate-featured.js
+++ b/scripts/rotate-featured.js
@@ -85,21 +85,79 @@ function renderFeaturedSection(pick, repo, summary, weekStart) {
 <!-- END featured-week -->`;
 }
 
+// Deterministic auto-pick for the weekly "featured community pick".
+//
+// The slot spotlights Hermes-native community tools (prior picks: gbrain,
+// hermes-workspace). A naive highest-star pick surfaces off-target mega-repos
+// (mem0, cc-switch) that merely mention Hermes, so the pool is scoped to repos
+// with "hermes" in the OWNER/REPO name, non-official, in the community-tool star
+// band (excludes both toy repos and mega general projects). Among those, pick
+// the highest-star one not featured in the recent window — cycling through the
+// top on-brand tools week over week. Deterministic (no randomness).
+// Kevin can always override with an explicit <owner>/<repo>.
+const RECENT_WINDOW = 12; // weeks of history to exclude from re-featuring
+const MIN_STARS = 15;
+const MAX_STARS = 3000; // above this = general mega-repo, not a "community pick"
+function isHermesNative(r) {
+  return /hermes/i.test(`${r.owner} ${r.repo}`);
+}
+function inBand(r) {
+  const s = r.stars || 0;
+  return !r.official && isHermesNative(r) && s >= MIN_STARS && s <= MAX_STARS;
+}
+function pickAuto(repos, featured) {
+  const recent = new Set(
+    featured.slice(0, RECENT_WINDOW).map((e) => e.slug.toLowerCase())
+  );
+  const byRank = (a, b) =>
+    (b.stars || 0) - (a.stars || 0) ||
+    `${a.owner}/${a.repo}`.localeCompare(`${b.owner}/${b.repo}`);
+  let eligible = repos
+    .filter(inBand)
+    .filter((r) => !recent.has(`${r.owner}/${r.repo}`.toLowerCase()))
+    .sort(byRank);
+  // If the whole on-brand pool was featured recently, relax the recency filter.
+  if (eligible.length === 0) {
+    eligible = repos.filter(inBand).sort(byRank);
+  }
+  return eligible[0] || null;
+}
+
 function main() {
   const arg = process.argv[2];
-  if (!arg || !arg.includes("/")) {
-    console.error("Usage: node scripts/rotate-featured.js <owner>/<repo>");
+  if (!arg || (arg !== "--auto" && !arg.includes("/"))) {
+    console.error("Usage: node scripts/rotate-featured.js <owner>/<repo> | --auto");
     process.exit(1);
   }
-  const [owner, repoName] = arg.split("/", 2);
 
   // Load repos
   const repos = JSON.parse(fs.readFileSync(path.join(ROOT, "data", "repos.json"), "utf-8"));
-  const repo = repos.find((r) => r.owner === owner && r.repo === repoName);
-  if (!repo) {
-    console.error(`✗ ${arg} not found in data/repos.json`);
-    process.exit(1);
+
+  // Load featured history early — --auto needs it to avoid re-picking recent picks.
+  const featuredPath = path.join(ROOT, "data", "featured.json");
+  let featured = [];
+  if (fs.existsSync(featuredPath)) {
+    featured = JSON.parse(fs.readFileSync(featuredPath, "utf-8"));
   }
+
+  let repo;
+  if (arg === "--auto") {
+    repo = pickAuto(repos, featured);
+    if (!repo) {
+      console.error("✗ --auto found no eligible repo to feature");
+      process.exit(1);
+    }
+    console.log(`--auto selected ${repo.owner}/${repo.repo} (★ ${repo.stars})`);
+  } else {
+    const [owner, repoName] = arg.split("/", 2);
+    repo = repos.find((r) => r.owner === owner && r.repo === repoName);
+    if (!repo) {
+      console.error(`✗ ${arg} not found in data/repos.json`);
+      process.exit(1);
+    }
+  }
+  const owner = repo.owner;
+  const repoName = repo.repo;
 
   // Load summary (optional)
   let summary = null;
@@ -111,12 +169,7 @@ function main() {
     console.warn(`⚠ No generated summary for ${arg} — falling back to repo.description`);
   }
 
-  // Load + update featured.json
-  const featuredPath = path.join(ROOT, "data", "featured.json");
-  let featured = [];
-  if (fs.existsSync(featuredPath)) {
-    featured = JSON.parse(fs.readFileSync(featuredPath, "utf-8"));
-  }
+  // Update featured.json (loaded above)
   const weekStart = mondayOf(new Date());
   const slug = `${owner}/${repoName}`;
   // Drop any existing entry for this same week (re-running same week shouldn't


### PR DESCRIPTION
## What
- Add `--auto` to `rotate-featured.js` + a weekly workflow (`rotate-featured.yml`, Mondays 10:00 UTC) so the "Featured this week" pick self-maintains (it was 5.5 weeks stale under manual rotation).
- The picker is scoped to **Hermes-native community tools**: `hermes` in owner/repo name, non-official, 15–3000★. This excludes off-target mega-repos (mem0, cc-switch) that merely mention Hermes — a naive highest-star pick would surface those and degrade the editorial slot. Picks highest-star not featured in 12 weeks; deterministic. Manual override still works: `rotate-featured.js <owner>/<repo>`.
- Ran `--auto` now → `dodo-reach/hermes-desktop` (1941★).
- Workflow uses the shared `main-bot-push` concurrency group + rebase-retry + failure escalation.

## Verification
Script syntax + workflow YAML valid; `--auto` produced a clean featured.json + index.html featured-block diff (markers only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)