### PR TITLE
Add sergebulaev/linkedin-skills (Skills & Skill Registries)

### DIFF
--- a/data/repos.json
+++ b/data/repos.json
@@ -1848,5 +1848,15 @@
     "url": "https://github.com/teixeirazeus/fablize-for-hermes",
     "official": false,
     "category": "Skills & Skill Registries"
+  },
+  {
+    "owner": "sergebulaev",
+    "repo": "linkedin-skills",
+    "name": "linkedin-skills",
+    "description": "10 LinkedIn growth skills following the agentskills.io open standard for Hermes Agent, Claude Code, and Codex: write human-sounding posts, draft comments, audit drafts, and plan a publishing cadence",
+    "stars": 329,
+    "url": "https://github.com/sergebulaev/linkedin-skills",
+    "official": false,
+    "category": "Skills & Skill Registries"
   }
 ]

--- a/index.html
+++ b/index.html
@@ -484,7 +484,7 @@
     <div class="cat-num">§03</div>
     <h2 class="cat-title">Skills &amp; skill registries</h2>
     <p class="cat-desc">Reusable capabilities following the agentskills.io open standard — libraries, registries, and meta-tools.</p>
-    <div class="cat-count"><span class="cat-count-n">30</span> repos</div>
+    <div class="cat-count"><span class="cat-count-n">31</span> repos</div>
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills" data-github="https://github.com/mukul975/Anthropic-Cybersecurity-Skills" data-desc="754 structured cybersecurity skills mapped to MITRE ATT&CK, NIST CSF 2.0, ATLAS, D3FEND & NIST AI RMF">
@@ -660,6 +660,14 @@
       <div class="repo-body">
         <div class="repo-name"><span class="org">ZeroPointRepo /</span> youtube-skills</div>
         <div class="repo-desc">YouTube transcript, search, channel, and playlist skills for Hermes Agent, OpenClaw, Claude Code, Cursor, and Windsurf.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/sergebulaev/linkedin-skills" data-github="https://github.com/sergebulaev/linkedin-skills" data-desc="10 LinkedIn growth skills following the agentskills.io open standard for Hermes Agent, Claude Code, and Codex: write human-sounding posts, draft comments, audit drafts, and plan a publishing cadence">
+      <div class="repo-stars">★ 329</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">sergebulaev /</span> linkedin-skills</div>
+        <div class="repo-desc">10 LinkedIn growth skills following the agentskills.io open standard for Hermes Agent, Claude Code, and Codex: write human-sounding posts, draft comments, audit drafts, and plan a publishing cadence.</div>
       </div>
       <div class="repo-delta">— / wk</div>
     </a>


### PR DESCRIPTION
### Repo
https://github.com/sergebulaev/linkedin-skills

### What it is
A bundle of 10 MIT-licensed SKILL.md skills for LinkedIn content work, built on the agentskills.io open standard that Hermes Agent supports. Skills cover human-sounding post drafting, comment drafting, pre-publish auditing, an AI-writing humanizer, profile optimization, and weekly content planning. Runs from the terminal via Hermes Agent, Claude Code, or Codex.

### Fit
- Category: **Skills & Skill Registries** (agentskills.io open standard, matching the category description)
- Created 2026-04-14 (after the 2025-07-22 gate)
- 329 GitHub stars, MIT licensed, actively maintained, not a fork
- Sits alongside existing multi-platform agentskills.io entries such as ZeroPointRepo/youtube-skills, wondelai/skills, and PederHP/skillsdotnet

### Changes
- Added one object to `data/repos.json`
- Added the matching `<a class="repo-row">` block in the Skills & Skill Registries section of `index.html` and bumped the category count 30 to 31

Sibling agentskills.io bundles exist for X, Instagram, YouTube, Threads, TikTok, and Facebook (same author, same standard). Happy to submit those separately if the map wants them; this PR adds only linkedin-skills.

Passes security review on request: no build step, no network calls in the skills themselves, MIT license.