### PR TITLE
Strip style attributes from sanitized README HTML

### DIFF
--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -124,11 +124,14 @@ marked.setOptions({
 });
 
 // ── Sanitize untrusted README HTML (contributor READMEs can carry raw
-// <script>/<iframe>/onerror=.../javascript: payloads → stored XSS). ──
+// <script>/<iframe>/onerror=.../javascript: payloads → stored XSS).
+// `style` is stripped too: the site CSP has no style-src 'unsafe-inline'
+// (#487), so browsers ignore inline styles anyway — emitting them would just
+// be dead markup and CSP-report noise. README images are sized by page.css. ──
 const DOMPurify = createDOMPurify(new JSDOM("").window);
 function sanitizeReadmeHtml(html) {
   if (!html) return html;
-  return DOMPurify.sanitize(html, { USE_PROFILES: { html: true } });
+  return DOMPurify.sanitize(html, { USE_PROFILES: { html: true }, FORBID_ATTR: ["style"] });
 }
 
 // ── Emit JSON-LD with `<` escaped so a `</script>` inside any user-supplied


### PR DESCRIPTION
## What

Post-#487 live verification found the one surface the stage-A sweep couldn't cover: **README-embedded HTML**. DOMPurify's default profile allows `style=` attributes, so 10 of 185 project pages still carried them (all trivial image sizing: `width`, `max-width`, `border-radius`, `margin`).

With `style-src` no longer allowing `'unsafe-inline'`, browsers silently ignore these — so they're dead markup today and would be pure noise in any future CSP violation reporting. One line: `FORBID_ATTR: ["style"]` on the sanitize call, so emitted markup matches what the policy actually renders. README images are size-constrained by `page.css` regardless.

## Verification

Ran `node scripts/build-pages.js` offline against the full catalog: `style=` files across `projects/` + `lists/` went **10 → 0**, README images intact (sample page keeps all 17 `<img>` tags). Generated pages intentionally not committed — `build-pages.yml` triggers on `scripts/build-pages.js` and rebuilds post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)