### PR TITLE
RAG: finer chunking for reference docs + CRLF-safe splitter

### DIFF
--- a/.github/workflows/rebuild-chunks.yml
+++ b/.github/workflows/rebuild-chunks.yml
@@ -18,6 +18,7 @@ on:
       - 'drafts/handbook-hub.md'
       - 'drafts/handbook-vs-claude-code.md'
       - 'scripts/build-chunks.js'
+      - 'lib/chunk-text.js'
   workflow_dispatch:
 
 jobs:

--- a/lib/chunk-text.js
+++ b/lib/chunk-text.js
@@ -1,0 +1,128 @@
+// Markdown → RAG chunk splitting, extracted from scripts/build-chunks.js so it
+// can be unit-tested (build-chunks.js exits at import time without an API key).
+//
+// Default behavior must stay byte-identical to the historical splitter: the
+// embedding cache in build-chunks.js is keyed on chunk text, so any change to
+// how non-reference sources chunk forces a full re-embed of the corpus.
+
+import { enrichChunkMetadata } from "./rag-scoring.js";
+
+export const CHUNK_SIZE = 500; // target tokens (~4 chars per token)
+export const CHUNK_CHARS = CHUNK_SIZE * 4;
+export const OVERLAP_CHARS = 200;
+// Hard ceiling per chunk — text-embedding-3-small caps input at 8192 tokens
+// (~32k chars). The paragraph splitter doesn't break inside a single paragraph,
+// so a wall-of-links page (e.g. user-stories) can otherwise produce a 30k+
+// char chunk that crashes the embedding call.
+export const MAX_CHUNK_CHARS = 6000;
+
+// Large reference docs (issue #400): cli-commands.md and friends pack many
+// narrow topics into big ## sections, so retrieval finds the right doc but the
+// specific answer sits deep inside a ~2000-char chunk. Reference sources get a
+// finer target size and ### subsection splitting so narrow topics surface as
+// their own chunks. Scoped to reference/ (294 of ~6.8k chunks, ~3 MB of
+// chunks.json) so the rest of the corpus keeps its cached embeddings and
+// chunks.json stays far from GitHub's 100 MB limit.
+const REFERENCE_PREFIX = "research/docs/reference/";
+export const REFERENCE_CHUNK_CHARS = 1200;
+
+export function chunkOptionsFor(source) {
+  if (String(source || "").startsWith(REFERENCE_PREFIX)) {
+    return { chunkChars: REFERENCE_CHUNK_CHARS, splitSubsections: true };
+  }
+  return { chunkChars: CHUNK_CHARS, splitSubsections: false };
+}
+
+export function chunkText(text, source) {
+  const { chunkChars, splitSubsections } = chunkOptionsFor(source);
+  const chunks = [];
+
+  // Normalize CRLF: the paragraph splitter below matches /\n\n+/, which never
+  // fires on \r\n\r\n — on a Windows checkout that silently disables paragraph
+  // splitting and produces completely different chunks than CI. No-op on the
+  // LF checkouts CI uses, so cached embeddings are unaffected.
+  text = text.replace(/\r\n/g, "\n");
+
+  // Split by sections (## headings)
+  const sections = text.split(/(?=^## )/m);
+
+  for (const section of sections) {
+    const headingMatch = section.match(/^## (.+)/);
+    const heading = headingMatch ? headingMatch[1].trim() : "";
+
+    // Reference docs: split oversized sections at ### subheadings first, so
+    // each narrow topic ("hermes webhook subscribe", "Global options") becomes
+    // its own chunk with a precise section label.
+    if (splitSubsections && section.length > chunkChars && /^### /m.test(section)) {
+      for (const sub of section.split(/(?=^### )/m)) {
+        const subMatch = sub.match(/^### (.+)/);
+        const subHeading = subMatch
+          ? (heading ? `${heading} › ${subMatch[1].trim()}` : subMatch[1].trim())
+          : heading;
+        chunkPiece(chunks, source, subHeading, sub, chunkChars);
+      }
+      continue;
+    }
+
+    chunkPiece(chunks, source, heading, section, chunkChars);
+  }
+
+  return chunks;
+}
+
+// Mirrors the historical splitter exactly: a piece within the target size is
+// one chunk; an oversized piece is accumulated paragraph-by-paragraph with an
+// OVERLAP_CHARS tail carried between chunks.
+function chunkPiece(chunks, source, heading, piece, chunkChars) {
+  if (piece.length <= chunkChars) {
+    pushChunk(chunks, source, heading, piece);
+    return;
+  }
+
+  const paragraphs = piece.split(/\n\n+/);
+  let current = "";
+
+  for (const para of paragraphs) {
+    if ((current + "\n\n" + para).length > chunkChars && current.length > 50) {
+      pushChunk(chunks, source, heading, current);
+      // Overlap: keep last portion
+      current = current.slice(-OVERLAP_CHARS) + "\n\n" + para;
+    } else {
+      current = current ? current + "\n\n" + para : para;
+    }
+  }
+
+  pushChunk(chunks, source, heading, current);
+}
+
+function pushChunk(chunks, source, heading, text) {
+  const trimmed = text.trim();
+  if (trimmed.length <= 50) return;
+  // Hard-split anything still oversized after paragraph splitting (mega
+  // paragraphs with no blank lines, e.g. wall-of-links pages).
+  for (const piece of hardSplitByLines(trimmed, MAX_CHUNK_CHARS)) {
+    chunks.push(enrichChunkMetadata({
+      id: `${source}:${chunks.length}`,
+      text: piece.trim(),
+      source,
+      section: heading,
+    }));
+  }
+}
+
+export function hardSplitByLines(text, maxChars) {
+  if (text.length <= maxChars) return [text];
+  const pieces = [];
+  let i = 0;
+  while (i < text.length) {
+    let end = Math.min(i + maxChars, text.length);
+    if (end < text.length) {
+      // Prefer a line-break boundary in the back half of the window
+      const nl = text.lastIndexOf("\n", end);
+      if (nl > i + maxChars / 2) end = nl;
+    }
+    pieces.push(text.slice(i, end));
+    i = end;
+  }
+  return pieces;
+}

--- a/scripts/build-chunks.js
+++ b/scripts/build-chunks.js
@@ -13,20 +13,11 @@ import fs from "fs";
 import path from "path";
 import crypto from "node:crypto";
 import { fileURLToPath } from "url";
-import { enrichChunkMetadata } from "../lib/rag-scoring.js";
+import { chunkText } from "../lib/chunk-text.js";
 import { findLatestReleaseFromMarkdownFiles } from "../lib/latest-release.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..");
-
-const CHUNK_SIZE = 500; // target tokens (~4 chars per token)
-const CHUNK_CHARS = CHUNK_SIZE * 4;
-const OVERLAP_CHARS = 200;
-// Hard ceiling per chunk — text-embedding-3-small caps input at 8192 tokens
-// (~32k chars). The paragraph splitter doesn't break inside a single paragraph,
-// so a wall-of-links page (e.g. user-stories) can otherwise produce a 30k+
-// char chunk that crashes the embedding call.
-const MAX_CHUNK_CHARS = 6000;
 // Embedding dimensions. Default for text-embedding-3-small is 1536, but the
 // model supports truncation via `dimensions`. At ~5k chunks, 1536-dim vectors
 // blow chunks.json past GitHub's 100MB file limit (147MB observed). 512-dim
@@ -193,74 +184,6 @@ function* walkMarkdown(dir) {
       yield full;
     }
   }
-}
-
-function pushChunk(chunks, source, heading, text) {
-  const trimmed = text.trim();
-  if (trimmed.length <= 50) return;
-  // Hard-split anything still oversized after paragraph splitting (mega
-  // paragraphs with no blank lines, e.g. wall-of-links pages).
-  for (const piece of hardSplitByLines(trimmed, MAX_CHUNK_CHARS)) {
-    chunks.push(enrichChunkMetadata({
-      id: `${source}:${chunks.length}`,
-      text: piece.trim(),
-      source,
-      section: heading,
-    }));
-  }
-}
-
-function hardSplitByLines(text, maxChars) {
-  if (text.length <= maxChars) return [text];
-  const pieces = [];
-  let i = 0;
-  while (i < text.length) {
-    let end = Math.min(i + maxChars, text.length);
-    if (end < text.length) {
-      // Prefer a line-break boundary in the back half of the window
-      const nl = text.lastIndexOf("\n", end);
-      if (nl > i + maxChars / 2) end = nl;
-    }
-    pieces.push(text.slice(i, end));
-    i = end;
-  }
-  return pieces;
-}
-
-function chunkText(text, source) {
-  const chunks = [];
-
-  // Split by sections (## headings)
-  const sections = text.split(/(?=^## )/m);
-
-  for (const section of sections) {
-    const headingMatch = section.match(/^## (.+)/);
-    const heading = headingMatch ? headingMatch[1].trim() : "";
-
-    // If section is small enough, keep as one chunk
-    if (section.length <= CHUNK_CHARS) {
-      pushChunk(chunks, source, heading, section);
-      continue;
-    }
-
-    // Split large sections by paragraphs
-    const paragraphs = section.split(/\n\n+/);
-    let current = "";
-
-    for (const para of paragraphs) {
-      if ((current + "\n\n" + para).length > CHUNK_CHARS && current.length > 50) {
-        pushChunk(chunks, source, heading, current);
-        // Overlap: keep last portion
-        current = current.slice(-OVERLAP_CHARS) + "\n\n" + para;
-      } else {
-        current = current ? current + "\n\n" + para : para;
-      }
-    }
-
-    pushChunk(chunks, source, heading, current);
-  }
-
-  return chunks;
 }
 
 async function getEmbeddings(texts) {

--- a/tests/chunk-text.test.js
+++ b/tests/chunk-text.test.js
@@ -1,0 +1,115 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  chunkText,
+  chunkOptionsFor,
+  CHUNK_CHARS,
+  REFERENCE_CHUNK_CHARS,
+} from "../lib/chunk-text.js";
+
+const REF_SOURCE = "research/docs/reference/cli-commands.md";
+const NON_REF_SOURCE = "research/docs/user-guide/configuration.md";
+
+function para(seed, chars) {
+  return `${seed} ${"lorem ipsum dolor sit amet ".repeat(Math.ceil(chars / 27))}`.slice(0, chars);
+}
+
+test("chunkOptionsFor scopes finer chunking to reference docs only (#400)", () => {
+  assert.deepEqual(chunkOptionsFor(REF_SOURCE), {
+    chunkChars: REFERENCE_CHUNK_CHARS,
+    splitSubsections: true,
+  });
+  assert.deepEqual(chunkOptionsFor(NON_REF_SOURCE), {
+    chunkChars: CHUNK_CHARS,
+    splitSubsections: false,
+  });
+  assert.deepEqual(chunkOptionsFor("repos/all-star-counts.md"), {
+    chunkChars: CHUNK_CHARS,
+    splitSubsections: false,
+  });
+});
+
+test("non-reference docs keep historical behavior: small section is one chunk, big section splits by paragraph", () => {
+  const small = `## Small section\n\n${para("intro", 300)}\n`;
+  assert.equal(chunkText(small, NON_REF_SOURCE).length, 1);
+
+  const big = `## Big section\n\n${para("a", 900)}\n\n${para("b", 900)}\n\n${para("c", 900)}\n`;
+  const chunks = chunkText(big, NON_REF_SOURCE);
+  assert.ok(chunks.length > 1, "oversized section should paragraph-split");
+  for (const c of chunks) assert.equal(c.section, "Big section");
+});
+
+test("a mid-size non-reference section stays whole even above the reference target", () => {
+  // 1500 chars: above REFERENCE_CHUNK_CHARS (1200), below CHUNK_CHARS (2000).
+  // Non-reference sources must NOT pick up the finer target.
+  const doc = `## Mid section\n\n${para("a", 700)}\n\n${para("b", 700)}\n`;
+  assert.equal(chunkText(doc, NON_REF_SOURCE).length, 1);
+  assert.ok(chunkText(doc, REF_SOURCE).length > 1, "same doc as reference source should split");
+});
+
+test("reference docs split oversized sections at ### subheadings with combined labels (#400)", () => {
+  const doc = [
+    "## `hermes webhook`",
+    "",
+    para("webhook intro", 600),
+    "",
+    "### `hermes webhook subscribe`",
+    "",
+    para("subscribe details", 600),
+    "",
+    "### `hermes webhook list`",
+    "",
+    para("list details", 600),
+    "",
+  ].join("\n");
+
+  const chunks = chunkText(doc, REF_SOURCE);
+  const sections = chunks.map((c) => c.section);
+  assert.ok(sections.includes("`hermes webhook`"), `preamble keeps H2 label, got ${sections}`);
+  assert.ok(sections.includes("`hermes webhook` › `hermes webhook subscribe`"), `H3 gets combined label, got ${sections}`);
+  assert.ok(sections.includes("`hermes webhook` › `hermes webhook list`"), `H3 gets combined label, got ${sections}`);
+});
+
+test("non-reference docs do NOT split at ### even when oversized (scoping guard)", () => {
+  const doc = [
+    "## Guide section",
+    "",
+    para("intro", 900),
+    "",
+    "### Subtopic",
+    "",
+    para("subtopic body", 900),
+    "",
+  ].join("\n");
+
+  const chunks = chunkText(doc, NON_REF_SOURCE);
+  for (const c of chunks) {
+    assert.equal(c.section, "Guide section", "### must not become a section label for non-reference sources");
+  }
+});
+
+test("reference section without ### splits at the finer target so trailing topics lead their own chunk (#400)", () => {
+  // Mirrors the #400 chronos case: a ~1300-char `hermes cron` section whose
+  // answer paragraph sits at the end. At the 2000-char target it was one chunk
+  // with the answer buried ~750 chars deep; at 1200 the answer paragraph
+  // starts near the top of its own chunk.
+  const doc = `## \`hermes cron\`\n\n${para("usage table", 700)}\n\n${"The cron trigger is pluggable via the cron.provider config key. " + para("chronos details", 500)}\n`;
+
+  const chunks = chunkText(doc, REF_SOURCE);
+  assert.ok(chunks.length > 1, "section above the reference target should split");
+  const answer = chunks.find((c) => c.text.includes("cron.provider"));
+  assert.ok(answer, "answer paragraph must survive chunking");
+  const pos = answer.text.indexOf("cron.provider");
+  assert.ok(pos < 300, `answer should sit near the top of its chunk, found at char ${pos}`);
+});
+
+test("CRLF input chunks identically to LF input", () => {
+  const lf = `## Section\n\n${para("a", 900)}\n\n${para("b", 900)}\n\n${para("c", 900)}\n`;
+  const crlf = lf.replace(/\n/g, "\r\n");
+
+  const a = chunkText(lf, NON_REF_SOURCE);
+  const b = chunkText(crlf, NON_REF_SOURCE);
+  assert.equal(a.length, b.length);
+  for (let i = 0; i < a.length; i++) assert.equal(a[i].text, b[i].text);
+});


### PR DESCRIPTION
## Problem (#400)

Large reference docs pack narrow topics into big `##` section chunks — retrieval returns the right doc, but the answer sits deep in a ~2000-char chunk (the audit example: `cron.provider`/chronos at char 754 of a 1,313-char `hermes cron` chunk).

## Fix

1. **Extract chunking into `lib/chunk-text.js`** — `build-chunks.js` calls `process.exit` at import time without an API key, so the splitter was untestable in place. The script now imports `chunkText` from the lib; no behavior change from the move itself.
2. **Reference-scoped finer chunking**: `research/docs/reference/*` sources chunk at **1,200 chars** (vs 2,000) and split oversized sections at `###` subheadings with combined `H2 › H3` section labels. Every other source chunks **byte-identically** to before, so the embedding cache stays warm.
3. **CRLF normalization** (found during verification): the paragraph splitter matches `/\n\n+/`, which never fires on `\r\n\r\n` — on a Windows checkout paragraph splitting was silently disabled entirely, producing completely different chunks than CI. Same Windows-no-op class as the #457 validator fix. No-op on CI's LF checkouts.
4. `rebuild-chunks.yml` also triggers on `lib/chunk-text.js` (it already triggers on `scripts/build-chunks.js`, so merging this PR fires the rebuild automatically).

## Verification

Full-corpus comparison (old vs new algorithm, LF-normalized to match CI):

| Metric | Old | New |
|---|---|---|
| Non-reference chunks | 6,613 | 6,613 — byte-identical |
| Reference chunks | 296 | 451 (avg 1,156 → 791 chars) |
| chunks.json size | 70.2 MB | ~71.8 MB projected (limit 100) |
| Chunks re-embedded on rebuild | — | ~501 (rest hit the sha256 cache) |
| #400 chronos answer position | char 754 of 1,313 | **char 245 of 804** |

Plus 7 new unit tests in `tests/chunk-text.test.js` (scoping, `###` labels, historical-behavior guards for non-reference sources, CRLF equivalence). `npm test`: 29/29.

## Post-merge

`rebuild-chunks.yml` fires on merge (build-chunks.js is in its path triggers) and re-embeds only the ~501 changed chunks.

Closes #400

🤖 Generated with [Claude Code](https://claude.com/claude-code)