### PR TITLE
Consolidate homepage search/sort to catalog controls; abortable embedding

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -349,7 +349,7 @@ export default async function handler(req, res) {
     console.log(`[RAG] Original: "${message}" → Search: "${searchQuery}"`);
 
     // 3. Embed the rewritten query
-    const queryEmbedding = await getEmbedding(searchQuery);
+    const queryEmbedding = await getEmbedding(searchQuery, ac.signal);
 
     // 4. Hybrid search: combine BM25 (keyword), cosine (semantic), and
     // source-aware Atlas policy. Official docs are favored, catalog/generated
@@ -698,7 +698,7 @@ Rewritten:`;
   }
 }
 
-async function getEmbedding(text) {
+async function getEmbedding(text, signal) {
   // Match the corpus dim. build-chunks.js may emit reduced-dim vectors
   // (e.g. 512) to keep chunks.json under GitHub's 100MB limit. Reading the
   // dim from the loaded corpus means there's never a query/corpus mismatch
@@ -718,6 +718,7 @@ async function getEmbedding(text) {
       "Content-Type": "application/json",
     },
     body: JSON.stringify(body),
+    signal,
   });
 
   if (!res.ok) throw new Error(`Embedding error: ${res.status}`);

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -351,61 +351,6 @@
   .featured-week-link { margin-left: 0; }
 }
 
-/* ─── Controls (search + sort) ─────────────────────────────── */
-.controls {
-  padding: 20px 40px;
-  border-bottom: 1px solid var(--rule);
-  display: flex;
-  align-items: center;
-  gap: 24px;
-  flex-wrap: wrap;
-}
-.search-wrap {
-  flex: 1;
-  min-width: 260px;
-  border-bottom: 1px solid var(--rule-strong);
-  padding-bottom: 6px;
-  transition: border-color 0.15s;
-}
-.search-wrap:focus-within { border-bottom-color: var(--accent); }
-#search-input {
-  width: 100%;
-  font-family: var(--font-mono);
-  font-size: 13px;
-  color: var(--ink);
-  padding: 2px 0;
-}
-#search-input::placeholder { color: var(--ink-mute); }
-.sort-btns {
-  display: flex;
-  gap: 2px;
-  font-family: var(--font-mono);
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-}
-.sort-btns .lbl {
-  color: var(--ink-mute);
-  padding: 6px 10px 6px 0;
-}
-.sort-btn {
-  color: var(--ink-mute);
-  padding: 6px 10px;
-  border-bottom: 1px solid transparent;
-  transition: color 0.15s, border-color 0.15s;
-}
-.sort-btn:hover { color: var(--ink); }
-.sort-btn.active {
-  color: var(--ink);
-  border-bottom-color: var(--accent);
-}
-#result-count {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  color: var(--ink-mute);
-  letter-spacing: 0.05em;
-}
-
 /* ─── Category section (220px meta | 1fr list) ─────────────── */
 .cat {
   padding: 40px 40px 48px;
@@ -843,7 +788,6 @@
   }
   .featured-name { font-size: 32px; }
   .featured-nums { grid-template-columns: repeat(2, 1fr); }
-  .controls { padding: 16px 20px; gap: 14px; }
   .report-banner { padding: 12px 20px; flex-wrap: wrap; }
   .cat {
     grid-template-columns: 1fr;

--- a/index.html
+++ b/index.html
@@ -216,21 +216,6 @@
   <p class="email-cta-status" role="status" aria-live="polite"></p>
 </aside>
 
-<!-- Controls -->
-<div class="controls" role="search">
-  <label class="search-wrap">
-    <span class="sr-only">Search repos</span>
-    <input type="text" id="search-input" placeholder="search repos by name or description..." autocomplete="off" aria-label="Search repos">
-  </label>
-  <div class="sort-btns" role="group" aria-label="Sort by">
-    <span class="lbl">sort</span>
-    <button class="sort-btn active" data-sort="stars">stars</button>
-    <button class="sort-btn" data-sort="name">name</button>
-    <button class="sort-btn" data-sort="updated">recent</button>
-  </div>
-  <span id="result-count" aria-live="polite"></span>
-</div>
-
 <!-- Tooltip (single shared element, positioned via JS) -->
 <div class="tooltip" id="tooltip" role="tooltip">
   <div class="tt-name" id="tt-name"></div>
@@ -2217,75 +2202,9 @@
     applySort();
   }
 
-  fetchStars();
-  fetchVersion();
-  initCatalogControls();
-
-  // ── Search ──
-  const searchInput = document.getElementById('search-input');
-  const sortBtns = document.querySelectorAll('.sort-btn');
-  const categories = document.querySelectorAll('.cat');
-
-  if (searchInput) {
-    searchInput.addEventListener('input', () => {
-      const q = searchInput.value.toLowerCase().trim();
-      let totalVisible = 0;
-
-      categories.forEach(cat => {
-        const items = cat.querySelectorAll('.repo-row');
-        let catVisible = 0;
-
-        items.forEach(item => {
-          const name = (item.getAttribute('data-repo') || item.textContent).toLowerCase();
-          const desc = (item.getAttribute('data-desc') || '').toLowerCase();
-          const match = !q || name.includes(q) || desc.includes(q);
-          item.style.display = match ? '' : 'none';
-          if (match) catVisible++;
-        });
-
-        cat.style.display = catVisible > 0 ? '' : 'none';
-        totalVisible += catVisible;
-
-        const countEl = cat.querySelector('.cat-count-n');
-        if (countEl && q) countEl.textContent = catVisible;
-      });
-
-      const resultCount = document.getElementById('result-count');
-      if (resultCount) resultCount.textContent = q ? totalVisible + ' results' : '';
-    });
-  }
-
-  // ── Sort ──
-  sortBtns.forEach(btn => {
-    btn.addEventListener('click', () => {
-      sortBtns.forEach(b => b.classList.remove('active'));
-      btn.classList.add('active');
-      const mode = btn.getAttribute('data-sort');
-      sortItems(mode);
-    });
-  });
-
-  function sortItems(mode) {
-    categories.forEach(cat => {
-      const container = cat.querySelector('.cat-list');
-      if (!container) return;
-      const items = Array.from(container.querySelectorAll('.repo-row'));
-
-      items.sort((a, b) => {
-        if (mode === 'stars') {
-          return (parseInt(b.getAttribute('data-stars')) || 0) - (parseInt(a.getAttribute('data-stars')) || 0);
-        } else if (mode === 'name') {
-          return (a.getAttribute('data-repo') || '').localeCompare(b.getAttribute('data-repo') || '');
-        } else if (mode === 'updated') {
-          return (b.getAttribute('data-updated') || '').localeCompare(a.getAttribute('data-updated') || '');
-        }
-        return 0;
-      });
-      items.forEach(item => container.appendChild(item));
-    });
-  }
-
-  // Initialize data-stars from current star text
+  // Initialize data-stars from current star text. Must run before
+  // initCatalogControls(): its initial sort reads data-stars, and its
+  // text-parsing fallback can't handle "1.2K"-style abbreviations.
   document.querySelectorAll('.repo-row').forEach(item => {
     const starsEl = item.querySelector('.repo-stars');
     if (starsEl && !item.getAttribute('data-stars')) {
@@ -2296,6 +2215,10 @@
       item.setAttribute('data-stars', val);
     }
   });
+
+  fetchStars();
+  fetchVersion();
+  initCatalogControls();
 
   // ── Chat Widget ──
   const chatBtn = document.getElementById('chat-btn');


### PR DESCRIPTION
## Summary
Fixes the two remaining Low findings from the 2026-07-04 independent review.

### 1. Duplicate homepage search/sort UIs
The homepage had two independent control sets — the original header controls (`#search-input` / `.sort-btn` / `#result-count`) and the catalog controls added by #471 — both mutating the same `.repo-row` / `.cat` display state and reordering `.cat-list`, with no coordination. Using one after the other produced conflicting filter/sort state; the old search also left stale per-category counts after clearing a query.

Removed the old controls (HTML block, JS, and the now-dead CSS in `assets/css/index.css`). The #471 catalog controls are the single search/sort surface — they're the better keeper: hidden without JS (progressive enhancement) instead of rendering a dead search box.

Bonus fix found while consolidating: `initCatalogControls()`'s initial sort ran **before** the `data-stars` initialization, falling back to text parsing that mis-reads "1.2K"-style star counts as 12. The init block now runs first.

### 2. Abortable embedding call
`api/chat.js` threads the request `AbortController` signal into `getEmbedding()` so a client disconnect also cancels the embedding fetch — the query-rewrite and completion calls were already wired in #461, and the existing AbortError handling at the catch site covers this path.

## Verification
- jsdom functional test (offline-stubbed fetch): old controls absent from DOM; catalog controls revealed by JS; `atropos` filter → 1 match with live count; clearing filter restores 184/184 rows; initial sort descending by stars in every category; name sort a→z in every category
- No references to the removed IDs/classes anywhere in `scripts/`, `lib/`, `api/`, `tests/`, or generators (`syncHomepageRepos` untouched by ID removal)
- `node --check` on api/chat.js and both inline homepage scripts — clean
- `npm test` — 16/16

🤖 Generated with [Claude Code](https://claude.com/claude-code)