### PR TITLE
RAG: strengthen official-docs preference on operational queries

### DIFF
--- a/lib/rag-scoring.js
+++ b/lib/rag-scoring.js
@@ -95,10 +95,15 @@ export function querySourceAdjustment(query, chunk) {
     adjustment += queryHasAny(query, TUI_SESSION_TERMS) ? 0.08 : 0;
   }
 
-  // Official docs are preferred for operational/how-to queries, but keep this
-  // small so semantic/BM25 relevance still dominates.
-  if (meta.authority === "official_docs" && /\b(how|install|configure|setup|use|docs?|official)\b/i.test(query || "")) {
-    adjustment += 0.03;
+  // Official docs are preferred for operational/how-to queries. Sized so that
+  // together with the base authority gap (0.12 vs 0.10) it outweighs a
+  // near-exact title/BM25 match on a curated write-up of the same topic
+  // (issue #399: max BM25 edge is 0.25-weighted, so a ~0.2 normalized edge
+  // ≈ 0.05 — the combined 0.09 how-to gap covers it), while staying small
+  // enough that a clearly more relevant curated chunk (cosine edge ≥ ~0.14)
+  // still wins.
+  if (meta.authority === "official_docs" && /\b(how|install|configure|set ?up|use|docs?|official|connect|enable)\b/i.test(query || "")) {
+    adjustment += 0.07;
   }
 
   return adjustment;

--- a/tests/rag-scoring.test.js
+++ b/tests/rag-scoring.test.js
@@ -31,6 +31,47 @@ test("skills catalog pages are penalized for broad questions but boosted for ski
   assert.ok(querySourceAdjustment("Which sources are in the Skills Hub catalog?", catalog) > 0);
 });
 
+test("official docs beat a near-exact curated title match on how-to queries (#399)", () => {
+  // The concrete #399 case: "How do I connect Hermes to Telegram?" — the
+  // curated write-up's title nearly equals the query, giving it the top BM25
+  // score (norm 1.0), while the official doc scores lower on keywords.
+  // Official docs must still win on operational intent.
+  const official = { source: "research/docs/user-guide/messaging/telegram.md", text: "Telegram: pair the bot, then message it" };
+  const curated = { source: "research/29-How-to-Set-Up-Hermes-on-Telegram.md", text: "How to Set Up Hermes on Telegram" };
+  const query = "How do I connect Hermes to Telegram?";
+
+  const officialScore = combinedRetrievalScore({ query, chunk: official, normCosine: 0.8, normBM25: 0.75 });
+  const curatedScore = combinedRetrievalScore({ query, chunk: curated, normCosine: 0.8, normBM25: 1.0 });
+
+  assert.ok(officialScore > curatedScore, `official ${officialScore} should beat curated ${curatedScore}`);
+});
+
+test("curated content keeps winning on non-operational queries despite the how-to boost (#399)", () => {
+  // Same chunks and retrieval scores, but the query has no operational intent
+  // — the curated piece with the stronger keyword match should stay on top.
+  const official = { source: "research/docs/user-guide/messaging/telegram.md", text: "Telegram: pair the bot, then message it" };
+  const curated = { source: "research/29-How-to-Set-Up-Hermes-on-Telegram.md", text: "How to Set Up Hermes on Telegram" };
+  const query = "hermes telegram community guide";
+
+  const officialScore = combinedRetrievalScore({ query, chunk: official, normCosine: 0.8, normBM25: 0.75 });
+  const curatedScore = combinedRetrievalScore({ query, chunk: curated, normCosine: 0.8, normBM25: 1.0 });
+
+  assert.ok(curatedScore > officialScore, `curated ${curatedScore} should beat official ${officialScore}`);
+});
+
+test("clearly more relevant curated content still beats official docs on how-to queries (#399)", () => {
+  // Guard against over-boosting: when the curated chunk is semantically much
+  // closer to the query (cosine edge ≥ ~0.15), authority must not override it.
+  const official = { source: "research/docs/user-guide/configuration.md", text: "General configuration reference" };
+  const curated = { source: "research/31-Hermes-Trading-Bot-Walkthrough.md", text: "Step-by-step trading bot walkthrough with Hermes" };
+  const query = "how do I use hermes to build a trading bot?";
+
+  const officialScore = combinedRetrievalScore({ query, chunk: official, normCosine: 0.5, normBM25: 0.5 });
+  const curatedScore = combinedRetrievalScore({ query, chunk: curated, normCosine: 0.75, normBM25: 0.7 });
+
+  assert.ok(curatedScore > officialScore, `curated ${curatedScore} should beat official ${officialScore}`);
+});
+
 test("TUI session docs get a query-sensitive feature boost", () => {
   const tui = { source: "research/docs/user-guide/tui.md", text: "active-session orchestrator list activate close launch sessions" };
   const unrelated = { source: "research/docs/user-guide/voice.md", text: "voice calls and audio output" };


### PR DESCRIPTION
## Problem (#399)

For queries closely matching a curated Atlas guide's title ("How do I connect Hermes to Telegram?"), `curated_atlas` chunks outrank `official_docs` on the same topic. Root cause: the official-vs-curated authority gap is 0.02 base + 0.03 operational-intent = 0.05, but a near-exact title/BM25 match is worth up to 0.25 weighted — a ~0.2 normalized BM25 edge (≈0.05) erases the gap.

## Fix

`lib/rag-scoring.js` — raise the operational-intent adjustment for `official_docs` from **+0.03 to +0.07** and extend the intent regex with `connect`, `enable`, and spaced `set up`. Combined how-to gap becomes 0.09:
- covers a near-max BM25 title edge (the #399 case), and
- still loses to a clearly more relevant curated chunk (cosine edge ≥ ~0.14 at the 0.65 weight), so authority can't override real semantic relevance.

Base authority boosts (0.12/0.10/0.03) are untouched — non-operational queries where curated content is the right answer (comparisons, ecosystem context, community guides) are unaffected.

## Verification

Three new unit tests in `tests/rag-scoring.test.js`:
1. The exact #399 Telegram scenario (curated normBM25 1.0 vs official 0.75, equal cosine) — official must win on how-to intent. **Fails under the old +0.03 value** (0.8575 vs 0.87), passes now (0.8975 vs 0.87).
2. Same chunks/scores, non-operational query — curated must stay on top (guards curated content strength).
3. Over-boost guard — semantically much-closer curated content still beats official docs on a how-to query.

`node --test tests/rag-scoring.test.js`: 7/7.

Note: this changes runtime scoring only (`api/chat.js` imports the lib) — no chunk rebuild needed.

Closes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)