### PR TITLE
Fix silently-green smoke gates: real preview URL, pipefail, protection bypass

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -110,10 +110,16 @@ jobs:
         id: smoke
         # Pass dispatch inputs via env, never interpolated straight into the
         # shell command (a crafted `base`/`sample` could otherwise inject shell).
+        #
+        # `set -o pipefail`: GitHub's default run shell is `bash -e` WITHOUT
+        # pipefail, so `node ... | tee` otherwise reports tee's exit code and a
+        # failing smoke run becomes a green check (bit the PR-preview gate for
+        # weeks before being caught on 2026-07-07).
         env:
           SMOKE_BASE: ${{ inputs.base || 'https://hermesatlas.com' }}
           SMOKE_SAMPLE: ${{ inputs.sample || '25' }}
         run: |
+          set -o pipefail
           node scripts/smoke-test-prod.js \
             --base "$SMOKE_BASE" \
             --sample "$SMOKE_SAMPLE" \

--- a/.github/workflows/smoke-test-pr.yml
+++ b/.github/workflows/smoke-test-pr.yml
@@ -52,42 +52,46 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            // Use the GitHub Deployments API, NOT the 'Vercel' commit status:
+            // the status's target_url points at the vercel.com dashboard, not
+            // the deployment. Probing the dashboard 404s on every path — which
+            // is exactly how this gate passed vacuously for weeks (the 404s
+            // "failed" but the exit code was masked downstream; see pipefail
+            // note on the run step). The deployment status's environment_url
+            // is the real, fetchable preview origin.
             const sha = context.payload.pull_request.head.sha;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const MAX_WAIT_MS = 10 * 60 * 1000;
             const INTERVAL_MS = 15 * 1000;
             const start = Date.now();
-            let lastState = null;
 
