### PR TITLE
Add Report-Only CSP as safe first stage of a full policy

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -36,6 +36,7 @@
         { "key": "X-Frame-Options", "value": "DENY" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
         { "key": "Content-Security-Policy", "value": "object-src 'none'; base-uri 'self'; frame-ancestors 'none'" },
+        { "key": "Content-Security-Policy-Report-Only", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self'; object-src 'none'; form-action 'self'" },
         { "key": "Cache-Control", "value": "public, max-age=3600, s-maxage=86400" }
       ]
     }


### PR DESCRIPTION
The enforcing CSP already live covers only resource-neutral directives (`object-src`/`base-uri`/`frame-ancestors`). A full `script-src`/`style-src`/`img-src` policy can't be flipped to enforce without a browser pass to confirm zero violations (gstack browse is down on this machine).

This ships the full policy as **`Content-Security-Policy-Report-Only`** — it cannot break any resource, and violations surface in the browser console (or a report endpoint if added), so a future browser-enabled session can verify and promote it to enforcing.

Policy derived from the site's actual origins: inline scripts (theme/CF beacon), `static.cloudflareinsights.com`, Google Fonts, arbitrary-https README images, same-origin `/api/*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)