### PR TITLE
Add regression tests for #475 charset validation and #476 catalog controls

### DIFF
--- a/tests/homepage-controls.test.js
+++ b/tests/homepage-controls.test.js
@@ -1,0 +1,112 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { JSDOM } from "jsdom";
+
+// Regression tests for PR #476: the catalog controls (#471) are the single
+// search/sort surface on the homepage. The old header controls must stay gone,
+// and the catalog controls must keep working (reveal, filter, sort) — verified
+// here the same way #476 was verified pre-merge, but committed.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const html = fs.readFileSync(path.join(__dirname, "..", "index.html"), "utf8");
+
+function loadHomepage({ runScripts = true } = {}) {
+  return new JSDOM(html, {
+    url: "https://hermesatlas.com/",
+    ...(runScripts ? { runScripts: "dangerously" } : {}),
+    beforeParse(window) {
+      // API calls (stars, version) are irrelevant here and both callers
+      // catch failures; keep the test hermetic.
+      window.fetch = () => Promise.reject(new Error("network disabled in test"));
+    },
+  }).window;
+}
+
+test("old header search/sort controls stay absent (removed in #476)", () => {
+  const { document } = loadHomepage({ runScripts: false });
+
+  assert.equal(document.getElementById("search-input"), null);
+  assert.equal(document.getElementById("result-count"), null);
+  assert.equal(document.querySelector(".sort-btn"), null);
+});
+
+test("catalog controls are the single search/sort surface", () => {
+  const { document } = loadHomepage({ runScripts: false });
+
+  const searches = document.querySelectorAll('input[type="search"]');
+  assert.equal(searches.length, 1, "exactly one search input on the page");
+  assert.equal(searches[0].id, "catalog-search");
+
+  const sorts = document.querySelectorAll("select");
+  assert.equal(sorts.length, 1, "exactly one sort control on the page");
+  assert.equal(sorts[0].id, "catalog-sort");
+});
+
+test("catalog controls are progressive enhancement: hidden without JS, revealed with JS", () => {
+  const noJs = loadHomepage({ runScripts: false });
+  assert.equal(noJs.document.getElementById("catalog-controls").hidden, true);
+
+  const withJs = loadHomepage();
+  assert.equal(withJs.document.getElementById("catalog-controls").hidden, false);
+});
+
+test("filter narrows visible rows and clearing restores all", () => {
+  const window = loadHomepage();
+  const { document } = window;
+
+  const rows = Array.from(document.querySelectorAll(".repo-row"));
+  assert.ok(rows.length > 100, `expected a populated catalog, got ${rows.length} rows`);
+  const visibleCount = () =>
+    rows.filter((r) => r.style.display !== "none").length;
+
+  assert.equal(visibleCount(), rows.length);
+
+  const search = document.getElementById("catalog-search");
+  search.value = "hermes-workspace";
+  search.dispatchEvent(new window.Event("input", { bubbles: true }));
+
+  const narrowed = visibleCount();
+  assert.ok(narrowed > 0, "filter should match at least one row");
+  assert.ok(narrowed < rows.length, "filter should hide non-matching rows");
+  assert.match(
+    document.getElementById("catalog-result-count").textContent,
+    /^\d+ match(es)?$/,
+  );
+
+  search.value = "";
+  search.dispatchEvent(new window.Event("input", { bubbles: true }));
+  assert.equal(visibleCount(), rows.length);
+  assert.equal(
+    document.getElementById("catalog-result-count").textContent,
+    "",
+  );
+});
+
+test("sort reorders rows within each category (stars desc, name asc)", () => {
+  const window = loadHomepage();
+  const { document } = window;
+  const sortSel = document.getElementById("catalog-sort");
+  const lists = Array.from(document.querySelectorAll(".cat-list"));
+  assert.ok(lists.length > 0, "expected category lists");
+
+  // Initial sort on load is by stars (applySort() runs in init).
+  const starsOf = (row) => parseInt(row.getAttribute("data-stars"), 10) || 0;
+  for (const list of lists) {
+    const stars = Array.from(list.querySelectorAll(".repo-row")).map(starsOf);
+    const sorted = [...stars].sort((a, b) => b - a);
+    assert.deepEqual(stars, sorted, "rows should be sorted by stars descending");
+  }
+
+  sortSel.value = "name";
+  sortSel.dispatchEvent(new window.Event("change", { bubbles: true }));
+  const nameOf = (row) => (row.getAttribute("href") || "").toLowerCase();
+  for (const list of lists) {
+    const names = Array.from(list.querySelectorAll(".repo-row")).map(nameOf);
+    const sorted = [...names].sort((a, b) => a.localeCompare(b));
+    assert.deepEqual(names, sorted, "rows should be sorted by name ascending");
+  }
+});

--- a/tests/validate-repos-json.test.js
+++ b/tests/validate-repos-json.test.js
@@ -37,6 +37,34 @@ test("rejects duplicate owner/repo pairs case-insensitively", () => {
   ]);
 });
 
+test("rejects owner/repo names outside the GitHub-safe charset", () => {
+  const injectionOwner = {
+    ...validRepo,
+    owner: 'evil"){ hacked }',
+    url: 'https://github.com/evil"){ hacked }/hermes-example',
+  };
+  const injectionRepo = {
+    ...validRepo,
+    repo: "hermes`example${x}",
+    url: "https://github.com/example/hermes`example${x}",
+  };
+  const traversalRepo = {
+    ...validRepo,
+    repo: "a/b",
+    url: "https://github.com/example/a/b",
+  };
+
+  assert.deepEqual(validateRepos([injectionOwner]), [
+    '[0] owner contains characters outside [A-Za-z0-9_.-]: evil"){ hacked }',
+  ]);
+  assert.deepEqual(validateRepos([injectionRepo]), [
+    "[0] repo contains characters outside [A-Za-z0-9_.-]: hermes`example${x}",
+  ]);
+  assert.deepEqual(validateRepos([traversalRepo]), [
+    "[0] repo contains characters outside [A-Za-z0-9_.-]: a/b",
+  ]);
+});
+
 test("rejects invalid category, URL, official, and stars values", () => {
   const badRepo = {
     ...validRepo,


### PR DESCRIPTION
## Why

Independent review of the #474–#476 batch confirmed the fixes but flagged that two of them relied on manual/ad-hoc verification with no committed tests:

1. `validateRepos()` rejecting unsafe owner/repo names (#475)
2. Homepage catalog controls staying single-source-of-truth / old controls absent (#476 — the jsdom functional test from that PR was scratch code, never committed; only the `jsdom` devDependency landed)

## What

- **`tests/validate-repos-json.test.js`**: new case asserting injection-shaped (`evil"){ hacked }`, `` hermes`example${x} ``) and traversal-shaped (`a/b`) owner/repo values produce the exact charset errors from `GITHUB_NAME_RE`.
- **`tests/homepage-controls.test.js`** (new): loads `index.html` in jsdom (`fetch` stubbed, hermetic) and asserts:
  - old header controls (`#search-input`, `#result-count`, `.sort-btn`) stay absent
  - exactly one search input and one sort select exist, and they're the catalog controls
  - progressive enhancement: `#catalog-controls` hidden without JS, revealed with JS
  - filter narrows visible rows, updates the live result count, and clearing restores all rows
  - within-category sort: stars descending on load, name ascending on switch

## Verification

`npm test`: 22/22 (was 16/16). Both suites run under the existing `node --test tests/*.test.js` script — no new tooling, no workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)