### PR TITLE
Enforce GitHub-safe charset on catalog owner/repo (defense-in-depth)

### DIFF
--- a/scripts/check-dead-repos.js
+++ b/scripts/check-dead-repos.js
@@ -27,12 +27,29 @@ if (!TOKEN) {
 
 const repos = JSON.parse(await fs.readFile("data/repos.json", "utf8"));
 
+// Guard the string interpolation below: owner/repo are validated to this
+// charset by validate-repos-json.js, but skip-and-warn here too so a bad
+// entry can never inject into the GraphQL document. Aliases keep the
+// ORIGINAL array index so the repos[idx] lookup in error handling stays
+// correct even when entries are skipped.
+const SAFE_NAME_RE = /^[A-Za-z0-9_.-]+$/;
 const repoQueries = repos
-  .map(
-    (r, i) =>
-      `repo${i}: repository(owner: "${r.owner}", name: "${r.repo}") { nameWithOwner }`
-  )
+  .map((r, i) => {
+    if (!SAFE_NAME_RE.test(r.owner ?? "") || !SAFE_NAME_RE.test(r.repo ?? "")) {
+      console.warn(
+        `Skipping entry ${i} with unsafe owner/repo: ${JSON.stringify(r.owner)}/${JSON.stringify(r.repo)}`
+      );
+      return null;
+    }
+    return `repo${i}: repository(owner: "${r.owner}", name: "${r.repo}") { nameWithOwner }`;
+  })
+  .filter(Boolean)
   .join("\n");
+
+if (!repoQueries) {
+  console.error("No valid repo entries to check; aborting.");
+  process.exit(1);
+}
 
 const res = await fetch("https://api.github.com/graphql", {
   method: "POST",

--- a/scripts/validate-repos-json.js
+++ b/scripts/validate-repos-json.js
@@ -37,6 +37,12 @@ function isNonEmptyString(value) {
   return typeof value === "string" && value.trim().length > 0;
 }
 
+// Same charset the repo-suggestion workflow enforces on intake
+// (validate-repo-suggestion.yml). Re-checked here so hand-edited catalog
+// PRs can't land names that break downstream string interpolation
+// (e.g. the GraphQL query built in check-dead-repos.js).
+const GITHUB_NAME_RE = /^[A-Za-z0-9_.-]+$/;
+
 export function validateRepos(repos) {
   const errors = [];
 
@@ -62,10 +68,18 @@ export function validateRepos(repos) {
 
     if ("owner" in entry && !isNonEmptyString(entry.owner)) {
       errors.push(`${label} owner must be a non-empty string`);
+    } else if ("owner" in entry && !GITHUB_NAME_RE.test(entry.owner)) {
+      errors.push(
+        `${label} owner contains characters outside [A-Za-z0-9_.-]: ${entry.owner}`,
+      );
     }
 
     if ("repo" in entry && !isNonEmptyString(entry.repo)) {
       errors.push(`${label} repo must be a non-empty string`);
+    } else if ("repo" in entry && !GITHUB_NAME_RE.test(entry.repo)) {
+      errors.push(
+        `${label} repo contains characters outside [A-Za-z0-9_.-]: ${entry.repo}`,
+      );
     }
 
     if ("name" in entry && !isNonEmptyString(entry.name)) {


### PR DESCRIPTION
## Summary
Closes the gap flagged by the 2026-07-04 independent review: `check-dead-repos.js` interpolates catalog `owner`/`repo` strings directly into a batched GraphQL query, and `validate-repos-json.js` only required non-empty strings.

Verification note from ground-truthing the finding: the automated repo-suggestion intake (`validate-repo-suggestion.yml`) already constrains names to `[a-zA-Z0-9_.-]`, so the exposure was limited to hand-edited catalog PRs. This PR makes the validator enforce the same charset (fail-loud) and adds a skip-and-warn guard at the interpolation site itself.

GraphQL variables were considered and skipped: once inputs are whitelist-validated at two layers, variables add complexity to the batched aliased query for no additional safety.

## Changes
- `scripts/validate-repos-json.js` — owner/repo must match `/^[A-Za-z0-9_.-]+$/`, error includes the offending value
- `scripts/check-dead-repos.js` — unsafe entries are skipped with a warning before query construction; aliases keep original array indexes so `repos[idx]` error mapping stays correct; aborts if nothing valid remains

## Verification
- `node scripts/validate-repos-json.js` — 185 repos pass
- Direct `validateRepos()` test: clean entry → no errors; `owner: 'x", evil: {} #'` and `repo: 'a` + backtick + `b'` → rejected with clear messages
- `npm test` — 16/16 pass
- `node --check` on both scripts — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)