### PR TITLE
CSP stage B: drop 'unsafe-inline' from script-src and style-src

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -35,7 +35,7 @@
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "X-Frame-Options", "value": "DENY" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self'; object-src 'none'; form-action 'self'" },
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' https://static.cloudflareinsights.com; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self'; object-src 'none'; form-action 'self'" },
         { "key": "Cache-Control", "value": "public, max-age=3600, s-maxage=86400" }
       ]
     }


### PR DESCRIPTION
## What

The one-line header flip that stage A (#486) makes safe: remove `'unsafe-inline'` from both `script-src` and `style-src` in the site-wide CSP. Completes the roadmapped follow-up to #470.

## ⚠️ Merge preconditions (why this is a draft)

1. **#486 merged** — externalizes every inline script/style on hand-written pages and in the build templates.
2. **Generated pages rebuilt** — `projects/**`, `lists/**`, and `reports/index.html` must be regenerated from the new templates (daily `build-pages.yml` cron, or dispatch it manually right after #486 lands). Until then, deployed generated pages still carry inline theme-init/toggle scripts that this policy would silently break (dead theme toggle on 190+ pages — and the HTTP smoke test wouldn't catch it, since pages still return 200).

**Safe sequence:** merge #486 → dispatch `build-pages.yml` → confirm a regenerated project page references `/assets/js/theme-init.js` → mark this ready and merge.

## Post-merge verification

- `curl -sI https://hermesatlas.com | grep -i content-security` — no `unsafe-inline`
- Spot-check theme toggle + chat widget on the live homepage and one project page (browser or devtools console — zero CSP violation messages expected)

What remains allowed: external scripts from self + Cloudflare Insights, styles from self + Google Fonts. JSON-LD blocks are unaffected (inert data). The `img-src 'self' data: https:` tightening mentioned in the roadmap is intentionally out of scope — separate discussion since README images hotlink arbitrary GitHub domains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)