### PR TITLE
Fix stale Hermes version on homepage (v0.10.0 → live v0.18.0)

### DIFF
--- a/api/stars.js
+++ b/api/stars.js
@@ -19,6 +19,27 @@ function loadRepos() {
   }
 }
 
+// Authoritative Hermes release, built deterministically from the merged release
+// notes (data/latest-release.json). Used as a fallback when the batched GitHub
+// GraphQL query returns a null `latestRelease` — which it has been doing in
+// production for the hermes-agent field while per-repo star counts still resolve,
+// leaving the homepage stuck on a stale baked version. undefined = not loaded.
+let latestReleaseCache;
+function loadLatestRelease() {
+  if (latestReleaseCache !== undefined) return latestReleaseCache;
+  try {
+    const raw = readFileSync(join(process.cwd(), "data", "latest-release.json"), "utf-8");
+    const r = JSON.parse(raw);
+    latestReleaseCache = r?.version
+      ? { version: r.version, tag: r.tag, name: r.name, publishedAt: r.publishedAt }
+      : null;
+  } catch (e) {
+    console.error("Failed to load latest-release.json:", e.message);
+    latestReleaseCache = null;
+  }
+  return latestReleaseCache;
+}
+
 export default async function handler(req, res) {
   try {
     const repoList = loadRepos();
@@ -136,7 +157,27 @@ export default async function handler(req, res) {
       };
     });
 
-    const atlasStars = ghData.data?.atlas?.stargazerCount ?? null;
+    // Fall back to the authoritative release notes when GraphQL's latestRelease
+    // comes back null (see loadLatestRelease). Keeps the homepage version live
+    // and correct regardless of the GraphQL field flaking out.
+    if (!hermesRelease) {
+      hermesRelease = loadLatestRelease();
+      if (hermesRelease) {
+        console.warn("stars: GraphQL latestRelease null — using data/latest-release.json fallback");
+      }
+    }
+
+    // Atlas star count for the masthead CTA. GraphQL's dedicated `atlas` block
+    // has also been returning null in production; ksimback/hermes-ecosystem is
+    // in the catalog, so fall back to its live entry in the star map.
+    let atlasStars = ghData.data?.atlas?.stargazerCount ?? null;
+    if (atlasStars == null) {
+      const self = starData.find(
+        (r) => r.owner === "ksimback" && r.repo === "hermes-ecosystem"
+      );
+      atlasStars = self?.stars ?? null;
+    }
+
     const response = buildResponse(starData, hermesRelease, atlasStars);
 
     // Cache the result

--- a/index.html
+++ b/index.html
@@ -106,7 +106,7 @@
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
     <span id="meta-count">95·repos</span>
-    <span id="meta-version">hermes·v0.10.0</span>
+    <span id="meta-version">hermes·v0.18.0</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
   <nav class="mast-nav" aria-label="Primary">
@@ -161,7 +161,7 @@
   <div class="featured-nums">
     <div><span class="big star" id="hero-stars">83.3K</span><div class="lbl">stars</div></div>
     <div><span class="big">11.2K</span><div class="lbl">forks</div></div>
-    <div><span class="big" id="hero-version">v0.10.0</span><span class="sub" id="hero-version-tag">v2026.4.16</span><div class="lbl">latest</div></div>
+    <div><span class="big" id="hero-version">v0.18.0</span><span class="sub" id="hero-version-tag">v2026.7.1</span><div class="lbl">latest</div></div>
     <div><span class="big">47</span><div class="lbl">built-in tools</div></div>
     <div><span class="big">20+</span><div class="lbl">llm providers</div></div>
     <div><span class="big">16</span><div class="lbl">platforms</div></div>

--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -1255,6 +1255,30 @@ function syncHomepageRepos(repos) {
     }
   }
 
+  // Bake the current Hermes version into the static homepage spans from the
+  // authoritative release notes (data/latest-release.json). Keeps the pre-JS
+  // fallback fresh — the /api/stars fetch still live-updates it in the browser,
+  // but without this the baked value drifts stale (it was stuck at v0.10.0 while
+  // the API's live release field was returning null). No-op when unchanged.
+  try {
+    const lr = JSON.parse(
+      fs.readFileSync(path.join(ROOT, "data", "latest-release.json"), "utf-8")
+    );
+    if (lr && lr.version) {
+      html = html
+        .replace(/(<span id="meta-version">)hermes·[^<]*(<\/span>)/, `$1hermes·${lr.version}$2`)
+        .replace(/(<span[^>]*id="hero-version">)[^<]*(<\/span>)/, `$1${lr.version}$2`);
+      if (lr.tag) {
+        html = html.replace(
+          /(<span[^>]*id="hero-version-tag">)[^<]*(<\/span>)/,
+          `$1${lr.tag}$2`
+        );
+      }
+    }
+  } catch (e) {
+    console.warn(`  Could not bake Hermes version into index.html: ${e.message}`);
+  }
+
   if (missingCount > 0) {
     fs.writeFileSync(indexPath, html, "utf-8");
     console.log(`  ✓ Wrote index.html (+${missingCount} new rows)`);


### PR DESCRIPTION
## Problem
Homepage header + featured card showed **v0.10.0 (v2026.4.16)** — 8 versions stale (current is v0.18.0).

## Root cause
The version is live-updated by JS from `/api/stars` → `hermes.version`. But the batched GitHub GraphQL query in `api/stars.js` has been returning a **null `latestRelease`** for `NousResearch/hermes-agent` in production (per-repo star counts still resolve; the identical query returns the release fine with a different token — a production-token/GitHub-side partial failure). With `hermes: null`, the JS can't update and the stale baked `v0.10.0` showed. The `atlas` star block was null for the same reason.

## Fix (resilient regardless of the GraphQL quirk)
- **`api/stars.js`**: fall back to `data/latest-release.json` (authoritative, deterministic from merged release notes, currently v0.18.0) when GraphQL `latestRelease` is null; source atlas stars from the catalog's own live entry when the atlas block is null.
- **`build-pages.js`**: bake the current version into the static `#meta-version`/`#hero-version`/`#hero-version-tag` spans every build so the pre-JS fallback self-heals.
- **`index.html`**: update the baked spans now for an instant fix before the 1h API cache refreshes.

## Verification
Offline build bakes v0.18.0/v2026.7.1 into the spans; fallback logic returns v0.18.0 from latest-release.json when GraphQL is null; `npm test` 16/16. Confirmed GitHub's actual latest release is v0.18.0/v2026.7.1 (not prerelease).

🤖 Generated with [Claude Code](https://claude.com/claude-code)