### PR TITLE
Add Tonbi Hermes Agent Masterclass

### DIFF
--- a/404.html
+++ b/404.html
@@ -27,19 +27,27 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">95·repos</span>
-    <span id="meta-version">hermes·v0.10.0</span>
+    <span id="meta-count">185·repos</span>
+    <span id="meta-version">hermes·v0.18.0</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
+    <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -6,19 +6,37 @@
    Source of truth: DESIGN.md §5 and mock-a-brutalist.html
    ================================================================= */
 
-/* ─── Theme toggle (text-based, inline in masthead per DESIGN.md §13) ── */
+/* ─── Compact icon theme control ───────────────────────────── */
 #theme-toggle {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
   color: var(--ink-soft);
-  padding: 2px 0;
-  white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 3px;
+  border: 1px solid var(--rule);
+  background: var(--bg-offset);
+  transition: border-color 0.2s, background 0.2s;
 }
-#theme-toggle .tt-active { color: var(--ink); }
-#theme-toggle .tt-sep { color: var(--rule-strong); margin: 0 6px; }
-#theme-toggle:hover { color: var(--ink); }
+#theme-toggle:hover { border-color: var(--rule-strong); }
+#theme-toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; }
+#theme-toggle .tt-icon {
+  width: 23px;
+  height: 21px;
+  display: grid;
+  place-items: center;
+  color: var(--ink-mute);
+  transition: color 0.2s, background 0.2s;
+}
+#theme-toggle .tt-icon svg {
+  width: 14px;
+  height: 14px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.7;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+#theme-toggle .tt-icon.tt-active { color: var(--bg); background: var(--accent); }
 
 /* ─── Masthead ─────────────────────────────────────────────── */
 .masthead {
@@ -762,7 +780,7 @@
 #chat-send:disabled { opacity: 0.4; cursor: not-allowed; }
 
 /* ─── Responsive ───────────────────────────────────────────── */
-@media (max-width: 900px) {
+@media (max-width: 1100px) {
   .masthead {
     grid-template-columns: 1fr;
     gap: 12px;

--- a/assets/css/masterclass.css
+++ b/assets/css/masterclass.css
@@ -1,0 +1,391 @@
+/* =================================================================
+   Hermes Atlas — Tonbi Masterclass
+   Editorial curriculum layout built on the shared industrial tokens.
+   ================================================================= */
+
+.masterclass-shell {
+  max-width: 1440px;
+  margin: 0 auto;
+}
+
+.series-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.55fr) minmax(300px, 0.65fr);
+  gap: clamp(48px, 8vw, 120px);
+  padding: clamp(64px, 9vw, 124px) 40px clamp(72px, 10vw, 132px);
+  border-bottom: 1px solid var(--rule-strong);
+}
+
+.series-kicker,
+.creator-kicker,
+.curriculum-label,
+.episode-kind,
+.notes-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--accent);
+}
+
+.series-kicker {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.series-kicker::before {
+  content: '';
+  width: 28px;
+  height: 1px;
+  background: var(--accent);
+}
+
+.series-title {
+  max-width: 10ch;
+  font-size: clamp(58px, 9.2vw, 132px);
+  font-weight: 500;
+  line-height: 0.84;
+  letter-spacing: -0.065em;
+  text-wrap: balance;
+}
+
+.series-title em {
+  display: block;
+  color: var(--accent);
+  font-style: normal;
+}
+
+.series-lede {
+  max-width: 62ch;
+  margin-top: 34px;
+  font-family: var(--font-mono);
+  font-size: clamp(14px, 1.5vw, 17px);
+  line-height: 1.75;
+  color: var(--ink-dim);
+  text-wrap: pretty;
+}
+
+.series-facts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 24px;
+  margin-top: 28px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--ink-soft);
+  font-variant-numeric: tabular-nums;
+}
+
+.series-facts span::before {
+  content: '▸ ';
+  color: var(--accent);
+}
+
+.creator-panel {
+  align-self: end;
+  border-left: 1px solid var(--rule-strong);
+  padding: 8px 0 8px 32px;
+}
+
+.creator-name {
+  margin: 18px 0 12px;
+  font-size: clamp(26px, 3vw, 40px);
+  font-weight: 550;
+  line-height: 1.02;
+  letter-spacing: -0.035em;
+}
+
+.creator-copy {
+  max-width: 37ch;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.7;
+  color: var(--ink-soft);
+}
+
+.creator-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 18px;
+  margin-top: 24px;
+}
+
+.creator-links a,
+.watch-link {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--ink);
+  border-bottom: 1px solid var(--accent);
+  padding-bottom: 3px;
+  transition: color 0.2s, border-color 0.2s;
+}
+
+.creator-links a:hover,
+.watch-link:hover {
+  color: var(--accent);
+  border-color: var(--ink);
+}
+
+.curriculum {
+  display: grid;
+  grid-template-columns: 180px minmax(0, 1fr);
+  gap: 32px;
+  padding: 26px 40px;
+  border-bottom: 1px solid var(--rule-strong);
+  background: var(--bg-offset);
+}
+
+.curriculum-label {
+  color: var(--ink-soft);
+  padding-top: 9px;
+}
+
+.curriculum-nav {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  border-left: 1px solid var(--rule);
+  border-top: 1px solid var(--rule);
+}
+
+.curriculum-nav a {
+  min-width: 0;
+  padding: 10px 12px 11px;
+  border-right: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  line-height: 1.35;
+  color: var(--ink-soft);
+  transition: color 0.2s, background 0.2s;
+}
+
+.curriculum-nav a:hover {
+  color: var(--ink);
+  background: var(--bg-elev);
+}
+
+.curriculum-nav strong {
+  display: block;
+  margin-bottom: 3px;
+  color: var(--accent);
+  font-variant-numeric: tabular-nums;
+}
+
+.episode {
+  display: grid;
+  grid-template-columns: minmax(130px, 0.23fr) minmax(0, 1fr);
+  gap: clamp(36px, 7vw, 104px);
+  padding: clamp(72px, 9vw, 120px) 40px clamp(82px, 10vw, 132px);
+  border-bottom: 1px solid var(--rule-strong);
+  scroll-margin-top: 24px;
+}
+
+.episode:nth-of-type(even) {
+  background: var(--bg-offset);
+}
+
+.episode-rail {
+  align-self: start;
+  position: sticky;
+  top: 24px;
+}
+
+.episode-number {
+  font-family: var(--font-mono);
+  font-size: clamp(56px, 7vw, 96px);
+  font-weight: 400;
+  line-height: 0.82;
+  letter-spacing: -0.08em;
+  color: var(--rule-strong);
+  font-variant-numeric: tabular-nums;
+}
+
+.episode-duration {
+  margin-top: 22px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--ink-mute);
+  font-variant-numeric: tabular-nums;
+}
+
+.episode-heading-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: end;
+  gap: 24px;
+  margin: 10px 0 30px;
+}
+
+.episode-title {
+  max-width: 18ch;
+  font-size: clamp(36px, 5.2vw, 72px);
+  font-weight: 500;
+  line-height: 0.98;
+  letter-spacing: -0.045em;
+  text-wrap: balance;
+}
+
+.watch-link {
+  flex: 0 0 auto;
+  margin-bottom: 7px;
+}
+
+.video-frame {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  background: #070604;
+  border: 1px solid var(--rule-strong);
+  box-shadow: 12px 12px 0 var(--rule);
+}
+
+.video-frame iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+.episode-notes {
+  margin-top: 34px;
+  border-top: 1px solid var(--rule-strong);
+  border-bottom: 1px solid var(--rule-strong);
+}
+
+.episode-notes summary {
+  min-height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 16px 0;
+  cursor: pointer;
+  list-style: none;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--ink);
+  transition: color 0.2s;
+}
+
+.episode-notes summary::-webkit-details-marker { display: none; }
+.episode-notes summary:hover { color: var(--accent); }
+.episode-notes summary:focus-visible { outline: 2px solid var(--accent); outline-offset: 5px; }
+
+.notes-arrow {
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--rule-strong);
+  color: var(--accent);
+  transition: transform 0.25s, background 0.25s;
+}
+
+.episode-notes[open] .notes-arrow {
+  transform: rotate(45deg);
+  background: var(--bg-elev);
+}
+
+.notes-body {
+  display: grid;
+  grid-template-columns: minmax(220px, 0.48fr) minmax(0, 1fr);
+  gap: clamp(28px, 6vw, 80px);
+  padding: 10px 0 42px;
+}
+
+.notes-label {
+  color: var(--ink-mute);
+  margin-bottom: 14px;
+}
+
+.notes-tldr {
+  font-size: clamp(20px, 2.2vw, 29px);
+  line-height: 1.25;
+  letter-spacing: -0.025em;
+  color: var(--ink);
+  text-wrap: pretty;
+}
+
+.takeaways {
+  list-style: none;
+  border-top: 1px solid var(--rule);
+}
+
+.takeaways li {
+  display: grid;
+  grid-template-columns: 54px minmax(0, 1fr);
+  gap: 16px;
+  padding: 15px 0 16px;
+  border-bottom: 1px solid var(--rule);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.68;
+  color: var(--ink-dim);
+}
+
+.takeaways strong { color: var(--ink); font-weight: 600; }
+
+.timecode {
+  align-self: start;
+  font-size: 10px;
+  color: var(--accent);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+  border-bottom: 1px solid var(--accent-dim);
+}
+
+.timecode:hover { color: var(--ink); }
+
+.source-note {
+  padding: 34px 40px 38px;
+  border-bottom: 1px solid var(--rule-strong);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.7;
+  color: var(--ink-mute);
+}
+
+.source-note strong { color: var(--ink-soft); }
+.source-note a { color: var(--accent); border-bottom: 1px solid var(--accent-dim); }
+
+@media (max-width: 900px) {
+  .series-hero { grid-template-columns: 1fr; padding-inline: 20px; }
+  .creator-panel { max-width: 640px; }
+  .curriculum { grid-template-columns: 1fr; padding-inline: 20px; }
+  .curriculum-nav { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .episode { grid-template-columns: 1fr; padding-inline: 20px; }
+  .episode-rail { position: static; display: flex; align-items: end; gap: 18px; }
+  .episode-number { font-size: 54px; }
+  .episode-duration { margin: 0 0 2px; }
+  .notes-body { grid-template-columns: 1fr; }
+  .source-note { padding-inline: 20px; }
+}
+
+@media (max-width: 560px) {
+  .series-title { font-size: clamp(50px, 17vw, 76px); }
+  .creator-panel { padding-left: 20px; }
+  .curriculum-nav { grid-template-columns: 1fr 1fr; }
+  .episode-heading-row { display: block; }
+  .watch-link { display: inline-block; margin-top: 18px; }
+  .video-frame { box-shadow: 7px 7px 0 var(--rule); }
+  .takeaways li { grid-template-columns: 46px minmax(0, 1fr); gap: 10px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .notes-arrow,
+  .creator-links a,
+  .watch-link,
+  .curriculum-nav a { transition: none; }
+}

--- a/assets/css/page.css
+++ b/assets/css/page.css
@@ -4,19 +4,37 @@
    Source of truth: DESIGN.md §5 + mock-a-brutalist.html
    ================================================================= */
 
-/* ─── Theme toggle (text-based, inline in masthead per DESIGN.md §13) ── */
+/* ─── Compact icon theme control ───────────────────────────── */
 #theme-toggle {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
   color: var(--ink-soft);
-  padding: 2px 0;
-  white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 3px;
+  border: 1px solid var(--rule);
+  background: var(--bg-offset);
+  transition: border-color 0.2s, background 0.2s;
 }
-#theme-toggle .tt-active { color: var(--ink); }
-#theme-toggle .tt-sep { color: var(--rule-strong); margin: 0 6px; }
-#theme-toggle:hover { color: var(--ink); }
+#theme-toggle:hover { border-color: var(--rule-strong); }
+#theme-toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; }
+#theme-toggle .tt-icon {
+  width: 23px;
+  height: 21px;
+  display: grid;
+  place-items: center;
+  color: var(--ink-mute);
+  transition: color 0.2s, background 0.2s;
+}
+#theme-toggle .tt-icon svg {
+  width: 14px;
+  height: 14px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.7;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+#theme-toggle .tt-icon.tt-active { color: var(--bg); background: var(--accent); }
 
 /* ─── Masthead (shared with index) ─────────────────────────── */
 .masthead {
@@ -926,7 +944,7 @@
 .notfound .back:hover { background: var(--accent-dim); }
 
 /* ─── Responsive ───────────────────────────────────────────── */
-@media (max-width: 900px) {
+@media (max-width: 1100px) {
   .masthead {
     grid-template-columns: 1fr;
     gap: 12px;

--- a/assets/js/homepage.js
+++ b/assets/js/homepage.js
@@ -7,6 +7,8 @@
     const isLight = current === 'light';
     toggle.querySelector('.tt-light').classList.toggle('tt-active', isLight);
     toggle.querySelector('.tt-dark').classList.toggle('tt-active', !isLight);
+    toggle.setAttribute('aria-label', isLight ? 'Switch to dark theme' : 'Switch to light theme');
+    toggle.setAttribute('title', isLight ? 'Switch to dark theme' : 'Switch to light theme');
   }
   renderThemeToggle();
 

--- a/assets/js/theme-toggle.js
+++ b/assets/js/theme-toggle.js
@@ -8,6 +8,8 @@
     var c = document.documentElement.getAttribute('data-theme');
     t.querySelector('.tt-light').classList.toggle('tt-active', c === 'light');
     t.querySelector('.tt-dark').classList.toggle('tt-active', c !== 'light');
+    t.setAttribute('aria-label', c === 'light' ? 'Switch to dark theme' : 'Switch to light theme');
+    t.setAttribute('title', c === 'light' ? 'Switch to dark theme' : 'Switch to light theme');
   }
   render();
   t.addEventListener('click', function () {

--- a/dev/agent-loop.html
+++ b/dev/agent-loop.html
@@ -58,21 +58,27 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
-    <span id="meta-version">hermes·v0.15.2</span>
+    <span id="meta-count">185·repos</span>
+    <span id="meta-version">hermes·v0.18.0</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/" class="active">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/dev/building-on-hermes.html
+++ b/dev/building-on-hermes.html
@@ -58,21 +58,27 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
-    <span id="meta-version">hermes·v0.15.2</span>
+    <span id="meta-count">185·repos</span>
+    <span id="meta-version">hermes·v0.18.0</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/" class="active">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/dev/codebase-map.html
+++ b/dev/codebase-map.html
@@ -58,21 +58,27 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
-    <span id="meta-version">hermes·v0.15.2</span>
+    <span id="meta-count">185·repos</span>
+    <span id="meta-version">hermes·v0.18.0</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/" class="active">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/dev/glossary.html
+++ b/dev/glossary.html
@@ -58,21 +58,27 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
-    <span id="meta-version">hermes·v0.15.2</span>
+    <span id="meta-count">185·repos</span>
+    <span id="meta-version">hermes·v0.18.0</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/" class="active">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/dev/index.html
+++ b/dev/index.html
@@ -52,21 +52,27 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
-    <span id="meta-version">hermes·v0.15.2</span>
+    <span id="meta-count">185·repos</span>
+    <span id="meta-version">hermes·v0.18.0</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/" class="active">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/dev/mcp-gateway-cron.html
+++ b/dev/mcp-gateway-cron.html
@@ -58,21 +58,27 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
-    <span id="meta-version">hermes·v0.15.2</span>
+    <span id="meta-count">185·repos</span>
+    <span id="meta-version">hermes·v0.18.0</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/" class="active">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/dev/memory.html
+++ b/dev/memory.html
@@ -58,21 +58,27 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
-    <span id="meta-version">hermes·v0.15.2</span>
+    <span id="meta-count">185·repos</span>
+    <span id="meta-version">hermes·v0.18.0</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/" class="active">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/dev/skill-template.html
+++ b/dev/skill-template.html
@@ -58,21 +58,27 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
-    <span id="meta-version">hermes·v0.15.2</span>
+    <span id="meta-count">185·repos</span>
+    <span id="meta-version">hermes·v0.18.0</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/" class="active">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/dev/skills.html
+++ b/dev/skills.html
@@ -58,21 +58,27 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
-    <span id="meta-version">hermes·v0.15.2</span>
+    <span id="meta-count">185·repos</span>
+    <span id="meta-version">hermes·v0.18.0</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/" class="active">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/dev/tools-and-toolsets.html
+++ b/dev/tools-and-toolsets.html
@@ -58,21 +58,27 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
-    <span id="meta-version">hermes·v0.15.2</span>
+    <span id="meta-count">185·repos</span>
+    <span id="meta-version">hermes·v0.18.0</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/" class="active">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/dev/what-is-hermes-agent.html
+++ b/dev/what-is-hermes-agent.html
@@ -58,21 +58,27 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">168·repos</span>
-    <span id="meta-version">hermes·v0.15.2</span>
+    <span id="meta-count">185·repos</span>
+    <span id="meta-version">hermes·v0.18.0</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/" class="active">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/drafts/handbook-hub.md
+++ b/drafts/handbook-hub.md
@@ -23,7 +23,7 @@ By [Kevin Simback](https://x.com/ksimback) · Hermes Atlas maintainer · Updated
 
 ## 1. What Hermes Agent actually is
 
-**Hermes Agent is an open-source AI agent by [Nous Research](https://nousresearch.com) that runs on your own machine or a cheap VPS, remembers what it learns across sessions, and writes its own reusable skills as it works. It talks to you through a CLI, Telegram, Discord, email, and many other messaging providers. It hit 211,795 GitHub stars (as of 2026-07-09), and it's the fastest-growing open-source agent of 2026.**
+**Hermes Agent is an open-source AI agent by [Nous Research](https://nousresearch.com) that runs on your own machine or a cheap VPS, remembers what it learns across sessions, and writes its own reusable skills as it works. It talks to you through a CLI, Telegram, Discord, email, and many other messaging providers. It hit 211,795 GitHub stars (as of 2026-07-11), and it's the fastest-growing open-source agent of 2026.**
 
 ### The 30-second version
 
@@ -434,11 +434,11 @@ If something is wrong, unclear, or out of date, open an issue on [the Atlas repo
 
 **Written by [Kevin Simback](https://x.com/ksimback)** · maintainer, Hermes Atlas
 
-**Last updated:** 2026-07-09 · Version and star figures re-stamp automatically with every site build.
+**Last updated:** 2026-07-11 · Version and star figures re-stamp automatically with every site build.
 
 **Cited stats:**
-- 211,795 GitHub stars (as of 2026-07-09) — source: `api.github.com/repos/NousResearch/hermes-agent`
-- 185+ projects in the Hermes Atlas (as of 2026-07-09)
+- 211,795 GitHub stars (as of 2026-07-11) — source: `api.github.com/repos/NousResearch/hermes-agent`
+- 185+ projects in the Hermes Atlas (as of 2026-07-11)
 - 643 skills in the community Hub (as of 2026-04-19)
 
 **Corrections and feedback:** [open an issue](https://github.com/ksimback/hermes-ecosystem/issues/new) or message on X.

--- a/drafts/handbook-vs-claude-code.md
+++ b/drafts/handbook-vs-claude-code.md
@@ -37,7 +37,7 @@ The frame people reach for is: **Claude Code is a specialist; Hermes is a genera
 | **Messaging channels** | Terminal only | Terminal, Telegram, Discord, email, webhooks |
 | **Multi-agent / delegation** | Subagents via the Task tool | Native delegation, multi-agent teams, profiles |
 | **Sandboxing** | Approval prompts, permission system | Approval policies, Docker backend, profile isolation |
-| **License & openness** | Proprietary (Anthropic) | Open-source (MIT), 211,795 stars as of 2026-07-09 |
+| **License & openness** | Proprietary (Anthropic) | Open-source (MIT), 211,795 stars as of 2026-07-11 |
 
 The two rows that matter most for the decision: **model support** (Anthropic-only vs multi-provider) and **where it runs** (inside a repo vs on a server).
 
@@ -64,7 +64,7 @@ Hermes is the right tool when your task crosses sessions, channels, or models.
 - **You want cross-channel access.** Message Hermes from Telegram during a commute. Check back on the CLI that evening. Same agent, same memory, same skills. Claude Code doesn't leave the terminal.
 - **You want the agent to get better over time.** The learning loop — five-tool-call retrospectives, auto-generated skills — compounds quietly. Day thirty doesn't feel like day one.
 - **You want model flexibility.** Swap from Claude to GPT to GLM-5 to local Ollama with one command. No code changes, no vendor lock-in. Cheap models for cheap jobs, frontier models for real work.
-- **You want it to be yours.** MIT-licensed, 211,795 stars (as of 2026-07-09), self-hostable on a $5 VPS. The code is open, the data lives on your disk, and nothing phones home.
+- **You want it to be yours.** MIT-licensed, 211,795 stars (as of 2026-07-11), self-hostable on a $5 VPS. The code is open, the data lives on your disk, and nothing phones home.
 
 Hermes falls short when you need deep in-editor coding support. It can read and write code, but it's not optimized for the minute-by-minute code-edit-test loop the way Claude Code is. Use Claude Code for that, and use Hermes around it.
 
@@ -113,7 +113,7 @@ For *simple* coding tasks — "refactor this file," "add a test" — yes. For su
 
 ### Is Hermes production-ready?
 
-As of 2026-07-09, yes, with caveats. 211,795 GitHub stars, an active Nous team shipping every two weeks, and a ~650-project community ecosystem. Real companies run Hermes in production. The honest caveats: the skill ecosystem is younger than Claude Code's, and some integrations still have rough edges. Read the **[State of Hermes report →](/reports/state-of-hermes-april-2026)** for the full picture.
+As of 2026-07-11, yes, with caveats. 211,795 GitHub stars, an active Nous team shipping every two weeks, and a ~650-project community ecosystem. Real companies run Hermes in production. The honest caveats: the skill ecosystem is younger than Claude Code's, and some integrations still have rough edges. Read the **[State of Hermes report →](/reports/state-of-hermes-april-2026)** for the full picture.
 
 ---
 
@@ -127,10 +127,10 @@ As of 2026-07-09, yes, with caveats. 211,795 GitHub stars, an active Nous team s
 
 **Written by [Kevin Simback](https://x.com/ksimback)** · maintainer, Hermes Atlas
 
-**Last updated:** 2026-07-09 · Version and star figures re-stamp automatically with every site build.
+**Last updated:** 2026-07-11 · Version and star figures re-stamp automatically with every site build.
 
 **Cited stats:**
-- 211,795 GitHub stars (as of 2026-07-09) — source: `api.github.com/repos/NousResearch/hermes-agent`
+- 211,795 GitHub stars (as of 2026-07-11) — source: `api.github.com/repos/NousResearch/hermes-agent`
 - 643 skills in the community Hub (research bank snapshot, as of 2026-04-19)
 
 **Corrections and feedback:** [open an issue](https://github.com/ksimback/hermes-ecosystem/issues/new) or message on X.

--- a/guide/index.html
+++ b/guide/index.html
@@ -12,7 +12,7 @@
 <meta property="og:url" content="https://hermesatlas.com/guide/">
 <meta property="og:site_name" content="Hermes Atlas">
 <meta property="article:published_time" content="2026-04-20T00:00:00Z">
-<meta property="article:modified_time" content="2026-07-09T00:00:00Z">
+<meta property="article:modified_time" content="2026-07-11T00:00:00Z">
 <meta property="article:author" content="https://x.com/ksimback">
 <meta property="og:image" content="https://hermesatlas.com/api/og?title=Hermes+Agent%3A+The+Complete+Beginner%27s+Guide&amp;subtitle=Install%2C+pick+a+model%2C+ship+your+first+workflow+%E2%80%94+with+the+best+community+tool+for+every+step.&amp;kind=handbook">
 <meta property="og:image:width" content="1200">
@@ -45,7 +45,7 @@
   "description": "The only beginner's guide to Nous Research's Hermes Agent that also shows you the best community tool for every step. Install, model pick, first workflow, skills.",
   "image": "https://hermesatlas.com/api/og?title=Hermes+Agent%3A+The+Complete+Beginner%27s+Guide&subtitle=Install%2C+pick+a+model%2C+ship+your+first+workflow+%E2%80%94+with+the+best+community+tool+for+every+step.&kind=handbook",
   "datePublished": "2026-04-20T00:00:00Z",
-  "dateModified": "2026-07-09T00:00:00Z",
+  "dateModified": "2026-07-11T00:00:00Z",
   "author": {
     "@type": "Person",
     "name": "Kevin Simback",
@@ -205,7 +205,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">95·repos</span>
+    <span id="meta-count">185·repos</span>
     <span id="meta-version">hermes·v0.18.0</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -213,13 +213,19 @@
     <a href="/">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/" class="active">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 
@@ -233,7 +239,7 @@
   <div class="article-badge">beginner's guide · the hermes handbook</div>
   <h1>Hermes Agent: The Complete Beginner's Guide (Jul 2026)</h1>
   <p class="subtitle">Install, pick a model, ship your first workflow, understand the learning loop — with the best community tool for every step.</p>
-  <p class="meta">By <a href="https://x.com/ksimback">Kevin Simback</a> · Hermes Atlas maintainer · Updated 2026-07-09 · ~18 min read</p>
+  <p class="meta">By <a href="https://x.com/ksimback">Kevin Simback</a> · Hermes Atlas maintainer · Updated 2026-07-11 · ~18 min read</p>
 </header>
 
 <blockquote><strong>More handbook guides:</strong> if you are here for memory architecture, provider comparisons, or how to choose between GBrain, Mnemosyne, Mem0, Hindsight, Honcho, and Supermemory, read <a href="/guide/memory/"><strong>The Hermes Agent Memory Guidebook →</strong></a></blockquote>
@@ -259,7 +265,7 @@
 
 <h2 id="1-what-hermes-agent-actually-is">1. What Hermes Agent actually is</h2>
 
-<p><strong>Hermes Agent is an open-source AI agent by <a href="https://nousresearch.com" target="_blank" rel="noopener">Nous Research</a> that runs on your own machine or a cheap VPS, remembers what it learns across sessions, and writes its own reusable skills as it works. It talks to you through a CLI, Telegram, Discord, email, and many other messaging providers. It hit 211,795 GitHub stars (as of 2026-07-09), and it's the fastest-growing open-source agent of 2026.</strong></p>
+<p><strong>Hermes Agent is an open-source AI agent by <a href="https://nousresearch.com" target="_blank" rel="noopener">Nous Research</a> that runs on your own machine or a cheap VPS, remembers what it learns across sessions, and writes its own reusable skills as it works. It talks to you through a CLI, Telegram, Discord, email, and many other messaging providers. It hit 211,795 GitHub stars (as of 2026-07-11), and it's the fastest-growing open-source agent of 2026.</strong></p>
 
 <h3>The 30-second version</h3>
 
@@ -654,11 +660,11 @@ hermes skills info &lt;name&gt;      # inspect before installing</code></pre>
 
 <div class="article-footer">
   <p><strong>Written by <a href="https://x.com/ksimback">Kevin Simback</a></strong> · maintainer, Hermes Atlas</p>
-  <p><strong>Last updated:</strong> 2026-07-09 · Version and star figures re-stamp automatically with every site build.</p>
+  <p><strong>Last updated:</strong> 2026-07-11 · Version and star figures re-stamp automatically with every site build.</p>
   <p><strong>Cited stats:</strong></p>
   <ul>
-    <li>211,795 GitHub stars (as of 2026-07-09) — source: <code>api.github.com/repos/NousResearch/hermes-agent</code></li>
-    <li>185+ projects in the Hermes Atlas (as of 2026-07-09)</li>
+    <li>211,795 GitHub stars (as of 2026-07-11) — source: <code>api.github.com/repos/NousResearch/hermes-agent</code></li>
+    <li>185+ projects in the Hermes Atlas (as of 2026-07-11)</li>
     <li>643 skills in the community Hub (as of 2026-04-19)</li>
   </ul>
   <p><strong>Corrections and feedback:</strong> <a href="https://github.com/ksimback/hermes-ecosystem/issues/new">open an issue</a> or message <a href="https://x.com/ksimback">@ksimback</a> on X.</p>

--- a/guide/install/index.html
+++ b/guide/install/index.html
@@ -12,7 +12,7 @@
 <meta property="og:url" content="https://hermesatlas.com/guide/install/">
 <meta property="og:site_name" content="Hermes Atlas">
 <meta property="article:published_time" content="2026-04-23T00:00:00Z">
-<meta property="article:modified_time" content="2026-07-09T00:00:00Z">
+<meta property="article:modified_time" content="2026-07-11T00:00:00Z">
 <meta property="article:author" content="https://x.com/ksimback">
 <meta property="og:image" content="https://hermesatlas.com/api/og?title=How+to+install+Hermes+Agent&amp;subtitle=The+complete+2026+setup+guide+for+macOS%2C+Linux%2C+and+Windows+%28WSL2%29.&amp;kind=handbook+%C2%B7+install">
 <meta property="og:image:width" content="1200">
@@ -45,7 +45,7 @@
   "description": "Install Hermes Agent, Nous Research's self-improving AI agent, in 2 minutes on macOS, Linux, or Windows WSL2. Includes the complete troubleshooting tree.",
   "image": "https://hermesatlas.com/api/og?title=How+to+install+Hermes+Agent&subtitle=The+complete+2026+setup+guide+for+macOS%2C+Linux%2C+and+Windows+%28WSL2%29.&kind=handbook+%C2%B7+install",
   "datePublished": "2026-04-23T00:00:00Z",
-  "dateModified": "2026-07-09T00:00:00Z",
+  "dateModified": "2026-07-11T00:00:00Z",
   "author": {
     "@type": "Person",
     "name": "Kevin Simback",
@@ -188,7 +188,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">95·repos</span>
+    <span id="meta-count">185·repos</span>
     <span id="meta-version">hermes·v0.18.0</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -196,13 +196,19 @@
     <a href="/">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/" class="active">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 
@@ -216,10 +222,10 @@
   <div class="article-badge">handbook · satellite · install</div>
   <h1>How to install Hermes Agent</h1>
   <p class="subtitle">The complete 2026 setup guide for macOS, Linux, and Windows (WSL2). With the full troubleshooting tree for every common install error.</p>
-  <p class="meta">By <a href="https://x.com/ksimback">Kevin Simback</a> · Hermes Atlas maintainer · Updated 2026-07-09 · ~8 min read</p>
+  <p class="meta">By <a href="https://x.com/ksimback">Kevin Simback</a> · Hermes Atlas maintainer · Updated 2026-07-11 · ~8 min read</p>
 </header>
 
-<blockquote><strong>TL;DR</strong> — Hermes Agent installs with a single curl command on macOS, Linux, or Windows via WSL2. The installer takes two to three minutes end-to-end and is maintained in lockstep with the main repo. This guide covers Hermes Agent <strong>v0.18.0</strong> (<a href="https://github.com/NousResearch/hermes-agent/releases" target="_blank" rel="noopener">current release</a> as of July 2026; 211,795 GitHub stars as of 2026-07-09).</blockquote>
+<blockquote><strong>TL;DR</strong> — Hermes Agent installs with a single curl command on macOS, Linux, or Windows via WSL2. The installer takes two to three minutes end-to-end and is maintained in lockstep with the main repo. This guide covers Hermes Agent <strong>v0.18.0</strong> (<a href="https://github.com/NousResearch/hermes-agent/releases" target="_blank" rel="noopener">current release</a> as of July 2026; 211,795 GitHub stars as of 2026-07-11).</blockquote>
 
 <h2>TL;DR</h2>
 
@@ -644,10 +650,10 @@ curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scri
 
 <div class="article-footer">
   <p><strong>Written by <a href="https://x.com/ksimback">Kevin Simback</a></strong> · maintainer, Hermes Atlas</p>
-  <p><strong>Last updated:</strong> 2026-07-09 · Version and star figures re-stamp automatically with every site build.</p>
+  <p><strong>Last updated:</strong> 2026-07-11 · Version and star figures re-stamp automatically with every site build.</p>
   <p><strong>Cited stats:</strong></p>
   <ul>
-    <li>211,795 GitHub stars (as of 2026-07-09) — source: <code>api.github.com/repos/NousResearch/hermes-agent</code></li>
+    <li>211,795 GitHub stars (as of 2026-07-11) — source: <code>api.github.com/repos/NousResearch/hermes-agent</code></li>
     <li>Hermes Agent v0.18.0 — <a href="https://github.com/NousResearch/hermes-agent/releases" target="_blank" rel="noopener">release notes</a></li>
   </ul>
   <p><strong>Corrections and feedback:</strong> <a href="https://github.com/ksimback/hermes-ecosystem/issues/new">open an issue</a> or message <a href="https://x.com/ksimback">@ksimback</a> on X.</p>

--- a/guide/memory/index.html
+++ b/guide/memory/index.html
@@ -92,7 +92,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">repos</span>
+    <span id="meta-count">185·repos</span>
     <span id="meta-version">hermes·v0.18.0</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -100,13 +100,19 @@
     <a href="/">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/" class="active">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 <div class="breadcrumb" aria-label="Breadcrumb">

--- a/guide/vs-claude-code/index.html
+++ b/guide/vs-claude-code/index.html
@@ -12,7 +12,7 @@
 <meta property="og:url" content="https://hermesatlas.com/guide/vs-claude-code/">
 <meta property="og:site_name" content="Hermes Atlas">
 <meta property="article:published_time" content="2026-04-20T00:00:00Z">
-<meta property="article:modified_time" content="2026-07-09T00:00:00Z">
+<meta property="article:modified_time" content="2026-07-11T00:00:00Z">
 <meta property="article:author" content="https://x.com/ksimback">
 <meta property="og:image" content="https://hermesatlas.com/api/og?title=Hermes+Agent+vs+Claude+Code&amp;subtitle=Architecture%2C+memory%2C+channels%2C+models.+Why+most+power+users+run+both.&amp;kind=handbook+%C2%B7+comparison">
 <meta property="og:image:width" content="1200">
@@ -45,7 +45,7 @@
   "description": "Side-by-side comparison of Hermes Agent and Claude Code: architecture, memory, channels, model support, and why most power users run both.",
   "image": "https://hermesatlas.com/api/og?title=Hermes+Agent+vs+Claude+Code&subtitle=Architecture%2C+memory%2C+channels%2C+models.+Why+most+power+users+run+both.&kind=handbook+%C2%B7+comparison",
   "datePublished": "2026-04-20T00:00:00Z",
-  "dateModified": "2026-07-09T00:00:00Z",
+  "dateModified": "2026-07-11T00:00:00Z",
   "author": {
     "@type": "Person",
     "name": "Kevin Simback",
@@ -106,7 +106,7 @@
       "name": "Is Hermes Agent production-ready?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "As of 2026-07-09, yes, with caveats. 211,795 GitHub stars, an active Nous team shipping every two weeks, and a ~650-project community ecosystem. The skill ecosystem is younger than Claude Code's, and some integrations still have rough edges."
+        "text": "As of 2026-07-11, yes, with caveats. 211,795 GitHub stars, an active Nous team shipping every two weeks, and a ~650-project community ecosystem. The skill ecosystem is younger than Claude Code's, and some integrations still have rough edges."
       }
     }
   ]
@@ -120,7 +120,7 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">95·repos</span>
+    <span id="meta-count">185·repos</span>
     <span id="meta-version">hermes·v0.18.0</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
@@ -128,13 +128,19 @@
     <a href="/">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/" class="active">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 
@@ -148,7 +154,7 @@
   <div class="article-badge">handbook · satellite · comparison</div>
   <h1>Hermes Agent vs Claude Code: Which AI Agent Should You Use?</h1>
   <p class="subtitle">A satellite page of <a href="/guide/">The Hermes Handbook</a>. Cross-checked against both tools' docs and real community usage as of July 2026.</p>
-  <p class="meta">By <a href="https://x.com/ksimback">Kevin Simback</a> · Hermes Atlas maintainer · Updated 2026-07-09 · ~6 min read</p>
+  <p class="meta">By <a href="https://x.com/ksimback">Kevin Simback</a> · Hermes Atlas maintainer · Updated 2026-07-11 · ~6 min read</p>
 </header>
 
 <h2>TL;DR</h2>
@@ -192,7 +198,7 @@
 <tr><td><strong>Messaging channels</strong></td><td>Terminal only</td><td>Terminal, Telegram, Discord, email, webhooks</td></tr>
 <tr><td><strong>Multi-agent / delegation</strong></td><td>Subagents via the Task tool</td><td>Native delegation, multi-agent teams, profiles</td></tr>
 <tr><td><strong>Sandboxing</strong></td><td>Approval prompts, permission system</td><td>Approval policies, Docker backend, profile isolation</td></tr>
-<tr><td><strong>License &amp; openness</strong></td><td>Proprietary (Anthropic)</td><td>Open-source (MIT), 211,795 stars as of 2026-07-09</td></tr>
+<tr><td><strong>License &amp; openness</strong></td><td>Proprietary (Anthropic)</td><td>Open-source (MIT), 211,795 stars as of 2026-07-11</td></tr>
 </tbody>
 </table>
 
@@ -224,7 +230,7 @@
 <li><strong>You want cross-channel access.</strong> Message Hermes from Telegram during a commute. Check back on the CLI that evening. Same agent, same memory, same skills. Claude Code doesn't leave the terminal.</li>
 <li><strong>You want the agent to get better over time.</strong> The learning loop — five-tool-call retrospectives, auto-generated skills — compounds quietly. Day thirty doesn't feel like day one.</li>
 <li><strong>You want model flexibility.</strong> Swap from Claude to GPT to GLM-5 to local Ollama with one command. No code changes, no vendor lock-in. Cheap models for cheap jobs, frontier models for real work.</li>
-<li><strong>You want it to be yours.</strong> MIT-licensed, 211,795 stars (as of 2026-07-09), self-hostable on a $5 VPS. The code is open, the data lives on your disk, and nothing phones home.</li>
+<li><strong>You want it to be yours.</strong> MIT-licensed, 211,795 stars (as of 2026-07-11), self-hostable on a $5 VPS. The code is open, the data lives on your disk, and nothing phones home.</li>
 </ul>
 
 <p>Hermes falls short when you need deep in-editor coding support. It can read and write code, but it's not optimized for the minute-by-minute code-edit-test loop the way Claude Code is. Use Claude Code for that, and use Hermes around it.</p>
@@ -274,7 +280,7 @@
 <p>For <em>simple</em> coding tasks — "refactor this file," "add a test" — yes. For sustained in-repo work with review cycles, Claude Code's editor integration and opinionated UX are genuinely better. The community consensus: use Hermes for one-shot code tasks and coding on the move (via Telegram), use Claude Code for sit-down coding sessions.</p>
 
 <h3>Is Hermes production-ready?</h3>
-<p>As of 2026-07-09, yes, with caveats. 211,795 GitHub stars, an active Nous team shipping every two weeks, and a ~650-project community ecosystem. Real companies run Hermes in production. The honest caveats: the skill ecosystem is younger than Claude Code's, and some integrations still have rough edges. Read the <strong><a href="/reports/state-of-hermes-april-2026">State of Hermes report →</a></strong> for the full picture.</p>
+<p>As of 2026-07-11, yes, with caveats. 211,795 GitHub stars, an active Nous team shipping every two weeks, and a ~650-project community ecosystem. Real companies run Hermes in production. The honest caveats: the skill ecosystem is younger than Claude Code's, and some integrations still have rough edges. Read the <strong><a href="/reports/state-of-hermes-april-2026">State of Hermes report →</a></strong> for the full picture.</p>
 
 <hr>
 
@@ -288,10 +294,10 @@
 
 <div class="article-footer">
   <p><strong>Written by <a href="https://x.com/ksimback">Kevin Simback</a></strong> · maintainer, Hermes Atlas</p>
-  <p><strong>Last updated:</strong> 2026-07-09 · Version and star figures re-stamp automatically with every site build.</p>
+  <p><strong>Last updated:</strong> 2026-07-11 · Version and star figures re-stamp automatically with every site build.</p>
   <p><strong>Cited stats:</strong></p>
   <ul>
-    <li>211,795 GitHub stars (as of 2026-07-09) — source: <code>api.github.com/repos/NousResearch/hermes-agent</code></li>
+    <li>211,795 GitHub stars (as of 2026-07-11) — source: <code>api.github.com/repos/NousResearch/hermes-agent</code></li>
     <li>643 skills in the community Hub (research bank snapshot, as of 2026-04-19)</li>
   </ul>
   <p><strong>Corrections and feedback:</strong> <a href="https://github.com/ksimback/hermes-ecosystem/issues/new">open an issue</a> or message <a href="https://x.com/ksimback">@ksimback</a> on X.</p>

--- a/index.html
+++ b/index.html
@@ -99,15 +99,21 @@
   </div>
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
-    <a href="#curated-lists">lists</a>
+    <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/lists/best-memory-providers.html
+++ b/lists/best-memory-providers.html
@@ -227,13 +227,19 @@
     <a href="/">map</a>
     <a href="/lists/" class="active">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/lists/deployment-options.html
+++ b/lists/deployment-options.html
@@ -143,13 +143,19 @@
     <a href="/">map</a>
     <a href="/lists/" class="active">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/lists/developer-tools.html
+++ b/lists/developer-tools.html
@@ -167,13 +167,19 @@
     <a href="/">map</a>
     <a href="/lists/" class="active">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/lists/index.html
+++ b/lists/index.html
@@ -120,13 +120,19 @@
     <a href="/">map</a>
     <a href="/lists/" class="active">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/lists/multi-agent-frameworks.html
+++ b/lists/multi-agent-frameworks.html
@@ -143,13 +143,19 @@
     <a href="/">map</a>
     <a href="/lists/" class="active">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/lists/top-skills.html
+++ b/lists/top-skills.html
@@ -257,13 +257,19 @@
     <a href="/">map</a>
     <a href="/lists/" class="active">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/lists/workspaces-and-guis.html
+++ b/lists/workspaces-and-guis.html
@@ -191,13 +191,19 @@
     <a href="/">map</a>
     <a href="/lists/" class="active">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,6 +1,6 @@
 # Hermes Atlas — Full Context Bundle
 
-> Complete content of hermesatlas.com as of 2026-07-09. Concatenated from guide pages, ecosystem overview, the quarterly report, and project summaries. Canonical URLs preserved throughout.
+> Complete content of hermesatlas.com as of 2026-07-11. Concatenated from guide pages, ecosystem overview, the quarterly report, and project summaries. Canonical URLs preserved throughout.
 
 This file is the companion to https://hermesatlas.com/llms.txt (the concise index).
 
@@ -336,7 +336,7 @@ By [Kevin Simback](https://x.com/ksimback) · Hermes Atlas maintainer · Updated
 
 ## 1. What Hermes Agent actually is
 
-**Hermes Agent is an open-source AI agent by [Nous Research](https://nousresearch.com) that runs on your own machine or a cheap VPS, remembers what it learns across sessions, and writes its own reusable skills as it works. It talks to you through a CLI, Telegram, Discord, email, and many other messaging providers. It hit 211,795 GitHub stars (as of 2026-07-09), and it's the fastest-growing open-source agent of 2026.**
+**Hermes Agent is an open-source AI agent by [Nous Research](https://nousresearch.com) that runs on your own machine or a cheap VPS, remembers what it learns across sessions, and writes its own reusable skills as it works. It talks to you through a CLI, Telegram, Discord, email, and many other messaging providers. It hit 211,795 GitHub stars (as of 2026-07-11), and it's the fastest-growing open-source agent of 2026.**
 
 ### The 30-second version
 
@@ -747,11 +747,11 @@ If something is wrong, unclear, or out of date, open an issue on [the Atlas repo
 
 **Written by [Kevin Simback](https://x.com/ksimback)** · maintainer, Hermes Atlas
 
-**Last updated:** 2026-07-09 · Version and star figures re-stamp automatically with every site build.
+**Last updated:** 2026-07-11 · Version and star figures re-stamp automatically with every site build.
 
 **Cited stats:**
-- 211,795 GitHub stars (as of 2026-07-09) — source: `api.github.com/repos/NousResearch/hermes-agent`
-- 185+ projects in the Hermes Atlas (as of 2026-07-09)
+- 211,795 GitHub stars (as of 2026-07-11) — source: `api.github.com/repos/NousResearch/hermes-agent`
+- 185+ projects in the Hermes Atlas (as of 2026-07-11)
 - 643 skills in the community Hub (as of 2026-04-19)
 
 **Corrections and feedback:** [open an issue](https://github.com/ksimback/hermes-ecosystem/issues/new) or message on X.
@@ -802,7 +802,7 @@ The frame people reach for is: **Claude Code is a specialist; Hermes is a genera
 | **Messaging channels** | Terminal only | Terminal, Telegram, Discord, email, webhooks |
 | **Multi-agent / delegation** | Subagents via the Task tool | Native delegation, multi-agent teams, profiles |
 | **Sandboxing** | Approval prompts, permission system | Approval policies, Docker backend, profile isolation |
-| **License & openness** | Proprietary (Anthropic) | Open-source (MIT), 211,795 stars as of 2026-07-09 |
+| **License & openness** | Proprietary (Anthropic) | Open-source (MIT), 211,795 stars as of 2026-07-11 |
 
 The two rows that matter most for the decision: **model support** (Anthropic-only vs multi-provider) and **where it runs** (inside a repo vs on a server).
 
@@ -829,7 +829,7 @@ Hermes is the right tool when your task crosses sessions, channels, or models.
 - **You want cross-channel access.** Message Hermes from Telegram during a commute. Check back on the CLI that evening. Same agent, same memory, same skills. Claude Code doesn't leave the terminal.
 - **You want the agent to get better over time.** The learning loop — five-tool-call retrospectives, auto-generated skills — compounds quietly. Day thirty doesn't feel like day one.
 - **You want model flexibility.** Swap from Claude to GPT to GLM-5 to local Ollama with one command. No code changes, no vendor lock-in. Cheap models for cheap jobs, frontier models for real work.
-- **You want it to be yours.** MIT-licensed, 211,795 stars (as of 2026-07-09), self-hostable on a $5 VPS. The code is open, the data lives on your disk, and nothing phones home.
+- **You want it to be yours.** MIT-licensed, 211,795 stars (as of 2026-07-11), self-hostable on a $5 VPS. The code is open, the data lives on your disk, and nothing phones home.
 
 Hermes falls short when you need deep in-editor coding support. It can read and write code, but it's not optimized for the minute-by-minute code-edit-test loop the way Claude Code is. Use Claude Code for that, and use Hermes around it.
 
@@ -878,7 +878,7 @@ For *simple* coding tasks — "refactor this file," "add a test" — yes. For su
 
 ### Is Hermes production-ready?
 
-As of 2026-07-09, yes, with caveats. 211,795 GitHub stars, an active Nous team shipping every two weeks, and a ~650-project community ecosystem. Real companies run Hermes in production. The honest caveats: the skill ecosystem is younger than Claude Code's, and some integrations still have rough edges. Read the **[State of Hermes report →](/reports/state-of-hermes-april-2026)** for the full picture.
+As of 2026-07-11, yes, with caveats. 211,795 GitHub stars, an active Nous team shipping every two weeks, and a ~650-project community ecosystem. Real companies run Hermes in production. The honest caveats: the skill ecosystem is younger than Claude Code's, and some integrations still have rough edges. Read the **[State of Hermes report →](/reports/state-of-hermes-april-2026)** for the full picture.
 
 ---
 
@@ -892,10 +892,10 @@ As of 2026-07-09, yes, with caveats. 211,795 GitHub stars, an active Nous team s
 
 **Written by [Kevin Simback](https://x.com/ksimback)** · maintainer, Hermes Atlas
 
-**Last updated:** 2026-07-09 · Version and star figures re-stamp automatically with every site build.
+**Last updated:** 2026-07-11 · Version and star figures re-stamp automatically with every site build.
 
 **Cited stats:**
-- 211,795 GitHub stars (as of 2026-07-09) — source: `api.github.com/repos/NousResearch/hermes-agent`
+- 211,795 GitHub stars (as of 2026-07-11) — source: `api.github.com/repos/NousResearch/hermes-agent`
 - 643 skills in the community Hub (research bank snapshot, as of 2026-04-19)
 
 **Corrections and feedback:** [open an issue](https://github.com/ksimback/hermes-ecosystem/issues/new) or message on X.
@@ -907,222 +907,221 @@ As of 2026-07-09, yes, with caveats. 211,795 GitHub stars, an active Nous team s
 
 Canonical URL: https://hermesatlas.com/guide/install/
 
-Skip to content 
+Skip to content
 
- hermes atlas 
- 
- 95·repos 
- hermes·v0.18.0 
- ★ star this repo 
+ hermes atlas
 
- map 
- lists 
- handbook 
- dev 
- reports 
- newsletter 
- source 
+ 185·repos
+ hermes·v0.18.0
+ ★ star this repo
 
- light / dark 
+ map
+ lists
+ handbook
+ masterclass
+ dev
+ reports
+ newsletter
+ source
 
  map / handbook / install
 
- handbook · satellite · install 
- How to install Hermes Agent 
- The complete 2026 setup guide for macOS, Linux, and Windows (WSL2). With the full troubleshooting tree for every common install error. 
- By Kevin Simback · Hermes Atlas maintainer · Updated 2026-07-09 · ~8 min read 
+ handbook · satellite · install
+ How to install Hermes Agent
+ The complete 2026 setup guide for macOS, Linux, and Windows (WSL2). With the full troubleshooting tree for every common install error.
+ By Kevin Simback · Hermes Atlas maintainer · Updated 2026-07-11 · ~8 min read
 
- TL;DR — Hermes Agent installs with a single curl command on macOS, Linux, or Windows via WSL2. The installer takes two to three minutes end-to-end and is maintained in lockstep with the main repo. This guide covers Hermes Agent v0.18.0 ( current release as of July 2026; 211,795 GitHub stars as of 2026-07-09). 
+ TL;DR — Hermes Agent installs with a single curl command on macOS, Linux, or Windows via WSL2. The installer takes two to three minutes end-to-end and is maintained in lockstep with the main repo. This guide covers Hermes Agent v0.18.0 ( current release as of July 2026; 211,795 GitHub stars as of 2026-07-11).
 
- TL;DR 
+ TL;DR
 
- One curl command. Two to three minutes. Works on macOS, Linux, and Windows via WSL2. 
+ One curl command. Two to three minutes. Works on macOS, Linux, and Windows via WSL2.
 
  curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
 source ~/.bashrc # or: source ~/.zshrc
-hermes # start chatting 
+hermes # start chatting
 
- If that worked, skip to first run and model provider . If it didn't, the troubleshooting tree covers the nine failure modes I've seen, in the order you should check them. 
+ If that worked, skip to first run and model provider . If it didn't, the troubleshooting tree covers the nine failure modes I've seen, in the order you should check them.
 
- Before you start 
+ Before you start
 
- Supported OSes (as of v0.18.0): 
+ Supported OSes (as of v0.18.0):
 
- macOS 13 Ventura or newer. Apple Silicon (M1/M2/M3/M4) and Intel both supported. Apple Silicon is faster for local-model workloads. 
- Linux — Ubuntu 22.04 or newer, Debian 12, Fedora 39+, Arch rolling. Any modern distro with glibc 2.35+ should work. 
- Windows — two options. WSL2 with Ubuntu or Debian inside is the road-tested path. Native Windows works via an early-beta PowerShell installer (Nous's wording: "not road-tested as broadly"). See Install on Windows below. 
- Termux (Android) — supported via a curated .[termux] extra. The same curl one-liner works inside Termux; voice dependencies are excluded. 
+ macOS 13 Ventura or newer. Apple Silicon (M1/M2/M3/M4) and Intel both supported. Apple Silicon is faster for local-model workloads.
+ Linux — Ubuntu 22.04 or newer, Debian 12, Fedora 39+, Arch rolling. Any modern distro with glibc 2.35+ should work.
+ Windows — two options. WSL2 with Ubuntu or Debian inside is the road-tested path. Native Windows works via an early-beta PowerShell installer (Nous's wording: "not road-tested as broadly"). See Install on Windows below.
+ Termux (Android) — supported via a curated .[termux] extra. The same curl one-liner works inside Termux; voice dependencies are excluded.
 
- Prerequisites — Hermes's installer is aggressive about setting up its own stack, so you need almost nothing pre-installed: 
+ Prerequisites — Hermes's installer is aggressive about setting up its own stack, so you need almost nothing pre-installed:
 
- Git — only hard requirement. 
- A terminal — bash, zsh, and fish all work. 
- ~200 MB of disk for the install itself; budget another 100–500 MB for memory, skills, and session logs as you use it. 
- Model access (optional on first install, required before useful work) — an API key from Anthropic / OpenAI / z.AI / MiniMax / DeepSeek, or a Nous Portal subscription, or a local model via Ollama / LM Studio. 
+ Git — only hard requirement.
+ A terminal — bash, zsh, and fish all work.
+ ~200 MB of disk for the install itself; budget another 100–500 MB for memory, skills, and session logs as you use it.
+ Model access (optional on first install, required before useful work) — an API key from Anthropic / OpenAI / z.AI / MiniMax / DeepSeek, or a Nous Portal subscription, or a local model via Ollama / LM Studio.
 
- The installer handles the rest automatically: uv , Python 3.11, Node.js, ripgrep , ffmpeg , the venv, the global hermes command, and the ~/.hermes/ directory tree. On native Windows it additionally bundles a portable Git Bash (~45 MB MinGit) inside %LOCALAPPDATA%\hermes\git . 
+ The installer handles the rest automatically: uv , Python 3.11, Node.js, ripgrep , ffmpeg , the venv, the global hermes command, and the ~/.hermes/ directory tree. On native Windows it additionally bundles a portable Git Bash (~45 MB MinGit) inside %LOCALAPPDATA%\hermes\git .
 
- Install on macOS 
+ Install on macOS
 
- Open Terminal (or iTerm, or Warp — any shell). Run: 
-
- curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash 
-
- Reload your shell so hermes is on PATH: 
-
- source ~/.zshrc # macOS default since Catalina
-# or: source ~/.bashrc if you switched to bash 
-
- Test it: 
-
- hermes version 
-
- Apple Silicon (M1/M2/M3/M4) notes 
-
- The installer auto-detects arm64 and pulls native binaries. No Rosetta required. If you already have Homebrew installed, the installer uses it to pull missing dependencies — otherwise it installs Homebrew for you (and prints what it's doing). 
-
- Intel Mac notes 
-
- Everything works identically. The only caveat: local-model inference via Ollama is meaningfully slower than Apple Silicon — budget a frontier API key (Anthropic, OpenAI, GLM) for real work. 
-
- Install on Linux 
-
- The command is identical across distros: 
+ Open Terminal (or iTerm, or Warp — any shell). Run:
 
  curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
-source ~/.bashrc 
 
- Distro-specific notes 
+ Reload your shell so hermes is on PATH:
 
- Ubuntu 22.04 / 24.04, Debian 12 — works out of the box. If you're on a fresh minimal cloud image, apt-get install -y git curl first. 
- Fedora 39+ — identical. Uses dnf under the hood for any missing system packages. 
- Arch / Manjaro — works; installer uses pacman for missing deps. The AUR has a community hermes-agent package too, but the official curl installer is what the Nous team ships against. 
- Alpine — works with caveats. glibc is required; the installer will fall back to a statically-linked path, but memory and skills with native deps (ffmpeg audio handling, image cache) can be flaky. A $5 Debian VPS is the path of least resistance. 
+ source ~/.zshrc # macOS default since Catalina
+# or: source ~/.bashrc if you switched to bash
 
- Install on Windows 
+ Test it:
 
- Two supported paths. WSL2 is the road-tested option that most users should pick. Native Windows via PowerShell is shipped as an early beta in the official installer — Nous's wording is "not road-tested as broadly" — and is the right call if you can't or won't enable WSL. 
+ hermes version
 
- Option A — WSL2 (recommended) 
+ Apple Silicon (M1/M2/M3/M4) notes
 
- WSL2 runs a real Linux kernel inside Windows 11 with near-native performance. 
+ The installer auto-detects arm64 and pulls native binaries. No Rosetta required. If you already have Homebrew installed, the installer uses it to pull missing dependencies — otherwise it installs Homebrew for you (and prints what it's doing).
 
- 1. Install WSL2 
+ Intel Mac notes
 
- Open PowerShell as Administrator: 
+ Everything works identically. The only caveat: local-model inference via Ollama is meaningfully slower than Apple Silicon — budget a frontier API key (Anthropic, OpenAI, GLM) for real work.
 
- wsl --install 
+ Install on Linux
 
- This installs WSL2 + Ubuntu by default. Reboot when prompted. On first boot of Ubuntu, create a username and password. 
-
- 2. Install Hermes inside WSL 
-
- Open the Ubuntu terminal (from Start Menu) and run the same Linux install command: 
+ The command is identical across distros:
 
  curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
 source ~/.bashrc
-hermes version 
 
- 3. Use Windows Terminal 
+ Distro-specific notes
 
- The default WSL console is workable but Windows Terminal (free, Microsoft Store) is substantially better — tabs, font control, and proper Unicode. Set Ubuntu as your default profile and you're done. 
+ Ubuntu 22.04 / 24.04, Debian 12 — works out of the box. If you're on a fresh minimal cloud image, apt-get install -y git curl first.
+ Fedora 39+ — identical. Uses dnf under the hood for any missing system packages.
+ Arch / Manjaro — works; installer uses pacman for missing deps. The AUR has a community hermes-agent package too, but the official curl installer is what the Nous team ships against.
+ Alpine — works with caveats. glibc is required; the installer will fall back to a statically-linked path, but memory and skills with native deps (ffmpeg audio handling, image cache) can be flaky. A $5 Debian VPS is the path of least resistance.
 
- Option B — Native Windows via PowerShell (early beta) 
+ Install on Windows
 
- Open PowerShell (not WSL, not cmd) and run: 
+ Two supported paths. WSL2 is the road-tested option that most users should pick. Native Windows via PowerShell is shipped as an early beta in the official installer — Nous's wording is "not road-tested as broadly" — and is the right call if you can't or won't enable WSL.
 
- irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 | iex 
+ Option A — WSL2 (recommended)
 
- The installer drops Hermes into %LOCALAPPDATA%\hermes and unpacks a portable Git Bash (~45 MB MinGit) into %LOCALAPPDATA%\hermes\git so shell-based tools work without a system-wide Git install. It also sets up uv , Python 3.11, Node.js, ripgrep , and ffmpeg in the same directory. 
+ WSL2 runs a real Linux kernel inside Windows 11 with near-native performance.
 
- After the script finishes, close and reopen PowerShell so hermes is on PATH, then: 
+ 1. Install WSL2
+
+ Open PowerShell as Administrator:
+
+ wsl --install
+
+ This installs WSL2 + Ubuntu by default. Reboot when prompted. On first boot of Ubuntu, create a username and password.
+
+ 2. Install Hermes inside WSL
+
+ Open the Ubuntu terminal (from Start Menu) and run the same Linux install command:
+
+ curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+source ~/.bashrc
+hermes version
+
+ 3. Use Windows Terminal
+
+ The default WSL console is workable but Windows Terminal (free, Microsoft Store) is substantially better — tabs, font control, and proper Unicode. Set Ubuntu as your default profile and you're done.
+
+ Option B — Native Windows via PowerShell (early beta)
+
+ Open PowerShell (not WSL, not cmd) and run:
+
+ irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 | iex
+
+ The installer drops Hermes into %LOCALAPPDATA%\hermes and unpacks a portable Git Bash (~45 MB MinGit) into %LOCALAPPDATA%\hermes\git so shell-based tools work without a system-wide Git install. It also sets up uv , Python 3.11, Node.js, ripgrep , and ffmpeg in the same directory.
+
+ After the script finishes, close and reopen PowerShell so hermes is on PATH, then:
 
  hermes version
-hermes doctor 
+hermes doctor
 
- What "early beta" actually means. The Nous team's own framing in the README: "not road-tested as broadly" as the Linux/macOS path. Expect more rough edges in the messaging gateway and any tool that shells out to native binaries. If something breaks and you have the option, WSL2 is the safer fallback. 
+ What "early beta" actually means. The Nous team's own framing in the README: "not road-tested as broadly" as the Linux/macOS path. Expect more rough edges in the messaging gateway and any tool that shells out to native binaries. If something breaks and you have the option, WSL2 is the safer fallback.
 
- Verify the install 
+ Verify the install
 
- Run these three commands. All three should return clean output: 
+ Run these three commands. All three should return clean output:
 
  hermes version # prints v0.18.0 (or newer)
 hermes doctor # system health check — every line should be green
-hermes status # current config + running daemons 
+hermes status # current config + running daemons
 
- For a live smoke test that exercises the model layer (skip this until you've configured a provider — see below): 
+ For a live smoke test that exercises the model layer (skip this until you've configured a provider — see below):
 
- hermes chat -q "Hello! What tools do you have available?" 
+ hermes chat -q "Hello! What tools do you have available?"
 
- You should see a short response plus a list of enabled tools. If this hangs, the model provider isn't reachable — jump to first run and model provider . 
+ You should see a short response plus a list of enabled tools. If this hangs, the model provider isn't reachable — jump to first run and model provider .
 
- First run and model provider 
+ First run and model provider
 
- Run hermes with no arguments on a fresh install to trigger the interactive setup: 
+ Run hermes with no arguments on a fresh install to trigger the interactive setup:
 
- hermes 
+ hermes
 
- Hermes walks you through provider selection. Pick one of these four paths: 
+ Hermes walks you through provider selection. Pick one of these four paths:
 
- Path 1 — Nous Portal (easiest) 
+ Path 1 — Nous Portal (easiest)
 
- Nous Portal is a single subscription that routes across Claude, GPT, GLM, MiniMax, Nous's own models, and many more via one auth. Sign in with OAuth from the CLI when prompted. One flat monthly bill, no key management. Most people end up here eventually. 
+ Nous Portal is a single subscription that routes across Claude, GPT, GLM, MiniMax, Nous's own models, and many more via one auth. Sign in with OAuth from the CLI when prompted. One flat monthly bill, no key management. Most people end up here eventually.
 
- Path 2 — Bring your own API key 
+ Path 2 — Bring your own API key
 
- Paste a key from Anthropic ( sk-ant-... ), OpenAI ( sk-... ), z.AI, MiniMax, or DeepSeek when prompted. You can swap later with hermes model . 
+ Paste a key from Anthropic ( sk-ant-... ), OpenAI ( sk-... ), z.AI, MiniMax, or DeepSeek when prompted. You can swap later with hermes model .
 
- Path 3 — Local model via Ollama 
+ Path 3 — Local model via Ollama
 
- Install Ollama first ( ollama.com ), pull a tool-calling-capable model (Qwen 2.5 Coder 32B is the community favorite), then point Hermes at it. Local models are great for coding and chat but weaker at multi-step tool chains — the full tradeoff is in chapter 5 of the handbook . 
+ Install Ollama first ( ollama.com ), pull a tool-calling-capable model (Qwen 2.5 Coder 32B is the community favorite), then point Hermes at it. Local models are great for coding and chat but weaker at multi-step tool chains — the full tradeoff is in chapter 5 of the handbook .
 
- Path 4 — Skip for now 
+ Path 4 — Skip for now
 
- You can install Hermes without configuring a model and wire one up later with hermes model . Useful if you're installing on a VPS and want to set up the Telegram gateway first. 
+ You can install Hermes without configuring a model and wire one up later with hermes model . Useful if you're installing on a VPS and want to set up the Telegram gateway first.
 
- Troubleshooting common install errors 
+ Troubleshooting common install errors
 
- Check these in order. The top three catch about 90% of failures. 
+ Check these in order. The top three catch about 90% of failures.
 
- 1. "Command not found: hermes" 
+ 1. "Command not found: hermes"
 
- Your shell didn't pick up the new PATH. Open a fresh terminal window, or run source ~/.bashrc (or ~/.zshrc , or ~/.config/fish/config.fish for fish). If that still doesn't work, check that ~/.hermes/bin is in your PATH: echo $PATH | tr ':' '\n' | grep hermes . 
+ Your shell didn't pick up the new PATH. Open a fresh terminal window, or run source ~/.bashrc (or ~/.zshrc , or ~/.config/fish/config.fish for fish). If that still doesn't work, check that ~/.hermes/bin is in your PATH: echo $PATH | tr ':' '\n' | grep hermes .
 
- 2. "Provider error: invalid API key" 
+ 2. "Provider error: invalid API key"
 
- Trailing whitespace is the #1 cause. Paste with care, or use the heredoc approach: hermes config set model.api_key "$(cat)" then paste and hit Ctrl-D. Second most common cause: wrong provider selected for the key type. 
+ Trailing whitespace is the #1 cause. Paste with care, or use the heredoc approach: hermes config set model.api_key "$(cat)" then paste and hit Ctrl-D. Second most common cause: wrong provider selected for the key type.
 
- 3. Windows: "bad interpreter", "cannot execute", or curl errors 
+ 3. Windows: "bad interpreter", "cannot execute", or curl errors
 
- You ran the Linux curl ... | bash command from PowerShell or cmd. That path is for WSL only. Either open your Ubuntu (WSL) terminal and rerun the bash installer, or use the native PowerShell installer instead: irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 | iex . 
+ You ran the Linux curl ... | bash command from PowerShell or cmd. That path is for WSL only. Either open your Ubuntu (WSL) terminal and rerun the bash installer, or use the native PowerShell installer instead: irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 | iex .
 
- 4. "Permission denied" during install 
+ 4. "Permission denied" during install
 
- Usually caused by running the curl command under sudo . Don't. Hermes installs per-user under ~/.hermes/ and doesn't need root. If you already ran it as root, sudo rm -rf ~/.hermes/ /root/.hermes/ and retry as your normal user. 
+ Usually caused by running the curl command under sudo . Don't. Hermes installs per-user under ~/.hermes/ and doesn't need root. If you already ran it as root, sudo rm -rf ~/.hermes/ /root/.hermes/ and retry as your normal user.
 
- 5. "uv: command not found" mid-install 
+ 5. "uv: command not found" mid-install
 
- The installer failed between installing uv and using it — usually because a previous interrupted run left a half-configured state. Simply re-run the install command; it's idempotent. 
+ The installer failed between installing uv and using it — usually because a previous interrupted run left a half-configured state. Simply re-run the install command; it's idempotent.
 
- 6. Python version mismatch 
+ 6. Python version mismatch
 
- You have Python 3.9 or older in PATH and something is resolving to that first. The installer pins Python 3.11 in its own venv, but if you see a version error, drop to the manual install below, which gives you explicit control. 
+ You have Python 3.9 or older in PATH and something is resolving to that first. The installer pins Python 3.11 in its own venv, but if you see a version error, drop to the manual install below, which gives you explicit control.
 
- 7. npm errors ("ENOENT", "EACCES") 
+ 7. npm errors ("ENOENT", "EACCES")
 
- Node.js didn't install cleanly. Delete ~/.hermes/ , reinstall Node via your OS package manager ( brew install node on Mac, apt install nodejs npm on Ubuntu), then rerun the Hermes curl installer. 
+ Node.js didn't install cleanly. Delete ~/.hermes/ , reinstall Node via your OS package manager ( brew install node on Mac, apt install nodejs npm on Ubuntu), then rerun the Hermes curl installer.
 
- 8. ffmpeg / ripgrep missing (macOS Apple Silicon) 
+ 8. ffmpeg / ripgrep missing (macOS Apple Silicon)
 
- Homebrew path mismatch — Apple Silicon's Homebrew lives at /opt/homebrew/bin , not /usr/local/bin . Add eval "$(/opt/homebrew/bin/brew shellenv)" to your ~/.zshrc and rerun. 
+ Homebrew path mismatch — Apple Silicon's Homebrew lives at /opt/homebrew/bin , not /usr/local/bin . Add eval "$(/opt/homebrew/bin/brew shellenv)" to your ~/.zshrc and rerun.
 
- 9. Installer hangs downloading the hermes binary 
+ 9. Installer hangs downloading the hermes binary
 
- GitHub release download from a rate-limited or corporate-firewalled network. Set export GITHUB_TOKEN=... (any personal access token) before rerunning, or use the manual install . 
+ GitHub release download from a rate-limited or corporate-firewalled network. Set export GITHUB_TOKEN=... (any personal access token) before rerunning, or use the manual install .
 
- Manual installation 
+ Manual installation
 
- When the curl installer fails and you want step-by-step control: 
+ When the curl installer fails and you want step-by-step control:
 
  git clone --recurse-submodules https://github.com/NousResearch/hermes-agent.git
 cd hermes-agent
@@ -1144,65 +1143,65 @@ cp cli-config.yaml.example ~/.hermes/config.yaml
 touch ~/.hermes/.env
 
 # symlink hermes to ~/.local/bin for PATH convenience
-ln -s "$(pwd)/bin/hermes" ~/.local/bin/hermes 
+ln -s "$(pwd)/bin/hermes" ~/.local/bin/hermes
 
- Add ~/.local/bin to your PATH if it isn't already. Verify with hermes version . 
+ Add ~/.local/bin to your PATH if it isn't already. Verify with hermes version .
 
- Uninstall or clean reinstall 
+ Uninstall or clean reinstall
 
- Complete uninstall — removes everything including memory, skills, and config: 
-
- rm -rf ~/.hermes/ 
-
- Reset config but keep memory and skills : 
-
- hermes config reset 
-
- Clean reinstall — useful when something is wedged: 
+ Complete uninstall — removes everything including memory, skills, and config:
 
  rm -rf ~/.hermes/
-curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash 
 
- Get the ecosystem inside your agent 
+ Reset config but keep memory and skills :
 
- Install the hermes-atlas MCP server so Claude Desktop, Cursor, Claude Code, or any MCP-aware client can search the catalog, fetch project summaries, and answer free-form questions about the Hermes ecosystem mid-chat. Five tools: search_projects , get_project , list_by_category , get_guide , ask_atlas . 
+ hermes config reset
 
- Recommended — one command 
+ Clean reinstall — useful when something is wedged:
 
- Run this in a terminal. The installer detects your OS, finds the right config file for your client, and safely merges in the hermes-atlas entry without touching anything else: 
+ rm -rf ~/.hermes/
+curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
 
- npx -y hermes-atlas-mcp install --client claude-desktop 
+ Get the ecosystem inside your agent
 
- Replace claude-desktop with cursor or claude-code as needed. Add --print first if you want to preview the exact diff without writing anything. 
+ Install the hermes-atlas MCP server so Claude Desktop, Cursor, Claude Code, or any MCP-aware client can search the catalog, fetch project summaries, and answer free-form questions about the Hermes ecosystem mid-chat. Five tools: search_projects , get_project , list_by_category , get_guide , ask_atlas .
 
- Then fully quit and reopen the client — closing the window isn't enough, the whole process has to restart. In a new chat, click the tool icon (usually at the bottom of the message box) and you'll see the five tools listed. 
+ Recommended — one command
 
- To remove later: 
+ Run this in a terminal. The installer detects your OS, finds the right config file for your client, and safely merges in the hermes-atlas entry without touching anything else:
 
- npx -y hermes-atlas-mcp uninstall --client claude-desktop 
+ npx -y hermes-atlas-mcp install --client claude-desktop
 
- Manual install — Claude Desktop 
+ Replace claude-desktop with cursor or claude-code as needed. Add --print first if you want to preview the exact diff without writing anything.
 
- If you'd rather edit the config yourself, or the installer doesn't work on your setup, here's the full walkthrough. 
+ Then fully quit and reopen the client — closing the window isn't enough, the whole process has to restart. In a new chat, click the tool icon (usually at the bottom of the message box) and you'll see the five tools listed.
 
- Step 1 — open the config file 
+ To remove later:
 
- The easiest way is through Claude Desktop's built-in button: 
+ npx -y hermes-atlas-mcp uninstall --client claude-desktop
 
- Open Claude Desktop. 
- Click the Settings gear (or Cmd/Ctrl+, ). 
- Select the Developer tab on the left. 
- Click the Edit Config button. The file opens in your default text editor. 
+ Manual install — Claude Desktop
 
- If you'd rather find it by path: 
- 
- macOS: ~/Library/Application Support/Claude/claude_desktop_config.json 
- Windows: %APPDATA%\Claude\claude_desktop_config.json (usually C:\Users\YOU\AppData\Roaming\Claude\claude_desktop_config.json ) 
- Linux: ~/.config/Claude/claude_desktop_config.json 
+ If you'd rather edit the config yourself, or the installer doesn't work on your setup, here's the full walkthrough.
 
- Step 2 — add the hermes-atlas entry 
+ Step 1 — open the config file
 
- If the file is empty, or doesn't exist, paste this as the full contents: 
+ The easiest way is through Claude Desktop's built-in button:
+
+ Open Claude Desktop.
+ Click the Settings gear (or Cmd/Ctrl+, ).
+ Select the Developer tab on the left.
+ Click the Edit Config button. The file opens in your default text editor.
+
+ If you'd rather find it by path:
+
+ macOS: ~/Library/Application Support/Claude/claude_desktop_config.json
+ Windows: %APPDATA%\Claude\claude_desktop_config.json (usually C:\Users\YOU\AppData\Roaming\Claude\claude_desktop_config.json )
+ Linux: ~/.config/Claude/claude_desktop_config.json
+
+ Step 2 — add the hermes-atlas entry
+
+ If the file is empty, or doesn't exist, paste this as the full contents:
 
  {
  "mcpServers": {
@@ -1211,9 +1210,9 @@ curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scri
  "args": ["-y", "hermes-atlas-mcp"]
  }
  }
-} 
+}
 
- If the file already has content, merge the new entry into the existing mcpServers block. For example, if your file currently looks like this: 
+ If the file already has content, merge the new entry into the existing mcpServers block. For example, if your file currently looks like this:
 
  {
  "mcpServers": {
@@ -1222,9 +1221,9 @@ curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scri
  "args": ["-y", "@modelcontextprotocol/server-filesystem", "/path"]
  }
  }
-} 
+}
 
- ...change it to this (add a comma after the filesystem block, then the new hermes-atlas object): 
+ ...change it to this (add a comma after the filesystem block, then the new hermes-atlas object):
 
  {
  "mcpServers": {
@@ -1237,105 +1236,105 @@ curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scri
  "args": ["-y", "hermes-atlas-mcp"]
  }
  }
-} 
+}
 
- If the file has top-level settings like preferences or anything other than mcpServers , leave those alone — only merge into the mcpServers object (or add it if it doesn't exist yet). 
+ If the file has top-level settings like preferences or anything other than mcpServers , leave those alone — only merge into the mcpServers object (or add it if it doesn't exist yet).
 
- Step 3 — save and fully restart Claude Desktop 
+ Step 3 — save and fully restart Claude Desktop
 
- Save the file. Then fully quit Claude Desktop — closing the window isn't enough, the background process has to restart. 
- 
- macOS: Cmd+Q with Claude Desktop focused, or right-click the dock icon → Quit. 
- Windows: File → Exit, or right-click the taskbar icon → Close window, or kill it in Task Manager if a Claude process lingers. 
- 
- Reopen Claude Desktop normally. 
+ Save the file. Then fully quit Claude Desktop — closing the window isn't enough, the background process has to restart.
 
- Step 4 — verify 
+ macOS: Cmd+Q with Claude Desktop focused, or right-click the dock icon → Quit.
+ Windows: File → Exit, or right-click the taskbar icon → Close window, or kill it in Task Manager if a Claude process lingers.
 
- Start a new chat. Click the tool / attachment icon at the bottom of the message box. You should see five tools listed under hermes-atlas : 
- 
- search_projects 
- get_project 
- list_by_category 
- get_guide 
- ask_atlas 
+ Reopen Claude Desktop normally.
 
- If they're missing, most-likely causes in order: 
- 
- You didn't fully quit Claude Desktop. Quit and reopen again. 
- The JSON isn't valid (a missing comma, extra trailing comma, unbalanced brace). Paste the file into any online JSON validator. 
- You don't have Node.js installed (the npx command needs it). Install from nodejs.org — any LTS version works. 
+ Step 4 — verify
 
- Manual install — Cursor 
+ Start a new chat. Click the tool / attachment icon at the bottom of the message box. You should see five tools listed under hermes-atlas :
 
- File: ~/.cursor/mcp.json (global, applies to every project) or .cursor/mcp.json at your project root (per-project). Use the same JSON shape as Claude Desktop above. Restart Cursor. 
+ search_projects
+ get_project
+ list_by_category
+ get_guide
+ ask_atlas
 
- Manual install — Claude Code 
+ If they're missing, most-likely causes in order:
 
- Easiest: inside a Claude Code session, run /mcp — the built-in UI walks you through adding a server without touching any file. Otherwise, edit ~/.claude.json using the same shape. 
+ You didn't fully quit Claude Desktop. Quit and reopen again.
+ The JSON isn't valid (a missing comma, extra trailing comma, unbalanced brace). Paste the file into any online JSON validator.
+ You don't have Node.js installed (the npx command needs it). Install from nodejs.org — any LTS version works.
 
- Continue, Windsurf, Zed, other MCP clients 
+ Manual install — Cursor
 
- Any MCP-compatible client works the same way. Configure a server named hermes-atlas that runs npx -y hermes-atlas-mcp via stdio. The client docs will point you at the right config file. 
+ File: ~/.cursor/mcp.json (global, applies to every project) or .cursor/mcp.json at your project root (per-project). Use the same JSON shape as Claude Desktop above. Restart Cursor.
 
- Source: github.com/ksimback/hermes-atlas-mcp · npm . MIT-licensed, experimental (0.x), batch releases weekly. 
+ Manual install — Claude Code
 
- What to do next 
+ Easiest: inside a Claude Code session, run /mcp — the built-in UI walks you through adding a server without touching any file. Otherwise, edit ~/.claude.json using the same shape.
 
- You're installed. The next three handbook chapters walk you through the mistakes most people make on day one: 
+ Continue, Windsurf, Zed, other MCP clients
 
- Pick your model — where most first setups silently fail. Don't use Gemma or Llama 8B for agent work. 
- Your first workflow — three concrete examples (coding assistant, Telegram bot, cron automation). Pick one and ship it today. 
- Essential skills to install first — five community skills that should be on every Hermes install on day one. 
+ Any MCP-compatible client works the same way. Configure a server named hermes-atlas that runs npx -y hermes-atlas-mcp via stdio. The client docs will point you at the right config file.
 
- FAQ 
+ Source: github.com/ksimback/hermes-atlas-mcp · npm . MIT-licensed, experimental (0.x), batch releases weekly.
 
- Does Hermes Agent work on bare Windows? 
+ What to do next
 
- Yes, in early beta. Since v0.10.0, Nous ships a native Windows installer you run from PowerShell: irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 | iex . It installs to %LOCALAPPDATA%\hermes and bundles a portable Git Bash. Nous explicitly flags this path as "not road-tested as broadly" — for production use, prefer WSL2: wsl --install in PowerShell, install Ubuntu, then run the standard curl installer from inside WSL. 
+ You're installed. The next three handbook chapters walk you through the mistakes most people make on day one:
 
- Does Hermes work on Apple Silicon (M1, M2, M3, M4)? 
+ Pick your model — where most first setups silently fail. Don't use Gemma or Llama 8B for agent work.
+ Your first workflow — three concrete examples (coding assistant, Telegram bot, cron automation). Pick one and ship it today.
+ Essential skills to install first — five community skills that should be on every Hermes install on day one.
 
- Yes, natively. Apple Silicon is a first-class target. The installer detects arm64 and pulls native binaries. No Rosetta required. 
+ FAQ
 
- Can I run Hermes Agent on a Raspberry Pi or low-end VPS? 
+ Does Hermes Agent work on bare Windows?
 
- Yes. Hermes itself runs comfortably on a $5 VPS (1 CPU, 1 GB RAM) or a Raspberry Pi 4/5 with 4+ GB RAM. The practical constraint is not Hermes but the model — pair it with a hosted API (Nous Portal, Anthropic) and the agent host stays lightweight. 
+ Yes, in early beta. Since v0.10.0, Nous ships a native Windows installer you run from PowerShell: irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 | iex . It installs to %LOCALAPPDATA%\hermes and bundles a portable Git Bash. Nous explicitly flags this path as "not road-tested as broadly" — for production use, prefer WSL2: wsl --install in PowerShell, install Ubuntu, then run the standard curl installer from inside WSL.
 
- How much disk space does Hermes Agent use? 
+ Does Hermes work on Apple Silicon (M1, M2, M3, M4)?
 
- About 200 MB for a fresh install. Memory, skills, and session logs accumulate in ~/.hermes/ over time — budget another 100–500 MB depending on how heavily you use it. 
+ Yes, natively. Apple Silicon is a first-class target. The installer detects arm64 and pulls native binaries. No Rosetta required.
 
- Can I run Hermes Agent fully offline? 
+ Can I run Hermes Agent on a Raspberry Pi or low-end VPS?
 
- Yes. Install Hermes, pair it with Ollama or LM Studio, disconnect the network. Memory, skills, cron, and file tools all work offline. Local models are weaker at multi-step tool chains, so complex workflows may degrade — but single-shot chat and coding work fine. 
+ Yes. Hermes itself runs comfortably on a $5 VPS (1 CPU, 1 GB RAM) or a Raspberry Pi 4/5 with 4+ GB RAM. The practical constraint is not Hermes but the model — pair it with a hosted API (Nous Portal, Anthropic) and the agent host stays lightweight.
 
- Do I need Docker to install Hermes? 
+ How much disk space does Hermes Agent use?
 
- No. The official installer is a native binary install; Docker is not required. Community-maintained Docker images exist (browse the deployment options list on Hermes Atlas) if you prefer containerized deploys, but the path of least resistance is the curl installer. 
+ About 200 MB for a fresh install. Memory, skills, and session logs accumulate in ~/.hermes/ over time — budget another 100–500 MB depending on how heavily you use it.
 
- What if the curl install fails mid-way? 
+ Can I run Hermes Agent fully offline?
 
- Re-running the same curl command is safe — the installer is idempotent. If it fails a second time, fall back to the manual install above. 
+ Yes. Install Hermes, pair it with Ollama or LM Studio, disconnect the network. Memory, skills, cron, and file tools all work offline. Local models are weaker at multi-step tool chains, so complex workflows may degrade — but single-shot chat and coding work fine.
 
- Written by Kevin Simback · maintainer, Hermes Atlas 
- Last updated: 2026-07-09 · Version and star figures re-stamp automatically with every site build. 
- Cited stats: 
- 
- 211,795 GitHub stars (as of 2026-07-09) — source: api.github.com/repos/NousResearch/hermes-agent 
- Hermes Agent v0.18.0 — release notes 
- 
- Corrections and feedback: open an issue or message @ksimback on X. 
- if this was useful, drop a ★ on the atlas repo → 
- back to The Hermes Handbook → 
+ Do I need Docker to install Hermes?
 
- newsletter · free · 1–2× / month 
+ No. The official installer is a native binary install; Docker is not required. Community-maintained Docker images exist (browse the deployment options list on Hermes Atlas) if you prefer containerized deploys, but the path of least resistance is the curl installer.
 
- subscribe 
+ What if the curl install fails mid-way?
 
- handled by beehiiv · privacy 
+ Re-running the same curl command is safe — the installer is idempotent. If it fails a second time, fall back to the manual install above.
 
- hermes atlas · curated by ksimback · suggest a repo · privacy 
+ Written by Kevin Simback · maintainer, Hermes Atlas
+ Last updated: 2026-07-11 · Version and star figures re-stamp automatically with every site build.
+ Cited stats:
+
+ 211,795 GitHub stars (as of 2026-07-11) — source: api.github.com/repos/NousResearch/hermes-agent
+ Hermes Agent v0.18.0 — release notes
+
+ Corrections and feedback: open an issue or message @ksimback on X.
+ if this was useful, drop a ★ on the atlas repo →
+ back to The Hermes Handbook →
+
+ newsletter · free · 1–2× / month
+
+ subscribe
+
+ handled by beehiiv · privacy
+
+ hermes atlas · curated by ksimback · suggest a repo · privacy
  v2 · 2026.04
 
 ---
@@ -1605,216 +1604,449 @@ I hope you enjoyed this Hermes Agent deep dive on all things memory. If you want
 
 ---
 
+# Tonbi's Hermes Agent Masterclass (/masterclass/)
+
+Canonical URL: https://hermesatlas.com/masterclass/
+
+Skip to content
+
+ hermes atlas
+
+ 185·repos
+ hermes·v0.18.0
+ ★ star this repo
+
+ map
+ lists
+ handbook
+ masterclass
+ dev
+ reports
+ newsletter
+ source
+
+ map / masterclass
+
+ watch · learn · build
+ Hermes Agent Masterclass
+ Ten modules that take Hermes from a fresh install to a hardened multi-agent team. Watch Tonbi build the whole system, then open our transcript-derived field notes for the decisions, shortcuts, and gotchas worth remembering.
+
+ 10 modules
+ 5h 14m
+ beginner → advanced
+
+ created & taught by
+ Tonbi's AI Garage
+ Tonbi turns Hermes Agent's fast-moving feature set into practical, screen-level walkthroughs. The videos and teaching are his; Hermes Atlas organized the series and distilled the notes below from his transcripts.
+
+ YouTube channel ↗
+ full playlist ↗
+ follow Tonbi ↗
+
+ jump to a module
+
+ 01 setup
+ 02 deploy
+ 03 memory
+ 04 skills
+ 05 models
+ 06 tools & MCP
+ 07 automation
+ 08 subagents
+ 09 profiles
+ 10 security
+
+ 01
+ 28:31 · foundations
+
+ module 01 · start here
+
+ Installation, setup & basic commands
+ watch on YouTube ↗
+
+ Here's what you need to know +
+
+ the short version Get one clean chat working before you add complexity. Pick a provider, learn the few commands that keep you oriented, and give Hermes a concrete first task whose result you can verify.
+
+ 02:12 The payoff compounds. Hermes is most useful when repeated sessions build memory and reusable skills. If all you need is an occasional chatbot, the extra machinery may not earn its keep.
+ 06:48 Stabilize the base provider first. Choose a model you can reliably call, then add fallback credentials or routing. Do not debug gateways, tools, and provider auth at the same time.
+ 13:08 Memorize the operator basics. hermes starts chat; hermes gateway starts messaging; hermes doctor checks the install; hermes model reopens model configuration.
+ 16:43 You can steer without restarting. Switch models in-session with /model , compact a long context with /compress , and use background or queued prompts when you do not want to derail the active task.
+ 19:40 Know where state lives. The .hermes directory holds config, environment, memories, sessions, cron, and logs. Tonbi's rule: edit config and memory deliberately; let Hermes manage session and cron internals.
+ 21:26 Test with real work. A bounded research task proves web search, tool calling, and synthesis in one go—and exposes a broken setup faster than a casual “hello.”
+
+ 02 30:50 · deployment
+
+ module 02 · run it anywhere
+ VPS, Docker & messaging watch on YouTube ↗
+
+ Here's what you need to know +
+
+ the short version Choose a backend by the blast radius and uptime you need: local for simplicity, Docker for containment, VPS for always-on access. One gateway can then expose the same agent through many messaging apps.
+
+ 01:06 Backend is an operating decision. Local is easiest, Docker keeps command execution off the host, and a VPS keeps Hermes awake when your laptop is closed.
+ 03:13 Persistence and isolation are separate. Configure the Docker backend so the sandbox keeps the files it needs between turns without handing it your whole host filesystem.
+ 09:37 Make an always-on host survive logout. Use SSH key authentication and install the gateway as a supervised service; enable linger when needed so the user service stays alive after SSH disconnects.
+ 14:53 The gateway is one room with many doors. Telegram, Discord, and the CLI can feed the same agent, memory, sessions, and skills. You do not need a separate Hermes install per channel.
+ 15:55 Treat bot tokens like passwords. Create the Telegram bot through BotFather, restrict who may talk to it, and never paste the token into prompts or public config.
+ 17:40 Discord's easy-to-miss step is intents. Enable the required message-content intents in the developer portal; skipping them produces a bot that connects but receives empty messages.
+
+ 03 34:20 · memory
+
+ module 03 · make context compound
+ Memory, Honcho & Obsidian watch on YouTube ↗
+
+ Here's what you need to know +
+
+ the short version Hermes memory is intentionally layered. Keep the tiny built-in files curated, search old sessions only when needed, add one provider for richer recall, and use an Obsidian vault for project-scale knowledge.
+
+ 01:30 The small cap is a feature. memory.md and user.md share a tightly bounded prompt budget, forcing Hermes to retain durable preferences, facts, corrections, and conventions instead of a junk drawer.
+ 06:00 Memory writes appear next session. Disk updates immediately, but the system prompt stays frozen for the current session so prompt caching remains useful. A same-session test can therefore look “forgotten” even when the write succeeded.
+ 12:00 Session search is the deep archive. FTS5 lets Hermes retrieve an old conversation on demand without paying to keep every session in the active prompt.
+ 15:00 Run one provider at a time. Honcho, Mem0, Hindsight, and SuperMemory augment the built-in layer; switching providers does not migrate the memory you accumulated in the previous one.
+ 21:00 Provider choice is about memory shape. Honcho emphasizes a modeled understanding of the user; other providers lean toward extraction, knowledge graphs, or partitioned containers. Pick the behavior you actually need.
+ 26:00 Obsidian is a skill, not a provider. Use it for structured, long-form project knowledge that would overwhelm the built-in cap. Point the skill at a vault path and let Hermes create linked Markdown files.
+
+ 04 41:19 · skills
+
+ module 04 · procedural memory
+ Skills that grow with the agent watch on YouTube ↗
+
+ Here's what you need to know +
+
+ the short version A skill is a reusable instruction package. The description gets it selected, the body teaches the procedure, and the Curator keeps custom skills from turning into an unmaintained pile.
+
+ 02:00 SKILL.md is the unit. Front matter names and describes the skill; the body contains the workflow. References, scripts, templates, and assets are optional supporting material.
+ 04:00 The description is the picker hint. Hermes sees names and descriptions before it reads a body. A vague description means the right skill may never load, no matter how good its instructions are.
+ 05:30 Progressive disclosure keeps context lean. Hermes can carry a large catalog because only the selected skill body enters the prompt; everything else stays on disk.
+ 23:00 Install narrowly and inspect sources. Prefer bundled or trusted hub skills, let the security scan run, and use /reload skills to pick up changes without restarting the whole agent.
+ 25:30 Agent-written skills are procedural memory. When a complex tool sequence works, capturing it as a skill makes the next run faster and more consistent than rediscovering the steps.
+ 31:00 Pin what must not drift. The Curator grades and consolidates custom skills; pin a business-critical workflow so automated housekeeping cannot rewrite or archive it.
+ 39:00 Know skill versus plugin. If you are teaching knowledge or a repeatable procedure, use a skill. If you are adding executable product surface, backend routes, or UI, build a plugin.
+
+ 05 25:20 · models
+
+ module 05 · spend intelligence wisely
+ Providers, models & local inference watch on YouTube ↗
+
+ Here's what you need to know +
+
+ the short version Use an expensive model where judgment matters and cheaper models everywhere else. Hermes separates providers, credentials, fallbacks, and auxiliary tasks so cost control does not require giving up a strong primary agent.
+
+ 01:12 Provider and model are different decisions. The provider controls authentication, billing, and transport; the model controls capability, context, and price.
+ 05:21 Tier the work. Put routine title generation, session search, compression, and other auxiliary jobs on inexpensive models. Keep a better default or specialist model for tasks where mistakes cost more.
+ 10:16 Credential pools are resilience, not just billing. Rotate keys when one hits a rate limit; cron jobs and subagents inherit the pool automatically.
+ 12:25 Manual switching stays useful. Hermes does not offer arbitrary per-skill or complexity-based routing. Use /model mid-session when you know the next phase deserves a different model.
+ 13:38 Local tool calling needs the right server flags. In Tonbi's llama.cpp setup, quantized KV cache and flash attention make the model fit; the Jinja chat template is the easy-to-miss requirement for tools.
+ 17:32 Ollama's context default can break agents. Set a sufficiently large context length before blaming Hermes for truncated plans or failed tool loops.
+ 20:04 Hermes Proxy makes subscriptions reusable. It exposes a local OpenAI-compatible endpoint backed by your configured OAuth provider, so compatible tools can share that access without receiving the real credential.
+
+ 06 26:16 · tools
+
+ module 06 · give the model hands
+ Tools & MCP servers watch on YouTube ↗
+
+ Here's what you need to know +
+
+ the short version The model requests; Hermes executes. Keep that boundary explicit, expose only the tools a task needs, and treat every MCP server as new code entering the agent's trust surface.
+
+ 03:04 A tool has three pieces. The function does the work, the schema tells the model when and how to call it, and the registry makes it available. The model never executes the function directly.
+ 04:00 Design the failure shape. Return a clean, structured error so the model can recover, choose another tool, or ask for missing input instead of crashing the whole turn.
+ 05:01 Prefer structured tools over shell improvisation. Purpose-built file, search, and patch tools are easier to audit and give the model a clearer recovery path than a chain of opaque shell commands.
+ 06:56 Scope and sandbox answer different questions. Tool sets decide what the agent can reach; local, Docker, or SSH backends decide where execution happens.
+ 10:00 Use the safe set for untrusted work. Read-only research and media tools without file writes or shell access are a better default for public-facing or research-only agents.
+ 12:12 Do not connect every MCP tool. Add the right server, filter it to the smallest useful surface, prefer OAuth to copied long-lived tokens, and let package scanning inspect local launchers.
+ 21:28 Build a native tool for repeated, stable capability. A small API-backed function with a precise schema is a good fit when the agent should recognize and call the same operation automatically.
+
+ 07 35:55 · automation
+
+ module 07 · remove yourself from the loop
+ Cron & automation watch on YouTube ↗
+
+ Here's what you need to know +
+
+ the short version A good cron job is a self-contained runbook, not a reminder to an agent that remembers yesterday. Use scripts for free polling, wake the model only when judgment is needed, and pass upstream output directly into downstream jobs.
+
+ 02:19 Cron lives in the gateway. The always-on gateway checks the schedule and creates a fresh, isolated session for each run.
+ 06:21 Runaway self-scheduling is blocked. A cron execution cannot create more cron jobs, preventing a job-spawns-job loop from multiplying unnoticed.
+ 09:10 Use silent for healthy states. Monitoring jobs can suppress routine “all good” deliveries while failures still surface.
+ 11:18 Fresh sessions know nothing about “that issue.” Include the host, path, command, expected state, delivery target, and success/failure behavior in the job prompt.
+ 12:39 no_agent is the zero-model path. If a deterministic script can collect or check the state, let it run alone rather than spending tokens on narration.
+ 14:50 Put a cheap gate before expensive judgment. A pre-run script can return “wake agent: false” until something changes, then hand the changed state to the model for triage.
+ 25:30 context-from is enough for many pipelines. Feed the latest completed output of one or several jobs directly into the next prompt; this removes file-path bookkeeping and extra tool calls.
+
+ 08 33:27 · delegation
+
+ module 08 · parallelize the right work
+ Subagents & delegation watch on YouTube ↗
+
+ Here's what you need to know +
+
+ the short version Delegate independent, messy work that benefits from a clean context or parallel execution. Brief each child like a stranger, keep its tools narrow, and reserve the stronger model for orchestration and final judgment.
+
+ 02:21 Delegation solves context poisoning and serial slowness. Tool traces and false starts stay in the child's clean room; only the final summary returns to the parent.
+ 09:07 Subagents know nothing. “Fix the error” is not a brief. Include the exact failure, files, project root, environment, constraints, and definition of done.
+ 10:00 Give each child the least surface it needs. Research may need only web; review may need only read access. Children cannot exceed the parent's tools and leaf children are blocked from sensitive shared operations by default.
+ 11:12 Use cheap children and a strong parent. Route token-heavy collection to one inexpensive delegation model, then let the primary model synthesize short summaries.
+ 13:30 Concurrency is bounded. The default batch is three; larger batches error rather than silently queueing. If the parent is interrupted, synchronous children are canceled too.
+ 20:47 Depth multiplies spend. Children cannot recurse by default. Orchestrator roles and higher spawn depth are opt-in because three branches across three levels can become 27 leaves.
+ 22:00 Background is not durable. background=true lets a child outlive the current turn, but not the session. Use cron or a durable workflow when the work must survive restart.
+ 23:00 Do not delegate tightly dependent work. Keep short, sequential, interactive tasks in one loop; use a script for deterministic mechanics and cron for scheduled or durable work.
+
+ 09 31:05 · orchestration
+
+ module 09 · build a durable team
+ Profiles & Kanban watch on YouTube ↗
+
+ Here's what you need to know +
+
+ the short version A profile is a whole persistent Hermes, not a temporary helper. Give each role its own state and model, contain its filesystem separately, then use Kanban when work must cross agents and survive restarts.
+
+ 02:58 One profile means one isolated Hermes home. It has its own config, model, memory, skills, sessions, cron, logs, gateway, and persona. Two concurrent agents must not share one home or SQLite state will collide.
+ 13:21 Each gateway needs its own bot token. Several profiles can run messaging gateways on one machine, but Hermes blocks a second process from claiming a token already in use.
+ 16:15 Profiles isolate state, not your disk. A local-backend profile can still read the host filesystem. Pin its working directory and use Docker or SSH when you need a real boundary.
+ 17:34 Profiles are portable. Export and import can package the agent's configuration, skills, cron, MCP setup, and persona as a reusable distribution.
+ 18:48 Use Kanban for durable cross-agent work. Subagents fit a task you watch finish in one session; the SQLite-backed board survives gateway restarts and lets a human comment, block, or unblock mid-flight.
+ 20:00 Routing reads descriptions, not names. Write each profile's one-line role precisely. The decomposer builds the task graph, then the router assigns tasks to the profile whose description fits.
+ 21:00 Workers update the board through gated tools. They show, create, complete, block, and comment through the Kanban tool set rather than shelling into the database.
+ 23:00 Model choice follows the assignee. There is no per-card override; route a task to a different profile when it needs a different model or tool surface.
+
+ 10 27:38 · security
+
+ module 10 · defense in depth
+ Security watch on YouTube ↗
+
+ Here's what you need to know +
+
+ the short version There is no fully capable, fully safe agent. Start with who can reach it, then layer approvals, containment, secret filtering, injection defenses, network controls, and per-profile least privilege.
+
+ 02:05 Capability and safety move against each other. Tune the system for its real trust level—a private laptop, a team service, and a public gateway should not share one security posture.
+ 05:00 The gateway fails closed. Configure explicit platform or global user allowlists. With no matching permission, a message never reaches the agent.
+ 07:51 Pick approvals deliberately. Manual asks on risky commands, smart mode lets an auxiliary model approve clear low-risk actions and escalate uncertainty, and YOLO skips almost every prompt. Approval timeouts deny by default.
+ 11:26 YOLO still has a floor. Obvious system-wiping commands are rejected before the approval layer and have no agent-side override. If an operation is truly that destructive, do it manually outside the agent.
+ 13:20 Containment limits the blast radius. Local execution leans heavily on approvals; Docker can sacrifice a container instead of the host. Anything you explicitly mount or forward into that container is still readable and exfiltratable.
+ 17:23 Secrets and instructions are filtered before the model sees them. MCP subprocesses receive a stripped environment, known token patterns are redacted, and prompt-bearing files are scanned for injection and exfiltration patterns.
+ 19:00 Network controls matter too. SSRF protection blocks private and link-local ranges and rechecks redirects; use the shared website blocklist, and only allow private URLs when a trusted local service genuinely requires it.
+ 20:08 Tirith catches what simple patterns miss. Its pre-execution scan looks for homoglyph domains, pipe-to-interpreter commands, and terminal injection tricks.
+ 22:00 Apply least privilege per profile. A researcher can have a domain blocklist and safe tools; a coder can run inside Docker with manual approvals; a low-risk writer may need far less friction.
+
+ About these notes: Hermes Atlas distilled each module from Tonbi's YouTube description and auto-generated English transcript, then linked every takeaway back to the relevant timestamp. They are editorial summaries, not verbatim transcripts. Hermes Agent changes quickly, so verify version-sensitive commands and feature counts against the current official documentation ↗ .
+
+ hermes atlas · curated by ksimback · suggest a repo · privacy
+ v2 · 2026.07
+
+---
+
 # State of Hermes — April 2026
 
 Canonical URL: https://hermesatlas.com/reports/state-of-hermes-april-2026
 
-Skip to content 
+Skip to content
 
- hermes atlas 
- 
- 95·repos 
- hermes·v0.10.0 
- ★ star this repo 
+ hermes atlas
 
- map 
- lists 
- handbook 
- reports 
- newsletter 
- source 
+ 185·repos
+ hermes·v0.18.0
+ ★ star this repo
 
- light / dark 
+ map
+ lists
+ handbook
+ masterclass
+ dev
+ reports
+ newsletter
+ source
 
  map / reports / state of hermes — april 2026
 
- community report · q1 2026 
- The state of Hermes Agent — April 2026 
- A community report on the first six weeks of Nous Research's self-improving AI agent. 
- Published apr 11, 2026 · 10 min read · hermesatlas.com 
+ community report · q1 2026
+ The state of Hermes Agent — April 2026
+ A community report on the first six weeks of Nous Research's self-improving AI agent.
+ Published apr 11, 2026 · 10 min read · hermesatlas.com
 
- TL;DR 
+ TL;DR
 
- Six weeks ago, Nous Research quietly released Hermes Agent — an open-source AI agent built around a single contrarian premise: what if your AI got smarter the more you used it, instead of resetting at the end of every session? The community noticed. The repo went from 0 to 57,200 GitHub stars in six weeks, growing faster than OpenClaw at the same stage. 
+ Six weeks ago, Nous Research quietly released Hermes Agent — an open-source AI agent built around a single contrarian premise: what if your AI got smarter the more you used it, instead of resetting at the end of every session? The community noticed. The repo went from 0 to 57,200 GitHub stars in six weeks, growing faster than OpenClaw at the same stage.
 
- But star counts only tell part of the story. The real signal is what's been built around it. In just six weeks, the community has shipped: 
+ But star counts only tell part of the story. The real signal is what's been built around it. In just six weeks, the community has shipped:
 
- 3 official Nous Research extensions (autonovel, hermes-paperclip-adapter, hermes-agent-self-evolution) 
- 17 community skill libraries (including the 4,132-star Anthropic Cybersecurity Skills collection mapped to MITRE ATT&CK) 
- 8 external memory providers (Honcho, Mem0, Hindsight, Supermemory, and others) 
- 9 multi-agent orchestration frameworks (mission-control alone has 3,875 stars) 
- 7 deployment templates spanning Docker, Nix, systemd, and managed cloud 
- 80+ quality-filtered repos in total , growing at roughly 5,000 GitHub stars per week ecosystem-wide 
+ 3 official Nous Research extensions (autonovel, hermes-paperclip-adapter, hermes-agent-self-evolution)
+ 17 community skill libraries (including the 4,132-star Anthropic Cybersecurity Skills collection mapped to MITRE ATT&CK)
+ 8 external memory providers (Honcho, Mem0, Hindsight, Supermemory, and others)
+ 9 multi-agent orchestration frameworks (mission-control alone has 3,875 stars)
+ 7 deployment templates spanning Docker, Nix, systemd, and managed cloud
+ 80+ quality-filtered repos in total , growing at roughly 5,000 GitHub stars per week ecosystem-wide
 
- This report unpacks how a model-research lab from upstate New York turned an open-source release into a movement, what Hermes does differently from OpenClaw and Claude Code, and what to watch for in Q2. 
+ This report unpacks how a model-research lab from upstate New York turned an open-source release into a movement, what Hermes does differently from OpenClaw and Claude Code, and what to watch for in Q2.
 
- newsletter · free · 1–2× / month 
+ newsletter · free · 1–2× / month
 
- subscribe 
+ subscribe
 
- 1. What Hermes Agent actually is 
+ 1. What Hermes Agent actually is
 
- Hermes Agent is an autonomous AI agent that lives on a server (or your laptop, or a $5 VPS) and gets more capable over time. Three things make it different from every other AI agent framework released in the last two years: 
+ Hermes Agent is an autonomous AI agent that lives on a server (or your laptop, or a $5 VPS) and gets more capable over time. Three things make it different from every other AI agent framework released in the last two years:
 
- 1. A built-in learning loop. When Hermes completes a complex task — say, debugging a microservice or refactoring a Rust crate — it can synthesize that experience into a permanent skill document. These skills follow the agentskills.io open standard: structured Markdown with metadata, written in natural language, callable as slash commands. Next time the agent encounters something similar, it doesn't start from zero. It loads the relevant skill and gets to work. 
+ 1. A built-in learning loop. When Hermes completes a complex task — say, debugging a microservice or refactoring a Rust crate — it can synthesize that experience into a permanent skill document. These skills follow the agentskills.io open standard: structured Markdown with metadata, written in natural language, callable as slash commands. Next time the agent encounters something similar, it doesn't start from zero. It loads the relevant skill and gets to work.
 
- 2. Persistent multi-level memory. Hermes maintains a bounded MEMORY.md (the agent's notes) and USER.md (user profile) that always live in the system prompt. Below that, every session is stored in SQLite with FTS5 full-text search, so the agent can recall any past conversation. Above that, eight pluggable external memory providers (Honcho, Mem0, Hindsight, Supermemory, RetainDB, ByteRover, OpenViking, Holographic) handle long-term semantic memory and graph-based recall. This three-layer architecture is the defining technical decision of the project. 
+ 2. Persistent multi-level memory. Hermes maintains a bounded MEMORY.md (the agent's notes) and USER.md (user profile) that always live in the system prompt. Below that, every session is stored in SQLite with FTS5 full-text search, so the agent can recall any past conversation. Above that, eight pluggable external memory providers (Honcho, Mem0, Hindsight, Supermemory, RetainDB, ByteRover, OpenViking, Holographic) handle long-term semantic memory and graph-based recall. This three-layer architecture is the defining technical decision of the project.
 
- 3. A unified gateway across 14 messaging platforms. A single Hermes instance can run as a Telegram bot, a Discord bot, a Slack app, a WhatsApp client, a Signal contact, an SMS endpoint, an Email auto-responder, a Matrix integration, a Mattermost bot, and more — all from the same daemon, with one shared session and one shared memory. You can start a conversation in CLI and continue it in Telegram, then ask it to send the result to your team in Slack. 
+ 3. A unified gateway across 14 messaging platforms. A single Hermes instance can run as a Telegram bot, a Discord bot, a Slack app, a WhatsApp client, a Signal contact, an SMS endpoint, an Email auto-responder, a Matrix integration, a Mattermost bot, and more — all from the same daemon, with one shared session and one shared memory. You can start a conversation in CLI and continue it in Telegram, then ask it to send the result to your team in Slack.
 
- The core repo is MIT-licensed Python (~9,200 lines in run_agent.py alone), supports 20+ LLM providers (OpenRouter, Nous Portal, Anthropic, OpenAI, Gemini, local Ollama, vLLM, etc.), and runs on six execution backends from local processes to Daytona cloud sandboxes. 
+ The core repo is MIT-licensed Python (~9,200 lines in run_agent.py alone), supports 20+ LLM providers (OpenRouter, Nous Portal, Anthropic, OpenAI, Gemini, local Ollama, vLLM, etc.), and runs on six execution backends from local processes to Daytona cloud sandboxes.
 
- 2. The launch timeline 
+ 2. The launch timeline
 
- February 25, 2026: Nous Research drops Hermes Agent on GitHub with a simple tweet: "Meet Hermes Agent, the open source agent that grows with you." The launch post gets 557 likes — strong but not viral. 
+ February 25, 2026: Nous Research drops Hermes Agent on GitHub with a simple tweet: "Meet Hermes Agent, the open source agent that grows with you." The launch post gets 557 likes — strong but not viral.
 
- February 26-March 10: Tech press picks it up. MarkTechPost runs a piece framing it as a fix for "AI forgetfulness." Bitcoin News crosses the crypto/AI divide with an explainer. The Top AI Product blog calls it "the open-source AI agent that finally remembers everything." 
+ February 26-March 10: Tech press picks it up. MarkTechPost runs a piece framing it as a fix for "AI forgetfulness." Bitcoin News crosses the crypto/AI divide with an explainer. The Top AI Product blog calls it "the open-source AI agent that finally remembers everything."
 
- March 11: Hits 22,000 GitHub stars and 242 contributors — this would have been a great six-month number for most projects. 
+ March 11: Hits 22,000 GitHub stars and 242 contributors — this would have been a great six-month number for most projects.
 
- March 15-25: The skill ecosystem explodes. Vercel Labs publishes their official vercel-labs/agent-skills library. Black Forest Labs (the FLUX image gen team) ships official Hermes-compatible image generation skills. Anthropic releases a 754-skill cybersecurity collection mapped to MITRE ATT&CK, NIST CSF 2.0, and D3FEND. 
+ March 15-25: The skill ecosystem explodes. Vercel Labs publishes their official vercel-labs/agent-skills library. Black Forest Labs (the FLUX image gen team) ships official Hermes-compatible image generation skills. Anthropic releases a 754-skill cybersecurity collection mapped to MITRE ATT&CK, NIST CSF 2.0, and D3FEND.
 
- March 23: Nous Research ships v0.4.0 — what Teknium calls "the platform expansion release." 200+ bug fixes, 6 new messaging adapters (Signal, DingTalk, SMS, Mattermost, Matrix, Webhook), MCP server management with OAuth 2.1, an OpenAI-compatible API server, and gateway prompt caching. The release is built from 300 PRs in five days. 
+ March 23: Nous Research ships v0.4.0 — what Teknium calls "the platform expansion release." 200+ bug fixes, 6 new messaging adapters (Signal, DingTalk, SMS, Mattermost, Matrix, Webhook), MCP server management with OAuth 2.1, an OpenAI-compatible API server, and gateway prompt caching. The release is built from 300 PRs in five days.
 
- April 3: Anthropic blocks OpenClaw from accessing Claude Code subscriptions. The Hacker News thread reaches #1 with 1,064 points and 811 comments. Nous Research immediately tweets: "If you're having trouble with your lobster-themed agent since the recent update, try downloading Hermes Agent, then running 'hermes claw migrate'. We've been told this helps a lot." The cheeky migration tool tweet picks up 813 likes. Migration traffic spikes. 
+ April 3: Anthropic blocks OpenClaw from accessing Claude Code subscriptions. The Hacker News thread reaches #1 with 1,064 points and 811 comments. Nous Research immediately tweets: "If you're having trouble with your lobster-themed agent since the recent update, try downloading Hermes Agent, then running 'hermes claw migrate'. We've been told this helps a lot." The cheeky migration tool tweet picks up 813 likes. Migration traffic spikes.
 
- April 8: v0.8.0 ships with 209 PRs and 82 issue closures. Headline features: live model switching mid-session, free Xiaomi MiMo v2 Pro via Nous Portal, native Google AI Studio (Gemini) integration, Matrix tier-1 support, MCP OAuth 2.1 with PKCE plus OSV malware scanning, and the long-awaited notify_on_complete for background tasks. Manim skill ships the same week and goes viral after Shopify CEO Tobi Lütke uses it to generate a 3Blue1Brown-style math animation in one prompt. 
+ April 8: v0.8.0 ships with 209 PRs and 82 issue closures. Headline features: live model switching mid-session, free Xiaomi MiMo v2 Pro via Nous Portal, native Google AI Studio (Gemini) integration, Matrix tier-1 support, MCP OAuth 2.1 with PKCE plus OSV malware scanning, and the long-awaited notify_on_complete for background tasks. Manim skill ships the same week and goes viral after Shopify CEO Tobi Lütke uses it to generate a 3Blue1Brown-style math animation in one prompt.
 
- April 11: 57,200+ GitHub stars , 7,572 forks, 274 contributors. The ecosystem map at hermesatlas.com now tracks 80+ community projects. Nous Portal partnerships announced with MiniMax (M2.7) and Xiaomi (free MiMo v2 Pro for two weeks). Paradigm + a16z confirmed as Nous Research's lead investors. 
+ April 11: 57,200+ GitHub stars , 7,572 forks, 274 contributors. The ecosystem map at hermesatlas.com now tracks 80+ community projects. Nous Portal partnerships announced with MiniMax (M2.7) and Xiaomi (free MiMo v2 Pro for two weeks). Paradigm + a16z confirmed as Nous Research's lead investors.
 
- That's six weeks. 
+ That's six weeks.
 
- 3. Growth in numbers 
+ 3. Growth in numbers
 
- Metric As of April 11, 2026 
- 
- GitHub stars (core repo) 57,200 
- Forks 7,572 
- Contributors 274+ 
- Issues closed 800+ 
- Releases 8 (v0.1 &rarr; v0.8) 
- Messaging platforms 14 
- Community ecosystem repos 80+ 
- External memory providers 8 
- Total ecosystem stars 90,750 
+ Metric As of April 11, 2026
 
- Growth velocity: Roughly 9,500 stars per week on the core repo over the last 30 days. For context, OpenClaw (which had a multi-month head start) is currently growing at ~3,000 stars per week. Hermes Agent has flipped OpenClaw on weekly star growth. 
+ GitHub stars (core repo) 57,200
+ Forks 7,572
+ Contributors 274+
+ Issues closed 800+
+ Releases 8 (v0.1 &rarr; v0.8)
+ Messaging platforms 14
+ Community ecosystem repos 80+
+ External memory providers 8
+ Total ecosystem stars 90,750
 
- Contributor profile: Teknium (Nous Research co-founder) leads the commit count with 179 PRs in v0.8 alone. Top community contributors include @SHL0MS , @alt-glitch , @benbarclay , @CharlieKerfoot , and @WAXLYY . Fourteen distinct contributors merged PRs in the v0.8 release window — a healthy bus factor for a six-week-old project. 
+ Growth velocity: Roughly 9,500 stars per week on the core repo over the last 30 days. For context, OpenClaw (which had a multi-month head start) is currently growing at ~3,000 stars per week. Hermes Agent has flipped OpenClaw on weekly star growth.
 
- International reach: Coverage has expanded well beyond English-language tech press. Chinese AI developer @wangray published a deep technical analysis of Hermes's 4-layer memory system that picked up 258 likes and 49,000 views. Japanese developers have shipped install tutorials. The Chinese AI community has noted Nous Research's Web3 connections (Paradigm + a16z) as a sign of credible long-term backing. 
+ Contributor profile: Teknium (Nous Research co-founder) leads the commit count with 179 PRs in v0.8 alone. Top community contributors include @SHL0MS , @alt-glitch , @benbarclay , @CharlieKerfoot , and @WAXLYY . Fourteen distinct contributors merged PRs in the v0.8 release window — a healthy bus factor for a six-week-old project.
 
- 4. The three-way positioning: Hermes vs OpenClaw vs Claude Code 
+ International reach: Coverage has expanded well beyond English-language tech press. Chinese AI developer @wangray published a deep technical analysis of Hermes's 4-layer memory system that picked up 258 likes and 49,000 views. Japanese developers have shipped install tutorials. The Chinese AI community has noted Nous Research's Web3 connections (Paradigm + a16z) as a sign of credible long-term backing.
 
- A fair comparison matters here, because the community keeps trying to frame this as a winner-takes-all competition, and that's not really what's happening. 
+ 4. The three-way positioning: Hermes vs OpenClaw vs Claude Code
 
- Dimension Claude Code OpenClaw Hermes Agent 
- 
- Core identity Pair-programmer in your IDE Operations platform for teams Personal assistant that learns 
- Architecture IDE-integrated Gateway control plane (Node.js) Runtime AIAgent loop (Python) 
- Memory model Auto-notes to disk Unbounded Markdown Bounded curation + SQLite FTS5 + 8 provider plugins 
- Skills Static, human-authored Static (5,700+ on ClawHub) Autonomously created + refined by the agent 
- Channels IDE only 22+ including iMessage, IRC, LINE 14 including Matrix, DingTalk, Feishu 
- License Proprietary MIT MIT 
- Stars N/A (Anthropic product) ~250,000 57,200 
- Execution Local sandbox Local Local + Docker + SSH + Modal + Daytona + Singularity 
+ A fair comparison matters here, because the community keeps trying to frame this as a winner-takes-all competition, and that's not really what's happening.
 
- Where each one wins: 
+ Dimension Claude Code OpenClaw Hermes Agent
 
- Claude Code wins for focused coding sessions in an IDE. It's the best in-editor pair programmer Anthropic could build, and it integrates deeply with VS Code, Zed, and JetBrains. If you want an AI that helps you write code in your editor, this is the answer. 
- OpenClaw wins for team operations and channel breadth. With 22 channel integrations and a 5,700-skill marketplace, it's the most mature option for running a single agent across an entire company's communication surface. The gateway-first architecture is a strength for ops workflows. 
- Hermes Agent wins for the learning loop and long-horizon work. If you want an agent that gets better at your specific workflows over time — that remembers your project's quirks, that builds reusable skills automatically, that you can trust to run cron jobs unsupervised — Hermes is currently the only credible option. 
+ Core identity Pair-programmer in your IDE Operations platform for teams Personal assistant that learns
+ Architecture IDE-integrated Gateway control plane (Node.js) Runtime AIAgent loop (Python)
+ Memory model Auto-notes to disk Unbounded Markdown Bounded curation + SQLite FTS5 + 8 provider plugins
+ Skills Static, human-authored Static (5,700+ on ClawHub) Autonomously created + refined by the agent
+ Channels IDE only 22+ including iMessage, IRC, LINE 14 including Matrix, DingTalk, Feishu
+ License Proprietary MIT MIT
+ Stars N/A (Anthropic product) ~250,000 57,200
+ Execution Local sandbox Local Local + Docker + SSH + Modal + Daytona + Singularity
 
- The community consensus, repeated across Reddit, X, Substack, and the Hermes Agent Discord: they're complementary, not competitive. A typical setup uses Claude Code for IDE coding, Hermes Agent for personal automation and learning, and OpenClaw or Slack-native bots for team-wide ops. 
+ Where each one wins:
 
- 5. The architectural bet that defines Hermes 
+ Claude Code wins for focused coding sessions in an IDE. It's the best in-editor pair programmer Anthropic could build, and it integrates deeply with VS Code, Zed, and JetBrains. If you want an AI that helps you write code in your editor, this is the answer.
+ OpenClaw wins for team operations and channel breadth. With 22 channel integrations and a 5,700-skill marketplace, it's the most mature option for running a single agent across an entire company's communication surface. The gateway-first architecture is a strength for ops workflows.
+ Hermes Agent wins for the learning loop and long-horizon work. If you want an agent that gets better at your specific workflows over time — that remembers your project's quirks, that builds reusable skills automatically, that you can trust to run cron jobs unsupervised — Hermes is currently the only credible option.
 
- If you read just one section of this report, read this one. Hermes Agent's design embodies a specific bet about where AI agents are going, and that bet differs sharply from its competition. 
+ The community consensus, repeated across Reddit, X, Substack, and the Hermes Agent Discord: they're complementary, not competitive. A typical setup uses Claude Code for IDE coding, Hermes Agent for personal automation and learning, and OpenClaw or Slack-native bots for team-wide ops.
 
- The bet: Memory-bounded, deliberately curated agents will outperform unbounded "remember everything" agents in real-world use, because the constraint forces consolidation and consolidation produces better priors. 
+ 5. The architectural bet that defines Hermes
 
- OpenClaw's memory is unbounded. You can dump anything into it. The agent reads everything every turn. The bet is that more context = better answers. 
+ If you read just one section of this report, read this one. Hermes Agent's design embodies a specific bet about where AI agents are going, and that bet differs sharply from its competition.
 
- Hermes's memory is strictly bounded : 2,200 characters for MEMORY.md , 1,375 for USER.md . When you hit the limit, you can't just keep adding — you have to consolidate. The agent must explicitly decide what's worth remembering. This is a constraint that forces the agent to develop a working theory of what matters about you and your work, and then refine that theory as it gets new evidence. 
+ The bet: Memory-bounded, deliberately curated agents will outperform unbounded "remember everything" agents in real-world use, because the constraint forces consolidation and consolidation produces better priors.
 
- It's the same bet that LLMs make about attention: you can't attend to everything, so you have to learn what to attend to. Hermes applies that bet at the memory layer. 
+ OpenClaw's memory is unbounded. You can dump anything into it. The agent reads everything every turn. The bet is that more context = better answers.
 
- The early evidence suggests it's working. Users consistently report that Hermes "feels different" after 2-3 weeks of use in a way that other agents don't. One r/LocalLLaMA user reported a 40% speedup on repeated research tasks after Hermes auto-generated three skill documents over two hours. Another user — quoted on X by Robert Scoble — said "my Hermes agent spooked me with a very specific detail from a setup I was discussing with it 3 weeks ago." 
+ Hermes's memory is strictly bounded : 2,200 characters for MEMORY.md , 1,375 for USER.md . When you hit the limit, you can't just keep adding — you have to consolidate. The agent must explicitly decide what's worth remembering. This is a constraint that forces the agent to develop a working theory of what matters about you and your work, and then refine that theory as it gets new evidence.
 
- Whether this bet is correct is still an open question. But it's a real bet, and it's the first credible alternative to the "infinite context window" school of thought that has dominated AI agent design for the past two years. 
+ It's the same bet that LLMs make about attention: you can't attend to everything, so you have to learn what to attend to. Hermes applies that bet at the memory layer.
 
- 6. Community sentiment 
+ The early evidence suggests it's working. Users consistently report that Hermes "feels different" after 2-3 weeks of use in a way that other agents don't. One r/LocalLLaMA user reported a 40% speedup on repeated research tasks after Hermes auto-generated three skill documents over two hours. Another user — quoted on X by Robert Scoble — said "my Hermes agent spooked me with a very specific detail from a setup I was discussing with it 3 weeks ago."
 
- Tracking community sentiment across X, Reddit, Substack, Hacker News, and the Hermes Agent Discord (~4,000 builders), three themes dominate: 
+ Whether this bet is correct is still an open question. But it's a real bet, and it's the first credible alternative to the "infinite context window" school of thought that has dominated AI agent design for the past two years.
 
- Positive: 
- 
- "The first agent harness that you immediately know was developed by people who have a vast knowledge" — @DataDeLaurier 
- "Much less token hungry" than competitors — repeated across r/LocalLLaMA 
- "Excellent right out of the box" with a "5-minute install" — repeated by multiple users 
- " @NousResearch may have cooked with hermes agent" — @fujikanaeda (retweeted by Nous itself) 
- "Hermes is definitely a better coder, id drop the claw altogether lol" — @teknium 
+ 6. Community sentiment
 
- Critical (acknowledged honestly): 
- 
- Some users report edge case issues with extended use; one well-known user ( @ksubedi ) returned to OpenClaw after testing 
- Local model performance can be slower than running the model directly through LMStudio (one user reported 1-2 tokens/s through Hermes vs 45 tokens/s native) 
- Setup, while generally praised, was called "more tedious than OpenClaw" by @chrysb in the most-liked critical post 
+ Tracking community sentiment across X, Reddit, Substack, Hacker News, and the Hermes Agent Discord (~4,000 builders), three themes dominate:
 
- The signal-to-noise ratio strongly favors Hermes. Out of dozens of posts I've reviewed, the negative ones are specific and technical (and generally being addressed in releases), while the positive ones tend to be more emotional and broader ("magical," "spooked me," "the future"). 
+ Positive:
 
- 7. The ecosystem map 
+ "The first agent harness that you immediately know was developed by people who have a vast knowledge" — @DataDeLaurier
+ "Much less token hungry" than competitors — repeated across r/LocalLLaMA
+ "Excellent right out of the box" with a "5-minute install" — repeated by multiple users
+ " @NousResearch may have cooked with hermes agent" — @fujikanaeda (retweeted by Nous itself)
+ "Hermes is definitely a better coder, id drop the claw altogether lol" — @teknium
 
- Here's the breakdown of what the community has built around Hermes Agent in six weeks. Numbers reflect star counts as of April 11, 2026. 
+ Critical (acknowledged honestly):
 
- Category Count Top project (stars) 
- 
- Core & Official 6 hermes-agent (57.2K) 
- Skills & Registries 17 Anthropic-Cybersecurity-Skills (4.1K) 
- Memory & Context 6 hindsight (8.4K) 
- Multi-Agent & Orchestration 7 mission-control (3.9K) 
- Workspaces & GUIs 4 hermes-workspace (830) 
- Plugins & Extensions 6 hermes-web-search-plus (21) 
- Deployment & Infra 7 llm-agents.nix (967) 
- Integrations & Bridges 5 hermes-android (38) 
- Developer Tools 9 tokscale (1.7K) 
- Domain Applications 8 DashClaw (204) 
- Guides & Docs 5 awesome-hermes-agent (898) 
- Forks & Derivatives 3 hermes-agent-camel (12) 
+ Some users report edge case issues with extended use; one well-known user ( @ksubedi ) returned to OpenClaw after testing
+ Local model performance can be slower than running the model directly through LMStudio (one user reported 1-2 tokens/s through Hermes vs 45 tokens/s native)
+ Setup, while generally praised, was called "more tedious than OpenClaw" by @chrysb in the most-liked critical post
 
- The full quality-filtered, security-reviewed, live-data-updated map is available at hermesatlas.com . 
+ The signal-to-noise ratio strongly favors Hermes. Out of dozens of posts I've reviewed, the negative ones are specific and technical (and generally being addressed in releases), while the positive ones tend to be more emotional and broader ("magical," "spooked me," "the future").
 
- The most surprising entries — to me, at least — are the cross-pollinations. Hermes-android puts Hermes on your phone via a Python bridge. Hermes-blockchain-oracle is a Solana intelligence MCP server. Hermes-embodied uses Hermes to fine-tune VLA robotics models on cloud GPUs. Hermes-mars-rover simulates Mars exploration with ROS2 and Gazebo. The fact that the ecosystem is already this diverse six weeks in suggests Hermes hit a real nerve. 
+ 7. The ecosystem map
 
- 8. What to watch for in Q2 
+ Here's the breakdown of what the community has built around Hermes Agent in six weeks. Numbers reflect star counts as of April 11, 2026.
 
- Five things I'd watch closely over the next 90 days: 
+ Category Count Top project (stars)
 
- 1. The skill marketplace network effect. Hermes ships 40+ bundled skills today. The skills hub (built into the CLI) browses agentskills.io, GitHub taps, skills.sh, and ClawHub. If the rate of community skill creation continues to accelerate, Hermes could have a more curated (smaller, but higher-quality) skill marketplace than OpenClaw's by mid-Q2. The wildcard: whether community skills meaningfully cross over from OpenClaw via the OGP (Open Gateway Protocol) federation that both projects support. 
+ Core & Official 6 hermes-agent (57.2K)
+ Skills & Registries 17 Anthropic-Cybersecurity-Skills (4.1K)
+ Memory & Context 6 hindsight (8.4K)
+ Multi-Agent & Orchestration 7 mission-control (3.9K)
+ Workspaces & GUIs 4 hermes-workspace (830)
+ Plugins & Extensions 6 hermes-web-search-plus (21)
+ Deployment & Infra 7 llm-agents.nix (967)
+ Integrations & Bridges 5 hermes-android (38)
+ Developer Tools 9 tokscale (1.7K)
+ Domain Applications 8 DashClaw (204)
+ Guides & Docs 5 awesome-hermes-agent (898)
+ Forks & Derivatives 3 hermes-agent-camel (12)
 
- 2. The multi-instance enterprise story. Hermes profiles let you run isolated agents per client/project on the same machine. If a few high-profile companies start using this for internal automation (DM Slack bot for engineering, separate Telegram bot for sales, all sharing infrastructure), Hermes becomes a real competitor to enterprise agent platforms. Watch for Hermes to ship per-tenant memory isolation and audit logging in v0.9 or v0.10. 
+ The full quality-filtered, security-reviewed, live-data-updated map is available at hermesatlas.com .
 
- 3. The self-improvement narrative becoming measurable. Right now, "the agent that grows with you" is a tagline backed by anecdotal evidence. If Nous Research publishes benchmark numbers showing measurable improvement on repeated task families over time — real numbers, not vibes — Hermes becomes impossible to ignore. 
+ The most surprising entries — to me, at least — are the cross-pollinations. Hermes-android puts Hermes on your phone via a Python bridge. Hermes-blockchain-oracle is a Solana intelligence MCP server. Hermes-embodied uses Hermes to fine-tune VLA robotics models on cloud GPUs. Hermes-mars-rover simulates Mars exploration with ROS2 and Gazebo. The fact that the ecosystem is already this diverse six weeks in suggests Hermes hit a real nerve.
 
- 4. The Nous Portal subscription economics. Nous gives away free tier access with promotional codes (AGENTHERMES01) and free MiMo v2 Pro for two weeks. At some point this has to convert to a sustainable subscription business. 
+ 8. What to watch for in Q2
 
- 5. The "first deletion" moment. Every fast-growing open-source project eventually faces a moment where its community has to decide what to remove from the core. Hermes is approaching this: 47 built-in tools, 14 platforms, 6 backends, 8 memory providers. At some point, things will need to move out of core into optional plugins. How Nous handles this transition — and whether the community trusts them with it — will define the next phase. 
+ Five things I'd watch closely over the next 90 days:
 
- Methodology: Synthesized from 27 research files including official documentation, GitHub release notes, press coverage, X/Twitter analysis, Reddit discussion, and the awesome-hermes-agent curated list. All 80+ ecosystem repos are independently security-reviewed and live-tracked. 
- Not affiliated with Nous Research. Hermes Atlas is an independent community project. 
- Corrections welcome: open an issue 
- if this was useful, drop a ★ on the atlas repo → 
- explore the ecosystem map → 
+ 1. The skill marketplace network effect. Hermes ships 40+ bundled skills today. The skills hub (built into the CLI) browses agentskills.io, GitHub taps, skills.sh, and ClawHub. If the rate of community skill creation continues to accelerate, Hermes could have a more curated (smaller, but higher-quality) skill marketplace than OpenClaw's by mid-Q2. The wildcard: whether community skills meaningfully cross over from OpenClaw via the OGP (Open Gateway Protocol) federation that both projects support.
 
- newsletter · free 
- stay in the loop 
- new research, reports, and project drops from across the Hermes ecosystem — 1–2× per month. no spam. 
+ 2. The multi-instance enterprise story. Hermes profiles let you run isolated agents per client/project on the same machine. If a few high-profile companies start using this for internal automation (DM Slack bot for engineering, separate Telegram bot for sales, all sharing infrastructure), Hermes becomes a real competitor to enterprise agent platforms. Watch for Hermes to ship per-tenant memory isolation and audit logging in v0.9 or v0.10.
 
- subscribe 
+ 3. The self-improvement narrative becoming measurable. Right now, "the agent that grows with you" is a tagline backed by anecdotal evidence. If Nous Research publishes benchmark numbers showing measurable improvement on repeated task families over time — real numbers, not vibes — Hermes becomes impossible to ignore.
 
- handled by beehiiv · privacy 
+ 4. The Nous Portal subscription economics. Nous gives away free tier access with promotional codes (AGENTHERMES01) and free MiMo v2 Pro for two weeks. At some point this has to convert to a sustainable subscription business.
 
- hermes atlas · curated by ksimback · suggest a repo · privacy 
+ 5. The "first deletion" moment. Every fast-growing open-source project eventually faces a moment where its community has to decide what to remove from the core. Hermes is approaching this: 47 built-in tools, 14 platforms, 6 backends, 8 memory providers. At some point, things will need to move out of core into optional plugins. How Nous handles this transition — and whether the community trusts them with it — will define the next phase.
+
+ Methodology: Synthesized from 27 research files including official documentation, GitHub release notes, press coverage, X/Twitter analysis, Reddit discussion, and the awesome-hermes-agent curated list. All 80+ ecosystem repos are independently security-reviewed and live-tracked.
+ Not affiliated with Nous Research. Hermes Atlas is an independent community project.
+ Corrections welcome: open an issue
+ if this was useful, drop a ★ on the atlas repo →
+ explore the ecosystem map →
+
+ newsletter · free
+ stay in the loop
+ new research, reports, and project drops from across the Hermes ecosystem — 1–2× per month. no spam.
+
+ subscribe
+
+ handled by beehiiv · privacy
+
+ hermes atlas · curated by ksimback · suggest a repo · privacy
  v2 · 2026.04
 
 ---

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Hermes Atlas
 
-> The community-curated ecosystem map for Hermes Agent by Nous Research — 185+ tools, skills, plugins, and integrations with live GitHub data and AI-generated summaries. Updated daily. As of 2026-07-09.
+> The community-curated ecosystem map for Hermes Agent by Nous Research — 185+ tools, skills, plugins, and integrations with live GitHub data and AI-generated summaries. Updated daily. As of 2026-07-11.
 
 Hermes Atlas tracks every open-source project in the Hermes Agent ecosystem across 12 categories. Each project has a dedicated page with a prose summary, live star count, README, and category metadata. The full catalog is also available as JSON at https://hermesatlas.com/data/repos.json for programmatic access.
 
@@ -9,6 +9,9 @@ Hermes Atlas tracks every open-source project in the Hermes Agent ecosystem acro
 - [Install Hermes Agent](https://hermesatlas.com/guide/install/): Step-by-step install for macOS, Linux, Windows, and WSL, with troubleshooting.
 - [The Hermes Agent Memory Guidebook](https://hermesatlas.com/guide/memory/): Kevin Simback's guide to native memory, MemoryProviders, and community memory plug-ins.
 - [Hermes Agent vs. Claude Code](https://hermesatlas.com/guide/vs-claude-code/): Feature-by-feature comparison for choosing between the two.
+
+## Masterclass
+- [Tonbi's Hermes Agent Masterclass](https://hermesatlas.com/masterclass/): Ten video modules covering setup, deployment, memory, skills, models, tools, automation, subagents, profiles, Kanban, and security, with transcript-derived field notes and timestamp links.
 
 ## Dev Tutorial
 A hands-on developer tutorial for building on the Hermes Agent codebase, written for agentic developers (no CS degree assumed). Seven modules plus reference sheets.

--- a/masterclass/index.html
+++ b/masterclass/index.html
@@ -1,0 +1,418 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Hermes Agent Masterclass — Tonbi's 10-part video course | Hermes Atlas</title>
+<meta name="description" content="Watch Tonbi's complete 10-part Hermes Agent Masterclass with transcript-derived highlights, practical tips, gotchas, and timestamp links for every module.">
+<link rel="canonical" href="https://hermesatlas.com/masterclass/">
+<meta property="og:title" content="Hermes Agent Masterclass — all 10 modules">
+<meta property="og:description" content="Five hours of Tonbi's Hermes Agent training, distilled into ten videos with practical field notes and timestamp links.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://hermesatlas.com/masterclass/">
+<meta property="og:site_name" content="Hermes Atlas">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=Hermes+Agent+Masterclass&amp;subtitle=10+modules+%C2%B7+5+hours+%C2%B7+field+notes+included&amp;kind=guide">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Hermes Agent Masterclass — all 10 modules">
+<meta name="twitter:description" content="Tonbi's complete Hermes Agent course with transcript-derived notes and timestamp links.">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Hermes+Agent+Masterclass&amp;subtitle=10+modules+%C2%B7+5+hours+%C2%B7+field+notes+included&amp;kind=guide">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "CollectionPage",
+      "@id": "https://hermesatlas.com/masterclass/#page",
+      "name": "Hermes Agent Masterclass",
+      "description": "Tonbi's ten-part Hermes Agent video course with transcript-derived field notes.",
+      "url": "https://hermesatlas.com/masterclass/",
+      "isPartOf": { "@id": "https://hermesatlas.com/#website" },
+      "about": { "@type": "SoftwareApplication", "name": "Hermes Agent" },
+      "mainEntity": {
+        "@type": "ItemList",
+        "numberOfItems": 10,
+        "itemListOrder": "https://schema.org/ItemListOrderAscending",
+        "itemListElement": [
+          { "@type": "ListItem", "position": 1, "name": "Installation, setup, and basic commands", "url": "https://www.youtube.com/watch?v=R3YOGfTBcQg" },
+          { "@type": "ListItem", "position": 2, "name": "Deploy to VPS and connect messaging platforms", "url": "https://www.youtube.com/watch?v=dcXmUUZvDLE" },
+          { "@type": "ListItem", "position": 3, "name": "Memory, plugins, Honcho, and Obsidian", "url": "https://www.youtube.com/watch?v=ZKZLko9kLm4" },
+          { "@type": "ListItem", "position": 4, "name": "Skills", "url": "https://www.youtube.com/watch?v=L3WdVeMaYZM" },
+          { "@type": "ListItem", "position": 5, "name": "Providers and models", "url": "https://www.youtube.com/watch?v=1oaaOWy7wSI" },
+          { "@type": "ListItem", "position": 6, "name": "Tools and MCP servers", "url": "https://www.youtube.com/watch?v=U140gP-1bEI" },
+          { "@type": "ListItem", "position": 7, "name": "Cron and automation", "url": "https://www.youtube.com/watch?v=grMNnzCv2gY" },
+          { "@type": "ListItem", "position": 8, "name": "Subagents and delegation", "url": "https://www.youtube.com/watch?v=_6DtQkDpcEs" },
+          { "@type": "ListItem", "position": 9, "name": "Profiles and Kanban", "url": "https://www.youtube.com/watch?v=KPsMThlFb8Y" },
+          { "@type": "ListItem", "position": 10, "name": "Security", "url": "https://www.youtube.com/watch?v=KtlY6ETPyKo" }
+        ]
+      }
+    },
+    {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "map", "item": "https://hermesatlas.com/" },
+        { "@type": "ListItem", "position": 2, "name": "masterclass" }
+      ]
+    }
+  ]
+}
+</script>
+<link rel="alternate" type="application/rss+xml" title="Hermes Atlas — new projects" href="/rss.xml">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+<link rel="apple-touch-icon" href="/apple-touch-icon.png">
+<link rel="manifest" href="/site.webmanifest">
+<script src="/assets/js/theme-init.js"></script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500;600;700&amp;display=swap">
+<link rel="stylesheet" href="/assets/css/tokens.css">
+<link rel="stylesheet" href="/assets/css/base.css">
+<link rel="stylesheet" href="/assets/css/page.css">
+<link rel="stylesheet" href="/assets/css/masterclass.css">
+</head>
+<body>
+
+<a class="skip-link" href="#main">Skip to content</a>
+
+<header class="masthead">
+  <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
+  <div class="mast-meta" aria-label="Site metadata">
+    <span id="meta-count">185·repos</span>
+    <span id="meta-version">hermes·v0.18.0</span>
+    <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
+  </div>
+  <nav class="mast-nav" aria-label="Primary">
+    <a href="/">map</a>
+    <a href="/lists/">lists</a>
+    <a href="/guide/">handbook</a>
+    <a href="/masterclass/" class="active">masterclass</a>
+    <a href="/dev/">dev</a>
+    <a href="/reports/">reports</a>
+    <a href="/#newsletter">newsletter</a>
+    <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
+  </nav>
+  <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
+  </button>
+</header>
+
+<div class="breadcrumb" aria-label="Breadcrumb">
+  <a href="/">map</a><span class="sep">/</span>masterclass
+</div>
+
+<main class="masterclass-shell" id="main">
+
+<section class="series-hero" aria-labelledby="series-title">
+  <div>
+    <div class="series-kicker">watch · learn · build</div>
+    <h1 class="series-title" id="series-title">Hermes Agent <em>Masterclass</em></h1>
+    <p class="series-lede">Ten modules that take Hermes from a fresh install to a hardened multi-agent team. Watch Tonbi build the whole system, then open our transcript-derived field notes for the decisions, shortcuts, and gotchas worth remembering.</p>
+    <div class="series-facts" aria-label="Course facts">
+      <span>10 modules</span>
+      <span>5h 14m</span>
+      <span>beginner → advanced</span>
+    </div>
+  </div>
+  <aside class="creator-panel" aria-label="About the instructor">
+    <div class="creator-kicker">created &amp; taught by</div>
+    <h2 class="creator-name">Tonbi's AI Garage</h2>
+    <p class="creator-copy">Tonbi turns Hermes Agent's fast-moving feature set into practical, screen-level walkthroughs. The videos and teaching are his; Hermes Atlas organized the series and distilled the notes below from his transcripts.</p>
+    <div class="creator-links">
+      <a href="https://www.youtube.com/@TonbisAIGarage" target="_blank" rel="noopener">YouTube channel ↗</a>
+      <a href="https://www.youtube.com/playlist?list=PLmpUb_PWAkDx-VWjh00tVCji794xAa_IX" target="_blank" rel="noopener">full playlist ↗</a>
+      <a href="https://x.com/tonbistudio" target="_blank" rel="noopener">follow Tonbi ↗</a>
+    </div>
+  </aside>
+</section>
+
+<nav class="curriculum" aria-label="Masterclass curriculum">
+  <div class="curriculum-label">jump to a module</div>
+  <div class="curriculum-nav">
+    <a href="#episode-1"><strong>01</strong>setup</a>
+    <a href="#episode-2"><strong>02</strong>deploy</a>
+    <a href="#episode-3"><strong>03</strong>memory</a>
+    <a href="#episode-4"><strong>04</strong>skills</a>
+    <a href="#episode-5"><strong>05</strong>models</a>
+    <a href="#episode-6"><strong>06</strong>tools &amp; MCP</a>
+    <a href="#episode-7"><strong>07</strong>automation</a>
+    <a href="#episode-8"><strong>08</strong>subagents</a>
+    <a href="#episode-9"><strong>09</strong>profiles</a>
+    <a href="#episode-10"><strong>10</strong>security</a>
+  </div>
+</nav>
+
+<article class="episode" id="episode-1">
+  <aside class="episode-rail" aria-hidden="true">
+    <div class="episode-number">01</div>
+    <div class="episode-duration">28:31 · foundations</div>
+  </aside>
+  <div class="episode-main">
+    <div class="episode-kind">module 01 · start here</div>
+    <div class="episode-heading-row">
+      <h2 class="episode-title">Installation, setup &amp; basic commands</h2>
+      <a class="watch-link" href="https://www.youtube.com/watch?v=R3YOGfTBcQg" target="_blank" rel="noopener">watch on YouTube ↗</a>
+    </div>
+    <div class="video-frame">
+      <iframe src="https://www.youtube-nocookie.com/embed/R3YOGfTBcQg?rel=0" title="Hermes Agent Masterclass episode 1: Installation, setup, and basic commands" loading="eager" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+    </div>
+    <details class="episode-notes" open>
+      <summary><span>Here's what you need to know</span><span class="notes-arrow" aria-hidden="true">+</span></summary>
+      <div class="notes-body">
+        <div><div class="notes-label">the short version</div><p class="notes-tldr">Get one clean chat working before you add complexity. Pick a provider, learn the few commands that keep you oriented, and give Hermes a concrete first task whose result you can verify.</p></div>
+        <ul class="takeaways">
+          <li><a class="timecode" href="https://youtu.be/R3YOGfTBcQg?t=132" target="_blank" rel="noopener">02:12</a><span><strong>The payoff compounds.</strong> Hermes is most useful when repeated sessions build memory and reusable skills. If all you need is an occasional chatbot, the extra machinery may not earn its keep.</span></li>
+          <li><a class="timecode" href="https://youtu.be/R3YOGfTBcQg?t=408" target="_blank" rel="noopener">06:48</a><span><strong>Stabilize the base provider first.</strong> Choose a model you can reliably call, then add fallback credentials or routing. Do not debug gateways, tools, and provider auth at the same time.</span></li>
+          <li><a class="timecode" href="https://youtu.be/R3YOGfTBcQg?t=788" target="_blank" rel="noopener">13:08</a><span><strong>Memorize the operator basics.</strong> <code>hermes</code> starts chat; <code>hermes gateway</code> starts messaging; <code>hermes doctor</code> checks the install; <code>hermes model</code> reopens model configuration.</span></li>
+          <li><a class="timecode" href="https://youtu.be/R3YOGfTBcQg?t=1003" target="_blank" rel="noopener">16:43</a><span><strong>You can steer without restarting.</strong> Switch models in-session with <code>/model</code>, compact a long context with <code>/compress</code>, and use background or queued prompts when you do not want to derail the active task.</span></li>
+          <li><a class="timecode" href="https://youtu.be/R3YOGfTBcQg?t=1180" target="_blank" rel="noopener">19:40</a><span><strong>Know where state lives.</strong> The <code>.hermes</code> directory holds config, environment, memories, sessions, cron, and logs. Tonbi's rule: edit config and memory deliberately; let Hermes manage session and cron internals.</span></li>
+          <li><a class="timecode" href="https://youtu.be/R3YOGfTBcQg?t=1286" target="_blank" rel="noopener">21:26</a><span><strong>Test with real work.</strong> A bounded research task proves web search, tool calling, and synthesis in one go—and exposes a broken setup faster than a casual “hello.”</span></li>
+        </ul>
+      </div>
+    </details>
+  </div>
+</article>
+
+<article class="episode" id="episode-2">
+  <aside class="episode-rail" aria-hidden="true"><div class="episode-number">02</div><div class="episode-duration">30:50 · deployment</div></aside>
+  <div class="episode-main">
+    <div class="episode-kind">module 02 · run it anywhere</div>
+    <div class="episode-heading-row"><h2 class="episode-title">VPS, Docker &amp; messaging</h2><a class="watch-link" href="https://www.youtube.com/watch?v=dcXmUUZvDLE" target="_blank" rel="noopener">watch on YouTube ↗</a></div>
+    <div class="video-frame"><iframe src="https://www.youtube-nocookie.com/embed/dcXmUUZvDLE?rel=0" title="Hermes Agent Masterclass episode 2: VPS, Docker, Telegram, and Discord" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe></div>
+    <details class="episode-notes">
+      <summary><span>Here's what you need to know</span><span class="notes-arrow" aria-hidden="true">+</span></summary>
+      <div class="notes-body">
+        <div><div class="notes-label">the short version</div><p class="notes-tldr">Choose a backend by the blast radius and uptime you need: local for simplicity, Docker for containment, VPS for always-on access. One gateway can then expose the same agent through many messaging apps.</p></div>
+        <ul class="takeaways">
+          <li><a class="timecode" href="https://youtu.be/dcXmUUZvDLE?t=66" target="_blank" rel="noopener">01:06</a><span><strong>Backend is an operating decision.</strong> Local is easiest, Docker keeps command execution off the host, and a VPS keeps Hermes awake when your laptop is closed.</span></li>
+          <li><a class="timecode" href="https://youtu.be/dcXmUUZvDLE?t=193" target="_blank" rel="noopener">03:13</a><span><strong>Persistence and isolation are separate.</strong> Configure the Docker backend so the sandbox keeps the files it needs between turns without handing it your whole host filesystem.</span></li>
+          <li><a class="timecode" href="https://youtu.be/dcXmUUZvDLE?t=577" target="_blank" rel="noopener">09:37</a><span><strong>Make an always-on host survive logout.</strong> Use SSH key authentication and install the gateway as a supervised service; enable linger when needed so the user service stays alive after SSH disconnects.</span></li>
+          <li><a class="timecode" href="https://youtu.be/dcXmUUZvDLE?t=893" target="_blank" rel="noopener">14:53</a><span><strong>The gateway is one room with many doors.</strong> Telegram, Discord, and the CLI can feed the same agent, memory, sessions, and skills. You do not need a separate Hermes install per channel.</span></li>
+          <li><a class="timecode" href="https://youtu.be/dcXmUUZvDLE?t=955" target="_blank" rel="noopener">15:55</a><span><strong>Treat bot tokens like passwords.</strong> Create the Telegram bot through BotFather, restrict who may talk to it, and never paste the token into prompts or public config.</span></li>
+          <li><a class="timecode" href="https://youtu.be/dcXmUUZvDLE?t=1060" target="_blank" rel="noopener">17:40</a><span><strong>Discord's easy-to-miss step is intents.</strong> Enable the required message-content intents in the developer portal; skipping them produces a bot that connects but receives empty messages.</span></li>
+        </ul>
+      </div>
+    </details>
+  </div>
+</article>
+
+<article class="episode" id="episode-3">
+  <aside class="episode-rail" aria-hidden="true"><div class="episode-number">03</div><div class="episode-duration">34:20 · memory</div></aside>
+  <div class="episode-main">
+    <div class="episode-kind">module 03 · make context compound</div>
+    <div class="episode-heading-row"><h2 class="episode-title">Memory, Honcho &amp; Obsidian</h2><a class="watch-link" href="https://www.youtube.com/watch?v=ZKZLko9kLm4" target="_blank" rel="noopener">watch on YouTube ↗</a></div>
+    <div class="video-frame"><iframe src="https://www.youtube-nocookie.com/embed/ZKZLko9kLm4?rel=0" title="Hermes Agent Masterclass episode 3: Memory, plugins, Honcho, and Obsidian" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe></div>
+    <details class="episode-notes">
+      <summary><span>Here's what you need to know</span><span class="notes-arrow" aria-hidden="true">+</span></summary>
+      <div class="notes-body">
+        <div><div class="notes-label">the short version</div><p class="notes-tldr">Hermes memory is intentionally layered. Keep the tiny built-in files curated, search old sessions only when needed, add one provider for richer recall, and use an Obsidian vault for project-scale knowledge.</p></div>
+        <ul class="takeaways">
+          <li><a class="timecode" href="https://youtu.be/ZKZLko9kLm4?t=90" target="_blank" rel="noopener">01:30</a><span><strong>The small cap is a feature.</strong> <code>memory.md</code> and <code>user.md</code> share a tightly bounded prompt budget, forcing Hermes to retain durable preferences, facts, corrections, and conventions instead of a junk drawer.</span></li>
+          <li><a class="timecode" href="https://youtu.be/ZKZLko9kLm4?t=360" target="_blank" rel="noopener">06:00</a><span><strong>Memory writes appear next session.</strong> Disk updates immediately, but the system prompt stays frozen for the current session so prompt caching remains useful. A same-session test can therefore look “forgotten” even when the write succeeded.</span></li>
+          <li><a class="timecode" href="https://youtu.be/ZKZLko9kLm4?t=720" target="_blank" rel="noopener">12:00</a><span><strong>Session search is the deep archive.</strong> FTS5 lets Hermes retrieve an old conversation on demand without paying to keep every session in the active prompt.</span></li>
+          <li><a class="timecode" href="https://youtu.be/ZKZLko9kLm4?t=900" target="_blank" rel="noopener">15:00</a><span><strong>Run one provider at a time.</strong> Honcho, Mem0, Hindsight, and SuperMemory augment the built-in layer; switching providers does not migrate the memory you accumulated in the previous one.</span></li>
+          <li><a class="timecode" href="https://youtu.be/ZKZLko9kLm4?t=1260" target="_blank" rel="noopener">21:00</a><span><strong>Provider choice is about memory shape.</strong> Honcho emphasizes a modeled understanding of the user; other providers lean toward extraction, knowledge graphs, or partitioned containers. Pick the behavior you actually need.</span></li>
+          <li><a class="timecode" href="https://youtu.be/ZKZLko9kLm4?t=1560" target="_blank" rel="noopener">26:00</a><span><strong>Obsidian is a skill, not a provider.</strong> Use it for structured, long-form project knowledge that would overwhelm the built-in cap. Point the skill at a vault path and let Hermes create linked Markdown files.</span></li>
+        </ul>
+      </div>
+    </details>
+  </div>
+</article>
+
+<article class="episode" id="episode-4">
+  <aside class="episode-rail" aria-hidden="true"><div class="episode-number">04</div><div class="episode-duration">41:19 · skills</div></aside>
+  <div class="episode-main">
+    <div class="episode-kind">module 04 · procedural memory</div>
+    <div class="episode-heading-row"><h2 class="episode-title">Skills that grow with the agent</h2><a class="watch-link" href="https://www.youtube.com/watch?v=L3WdVeMaYZM" target="_blank" rel="noopener">watch on YouTube ↗</a></div>
+    <div class="video-frame"><iframe src="https://www.youtube-nocookie.com/embed/L3WdVeMaYZM?rel=0" title="Hermes Agent Masterclass episode 4: Skills" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe></div>
+    <details class="episode-notes">
+      <summary><span>Here's what you need to know</span><span class="notes-arrow" aria-hidden="true">+</span></summary>
+      <div class="notes-body">
+        <div><div class="notes-label">the short version</div><p class="notes-tldr">A skill is a reusable instruction package. The description gets it selected, the body teaches the procedure, and the Curator keeps custom skills from turning into an unmaintained pile.</p></div>
+        <ul class="takeaways">
+          <li><a class="timecode" href="https://youtu.be/L3WdVeMaYZM?t=120" target="_blank" rel="noopener">02:00</a><span><strong><code>SKILL.md</code> is the unit.</strong> Front matter names and describes the skill; the body contains the workflow. References, scripts, templates, and assets are optional supporting material.</span></li>
+          <li><a class="timecode" href="https://youtu.be/L3WdVeMaYZM?t=240" target="_blank" rel="noopener">04:00</a><span><strong>The description is the picker hint.</strong> Hermes sees names and descriptions before it reads a body. A vague description means the right skill may never load, no matter how good its instructions are.</span></li>
+          <li><a class="timecode" href="https://youtu.be/L3WdVeMaYZM?t=330" target="_blank" rel="noopener">05:30</a><span><strong>Progressive disclosure keeps context lean.</strong> Hermes can carry a large catalog because only the selected skill body enters the prompt; everything else stays on disk.</span></li>
+          <li><a class="timecode" href="https://youtu.be/L3WdVeMaYZM?t=1380" target="_blank" rel="noopener">23:00</a><span><strong>Install narrowly and inspect sources.</strong> Prefer bundled or trusted hub skills, let the security scan run, and use <code>/reload skills</code> to pick up changes without restarting the whole agent.</span></li>
+          <li><a class="timecode" href="https://youtu.be/L3WdVeMaYZM?t=1530" target="_blank" rel="noopener">25:30</a><span><strong>Agent-written skills are procedural memory.</strong> When a complex tool sequence works, capturing it as a skill makes the next run faster and more consistent than rediscovering the steps.</span></li>
+          <li><a class="timecode" href="https://youtu.be/L3WdVeMaYZM?t=1860" target="_blank" rel="noopener">31:00</a><span><strong>Pin what must not drift.</strong> The Curator grades and consolidates custom skills; pin a business-critical workflow so automated housekeeping cannot rewrite or archive it.</span></li>
+          <li><a class="timecode" href="https://youtu.be/L3WdVeMaYZM?t=2340" target="_blank" rel="noopener">39:00</a><span><strong>Know skill versus plugin.</strong> If you are teaching knowledge or a repeatable procedure, use a skill. If you are adding executable product surface, backend routes, or UI, build a plugin.</span></li>
+        </ul>
+      </div>
+    </details>
+  </div>
+</article>
+
+<article class="episode" id="episode-5">
+  <aside class="episode-rail" aria-hidden="true"><div class="episode-number">05</div><div class="episode-duration">25:20 · models</div></aside>
+  <div class="episode-main">
+    <div class="episode-kind">module 05 · spend intelligence wisely</div>
+    <div class="episode-heading-row"><h2 class="episode-title">Providers, models &amp; local inference</h2><a class="watch-link" href="https://www.youtube.com/watch?v=1oaaOWy7wSI" target="_blank" rel="noopener">watch on YouTube ↗</a></div>
+    <div class="video-frame"><iframe src="https://www.youtube-nocookie.com/embed/1oaaOWy7wSI?rel=0" title="Hermes Agent Masterclass episode 5: Providers and models" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe></div>
+    <details class="episode-notes">
+      <summary><span>Here's what you need to know</span><span class="notes-arrow" aria-hidden="true">+</span></summary>
+      <div class="notes-body">
+        <div><div class="notes-label">the short version</div><p class="notes-tldr">Use an expensive model where judgment matters and cheaper models everywhere else. Hermes separates providers, credentials, fallbacks, and auxiliary tasks so cost control does not require giving up a strong primary agent.</p></div>
+        <ul class="takeaways">
+          <li><a class="timecode" href="https://youtu.be/1oaaOWy7wSI?t=72" target="_blank" rel="noopener">01:12</a><span><strong>Provider and model are different decisions.</strong> The provider controls authentication, billing, and transport; the model controls capability, context, and price.</span></li>
+          <li><a class="timecode" href="https://youtu.be/1oaaOWy7wSI?t=321" target="_blank" rel="noopener">05:21</a><span><strong>Tier the work.</strong> Put routine title generation, session search, compression, and other auxiliary jobs on inexpensive models. Keep a better default or specialist model for tasks where mistakes cost more.</span></li>
+          <li><a class="timecode" href="https://youtu.be/1oaaOWy7wSI?t=616" target="_blank" rel="noopener">10:16</a><span><strong>Credential pools are resilience, not just billing.</strong> Rotate keys when one hits a rate limit; cron jobs and subagents inherit the pool automatically.</span></li>
+          <li><a class="timecode" href="https://youtu.be/1oaaOWy7wSI?t=745" target="_blank" rel="noopener">12:25</a><span><strong>Manual switching stays useful.</strong> Hermes does not offer arbitrary per-skill or complexity-based routing. Use <code>/model</code> mid-session when you know the next phase deserves a different model.</span></li>
+          <li><a class="timecode" href="https://youtu.be/1oaaOWy7wSI?t=818" target="_blank" rel="noopener">13:38</a><span><strong>Local tool calling needs the right server flags.</strong> In Tonbi's llama.cpp setup, quantized KV cache and flash attention make the model fit; the Jinja chat template is the easy-to-miss requirement for tools.</span></li>
+          <li><a class="timecode" href="https://youtu.be/1oaaOWy7wSI?t=1052" target="_blank" rel="noopener">17:32</a><span><strong>Ollama's context default can break agents.</strong> Set a sufficiently large context length before blaming Hermes for truncated plans or failed tool loops.</span></li>
+          <li><a class="timecode" href="https://youtu.be/1oaaOWy7wSI?t=1204" target="_blank" rel="noopener">20:04</a><span><strong>Hermes Proxy makes subscriptions reusable.</strong> It exposes a local OpenAI-compatible endpoint backed by your configured OAuth provider, so compatible tools can share that access without receiving the real credential.</span></li>
+        </ul>
+      </div>
+    </details>
+  </div>
+</article>
+
+<article class="episode" id="episode-6">
+  <aside class="episode-rail" aria-hidden="true"><div class="episode-number">06</div><div class="episode-duration">26:16 · tools</div></aside>
+  <div class="episode-main">
+    <div class="episode-kind">module 06 · give the model hands</div>
+    <div class="episode-heading-row"><h2 class="episode-title">Tools &amp; MCP servers</h2><a class="watch-link" href="https://www.youtube.com/watch?v=U140gP-1bEI" target="_blank" rel="noopener">watch on YouTube ↗</a></div>
+    <div class="video-frame"><iframe src="https://www.youtube-nocookie.com/embed/U140gP-1bEI?rel=0" title="Hermes Agent Masterclass episode 6: Tools and MCP servers" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe></div>
+    <details class="episode-notes">
+      <summary><span>Here's what you need to know</span><span class="notes-arrow" aria-hidden="true">+</span></summary>
+      <div class="notes-body">
+        <div><div class="notes-label">the short version</div><p class="notes-tldr">The model requests; Hermes executes. Keep that boundary explicit, expose only the tools a task needs, and treat every MCP server as new code entering the agent's trust surface.</p></div>
+        <ul class="takeaways">
+          <li><a class="timecode" href="https://youtu.be/U140gP-1bEI?t=184" target="_blank" rel="noopener">03:04</a><span><strong>A tool has three pieces.</strong> The function does the work, the schema tells the model when and how to call it, and the registry makes it available. The model never executes the function directly.</span></li>
+          <li><a class="timecode" href="https://youtu.be/U140gP-1bEI?t=240" target="_blank" rel="noopener">04:00</a><span><strong>Design the failure shape.</strong> Return a clean, structured error so the model can recover, choose another tool, or ask for missing input instead of crashing the whole turn.</span></li>
+          <li><a class="timecode" href="https://youtu.be/U140gP-1bEI?t=301" target="_blank" rel="noopener">05:01</a><span><strong>Prefer structured tools over shell improvisation.</strong> Purpose-built file, search, and patch tools are easier to audit and give the model a clearer recovery path than a chain of opaque shell commands.</span></li>
+          <li><a class="timecode" href="https://youtu.be/U140gP-1bEI?t=416" target="_blank" rel="noopener">06:56</a><span><strong>Scope and sandbox answer different questions.</strong> Tool sets decide what the agent can reach; local, Docker, or SSH backends decide where execution happens.</span></li>
+          <li><a class="timecode" href="https://youtu.be/U140gP-1bEI?t=600" target="_blank" rel="noopener">10:00</a><span><strong>Use the safe set for untrusted work.</strong> Read-only research and media tools without file writes or shell access are a better default for public-facing or research-only agents.</span></li>
+          <li><a class="timecode" href="https://youtu.be/U140gP-1bEI?t=732" target="_blank" rel="noopener">12:12</a><span><strong>Do not connect every MCP tool.</strong> Add the right server, filter it to the smallest useful surface, prefer OAuth to copied long-lived tokens, and let package scanning inspect local launchers.</span></li>
+          <li><a class="timecode" href="https://youtu.be/U140gP-1bEI?t=1288" target="_blank" rel="noopener">21:28</a><span><strong>Build a native tool for repeated, stable capability.</strong> A small API-backed function with a precise schema is a good fit when the agent should recognize and call the same operation automatically.</span></li>
+        </ul>
+      </div>
+    </details>
+  </div>
+</article>
+
+<article class="episode" id="episode-7">
+  <aside class="episode-rail" aria-hidden="true"><div class="episode-number">07</div><div class="episode-duration">35:55 · automation</div></aside>
+  <div class="episode-main">
+    <div class="episode-kind">module 07 · remove yourself from the loop</div>
+    <div class="episode-heading-row"><h2 class="episode-title">Cron &amp; automation</h2><a class="watch-link" href="https://www.youtube.com/watch?v=grMNnzCv2gY" target="_blank" rel="noopener">watch on YouTube ↗</a></div>
+    <div class="video-frame"><iframe src="https://www.youtube-nocookie.com/embed/grMNnzCv2gY?rel=0" title="Hermes Agent Masterclass episode 7: Cron and automation" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe></div>
+    <details class="episode-notes">
+      <summary><span>Here's what you need to know</span><span class="notes-arrow" aria-hidden="true">+</span></summary>
+      <div class="notes-body">
+        <div><div class="notes-label">the short version</div><p class="notes-tldr">A good cron job is a self-contained runbook, not a reminder to an agent that remembers yesterday. Use scripts for free polling, wake the model only when judgment is needed, and pass upstream output directly into downstream jobs.</p></div>
+        <ul class="takeaways">
+          <li><a class="timecode" href="https://youtu.be/grMNnzCv2gY?t=139" target="_blank" rel="noopener">02:19</a><span><strong>Cron lives in the gateway.</strong> The always-on gateway checks the schedule and creates a fresh, isolated session for each run.</span></li>
+          <li><a class="timecode" href="https://youtu.be/grMNnzCv2gY?t=381" target="_blank" rel="noopener">06:21</a><span><strong>Runaway self-scheduling is blocked.</strong> A cron execution cannot create more cron jobs, preventing a job-spawns-job loop from multiplying unnoticed.</span></li>
+          <li><a class="timecode" href="https://youtu.be/grMNnzCv2gY?t=550" target="_blank" rel="noopener">09:10</a><span><strong>Use <code>silent</code> for healthy states.</strong> Monitoring jobs can suppress routine “all good” deliveries while failures still surface.</span></li>
+          <li><a class="timecode" href="https://youtu.be/grMNnzCv2gY?t=678" target="_blank" rel="noopener">11:18</a><span><strong>Fresh sessions know nothing about “that issue.”</strong> Include the host, path, command, expected state, delivery target, and success/failure behavior in the job prompt.</span></li>
+          <li><a class="timecode" href="https://youtu.be/grMNnzCv2gY?t=759" target="_blank" rel="noopener">12:39</a><span><strong><code>no_agent</code> is the zero-model path.</strong> If a deterministic script can collect or check the state, let it run alone rather than spending tokens on narration.</span></li>
+          <li><a class="timecode" href="https://youtu.be/grMNnzCv2gY?t=890" target="_blank" rel="noopener">14:50</a><span><strong>Put a cheap gate before expensive judgment.</strong> A pre-run script can return “wake agent: false” until something changes, then hand the changed state to the model for triage.</span></li>
+          <li><a class="timecode" href="https://youtu.be/grMNnzCv2gY?t=1530" target="_blank" rel="noopener">25:30</a><span><strong><code>context-from</code> is enough for many pipelines.</strong> Feed the latest completed output of one or several jobs directly into the next prompt; this removes file-path bookkeeping and extra tool calls.</span></li>
+        </ul>
+      </div>
+    </details>
+  </div>
+</article>
+
+<article class="episode" id="episode-8">
+  <aside class="episode-rail" aria-hidden="true"><div class="episode-number">08</div><div class="episode-duration">33:27 · delegation</div></aside>
+  <div class="episode-main">
+    <div class="episode-kind">module 08 · parallelize the right work</div>
+    <div class="episode-heading-row"><h2 class="episode-title">Subagents &amp; delegation</h2><a class="watch-link" href="https://www.youtube.com/watch?v=_6DtQkDpcEs" target="_blank" rel="noopener">watch on YouTube ↗</a></div>
+    <div class="video-frame"><iframe src="https://www.youtube-nocookie.com/embed/_6DtQkDpcEs?rel=0" title="Hermes Agent Masterclass episode 8: Subagents and delegation" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe></div>
+    <details class="episode-notes">
+      <summary><span>Here's what you need to know</span><span class="notes-arrow" aria-hidden="true">+</span></summary>
+      <div class="notes-body">
+        <div><div class="notes-label">the short version</div><p class="notes-tldr">Delegate independent, messy work that benefits from a clean context or parallel execution. Brief each child like a stranger, keep its tools narrow, and reserve the stronger model for orchestration and final judgment.</p></div>
+        <ul class="takeaways">
+          <li><a class="timecode" href="https://youtu.be/_6DtQkDpcEs?t=141" target="_blank" rel="noopener">02:21</a><span><strong>Delegation solves context poisoning and serial slowness.</strong> Tool traces and false starts stay in the child's clean room; only the final summary returns to the parent.</span></li>
+          <li><a class="timecode" href="https://youtu.be/_6DtQkDpcEs?t=547" target="_blank" rel="noopener">09:07</a><span><strong>Subagents know nothing.</strong> “Fix the error” is not a brief. Include the exact failure, files, project root, environment, constraints, and definition of done.</span></li>
+          <li><a class="timecode" href="https://youtu.be/_6DtQkDpcEs?t=600" target="_blank" rel="noopener">10:00</a><span><strong>Give each child the least surface it needs.</strong> Research may need only web; review may need only read access. Children cannot exceed the parent's tools and leaf children are blocked from sensitive shared operations by default.</span></li>
+          <li><a class="timecode" href="https://youtu.be/_6DtQkDpcEs?t=672" target="_blank" rel="noopener">11:12</a><span><strong>Use cheap children and a strong parent.</strong> Route token-heavy collection to one inexpensive delegation model, then let the primary model synthesize short summaries.</span></li>
+          <li><a class="timecode" href="https://youtu.be/_6DtQkDpcEs?t=810" target="_blank" rel="noopener">13:30</a><span><strong>Concurrency is bounded.</strong> The default batch is three; larger batches error rather than silently queueing. If the parent is interrupted, synchronous children are canceled too.</span></li>
+          <li><a class="timecode" href="https://youtu.be/_6DtQkDpcEs?t=1247" target="_blank" rel="noopener">20:47</a><span><strong>Depth multiplies spend.</strong> Children cannot recurse by default. Orchestrator roles and higher spawn depth are opt-in because three branches across three levels can become 27 leaves.</span></li>
+          <li><a class="timecode" href="https://youtu.be/_6DtQkDpcEs?t=1320" target="_blank" rel="noopener">22:00</a><span><strong>Background is not durable.</strong> <code>background=true</code> lets a child outlive the current turn, but not the session. Use cron or a durable workflow when the work must survive restart.</span></li>
+          <li><a class="timecode" href="https://youtu.be/_6DtQkDpcEs?t=1380" target="_blank" rel="noopener">23:00</a><span><strong>Do not delegate tightly dependent work.</strong> Keep short, sequential, interactive tasks in one loop; use a script for deterministic mechanics and cron for scheduled or durable work.</span></li>
+        </ul>
+      </div>
+    </details>
+  </div>
+</article>
+
+<article class="episode" id="episode-9">
+  <aside class="episode-rail" aria-hidden="true"><div class="episode-number">09</div><div class="episode-duration">31:05 · orchestration</div></aside>
+  <div class="episode-main">
+    <div class="episode-kind">module 09 · build a durable team</div>
+    <div class="episode-heading-row"><h2 class="episode-title">Profiles &amp; Kanban</h2><a class="watch-link" href="https://www.youtube.com/watch?v=KPsMThlFb8Y" target="_blank" rel="noopener">watch on YouTube ↗</a></div>
+    <div class="video-frame"><iframe src="https://www.youtube-nocookie.com/embed/KPsMThlFb8Y?rel=0" title="Hermes Agent Masterclass episode 9: Profiles and Kanban" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe></div>
+    <details class="episode-notes">
+      <summary><span>Here's what you need to know</span><span class="notes-arrow" aria-hidden="true">+</span></summary>
+      <div class="notes-body">
+        <div><div class="notes-label">the short version</div><p class="notes-tldr">A profile is a whole persistent Hermes, not a temporary helper. Give each role its own state and model, contain its filesystem separately, then use Kanban when work must cross agents and survive restarts.</p></div>
+        <ul class="takeaways">
+          <li><a class="timecode" href="https://youtu.be/KPsMThlFb8Y?t=178" target="_blank" rel="noopener">02:58</a><span><strong>One profile means one isolated Hermes home.</strong> It has its own config, model, memory, skills, sessions, cron, logs, gateway, and persona. Two concurrent agents must not share one home or SQLite state will collide.</span></li>
+          <li><a class="timecode" href="https://youtu.be/KPsMThlFb8Y?t=801" target="_blank" rel="noopener">13:21</a><span><strong>Each gateway needs its own bot token.</strong> Several profiles can run messaging gateways on one machine, but Hermes blocks a second process from claiming a token already in use.</span></li>
+          <li><a class="timecode" href="https://youtu.be/KPsMThlFb8Y?t=975" target="_blank" rel="noopener">16:15</a><span><strong>Profiles isolate state, not your disk.</strong> A local-backend profile can still read the host filesystem. Pin its working directory and use Docker or SSH when you need a real boundary.</span></li>
+          <li><a class="timecode" href="https://youtu.be/KPsMThlFb8Y?t=1054" target="_blank" rel="noopener">17:34</a><span><strong>Profiles are portable.</strong> Export and import can package the agent's configuration, skills, cron, MCP setup, and persona as a reusable distribution.</span></li>
+          <li><a class="timecode" href="https://youtu.be/KPsMThlFb8Y?t=1128" target="_blank" rel="noopener">18:48</a><span><strong>Use Kanban for durable cross-agent work.</strong> Subagents fit a task you watch finish in one session; the SQLite-backed board survives gateway restarts and lets a human comment, block, or unblock mid-flight.</span></li>
+          <li><a class="timecode" href="https://youtu.be/KPsMThlFb8Y?t=1200" target="_blank" rel="noopener">20:00</a><span><strong>Routing reads descriptions, not names.</strong> Write each profile's one-line role precisely. The decomposer builds the task graph, then the router assigns tasks to the profile whose description fits.</span></li>
+          <li><a class="timecode" href="https://youtu.be/KPsMThlFb8Y?t=1260" target="_blank" rel="noopener">21:00</a><span><strong>Workers update the board through gated tools.</strong> They show, create, complete, block, and comment through the Kanban tool set rather than shelling into the database.</span></li>
+          <li><a class="timecode" href="https://youtu.be/KPsMThlFb8Y?t=1380" target="_blank" rel="noopener">23:00</a><span><strong>Model choice follows the assignee.</strong> There is no per-card override; route a task to a different profile when it needs a different model or tool surface.</span></li>
+        </ul>
+      </div>
+    </details>
+  </div>
+</article>
+
+<article class="episode" id="episode-10">
+  <aside class="episode-rail" aria-hidden="true"><div class="episode-number">10</div><div class="episode-duration">27:38 · security</div></aside>
+  <div class="episode-main">
+    <div class="episode-kind">module 10 · defense in depth</div>
+    <div class="episode-heading-row"><h2 class="episode-title">Security</h2><a class="watch-link" href="https://www.youtube.com/watch?v=KtlY6ETPyKo" target="_blank" rel="noopener">watch on YouTube ↗</a></div>
+    <div class="video-frame"><iframe src="https://www.youtube-nocookie.com/embed/KtlY6ETPyKo?rel=0" title="Hermes Agent Masterclass episode 10: Security" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe></div>
+    <details class="episode-notes">
+      <summary><span>Here's what you need to know</span><span class="notes-arrow" aria-hidden="true">+</span></summary>
+      <div class="notes-body">
+        <div><div class="notes-label">the short version</div><p class="notes-tldr">There is no fully capable, fully safe agent. Start with who can reach it, then layer approvals, containment, secret filtering, injection defenses, network controls, and per-profile least privilege.</p></div>
+        <ul class="takeaways">
+          <li><a class="timecode" href="https://youtu.be/KtlY6ETPyKo?t=125" target="_blank" rel="noopener">02:05</a><span><strong>Capability and safety move against each other.</strong> Tune the system for its real trust level—a private laptop, a team service, and a public gateway should not share one security posture.</span></li>
+          <li><a class="timecode" href="https://youtu.be/KtlY6ETPyKo?t=300" target="_blank" rel="noopener">05:00</a><span><strong>The gateway fails closed.</strong> Configure explicit platform or global user allowlists. With no matching permission, a message never reaches the agent.</span></li>
+          <li><a class="timecode" href="https://youtu.be/KtlY6ETPyKo?t=471" target="_blank" rel="noopener">07:51</a><span><strong>Pick approvals deliberately.</strong> Manual asks on risky commands, smart mode lets an auxiliary model approve clear low-risk actions and escalate uncertainty, and YOLO skips almost every prompt. Approval timeouts deny by default.</span></li>
+          <li><a class="timecode" href="https://youtu.be/KtlY6ETPyKo?t=686" target="_blank" rel="noopener">11:26</a><span><strong>YOLO still has a floor.</strong> Obvious system-wiping commands are rejected before the approval layer and have no agent-side override. If an operation is truly that destructive, do it manually outside the agent.</span></li>
+          <li><a class="timecode" href="https://youtu.be/KtlY6ETPyKo?t=800" target="_blank" rel="noopener">13:20</a><span><strong>Containment limits the blast radius.</strong> Local execution leans heavily on approvals; Docker can sacrifice a container instead of the host. Anything you explicitly mount or forward into that container is still readable and exfiltratable.</span></li>
+          <li><a class="timecode" href="https://youtu.be/KtlY6ETPyKo?t=1043" target="_blank" rel="noopener">17:23</a><span><strong>Secrets and instructions are filtered before the model sees them.</strong> MCP subprocesses receive a stripped environment, known token patterns are redacted, and prompt-bearing files are scanned for injection and exfiltration patterns.</span></li>
+          <li><a class="timecode" href="https://youtu.be/KtlY6ETPyKo?t=1140" target="_blank" rel="noopener">19:00</a><span><strong>Network controls matter too.</strong> SSRF protection blocks private and link-local ranges and rechecks redirects; use the shared website blocklist, and only allow private URLs when a trusted local service genuinely requires it.</span></li>
+          <li><a class="timecode" href="https://youtu.be/KtlY6ETPyKo?t=1208" target="_blank" rel="noopener">20:08</a><span><strong>Tirith catches what simple patterns miss.</strong> Its pre-execution scan looks for homoglyph domains, pipe-to-interpreter commands, and terminal injection tricks.</span></li>
+          <li><a class="timecode" href="https://youtu.be/KtlY6ETPyKo?t=1320" target="_blank" rel="noopener">22:00</a><span><strong>Apply least privilege per profile.</strong> A researcher can have a domain blocklist and safe tools; a coder can run inside Docker with manual approvals; a low-risk writer may need far less friction.</span></li>
+        </ul>
+      </div>
+    </details>
+  </div>
+</article>
+
+<aside class="source-note">
+  <strong>About these notes:</strong> Hermes Atlas distilled each module from Tonbi's YouTube description and auto-generated English transcript, then linked every takeaway back to the relevant timestamp. They are editorial summaries, not verbatim transcripts. Hermes Agent changes quickly, so verify version-sensitive commands and feature counts against the <a href="https://hermes-agent.nousresearch.com/docs/" target="_blank" rel="noopener">current official documentation ↗</a>.
+</aside>
+
+</main>
+
+<footer class="page-footer">
+  <div class="fn-left">hermes atlas · curated by <a href="https://github.com/ksimback">ksimback</a> · <a href="https://github.com/ksimback/hermes-ecosystem/issues">suggest a repo</a> · <a href="/privacy">privacy</a></div>
+  <div>v2 · 2026.07</div>
+</footer>
+
+<script src="/assets/js/theme-toggle.js" defer></script>
+<script src="/assets/js/masthead-fetch.js" defer></script>
+<!-- Cloudflare Web Analytics -->
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "fe0d4d79280b4386b6b0cd99b2d94dbc"}'></script>
+<!-- End Cloudflare Web Analytics -->
+</body>
+</html>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -40,21 +40,27 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">95·repos</span>
-    <span id="meta-version">hermes·v0.10.0</span>
+    <span id="meta-count">185·repos</span>
+    <span id="meta-version">hermes·v0.18.0</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/0xNyk/awesome-hermes-agent.html
+++ b/projects/0xNyk/awesome-hermes-agent.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/0xNyk/openclaw-to-hermes.html
+++ b/projects/0xNyk/openclaw-to-hermes.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/0xrsydn/nix-hermes-agent.html
+++ b/projects/0xrsydn/nix-hermes-agent.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/1ilkhamov/opencode-hermes-multiagent.html
+++ b/projects/1ilkhamov/opencode-hermes-multiagent.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/335234131/agent-browser-mcp.html
+++ b/projects/335234131/agent-browser-mcp.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/42-evey/evey-bridge-plugin.html
+++ b/projects/42-evey/evey-bridge-plugin.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/42-evey/evey-setup.html
+++ b/projects/42-evey/evey-setup.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/42-evey/hermes-plugins.html
+++ b/projects/42-evey/hermes-plugins.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/8bit64k/cronalytics.html
+++ b/projects/8bit64k/cronalytics.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/AMAP-ML/SkillClaw.html
+++ b/projects/AMAP-ML/SkillClaw.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/AaronWong1999/hermesclaw.html
+++ b/projects/AaronWong1999/hermesclaw.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/Abruptive/Ankh.md.html
+++ b/projects/Abruptive/Ankh.md.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/AbuZar-Ansarii/Hermes-Agent-On-Android.html
+++ b/projects/AbuZar-Ansarii/Hermes-Agent-On-Android.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/Agent-3-7/minions.html
+++ b/projects/Agent-3-7/minions.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/AgentLineHQ/agentline-skill.html
+++ b/projects/AgentLineHQ/agentline-skill.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/Agents365-ai/drawio-skill.html
+++ b/projects/Agents365-ai/drawio-skill.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/AkoliteZA/hermes-agent-idea-workflow.html
+++ b/projects/AkoliteZA/hermes-agent-idea-workflow.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/AlexAI-MCP/hermes-CCC.html
+++ b/projects/AlexAI-MCP/hermes-CCC.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/AxDSan/mnemosyne.html
+++ b/projects/AxDSan/mnemosyne.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/BORT-AGENTS/hermes-bort.html
+++ b/projects/BORT-AGENTS/hermes-bort.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/Christabel337/job-scout-agent.html
+++ b/projects/Christabel337/job-scout-agent.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/Codename-11/hermes-relay.html
+++ b/projects/Codename-11/hermes-relay.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/Context4GPTs/klodi-plugin.html
+++ b/projects/Context4GPTs/klodi-plugin.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/Cranot/super-hermes.html
+++ b/projects/Cranot/super-hermes.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/CryptoDmitry/hermes-agent-control-room.html
+++ b/projects/CryptoDmitry/hermes-agent-control-room.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/Cyber-Yichen/hermes-feishu-group-context.html
+++ b/projects/Cyber-Yichen/hermes-feishu-group-context.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/Cyber-Yichen/hermes-xiaomi-mimo-tts.html
+++ b/projects/Cyber-Yichen/hermes-xiaomi-mimo-tts.html
@@ -79,13 +79,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/DIALLOUBE-RESEARCH/hypernatt-terminal.html
+++ b/projects/DIALLOUBE-RESEARCH/hypernatt-terminal.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/DanielLi202/hermes-tag.html
+++ b/projects/DanielLi202/hermes-tag.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/DougTrajano/pydantic-ai-skills.html
+++ b/projects/DougTrajano/pydantic-ai-skills.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/EKKOLearnAI/hermes-web-ui.html
+++ b/projects/EKKOLearnAI/hermes-web-ui.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/EfficientContext/ContextPilot.html
+++ b/projects/EfficientContext/ContextPilot.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/Euraika-Labs/pan-ui.html
+++ b/projects/Euraika-Labs/pan-ui.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/Eynzof/hermes-agent-cn-desktop.html
+++ b/projects/Eynzof/hermes-agent-cn-desktop.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/FahrenheitResearch/hermes-weather-plugin.html
+++ b/projects/FahrenheitResearch/hermes-weather-plugin.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/Felix-Forever/hermes-agent-desktop.html
+++ b/projects/Felix-Forever/hermes-agent-desktop.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/JackTheGit/hermes-ai-infrastructure-monitoring-toolkit.html
+++ b/projects/JackTheGit/hermes-ai-infrastructure-monitoring-toolkit.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/JackTheGit/hermes-autonomous-server.html
+++ b/projects/JackTheGit/hermes-autonomous-server.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/Ladybug-Memory/hermes-memory-plugin.html
+++ b/projects/Ladybug-Memory/hermes-memory-plugin.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/Lethe044/hermes-incident-commander.html
+++ b/projects/Lethe044/hermes-incident-commander.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/MnrGreg/hermes-venice-web.html
+++ b/projects/MnrGreg/hermes-venice-web.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/MukundaKatta/hermes-agentmemory.html
+++ b/projects/MukundaKatta/hermes-agentmemory.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/NousResearch/Hermes-Function-Calling.html
+++ b/projects/NousResearch/Hermes-Function-Calling.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/NousResearch/atropos.html
+++ b/projects/NousResearch/atropos.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/NousResearch/autonovel.html
+++ b/projects/NousResearch/autonovel.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/NousResearch/hermes-agent-self-evolution.html
+++ b/projects/NousResearch/hermes-agent-self-evolution.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/NousResearch/hermes-agent.html
+++ b/projects/NousResearch/hermes-agent.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/NousResearch/hermes-paperclip-adapter.html
+++ b/projects/NousResearch/hermes-paperclip-adapter.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/OnlyTerp/hermes-optimization-guide.html
+++ b/projects/OnlyTerp/hermes-optimization-guide.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/PederHP/skillsdotnet.html
+++ b/projects/PederHP/skillsdotnet.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/Rainhoole/hermes-agent-acp-skill.html
+++ b/projects/Rainhoole/hermes-agent-acp-skill.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/ReinaMacCredy/maestro.html
+++ b/projects/ReinaMacCredy/maestro.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/Ridwannurudeen/hermes-council.html
+++ b/projects/Ridwannurudeen/hermes-council.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/Romanescu11/hermes-skill-factory.html
+++ b/projects/Romanescu11/hermes-skill-factory.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/Sahil-SS9/MrHermagi-tutorbot.html
+++ b/projects/Sahil-SS9/MrHermagi-tutorbot.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/Sahil-SS9/Toolaria.html
+++ b/projects/Sahil-SS9/Toolaria.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/Sahil-SS9/hermaguard.html
+++ b/projects/Sahil-SS9/hermaguard.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/Sahil-SS9/hermes-Custom-CLI-Themes.html
+++ b/projects/Sahil-SS9/hermes-Custom-CLI-Themes.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/Sahil-SS9/hermes-memlock.html
+++ b/projects/Sahil-SS9/hermes-memlock.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/Sahil-SS9/hermes-multichannel-prompt-optimizer.html
+++ b/projects/Sahil-SS9/hermes-multichannel-prompt-optimizer.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/Sahil-SS9/hermes-simplify-swarm.html
+++ b/projects/Sahil-SS9/hermes-simplify-swarm.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/Salomondiei08/oh-my-hermes.html
+++ b/projects/Salomondiei08/oh-my-hermes.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server.html
+++ b/projects/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/Signet-AI/signetai.html
+++ b/projects/Signet-AI/signetai.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/TheAiSingularity/hermesclaw.html
+++ b/projects/TheAiSingularity/hermesclaw.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/Xquik-dev/hermes-tweet.html
+++ b/projects/Xquik-dev/hermes-tweet.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/ZeroPointRepo/youtube-skills.html
+++ b/projects/ZeroPointRepo/youtube-skills.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/abundantbeing/hermes-browser-extension.html
+++ b/projects/abundantbeing/hermes-browser-extension.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/adityahimaone/hermes-agent-rtk-caveman.html
+++ b/projects/adityahimaone/hermes-agent-rtk-caveman.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/adnw-vinc/hermes-nextcloud.html
+++ b/projects/adnw-vinc/hermes-nextcloud.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/agent-of-empires/agent-of-empires.html
+++ b/projects/agent-of-empires/agent-of-empires.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/aidevelopers2/remoteopenclaw-mcp.html
+++ b/projects/aidevelopers2/remoteopenclaw-mcp.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/aivrar/portable-hermes-agent.html
+++ b/projects/aivrar/portable-hermes-agent.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/alchaincyf/hermes-agent-orange-book.html
+++ b/projects/alchaincyf/hermes-agent-orange-book.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/alias8818/hermes-tool-slimmer.html
+++ b/projects/alias8818/hermes-tool-slimmer.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/amanning3390/flowstate-qmd.html
+++ b/projects/amanning3390/flowstate-qmd.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/amanning3390/hermeshub.html
+++ b/projects/amanning3390/hermeshub.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/anneheartrecord/hermes-agent-anatomy.html
+++ b/projects/anneheartrecord/hermes-agent-anatomy.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/armelhbobdad/bmad-module-skill-forge.html
+++ b/projects/armelhbobdad/bmad-module-skill-forge.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/basilisk-labs/agentplane-hermes-plugin.html
+++ b/projects/basilisk-labs/agentplane-hermes-plugin.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/beardthelion/hermes-skill-distillation.html
+++ b/projects/beardthelion/hermes-skill-distillation.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/bergside/typeui.html
+++ b/projects/bergside/typeui.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/bigph00t/hermescraft.html
+++ b/projects/bigph00t/hermescraft.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/black-forest-labs/skills.html
+++ b/projects/black-forest-labs/skills.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/briancaffey/hermes-otel.html
+++ b/projects/briancaffey/hermes-otel.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/bryercowan/hermes-embodied.html
+++ b/projects/bryercowan/hermes-embodied.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/builderz-labs/mission-control.html
+++ b/projects/builderz-labs/mission-control.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/cablate/Agentic-MCP-Skill.html
+++ b/projects/cablate/Agentic-MCP-Skill.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/campfirein/byterover-cli.html
+++ b/projects/campfirein/byterover-cli.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/carterwayneskhizeine/hermes-agent-windows-R.html
+++ b/projects/carterwayneskhizeine/hermes-agent-windows-R.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/chainbase-labs/Agentkey.html
+++ b/projects/chainbase-labs/Agentkey.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/chigwell/skilldock.io.html
+++ b/projects/chigwell/skilldock.io.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/clawshell/clawshell.html
+++ b/projects/clawshell/clawshell.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/clawvader-tech/hermes-telegram-miniapp.html
+++ b/projects/clawvader-tech/hermes-telegram-miniapp.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/colbymchenry/codegraph.html
+++ b/projects/colbymchenry/codegraph.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/conorbronsdon/avoid-ai-writing.html
+++ b/projects/conorbronsdon/avoid-ai-writing.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/dodo-reach/hermes-desktop.html
+++ b/projects/dodo-reach/hermes-desktop.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/elkimek/honcho-self-hosted.html
+++ b/projects/elkimek/honcho-self-hosted.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/ellickjohnson/portainer-stack-hermes.html
+++ b/projects/ellickjohnson/portainer-stack-hermes.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/esaradev/icarus-plugin.html
+++ b/projects/esaradev/icarus-plugin.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/farion1231/cc-switch.html
+++ b/projects/farion1231/cc-switch.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/fathah/hermes-desktop.html
+++ b/projects/fathah/hermes-desktop.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/futurebrowser/hermes-exabase-plugin.html
+++ b/projects/futurebrowser/hermes-exabase-plugin.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/garrytan/gbrain.html
+++ b/projects/garrytan/gbrain.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/gizdusum/hermes-blockchain-oracle.html
+++ b/projects/gizdusum/hermes-blockchain-oracle.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/greyhaven-ai/autocontext.html
+++ b/projects/greyhaven-ai/autocontext.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/hlothaire/hermes-trace.html
+++ b/projects/hlothaire/hermes-trace.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/howdymary/hermes-agent-metaharness.html
+++ b/projects/howdymary/hermes-agent-metaharness.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/hxsteric/mercury.html
+++ b/projects/hxsteric/mercury.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/iOfficeAI/AionUi.html
+++ b/projects/iOfficeAI/AionUi.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/indranilbanerjee/digital-marketing-pro.html
+++ b/projects/indranilbanerjee/digital-marketing-pro.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/indranilbanerjee/socialforge.html
+++ b/projects/indranilbanerjee/socialforge.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/jau123/MeiGen-AI-Design-MCP.html
+++ b/projects/jau123/MeiGen-AI-Design-MCP.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/jazzyalex/agent-sessions.html
+++ b/projects/jazzyalex/agent-sessions.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/jefferyjob/awesome-hermes-agent-zh.html
+++ b/projects/jefferyjob/awesome-hermes-agent-zh.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/joeynyc/hermes-skins.html
+++ b/projects/joeynyc/hermes-skins.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/jpalmae/hermeshq.html
+++ b/projects/jpalmae/hermeshq.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/junhoyeo/tokscale.html
+++ b/projects/junhoyeo/tokscale.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/jwangkun/hermes-agent-guide.html
+++ b/projects/jwangkun/hermes-agent-guide.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/kaminocorp/hermes-alpha.html
+++ b/projects/kaminocorp/hermes-alpha.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/keepnotes-ai/keep.html
+++ b/projects/keepnotes-ai/keep.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/kevinmarmstrong/hermes-claude-code-rc.html
+++ b/projects/kevinmarmstrong/hermes-claude-code-rc.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/kfa-ai/hermes-timetree-sync.html
+++ b/projects/kfa-ai/hermes-timetree-sync.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/ksimback/hermes-ecosystem.html
+++ b/projects/ksimback/hermes-ecosystem.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/liaohch3/claude-tap.html
+++ b/projects/liaohch3/claude-tap.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/liftaris/herm.html
+++ b/projects/liftaris/herm.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/linke-ai/hermes-agent-team.html
+++ b/projects/linke-ai/hermes-agent-team.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/longyunfeigu/learn-hermes-agent.html
+++ b/projects/longyunfeigu/learn-hermes-agent.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/mag3nt-com/openclaw-skill.html
+++ b/projects/mag3nt-com/openclaw-skill.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/marshallrichards/ClawPhone.html
+++ b/projects/marshallrichards/ClawPhone.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/martymcenroe/HermesWiki.html
+++ b/projects/martymcenroe/HermesWiki.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/mem0ai/mem0.html
+++ b/projects/mem0ai/mem0.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/metantonio/hermes-wsl-ubuntu.html
+++ b/projects/metantonio/hermes-wsl-ubuntu.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/mudrii/hermes-agent-docs.html
+++ b/projects/mudrii/hermes-agent-docs.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/mukul975/Anthropic-Cybersecurity-Skills.html
+++ b/projects/mukul975/Anthropic-Cybersecurity-Skills.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/nativ3ai/hermes-agent-camel.html
+++ b/projects/nativ3ai/hermes-agent-camel.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/nativ3ai/hermes-payguard.html
+++ b/projects/nativ3ai/hermes-payguard.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/ndesv21/socialclaw.html
+++ b/projects/ndesv21/socialclaw.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/nesquena/hermes-webui.html
+++ b/projects/nesquena/hermes-webui.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/nexu-io/open-design.html
+++ b/projects/nexu-io/open-design.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/nickvasilescu/hermes-desktop-os1.html
+++ b/projects/nickvasilescu/hermes-desktop-os1.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/nujovich/hermes-telemetry.html
+++ b/projects/nujovich/hermes-telemetry.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/numtide/llm-agents.nix.html
+++ b/projects/numtide/llm-agents.nix.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/observeco/observeco.html
+++ b/projects/observeco/observeco.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/outsourc-e/hermes-workspace.html
+++ b/projects/outsourc-e/hermes-workspace.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/penfieldlabs/hermes-penfield.html
+++ b/projects/penfieldlabs/hermes-penfield.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/pengchengxia75-arch/hermes-agent-windows.html
+++ b/projects/pengchengxia75-arch/hermes-agent-windows.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/plastic-labs/honcho.html
+++ b/projects/plastic-labs/honcho.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/plur-ai/plur.html
+++ b/projects/plur-ai/plur.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/pyrate-llama/hermes-ui.html
+++ b/projects/pyrate-llama/hermes-ui.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/raulvidis/hermes-android.html
+++ b/projects/raulvidis/hermes-android.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/raulvidis/hermes-cloudflare.html
+++ b/projects/raulvidis/hermes-cloudflare.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/robbyczgw-cla/hermes-web-search-plus.html
+++ b/projects/robbyczgw-cla/hermes-web-search-plus.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/rodmarkun/anihermes.html
+++ b/projects/rodmarkun/anihermes.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/roli-lpci/lintlang.html
+++ b/projects/roli-lpci/lintlang.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/rookiemann/portable-hermes-agent.html
+++ b/projects/rookiemann/portable-hermes-agent.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/runtimenoteslabs/gladiator.html
+++ b/projects/runtimenoteslabs/gladiator.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/sanchomuzax/hermes-webui.html
+++ b/projects/sanchomuzax/hermes-webui.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/shannhk/hermes-agent-control-room.html
+++ b/projects/shannhk/hermes-agent-control-room.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/sheawinkler/hermes-agent-ultra.html
+++ b/projects/sheawinkler/hermes-agent-ultra.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/smartcontractkit/chainlink-agent-skills.html
+++ b/projects/smartcontractkit/chainlink-agent-skills.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/stainlu/hermes-labyrinth.html
+++ b/projects/stainlu/hermes-labyrinth.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/stephenschoettler/hermes-lcm.html
+++ b/projects/stephenschoettler/hermes-lcm.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/supermemoryai/supermemory.html
+++ b/projects/supermemoryai/supermemory.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/swarmclawai/swarmclaw.html
+++ b/projects/swarmclawai/swarmclaw.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/teixeirazeus/fablize-for-hermes.html
+++ b/projects/teixeirazeus/fablize-for-hermes.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/teknium1/hermes-miniverse.html
+++ b/projects/teknium1/hermes-miniverse.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/tiann/execplan-skill.html
+++ b/projects/tiann/execplan-skill.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/tinyhumansai/tiny.place.html
+++ b/projects/tinyhumansai/tiny.place.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/tlehman/litprog-skill.html
+++ b/projects/tlehman/litprog-skill.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/ucsandman/DashClaw.html
+++ b/projects/ucsandman/DashClaw.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/ultraworkers/hermes-agent-helm-chart.html
+++ b/projects/ultraworkers/hermes-agent-helm-chart.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/unmodeled-tyler/vessel-browser.html
+++ b/projects/unmodeled-tyler/vessel-browser.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/vectorize-io/hindsight.html
+++ b/projects/vectorize-io/hindsight.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/vectrocomputers/Hermes-Agent-Action-Plan.html
+++ b/projects/vectrocomputers/Hermes-Agent-Action-Plan.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/volcengine/OpenViking.html
+++ b/projects/volcengine/OpenViking.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/willingning-coder/eagle-eye.html
+++ b/projects/willingning-coder/eagle-eye.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/wondelai/skills.html
+++ b/projects/wondelai/skills.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/xaspx/hermes-control-interface.html
+++ b/projects/xaspx/hermes-control-interface.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/xiaonancs/hermes-agent-study.html
+++ b/projects/xiaonancs/hermes-agent-study.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/xmbshwll/hermes-agent-docker.html
+++ b/projects/xmbshwll/hermes-agent-docker.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/yantrikos/yantrikdb-hermes-plugin.html
+++ b/projects/yantrikos/yantrikdb-hermes-plugin.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/yepyhun/Brainstack.html
+++ b/projects/yepyhun/Brainstack.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/yoloshii/ClawMem.html
+++ b/projects/yoloshii/ClawMem.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/projects/yonro/hermes-xmemo-plugin.html
+++ b/projects/yonro/hermes-xmemo-plugin.html
@@ -86,13 +86,19 @@
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/reports/index.html
+++ b/reports/index.html
@@ -97,13 +97,19 @@
     <a href="/">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
     <a href="/dev/">dev</a>
     <a href="/reports/" class="active">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/reports/state-of-hermes-april-2026.html
+++ b/reports/state-of-hermes-april-2026.html
@@ -125,20 +125,27 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">95·repos</span>
-    <span id="meta-version">hermes·v0.10.0</span>
+    <span id="meta-count">185·repos</span>
+    <span id="meta-version">hermes·v0.18.0</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
+    <a href="/dev/">dev</a>
     <a href="/reports/" class="active">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/reports/state-of-hermes-may-2026.html
+++ b/reports/state-of-hermes-may-2026.html
@@ -125,20 +125,27 @@
 <header class="masthead">
   <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
   <div class="mast-meta" aria-label="Site metadata">
-    <span id="meta-count">123·repos</span>
-    <span id="meta-version">hermes·v0.14.0</span>
+    <span id="meta-count">185·repos</span>
+    <span id="meta-version">hermes·v0.18.0</span>
     <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
   </div>
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
     <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
+    <a href="/dev/">dev</a>
     <a href="/reports/" class="active">reports</a>
     <a href="/#newsletter">newsletter</a>
     <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>
 

--- a/rss.xml
+++ b/rss.xml
@@ -6,7 +6,7 @@
     <atom:link href="https://hermesatlas.com/rss.xml" rel="self" type="application/rss+xml" />
     <description>Newly added community-built tools, skills, plugins, and integrations for Nous Research's Hermes Agent. Updated daily.</description>
     <language>en</language>
-    <lastBuildDate>Thu, 09 Jul 2026 14:43:21 GMT</lastBuildDate>
+    <lastBuildDate>Sat, 11 Jul 2026 20:37:02 GMT</lastBuildDate>
     <generator>hermesatlas.com/scripts/build-pages.js</generator>
     <item>
       <title>fablize-for-hermes (Skills &amp; Skill Registries)</title>

--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -12,7 +12,7 @@
 
 import fs from "fs";
 import path from "path";
-import { execSync } from "child_process";
+import { execFileSync, execSync } from "child_process";
 import { fileURLToPath } from "url";
 import { marked } from "marked";
 import { JSDOM } from "jsdom";
@@ -279,6 +279,7 @@ function renderMasthead(activeNav) {
     { href: "/", label: "map", id: "map" },
     { href: "/lists/", label: "lists", id: "lists" },
     { href: "/guide/", label: "handbook", id: "handbook" },
+    { href: "/masterclass/", label: "masterclass", id: "masterclass" },
     { href: "/dev/", label: "dev", id: "dev" },
     { href: "/reports/", label: "reports", id: "reports" },
     { href: "/#newsletter", label: "newsletter", id: "newsletter" },
@@ -298,7 +299,12 @@ function renderMasthead(activeNav) {
     ${navHtml}
   </nav>
   <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
-    <span class="tt-light">light</span><span class="tt-sep">/</span><span class="tt-dark">dark</span>
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
   </button>
 </header>`;
 }
@@ -308,6 +314,48 @@ const PAGE_FOOTER = `<footer class="page-footer">
   <div class="fn-left">hermes atlas · curated by <a href="https://github.com/ksimback">ksimback</a> · <a href="https://github.com/ksimback/hermes-ecosystem/issues">suggest a repo</a> · <a href="/privacy">privacy</a></div>
   <div>v2 · 2026.04</div>
 </footer>`;
+
+// Keep the hand-authored surfaces on the same static masthead as generated
+// project/list pages. The site deploys plain HTML, so navigation must be in the
+// document itself (not injected client-side) for keyboard users and crawlers.
+function refreshSiteChrome() {
+  const targets = ["index.html", "404.html"];
+  const roots = ["guide", "dev", "reports", "privacy", "masterclass"];
+
+  const collect = (relDir) => {
+    const absDir = path.join(ROOT, relDir);
+    if (!fs.existsSync(absDir)) return;
+    for (const entry of fs.readdirSync(absDir, { withFileTypes: true })) {
+      const rel = `${relDir}/${entry.name}`;
+      if (entry.isDirectory()) collect(rel);
+      else if (entry.name.endsWith(".html")) targets.push(rel);
+    }
+  };
+  for (const relDir of roots) collect(relDir);
+
+  const activeFor = (rel) => {
+    if (rel === "index.html") return "map";
+    if (rel.startsWith("guide/")) return "handbook";
+    if (rel.startsWith("masterclass/")) return "masterclass";
+    if (rel.startsWith("dev/")) return "dev";
+    if (rel.startsWith("reports/")) return "reports";
+    return null;
+  };
+
+  let refreshed = 0;
+  for (const rel of [...new Set(targets)]) {
+    const abs = path.join(ROOT, rel);
+    if (!fs.existsSync(abs)) continue;
+    const original = fs.readFileSync(abs, "utf-8");
+    if (!/<header class="masthead">/.test(original)) continue;
+    const next = original.replace(
+      /<header class="masthead">[\s\S]*?<\/header>/,
+      renderMasthead(activeFor(rel)),
+    );
+    if (next !== original && writePage(abs, next)) refreshed++;
+  }
+  console.log(`  refreshed shared masthead on ${refreshed} hand-authored page(s)`);
+}
 
 // ── Split owner/repo for display ──
 function splitName(full) {
@@ -463,6 +511,7 @@ function stripHtmlToText(html) {
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
     .replace(/[ \t]+/g, " ")
+    .replace(/[ \t]+(?=\r?\n)/g, "")
     .replace(/\n\s*\n\s*\n+/g, "\n\n")
     .trim();
 }
@@ -579,6 +628,9 @@ Hermes Atlas tracks every open-source project in the Hermes Agent ecosystem acro
 - [The Hermes Agent Memory Guidebook](${SITE_URL}/guide/memory/): Kevin Simback's guide to native memory, MemoryProviders, and community memory plug-ins.
 - [Hermes Agent vs. Claude Code](${SITE_URL}/guide/vs-claude-code/): Feature-by-feature comparison for choosing between the two.
 
+## Masterclass
+- [Tonbi's Hermes Agent Masterclass](${SITE_URL}/masterclass/): Ten video modules covering setup, deployment, memory, skills, models, tools, automation, subagents, profiles, Kanban, and security, with transcript-derived field notes and timestamp links.
+
 ## Dev Tutorial
 A hands-on developer tutorial for building on the Hermes Agent codebase, written for agentic developers (no CS degree assumed). Seven modules plus reference sheets.
 - [Build on Hermes Agent (index)](${SITE_URL}/dev/): The tutorial hub — 7 modules from mental model to shipping your own extension.
@@ -651,6 +703,12 @@ This file is the companion to ${SITE_URL}/llms.txt (the concise index).`);
   try {
     const memoryDraft = fs.readFileSync(path.join(ROOT, "drafts", "guide-memory.md"), "utf-8");
     sections.push(`# The Hermes Agent Memory Guidebook (/guide/memory/)\n\nCanonical URL: ${SITE_URL}/guide/memory/\n\n${memoryDraft}`);
+  } catch {}
+
+  try {
+    const masterclassHtml = fs.readFileSync(path.join(ROOT, "masterclass", "index.html"), "utf-8");
+    const stripped = stripHtmlToText(masterclassHtml);
+    if (stripped) sections.push(`# Tonbi's Hermes Agent Masterclass (/masterclass/)\n\nCanonical URL: ${SITE_URL}/masterclass/\n\n${stripped}`);
   } catch {}
 
   try {
@@ -1265,6 +1323,8 @@ function generateSitemap(projectPages, listPages, reportPages = []) {
     urls += entry(`/guide/${slug}/`, `guide/${slug}/index.html`, "monthly", "0.8");
   }
 
+  urls += entry("/masterclass/", "masterclass/index.html", "monthly", "0.9");
+
   urls += entry("/dev/", "dev/index.html", "monthly", "0.9");
   const devSlugs = fs.readdirSync(path.join(ROOT, "dev"))
     .filter((f) => f.endsWith(".html") && f !== "index.html")
@@ -1701,22 +1761,28 @@ async function main() {
         }
       }
     } else {
-      // Offline: reuse the README HTML already baked into the existing page.
-      // Demote heading levels (h1→h2, ..., h5→h6) so the page has one <h1>,
-      // matching what the online `marked` renderer emits.
+      // Offline: reuse the README HTML already baked into the committed page.
+      // The online renderer has already demoted its headings exactly once; doing
+      // that again on every local build progressively collapses h2→h3→...→h6.
+      // Prefer HEAD so an in-progress generated-page diff cannot become the next
+      // build's input. Fall back to disk for a brand-new, not-yet-committed page.
       const existingPath = path.join(projectsDir, repo.owner, `${repo.repo}.html`);
       if (fs.existsSync(existingPath)) {
         try {
-          const existing = fs.readFileSync(existingPath, "utf-8");
+          const rel = path.relative(ROOT, existingPath).split(path.sep).join("/");
+          let existing;
+          try {
+            existing = execFileSync("git", ["show", `HEAD:${rel}`], {
+              cwd: ROOT,
+              encoding: "utf-8",
+              stdio: ["ignore", "pipe", "ignore"],
+            });
+          } catch {
+            existing = fs.readFileSync(existingPath, "utf-8");
+          }
           const match = existing.match(/<section class="readme"[^>]*>([\s\S]*?)<\/section>/);
           if (match && !match[1].includes("no-readme")) {
-            readmeHtml = sanitizeReadmeHtml(match[1]
-              .replace(/<(\/?)h5(\s|>)/g, "<$1h6$2")
-              .replace(/<(\/?)h4(\s|>)/g, "<$1h5$2")
-              .replace(/<(\/?)h3(\s|>)/g, "<$1h4$2")
-              .replace(/<(\/?)h2(\s|>)/g, "<$1h3$2")
-              .replace(/<(\/?)h1(\s|>)/g, "<$1h2$2")
-              .trim());
+            readmeHtml = sanitizeReadmeHtml(match[1].trim());
           }
         } catch {}
       }
@@ -1788,6 +1854,10 @@ async function main() {
   // Must run before writeLlmsFiles (which bundles the drafts and guide HTML)
   // and before generateSitemap (so refreshed pages get today's lastmod).
   refreshHandAuthoredPages(repos);
+
+  // Apply the canonical navigation + compact icon theme control to every
+  // hand-authored surface after its content freshness pass.
+  refreshSiteChrome();
 
   // Generate list pages
   console.log("Generating list pages...");

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,25 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://hermesatlas.com/</loc><changefreq>daily</changefreq><priority>1.0</priority><lastmod>2026-07-09</lastmod></url>
-  <url><loc>https://hermesatlas.com/guide/</loc><changefreq>monthly</changefreq><priority>0.9</priority><lastmod>2026-07-06</lastmod></url>
-  <url><loc>https://hermesatlas.com/guide/install/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>2026-07-06</lastmod></url>
+  <url><loc>https://hermesatlas.com/guide/</loc><changefreq>monthly</changefreq><priority>0.9</priority><lastmod>2026-07-09</lastmod></url>
+  <url><loc>https://hermesatlas.com/guide/install/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>2026-07-09</lastmod></url>
   <url><loc>https://hermesatlas.com/guide/memory/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>2026-07-09</lastmod></url>
-  <url><loc>https://hermesatlas.com/guide/vs-claude-code/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>2026-07-06</lastmod></url>
-  <url><loc>https://hermesatlas.com/dev/</loc><changefreq>monthly</changefreq><priority>0.9</priority><lastmod>2026-07-06</lastmod></url>
-  <url><loc>https://hermesatlas.com/dev/agent-loop</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-07-06</lastmod></url>
-  <url><loc>https://hermesatlas.com/dev/building-on-hermes</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-07-06</lastmod></url>
-  <url><loc>https://hermesatlas.com/dev/codebase-map</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-07-06</lastmod></url>
-  <url><loc>https://hermesatlas.com/dev/glossary</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-07-06</lastmod></url>
-  <url><loc>https://hermesatlas.com/dev/mcp-gateway-cron</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-07-06</lastmod></url>
-  <url><loc>https://hermesatlas.com/dev/memory</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-07-06</lastmod></url>
-  <url><loc>https://hermesatlas.com/dev/skill-template</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-07-06</lastmod></url>
-  <url><loc>https://hermesatlas.com/dev/skills</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-07-06</lastmod></url>
-  <url><loc>https://hermesatlas.com/dev/tools-and-toolsets</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-07-06</lastmod></url>
-  <url><loc>https://hermesatlas.com/dev/what-is-hermes-agent</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-07-06</lastmod></url>
-  <url><loc>https://hermesatlas.com/reports/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>2026-07-06</lastmod></url>
-  <url><loc>https://hermesatlas.com/reports/state-of-hermes-may-2026</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-07-06</lastmod></url>
-  <url><loc>https://hermesatlas.com/reports/state-of-hermes-april-2026</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-07-06</lastmod></url>
-  <url><loc>https://hermesatlas.com/privacy</loc><changefreq>yearly</changefreq><priority>0.3</priority><lastmod>2026-07-06</lastmod></url>
+  <url><loc>https://hermesatlas.com/guide/vs-claude-code/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>2026-07-09</lastmod></url>
+  <url><loc>https://hermesatlas.com/masterclass/</loc><changefreq>monthly</changefreq><priority>0.9</priority><lastmod>2026-07-11</lastmod></url>
+  <url><loc>https://hermesatlas.com/dev/</loc><changefreq>monthly</changefreq><priority>0.9</priority><lastmod>2026-07-09</lastmod></url>
+  <url><loc>https://hermesatlas.com/dev/agent-loop</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-07-09</lastmod></url>
+  <url><loc>https://hermesatlas.com/dev/building-on-hermes</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-07-09</lastmod></url>
+  <url><loc>https://hermesatlas.com/dev/codebase-map</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-07-09</lastmod></url>
+  <url><loc>https://hermesatlas.com/dev/glossary</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-07-09</lastmod></url>
+  <url><loc>https://hermesatlas.com/dev/mcp-gateway-cron</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-07-09</lastmod></url>
+  <url><loc>https://hermesatlas.com/dev/memory</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-07-09</lastmod></url>
+  <url><loc>https://hermesatlas.com/dev/skill-template</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-07-09</lastmod></url>
+  <url><loc>https://hermesatlas.com/dev/skills</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-07-09</lastmod></url>
+  <url><loc>https://hermesatlas.com/dev/tools-and-toolsets</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-07-09</lastmod></url>
+  <url><loc>https://hermesatlas.com/dev/what-is-hermes-agent</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-07-09</lastmod></url>
+  <url><loc>https://hermesatlas.com/reports/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>2026-07-09</lastmod></url>
+  <url><loc>https://hermesatlas.com/reports/state-of-hermes-may-2026</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-07-09</lastmod></url>
+  <url><loc>https://hermesatlas.com/reports/state-of-hermes-april-2026</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-07-09</lastmod></url>
+  <url><loc>https://hermesatlas.com/privacy</loc><changefreq>yearly</changefreq><priority>0.3</priority><lastmod>2026-07-09</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/NousResearch/hermes-agent</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-07-09</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/NousResearch/Hermes-Function-Calling</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-07-09</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/NousResearch/atropos</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-07-09</lastmod></url>
@@ -205,7 +206,7 @@
   <url><loc>https://hermesatlas.com/projects/aidevelopers2/remoteopenclaw-mcp</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-07-09</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/chainbase-labs/Agentkey</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-07-09</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/teixeirazeus/fablize-for-hermes</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-07-09</lastmod></url>
-  <url><loc>https://hermesatlas.com/lists/</loc><changefreq>weekly</changefreq><priority>0.7</priority><lastmod>2026-06-03</lastmod></url>
+  <url><loc>https://hermesatlas.com/lists/</loc><changefreq>weekly</changefreq><priority>0.7</priority><lastmod>2026-07-09</lastmod></url>
   <url><loc>https://hermesatlas.com/lists/best-memory-providers</loc><changefreq>weekly</changefreq><priority>0.6</priority><lastmod>2026-07-09</lastmod></url>
   <url><loc>https://hermesatlas.com/lists/top-skills</loc><changefreq>weekly</changefreq><priority>0.6</priority><lastmod>2026-07-09</lastmod></url>
   <url><loc>https://hermesatlas.com/lists/deployment-options</loc><changefreq>weekly</changefreq><priority>0.6</priority><lastmod>2026-07-09</lastmod></url>

--- a/tests/csp-compliance.test.js
+++ b/tests/csp-compliance.test.js
@@ -34,7 +34,11 @@ const HAND_WRITTEN = [
   path.join(root, "reports", "state-of-hermes-april-2026.html"),
   path.join(root, "reports", "state-of-hermes-may-2026.html"),
   ...walk(path.join(root, "guide"), []),
-  ...walk(path.join(root, "dev"), []),
+  ...walk(path.join(root, "dev"), []).filter((file) =>
+    !file.includes(`${path.sep}_repo${path.sep}`) &&
+    !file.includes(`${path.sep}lessons${path.sep}`)
+  ),
+  ...walk(path.join(root, "masterclass"), []),
 ].sort();
 
 const rel = (f) => path.relative(root, f).replace(/\\/g, "/");

--- a/tests/masterclass-page.test.js
+++ b/tests/masterclass-page.test.js
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { JSDOM } from "jsdom";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel), "utf-8");
+const masterclass = read("masterclass/index.html");
+const document = new JSDOM(masterclass).window.document;
+
+const VIDEO_IDS = [
+  "R3YOGfTBcQg",
+  "dcXmUUZvDLE",
+  "ZKZLko9kLm4",
+  "L3WdVeMaYZM",
+  "1oaaOWy7wSI",
+  "U140gP-1bEI",
+  "grMNnzCv2gY",
+  "_6DtQkDpcEs",
+  "KPsMThlFb8Y",
+  "KtlY6ETPyKo",
+];
+
+test("masterclass presents all ten modules in order with privacy-enhanced embeds", () => {
+  const episodes = [...document.querySelectorAll("article.episode")];
+  assert.equal(episodes.length, 10);
+  assert.deepEqual(episodes.map((el) => el.id), VIDEO_IDS.map((_, i) => `episode-${i + 1}`));
+
+  const embeds = episodes.map((el) => el.querySelector("iframe")?.getAttribute("src"));
+  assert.deepEqual(
+    embeds,
+    VIDEO_IDS.map((id) => `https://www.youtube-nocookie.com/embed/${id}?rel=0`),
+  );
+  for (const iframe of document.querySelectorAll("iframe")) {
+    assert.ok(iframe.hasAttribute("title"), "every iframe has a title");
+    assert.ok(iframe.hasAttribute("allowfullscreen"), "every iframe allows fullscreen");
+  }
+});
+
+test("every episode has useful expandable notes and timestamp links", () => {
+  const episodes = [...document.querySelectorAll("article.episode")];
+  for (const [index, episode] of episodes.entries()) {
+    const details = episode.querySelector("details.episode-notes");
+    assert.ok(details, `episode ${index + 1} has expandable notes`);
+    assert.ok(details.querySelector(".notes-tldr")?.textContent.trim().length > 80);
+    assert.ok(details.querySelectorAll(".takeaways li").length >= 6);
+    assert.ok(details.querySelectorAll("a.timecode").length >= 6);
+  }
+});
+
+test("Tonbi attribution and source links are prominent", () => {
+  assert.ok(masterclass.includes("https://www.youtube.com/@TonbisAIGarage"));
+  assert.ok(masterclass.includes("PLmpUb_PWAkDx-VWjh00tVCji794xAa_IX"));
+  assert.ok(masterclass.includes("https://x.com/tonbistudio"));
+  assert.match(masterclass, /distilled each module from Tonbi's YouTube description and auto-generated English transcript/);
+});
+
+test("shared navigation exposes Masterclass and uses compact theme icons", () => {
+  const repos = JSON.parse(read("data/repos.json"));
+  const samples = [
+    "index.html",
+    "guide/index.html",
+    "lists/index.html",
+    "reports/index.html",
+    `projects/${repos[0].owner}/${repos[0].repo}.html`,
+    "masterclass/index.html",
+  ];
+
+  for (const rel of samples) {
+    const html = read(rel);
+    assert.ok(html.includes('href="/masterclass/"'), `${rel} links Masterclass`);
+    const doc = new JSDOM(html).window.document;
+    const toggle = doc.querySelector("#theme-toggle");
+    assert.ok(toggle, `${rel} has a theme toggle`);
+    assert.equal(toggle.querySelectorAll("svg").length, 2, `${rel} uses two theme icons`);
+    assert.equal(toggle.textContent.trim(), "", `${rel} has no visible Light / Dark text`);
+  }
+});
+
+test("CSP explicitly allows only the privacy-enhanced YouTube frame origin", () => {
+  const vercel = JSON.parse(read("vercel.json"));
+  const staticHeaders = vercel.headers.find((entry) => entry.source === "/((?!api/).*)");
+  const csp = staticHeaders?.headers.find((header) => header.key === "Content-Security-Policy")?.value;
+  assert.ok(csp?.includes("frame-src https://www.youtube-nocookie.com"));
+  assert.ok(!csp?.includes("frame-src https://www.youtube.com"));
+});

--- a/tests/seo-pages.test.js
+++ b/tests/seo-pages.test.js
@@ -76,6 +76,7 @@ test("homepage baked counters match the catalog", () => {
 test("sitemap covers lists index + all projects, with lastmod on every URL", () => {
   const sitemap = read("sitemap.xml");
   assert.ok(sitemap.includes("<loc>https://hermesatlas.com/lists/</loc>"), "/lists/ in sitemap");
+  assert.ok(sitemap.includes("<loc>https://hermesatlas.com/masterclass/</loc>"), "/masterclass/ in sitemap");
   for (const r of repos) {
     assert.ok(
       sitemap.includes(`<loc>https://hermesatlas.com/projects/${r.owner}/${r.repo}</loc>`),

--- a/vercel.json
+++ b/vercel.json
@@ -35,7 +35,7 @@
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "X-Frame-Options", "value": "DENY" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' https://static.cloudflareinsights.com; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://cloudflareinsights.com; frame-ancestors 'none'; base-uri 'self'; object-src 'none'; form-action 'self'" },
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' https://static.cloudflareinsights.com; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://cloudflareinsights.com; frame-src https://www.youtube-nocookie.com; frame-ancestors 'none'; base-uri 'self'; object-src 'none'; form-action 'self'" },
         { "key": "Cache-Control", "value": "public, max-age=3600, s-maxage=86400" }
       ]
     }


### PR DESCRIPTION
## What changed

- adds a top-level Masterclass page containing Tonbi's complete ten-part Hermes Agent course
- adds transcript-derived expandable takeaways and timestamp links for every episode
- adds Tonbi channel and playlist attribution
- adds the Masterclass navigation item and compact light/dark icons site-wide
- updates the generator, sitemap, LLM indexes, structured metadata, and YouTube CSP
- adds regression coverage for video order, notes, attribution, navigation, and CSP

## Why

Hermes Atlas should provide an elegant, useful learning path around Tonbi's course instead of only linking to raw videos.

## Validation

- `npm test` - 121/121 passing
- desktop and mobile responsive browser QA
- remote Git tree verified byte-for-byte against the tested local commit