-            core.info(`Polling Vercel preview status for PR #${context.payload.pull_request.number} @ ${sha}`);
+            core.info(`Polling Vercel preview deployment for PR #${context.payload.pull_request.number} @ ${sha}`);
 
             while (Date.now() - start < MAX_WAIT_MS) {
-              const { data } = await github.rest.repos.getCombinedStatusForRef({
-                owner,
-                repo,
-                ref: sha,
+              const { data: deployments } = await github.rest.repos.listDeployments({
+                owner, repo, sha, per_page: 10,
               });
-              const vercel = data.statuses.find((status) => status.context === 'Vercel');
-              const state = vercel ? vercel.state : 'no-status-yet';
-              if (state !== lastState) {
-                core.info(`Vercel status: ${state}`);
-                lastState = state;
-              }
+              const previews = deployments.filter((d) => /preview/i.test(d.environment || ''));
 
-              if (state === 'success') {
-                if (!vercel.target_url) {
-                  core.setFailed('Vercel status succeeded but did not expose a preview URL');
+              for (const dep of previews) {
+                const { data: statuses } = await github.rest.repos.listDeploymentStatuses({
+                  owner, repo, deployment_id: dep.id, per_page: 5,
+                });
+                const done = statuses.find((s) => s.state === 'success' && s.environment_url);
+                if (done) {
+                  if (!/^https:\/\//.test(done.environment_url) || done.environment_url.includes('vercel.com/')) {
+                    core.setFailed(`environment_url does not look like a deployment origin: ${done.environment_url}`);
+                    return;
+                  }
+                  core.setOutput('base_url', done.environment_url);
+                  core.info(`Vercel preview ready: ${done.environment_url}`);
                   return;
                 }
-                core.setOutput('base_url', vercel.target_url);
-                core.info(`Vercel preview ready: ${vercel.target_url}`);
-                return;
-              }
-
-              if (state === 'failure' || state === 'error') {
-                core.setFailed(`Vercel preview failed for ${sha}; smoke test skipped`);
-                return;
+                if (statuses.find((s) => s.state === 'failure' || s.state === 'error')) {
+                  core.setFailed(`Vercel preview deployment failed for ${sha}; smoke test cannot run`);
+                  return;
+                }
               }
 
               await new Promise((resolve) => setTimeout(resolve, INTERVAL_MS));
@@ -99,12 +103,32 @@ jobs:
         id: smoke
         # Pass the preview URL via env, never interpolated straight into the
         # shell command.
+        #
+        # VERCEL_AUTOMATION_BYPASS_SECRET: preview deployments sit behind
+        # Vercel Authentication; the script sends the secret as the
+        # x-vercel-protection-bypass header. Guarded loudly below — without it
+        # every probe would 401 and the failure cause would be unobvious.
+        # NOTE: secrets are not available to PRs from forks, so fork-submitted
+        # PRs fail here by design (fork previews also require manual
+        # authorization on Vercel) — a maintainer reviews and merges those by
+        # hand.
+        #
+        # `set -o pipefail`: without it, `node ... | tee` reports tee's exit
+        # code and a failing smoke run turns into a green check — the silent
+        # failure that let this gate pass while probing the wrong host.
         env:
           SMOKE_BASE: ${{ steps.vercel.outputs.base_url }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: |
+          set -o pipefail
+          if [ -z "$VERCEL_AUTOMATION_BYPASS_SECRET" ]; then
+            echo "::error::VERCEL_AUTOMATION_BYPASS_SECRET is not set (repo secret missing, or this is a fork PR — secrets are withheld from forks). Preview probes would all 401."
+            exit 1
+          fi
           node scripts/smoke-test-prod.js \
             --base "$SMOKE_BASE" \
             --sample "25" \
+            --preview \
             --continue \
             | tee smoke-output.txt
 

--- a/scripts/smoke-test-prod.js
+++ b/scripts/smoke-test-prod.js
@@ -37,6 +37,15 @@
  *   node scripts/smoke-test-prod.js --sample 50
  *   node scripts/smoke-test-prod.js --continue   # don't stop on first failure
  *   node scripts/smoke-test-prod.js --verbose
+ *   node scripts/smoke-test-prod.js --preview    # deployment is the same commit
+ *       as this checkout: repos.json entries whose projects/<owner>/<repo>.html
+ *       hasn't been generated yet (added by this PR; built post-merge) are
+ *       excluded from page/sitemap/link expectations, with the skip count
+ *       logged. Never use on prod — there every entry must have a page.
+ *
+ * Vercel deployment protection: if VERCEL_AUTOMATION_BYPASS_SECRET is set in
+ * the environment, it's sent as the x-vercel-protection-bypass header on every
+ * request so the test can reach auth-protected preview deployments.
  *
  * Acknowledging known-broken checks (downgrade FAIL → WARN, exit stays 0):
  *   SMOKE_ALLOW_FAILURES='/lists/,Core & Official count' node scripts/smoke-test-prod.js
@@ -77,7 +86,9 @@ const CONCURRENCY = parseInt(opt("concurrency", "10"), 10);
 const TIMEOUT_MS = parseInt(opt("timeout", "15000"), 10);
 const CONTINUE_ON_FAIL = flag("continue");
 const VERBOSE = flag("verbose");
+const PREVIEW_MODE = flag("preview");
 const USER_AGENT = "HermesAtlas-SmokeTest/1.0";
+const BYPASS_SECRET = process.env.VERCEL_AUTOMATION_BYPASS_SECRET || "";
 
 // Acknowledged failures: substring-matched against the `check` name. Anything
 // matched becomes a WARN instead of a FAIL (still printed, doesn't affect exit
@@ -139,7 +150,11 @@ async function fetchWithTimeout(url, opts = {}) {
       ...opts,
       signal: controller.signal,
       redirect: "follow",
-      headers: { "User-Agent": USER_AGENT, ...(opts.headers || {}) },
+      headers: {
+        "User-Agent": USER_AGENT,
+        ...(BYPASS_SECRET ? { "x-vercel-protection-bypass": BYPASS_SECRET } : {}),
+        ...(opts.headers || {}),
+      },
     });
     return res;
   } finally {
@@ -190,11 +205,44 @@ const repos = JSON.parse(
   await fs.readFile(path.join(ROOT, "data/repos.json"), "utf8")
 );
 
+// Preview mode: a preview deploy serves exactly this commit, so an entry
+// whose project page hasn't been generated yet (a repo-add PR; build-pages
+// runs post-merge) will 404 there legitimately. Compute that set from the
+// local checkout and exclude it from page/sitemap/link expectations. The
+// skip is always logged loudly — a silent cap here would recreate the exact
+// class of fake-green this script exists to prevent.
+const pendingProjectPaths = new Set();
+if (PREVIEW_MODE) {
+  for (const r of repos) {
+    try {
+      await fs.access(path.join(ROOT, "projects", r.owner, `${r.repo}.html`));
+    } catch {
+      pendingProjectPaths.add(`/projects/${r.owner}/${r.repo}`);
+    }
+  }
+}
+function isPending(repo) {
+  return pendingProjectPaths.has(`/projects/${repo.owner}/${repo.repo}`);
+}
+
 // ---------- Section runners ----------
 
 console.log(c.bold(`\nHermes Atlas smoke test`));
 console.log(c.dim(`  base: ${BASE}`));
 console.log(c.dim(`  repos.json entries: ${repos.length}`));
+if (PREVIEW_MODE) {
+  console.log(c.dim(`  preview mode: on (deployment == this checkout)`));
+  if (pendingProjectPaths.size > 0) {
+    console.log(
+      c.yellow(
+        `  ${pendingProjectPaths.size} entries have no generated project page yet ` +
+          `(added by this PR, built post-merge) — excluded from page/sitemap/link checks:`
+      )
+    );
+    for (const p of pendingProjectPaths) console.log(c.yellow(`    - ${p}`));
+  }
+}
+if (BYPASS_SECRET) console.log(c.dim(`  deployment-protection bypass: header set`));
 console.log(c.dim(`  sample size: ${SAMPLE_SIZE} (plus all entries newer than ${RECENT_DAYS}d in repos.json if dated)`));
 console.log("");
 
@@ -303,12 +351,17 @@ await section("3. Project pages return 2xx (sample + recent)", async () => {
     return Number.isFinite(d) && d >= recentCutoff;
   });
 
+  const eligible = repos.filter((r) => !isPending(r));
   const randomSlice = sample(
-    repos.filter((r) => !recent.includes(r)),
+    eligible.filter((r) => !recent.includes(r)),
     Math.max(0, SAMPLE_SIZE - recent.length)
   );
-  const checkSet = [...recent, ...randomSlice];
-  info(`testing ${checkSet.length} project pages (${recent.length} recent + ${randomSlice.length} random)`);
+  const checkSet = [...recent.filter((r) => !isPending(r)), ...randomSlice];
+  info(
+    `testing ${checkSet.length} project pages (${recent.length} recent + ${randomSlice.length} random` +
+      (pendingProjectPaths.size > 0 ? `; ${pendingProjectPaths.size} pending-page entries skipped` : "") +
+      `)`
+  );
 
   const checked = await pool(checkSet, CONCURRENCY, async (repo) => {
     const url = `${BASE}/projects/${repo.owner}/${repo.repo}`;
@@ -353,7 +406,12 @@ await section("4. Sitemap covers every /projects/<owner>/<repo> in repos.json", 
       .filter((p) => p && p.startsWith("/projects/"))
   );
 
-  const expected = repos.map((r) => `/projects/${r.owner}/${r.repo}`);
+  const expected = repos
+    .filter((r) => !isPending(r))
+    .map((r) => `/projects/${r.owner}/${r.repo}`);
+  if (pendingProjectPaths.size > 0) {
+    info(`${pendingProjectPaths.size} pending-page entries excluded from sitemap expectation`);
+  }
   const missing = expected.filter((p) => !projectLocs.has(p));
 
   if (missing.length === 0) {
@@ -405,9 +463,14 @@ await section("6. Sample of internal links from homepage resolve", async () => {
     const href = a.getAttribute("href") || "";
     if (href.startsWith("/") && !href.startsWith("//")) internal.add(href.split("#")[0].split("?")[0]);
   }
-  const list = Array.from(internal).filter(Boolean);
+  const list = Array.from(internal)
+    .filter(Boolean)
+    .filter((p) => !pendingProjectPaths.has(p.replace(/\/$/, "")));
   const checked = sample(list, Math.min(SAMPLE_SIZE, list.length));
-  info(`sampling ${checked.length}/${list.length} internal links`);
+  info(
+    `sampling ${checked.length}/${list.length} internal links` +
+      (pendingProjectPaths.size > 0 ? ` (pending-page links excluded)` : "")
+  );
 
   const results = await pool(checked, CONCURRENCY, async (p) => {
     const url = `${BASE}${p}`;


### PR DESCRIPTION
## What

The PR-preview smoke gate has been passing **vacuously** — #492's run probed `vercel.com` dashboard paths, printed 40+ failures, and still went green. Three stacked bugs, all fixed:

1. **Wrong probe target.** The `Vercel` commit status `target_url` points at the vercel.com *dashboard*, not the deployment. Now uses the GitHub Deployments API → deployment status `environment_url` (the real preview origin), with a sanity check rejecting `vercel.com` URLs.
2. **Masked exit code.** GitHub's default run shell is `bash -e` **without** pipefail, so `node smoke.js | tee` reported tee's exit 0. Demonstrated: `node -e "process.exit(1)" | tee` → exit 0 without pipefail, 1 with. `set -o pipefail` added to **both** smoke workflows — the prod post-deploy gate had the same mask.
3. **Auth-blocked previews.** Previews sit behind Vercel Authentication (anonymous → 401). The script now sends `VERCEL_AUTOMATION_BYPASS_SECRET` as `x-vercel-protection-bypass` on every request; the workflow fails loudly with a clear message when the secret is absent.

An honestly-failing gate then exposed a design gap: repo-add PRs ship `repos.json`+`index.html`, but the project page is generated **post-merge** — so an honest gate would red every community submission (sitemap check deterministically, page sample ~13%). New **`--preview` mode** (PR workflow only): entries whose `projects/<owner>/<repo>.html` doesn't exist in the same commit are excluded from page/sitemap/link expectations, **with the skipped set always logged**. Prod runs stay strict.

## Verification (all against live production)

- Strict run: **24/24 pass**, exit 0. `--preview` on main is a no-op (all pages exist).
- Simulated repo-add entry: `--preview` skips its page checks and logs it, **but still fails the category-count check** (a real PR must bump index.html — the gate still gates); strict mode fails sitemap coverage with **exit 1**.
- Both workflow files parse as valid YAML.
- This PR's own smoke run executes the fixed workflow — expected **red** until the Vercel bypass secret is configured (see below), then green on re-run. That first honest red is the proof.

## Deployment prerequisite (one manual step)

Vercel dashboard → **hermes-ecosystem → Settings → Deployment Protection → Protection Bypass for Automation → Add secret**. After that, mirror it: `vercel env pull` + `gh secret set VERCEL_AUTOMATION_BYPASS_SECRET`.

## Known limitation

Fork PRs get neither repo secrets nor auto-authorized previews → their smoke fails by design; maintainer merges by hand. Structural fix is the `/submit` revamp (roadmap 19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)