### PR TITLE
Fix generated artifact staging drift

### DIFF
--- a/lib/build-artifacts.js
+++ b/lib/build-artifacts.js
@@ -1,7 +1,24 @@
 import { execFileSync } from "child_process";
 
+// build-pages.js refreshes facts and dates in these hand-authored pages. Keep
+// the targets here so the generator and the staging manifest cannot drift.
+export const REFRESHED_CONTENT_PATHS = [
+  "guide/index.html",
+  "guide/install/index.html",
+  "guide/memory/index.html",
+  "guide/vs-claude-code/index.html",
+  "drafts/handbook-hub.md",
+  "drafts/handbook-vs-claude-code.md",
+  "drafts/guide-memory.md",
+];
+
 export const GENERATED_ARTIFACT_PATHS = [
   "index.html",
+  "404.html",
+  ...REFRESHED_CONTENT_PATHS,
+  "dev/",
+  "privacy/",
+  "masterclass/",
   "projects/",
   "lists/",
   "reports/",

--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -18,6 +18,7 @@ import { marked } from "marked";
 import { JSDOM } from "jsdom";
 import createDOMPurify from "dompurify";
 import { githubHeaders, fetchReadme, fetchAllMetadata } from "../lib/github.js";
+import { REFRESHED_CONTENT_PATHS } from "../lib/build-artifacts.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..");
@@ -1641,18 +1642,8 @@ function refreshHandAuthoredPages(repos) {
     [/\*\*Last updated:\*\* \d{4}-\d{2}-\d{2}/g, `**Last updated:** ${today}`],
   ];
 
-  const targets = [
-    "guide/index.html",
-    "guide/install/index.html",
-    "guide/memory/index.html",
-    "guide/vs-claude-code/index.html",
-    "drafts/handbook-hub.md",
-    "drafts/handbook-vs-claude-code.md",
-    "drafts/guide-memory.md",
-  ];
-
   console.log("\nRefreshing hand-authored guide pages...");
-  for (const rel of targets) {
+  for (const rel of REFRESHED_CONTENT_PATHS) {
     const abs = path.join(ROOT, rel);
     if (!fs.existsSync(abs)) continue;
     const original = fs.readFileSync(abs, "utf-8");

--- a/tests/build-artifacts.test.js
+++ b/tests/build-artifacts.test.js
@@ -3,6 +3,7 @@ import { test } from "node:test";
 
 import {
   GENERATED_ARTIFACT_PATHS,
+  REFRESHED_CONTENT_PATHS,
   assertNoUnstagedChanges,
   parsePorcelainStatus,
 } from "../lib/build-artifacts.js";
@@ -10,6 +11,11 @@ import {
 test("generated artifact manifest covers current build outputs", () => {
   assert.deepEqual(GENERATED_ARTIFACT_PATHS, [
     "index.html",
+    "404.html",
+    ...REFRESHED_CONTENT_PATHS,
+    "dev/",
+    "privacy/",
+    "masterclass/",
     "projects/",
     "lists/",
     "reports/",
@@ -23,6 +29,15 @@ test("generated artifact manifest covers current build outputs", () => {
     "data/list-summaries.json",
     "data/latest-release.json",
   ]);
+});
+
+test("every hand-authored page refreshed by the build is staged", () => {
+  for (const outputPath of REFRESHED_CONTENT_PATHS) {
+    assert.ok(
+      GENERATED_ARTIFACT_PATHS.includes(outputPath),
+      `${outputPath} is missing from the generated artifact manifest`
+    );
+  }
 });
 
 test("porcelain parser identifies unstaged modified and untracked files", () => {


### PR DESCRIPTION
## What changed

- defines the hand-authored freshness targets once and shares them between the page generator and artifact staging
- stages every surface that the shared masthead updater can rewrite, including 404, dev, privacy, and masterclass pages
- adds regression coverage for the refreshed-content manifest

## Root cause

`build-pages.js` legitimately refreshed guide and handbook files that were absent from `GENERATED_ARTIFACT_PATHS`. The scheduled workflow generated the site successfully, then failed because those outputs remained unstaged. The generator also had a second undocumented output surface through `refreshSiteChrome()`.

## Validation

- `npm test` — 122/122 passed
- `node --test tests/build-artifacts.test.js` — 5/5 passed
- clean detached-worktree integration: `node scripts/build-pages.js` then `node scripts/stage-build-artifacts.js` — passed with zero unstaged outputs
- `git diff --check` — passed

## Operational acceptance after merge

Run the workflow manually once, then require the next two scheduled `build-pages` runs to complete successfully before closing the existing workflow alert.