### PR TITLE
Harden workflow scripts: env-pass commit_msg, fix smoke-issue label/dedup

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -163,13 +163,17 @@ jobs:
 
             // Find or open the tracking issue. We keep one issue open at a time
             // so successive failures comment on the same thread instead of
-            // spamming N separate issues.
+            // spamming N separate issues. Uses the repo-standard workflow-issue
+            // label + exact-title dedup (same pattern as build-pages et al.);
+            // the old smoke-test-failure label was never created in the repo.
+            const title = 'Smoke test failure on production';
             const issues = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
-              labels: 'smoke-test-failure',
+              labels: 'workflow-issue',
             });
+            const match = issues.data.find(i => i.title === title);
             const body = [
               context.eventName === 'schedule'
                 ? 'Daily production smoke test failed.'
@@ -182,19 +186,19 @@ jobs:
               '```',
             ].join('\n');
 
-            if (issues.data.length > 0) {
+            if (match) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: issues.data[0].number,
+                issue_number: match.number,
                 body,
               });
             } else {
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                title: 'Smoke test failure on production',
+                title,
                 body,
-                labels: ['smoke-test-failure'],
+                labels: ['workflow-issue'],
               });
             }

--- a/.github/workflows/release-monitor.yml
+++ b/.github/workflows/release-monitor.yml
@@ -353,10 +353,15 @@ jobs:
 
       - name: Create issue for docs update
         if: steps.docs_check.outputs.docs_updated == 'true'
+        env:
+          # Read from env to avoid JS string-injection issues with quote
+          # characters etc. in the upstream commit message (same pattern as
+          # the release-notes steps above).
+          COMMIT_MSG: ${{ steps.docs_check.outputs.commit_msg }}
         uses: actions/github-script@v7
         with:
           script: |
-            const msg = '${{ steps.docs_check.outputs.commit_msg }}';
+            const msg = process.env.COMMIT_MSG || '';
             const today = new Date().toISOString().slice(0, 10);
 
             // Get all open docs-update issues. These are informational only —


### PR DESCRIPTION
## Summary
Two Medium/Low findings from the 2026-07-04 independent review of recent PRs, both verified against current code before fixing.

### 1. `release-monitor.yml` — script injection via upstream commit message
The "Create issue for docs update" step interpolated the first line of a **NousResearch/hermes-agent** commit message directly into github-script JS:
```js
const msg = '${{ steps.docs_check.outputs.commit_msg }}';
```
Even a benign apostrophe in an upstream commit message would syntax-error the step; crafted content is script injection with the workflow token. The same file already uses the safe env pattern elsewhere (with an explanatory comment) — this was the one spot that missed the sweep. Now passed via `env: COMMIT_MSG` and read from `process.env`.

### 2. `post-deploy-smoke.yml` — nonexistent label + weak dedup
The failure-escalation path searched/created issues with a `smoke-test-failure` label that was never created in the repo (it would have been silently auto-minted as an orphan gray label on first failure), and deduped by label alone (`issues.data[0]`). Now uses the repo-standard pattern shared by build-pages / rebuild-chunks / refresh-docs / rotate-featured: existing `workflow-issue` label + exact-title dedup, so it can't cross-comment on other workflows' tracking issues.

## Verification
- `python -c yaml.safe_load` — both workflows parse
- Extracted both edited github-script blocks, wrapped as async fn, `node --check` — both OK
- `gh label list` — `workflow-issue` exists; `smoke-test-failure` never did
- No remaining raw `${{ }}` interpolation inside any script block in release-monitor.yml (all 8 expressions now in `env:` or `run:` contexts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)