### PR TITLE
Homepage catalog search + sort (progressive enhancement)

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -869,3 +869,51 @@
   #chat-btn { right: 16px; bottom: 16px; }
   #chat-panel { right: 16px; bottom: 60px; width: calc(100vw - 32px); }
 }
+
+/* ─── Catalog search + sort (progressive enhancement) ─────────── */
+.catalog-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 14px;
+  padding: 36px 40px 4px;
+}
+.catalog-search {
+  flex: 1 1 320px;
+  min-width: 0;
+  font-family: var(--font-mono);
+  font-size: 15px;
+  color: var(--ink);
+  background: var(--bg-elev);
+  border: 1px solid var(--rule-strong);
+  padding: 12px 14px;
+}
+.catalog-search::placeholder { color: var(--ink-mute); }
+.catalog-search:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.catalog-sort-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--ink-mute);
+}
+.catalog-sort {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  color: var(--ink);
+  background: var(--bg-elev);
+  border: 1px solid var(--rule-strong);
+  padding: 11px 12px;
+  cursor: pointer;
+}
+.catalog-sort:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.catalog-result-count {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--ink-mute);
+  white-space: nowrap;
+}
+@media (max-width: 720px) {
+  .catalog-controls { padding: 24px 20px 4px; }
+}

--- a/index.html
+++ b/index.html
@@ -276,6 +276,22 @@
 
 <!-- ═══ Category Sections ═══ -->
 
+<!-- Catalog search + sort. Progressive enhancement: hidden by default and
+     revealed + wired by initCatalogControls(); with JS off, the full
+     categorized list below stays fully browsable. -->
+<div class="catalog-controls" id="catalog-controls" hidden>
+  <input type="search" id="catalog-search" class="catalog-search" placeholder="filter projects by name or description…" aria-label="Filter projects">
+  <label class="catalog-sort-wrap">
+    <span class="catalog-sort-label">sort</span>
+    <select id="catalog-sort" class="catalog-sort" aria-label="Sort projects">
+      <option value="stars">most stars</option>
+      <option value="name">name a–z</option>
+      <option value="active">recently active</option>
+    </select>
+  </label>
+  <span class="catalog-result-count" id="catalog-result-count" aria-live="polite"></span>
+</div>
+
 <section class="cat" data-category="Core & Official">
   <div class="cat-meta">
     <div class="cat-num">§01</div>
@@ -2143,8 +2159,67 @@
     return String(n);
   }
 
+  // Catalog search + sort (progressive enhancement). Reveals the controls
+  // (hidden by default so no-JS users get the full browsable list) and wires
+  // live text filtering + within-category sorting over the existing repo rows.
+  function initCatalogControls() {
+    const controls = document.getElementById('catalog-controls');
+    if (!controls) return;
+    const search = document.getElementById('catalog-search');
+    const sortSel = document.getElementById('catalog-sort');
+    const countEl = document.getElementById('catalog-result-count');
+    const sections = Array.from(document.querySelectorAll('section.cat'));
+    const rows = [];
+    sections.forEach(sec => {
+      sec.querySelectorAll('.repo-row').forEach(row => {
+        const slug = (row.getAttribute('href') || '').replace('/projects/', '').toLowerCase();
+        const desc = (row.getAttribute('data-desc') || '').toLowerCase();
+        rows.push({ row, sec, hay: slug + ' ' + desc });
+      });
+    });
+    const starsOf = row => {
+      const attr = row.getAttribute('data-stars');
+      if (attr) return parseInt(attr, 10) || 0;
+      const el = row.querySelector('.repo-stars');
+      return el ? parseInt(el.textContent.replace(/[^0-9]/g, ''), 10) || 0 : 0;
+    };
+    const nameOf = row => (row.getAttribute('href') || '').toLowerCase();
+    const updatedOf = row => row.getAttribute('data-updated') || '';
+    function applyFilter() {
+      const q = search.value.trim().toLowerCase();
+      let visible = 0;
+      rows.forEach(({ row, hay }) => {
+        const show = !q || hay.indexOf(q) !== -1;
+        row.style.display = show ? '' : 'none';
+        if (show) visible++;
+      });
+      sections.forEach(sec => {
+        const any = Array.from(sec.querySelectorAll('.repo-row')).some(r => r.style.display !== 'none');
+        sec.style.display = any ? '' : 'none';
+      });
+      countEl.textContent = q ? visible + ' match' + (visible === 1 ? '' : 'es') : '';
+    }
+    function applySort() {
+      const key = sortSel.value;
+      document.querySelectorAll('.cat-list').forEach(list => {
+        Array.from(list.querySelectorAll('.repo-row'))
+          .sort((a, b) => {
+            if (key === 'name') return nameOf(a).localeCompare(nameOf(b));
+            if (key === 'active') return updatedOf(b).localeCompare(updatedOf(a));
+            return starsOf(b) - starsOf(a);
+          })
+          .forEach(it => list.appendChild(it));
+      });
+    }
+    search.addEventListener('input', applyFilter);
+    sortSel.addEventListener('change', applySort);
+    controls.hidden = false;
+    applySort();
+  }
+
   fetchStars();
   fetchVersion();
+  initCatalogControls();
 
   // ── Search ──
   const searchInput = document.getElementById('search-input');


### PR DESCRIPTION
First product-build item. The catalog is 185 projects across 12 sections with no way to search — this adds a live filter + sort bar above the grid.

- **Filter** by owner/repo name or description → non-matching rows hide, empty category sections collapse, live "N matches" count.
- **Sort** within each category: most stars (default), name A–Z, recently active.
- **Progressive enhancement**: controls are `hidden` by default and only revealed/wired by JS, so with JS off the full categorized catalog stays browsable. No new external resources → compatible with the enforcing CSP.

## Verification
Functionally tested via jsdom against the real page: `search "memory"` → 26 matches, 158 hidden, 7 empty sections collapsed, clear restores all 184; sort produces stars-descending default and monotonic A–Z. CSS braces balanced.

Note: visual/interaction QA still wants a real browser (unavailable here) — happy to iterate on placement/styling. Graceful degradation makes it safe to ship meanwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)