### PR TITLE
Promote CSP from Report-Only to enforcing (static-verified)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -35,8 +35,7 @@
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "X-Frame-Options", "value": "DENY" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
-        { "key": "Content-Security-Policy", "value": "object-src 'none'; base-uri 'self'; frame-ancestors 'none'" },
-        { "key": "Content-Security-Policy-Report-Only", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self'; object-src 'none'; form-action 'self'" },
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self'; object-src 'none'; form-action 'self'" },
         { "key": "Cache-Control", "value": "public, max-age=3600, s-maxage=86400" }
       ]
     }


### PR DESCRIPTION
Static-audited every page type (home, guide, reports, privacy, 404, all project + list pages, assets):
- Only external script = Cloudflare Insights (in `script-src`)
- External styles = Google Fonts (in `style-src`/`font-src`)
- **All fetch/XHR calls are same-origin** (`connect-src 'self'` + CF beacon host)
- The one `onerror=` is inside a JS comment — **no real inline event handlers**

So the full policy is safe to enforce (with `'unsafe-inline'` for scripts/styles, `img-src https:` for README images). Replaces the resource-neutral enforcing CSP + the Report-Only staging header. README XSS is already handled by DOMPurify (#455); this is defense-in-depth.

Verification is static (the gstack browser is unavailable on this machine); the audit enumerated every script/style/img/connect origin. Trivially revertable if any console violation surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)