### PR TITLE
Make release ingestion complete and self-healing

### DIFF
--- a/.github/workflows/rebuild-chunks.yml
+++ b/.github/workflows/rebuild-chunks.yml
@@ -25,6 +25,7 @@ jobs:
   rebuild:
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
       issues: write
 
@@ -90,6 +91,22 @@ jobs:
           done
           echo "Push failed after 3 attempts"
           exit 1
+
+      # Commits made with GITHUB_TOKEN do not trigger another workflow from a
+      # push event. Dispatch the page build explicitly so latest-release.json
+      # reaches the static homepage instead of stopping at the RAG artifact.
+      - name: Dispatch page rebuild
+        if: steps.diff.outputs.changed == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'build-pages.yml',
+              ref: 'main'
+            });
+            console.log('Dispatched build-pages.yml after knowledge data update');
 
       # Escalate silent failures — this workflow rebuilds the RAG knowledge base
       # that Ask the Atlas answers from; a failed run was previously only a red X.

--- a/.github/workflows/release-monitor.yml
+++ b/.github/workflows/release-monitor.yml
@@ -5,14 +5,14 @@ env:
 
 on:
   schedule:
-    # Run daily at 06:00 UTC (checks releases + docs changes)
     - cron: '0 6 * * *'
-  workflow_dispatch: # Allow manual trigger
+  workflow_dispatch:
 
 jobs:
   check-releases:
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
       pull-requests: write
       issues: write
@@ -21,314 +21,33 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Check for new Hermes Agent releases
-        id: check
-        uses: actions/github-script@v7
+      - name: Setup Node
+        uses: actions/setup-node@v4
         with:
-          script: |
-            const fs = require('fs');
+          node-version: '22'
 
-            // Get latest release from NousResearch/hermes-agent
-            let latestRelease;
-            try {
-              const { data } = await github.rest.repos.getLatestRelease({
-                owner: 'NousResearch',
-                repo: 'hermes-agent'
-              });
-              latestRelease = data;
-            } catch (e) {
-              console.log('No releases found or API error:', e.message);
-              core.setOutput('new_release', 'false');
-              return;
-            }
-
-            const tag = latestRelease.tag_name;
-            const releaseName = latestRelease.name || tag;
-            const publishedAt = latestRelease.published_at;
-            const body = latestRelease.body || '';
-
-            console.log(`Latest release: ${releaseName} (${tag}) published ${publishedAt}`);
-
-            // Check if we already have this release documented
-            const researchDir = 'research';
-            const existingFiles = fs.readdirSync(researchDir);
-
-            // Look for the version number in existing research files
-            const versionClean = tag.replace(/^v/, '').replace(/[^0-9.]/g, '');
-            const alreadyTracked = existingFiles.some(f => {
-              if (!f.endsWith('.md')) return false;
-              const content = fs.readFileSync(`${researchDir}/${f}`, 'utf-8');
-              return content.includes(tag) || content.includes(versionClean);
-            });
-
-            if (alreadyTracked) {
-              console.log(`Release ${tag} already tracked in research files`);
-              core.setOutput('new_release', 'false');
-              return;
-            }
-
-            console.log(`New release found: ${tag} — not yet in research files`);
-            core.setOutput('new_release', 'true');
-            core.setOutput('tag', tag);
-            core.setOutput('release_name', releaseName);
-            core.setOutput('published_at', publishedAt);
-            core.setOutput('body', body);
-
-      - name: Fetch full release notes from repo
-        if: steps.check.outputs.new_release == 'true'
-        id: notes
+      - name: Synchronize every missing Hermes Agent release
+        id: releases
         env:
-          RELEASE_TAG: ${{ steps.check.outputs.tag }}
-          RELEASE_BODY: ${{ steps.check.outputs.body }}
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const tag = process.env.RELEASE_TAG || '';
-            const versionClean = tag.replace(/^v/, '').replace(/[^0-9.]/g, '');
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/sync-releases.js
 
-            // Try to fetch the RELEASE_vX.Y.Z.md file from the repo
-            let releaseNotes = '';
-            const filenames = [
-              `RELEASE_v${versionClean}.md`,
-              `RELEASE_${tag}.md`,
-              `CHANGELOG.md`
-            ];
-
-            for (const filename of filenames) {
-              try {
-                const { data } = await github.rest.repos.getContent({
-                  owner: 'NousResearch',
-                  repo: 'hermes-agent',
-                  path: filename,
-                  ref: 'main'
-                });
-                releaseNotes = Buffer.from(data.content, 'base64').toString('utf-8');
-                console.log(`Found release notes in ${filename} (${releaseNotes.length} chars)`);
-                break;
-              } catch {
-                console.log(`${filename} not found, trying next...`);
-              }
-            }
-
-            // Fall back to the release body from GitHub Releases.
-            // Read from env to avoid JS string-injection issues with backticks,
-            // ${} template syntax, and quote characters in the release body.
-            if (!releaseNotes) {
-              releaseNotes = process.env.RELEASE_BODY || '';
-              console.log(`Using GitHub Release body (${releaseNotes.length} chars)`);
-            }
-
-            // Only truncate truly massive files (200K+). We want FULL release notes
-            // in the KB so the chatbot can answer detailed questions.
-            if (releaseNotes.length > 200000) {
-              releaseNotes = releaseNotes.slice(0, 200000) + '\n\n[Truncated — see full release notes on GitHub]';
-            }
-
-            core.setOutput('content', releaseNotes);
-            core.setOutput('has_notes', releaseNotes.length > 100 ? 'true' : 'false');
-
-      - name: Create research file and open PR
-        if: steps.check.outputs.new_release == 'true' && steps.notes.outputs.has_notes == 'true'
-        env:
-          RELEASE_TAG: ${{ steps.check.outputs.tag }}
-          RELEASE_NAME: ${{ steps.check.outputs.release_name }}
-          PUBLISHED_AT: ${{ steps.check.outputs.published_at }}
-          RELEASE_CONTENT: ${{ steps.notes.outputs.content }}
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const tag = process.env.RELEASE_TAG || '';
-            const releaseName = process.env.RELEASE_NAME || tag;
-            const publishedAt = process.env.PUBLISHED_AT || '';
-            const content = process.env.RELEASE_CONTENT || '';
-            const versionClean = tag.replace(/^v/, '').replace(/[^0-9.]/g, '');
-
-            // Build the research file content (inline to keep YAML block
-            // scalar indentation valid — literal newlines that dedent to
-            // column 0 break YAML parsing).
-            const fileContent = [
-              `# Hermes Agent ${tag} Release Notes`,
-              '',
-              `**Version:** ${tag}`,
-              `**Published:** ${publishedAt}`,
-              `**Source:** https://github.com/NousResearch/hermes-agent/releases/tag/${tag}`,
-              '',
-              content,
-              ''
-            ].join('\n');
-
-            // Determine filename (increment from existing)
-            const fs = require('fs');
-            const existing = fs.readdirSync('research')
-              .filter(f => f.match(/^\d+-/))
-              .sort()
-              .pop();
-            const nextNum = existing ? parseInt(existing.split('-')[0]) + 1 : 30;
-            const filename = `research/${nextNum}-release-${versionClean.replace(/\./g, '-')}.md`;
-
-            // Create branch and PR
-            const branch = `release-notes-${versionClean}`;
-
-            // Idempotency: if an open PR already exists for this version,
-            // skip cleanly (don't disturb the existing PR or branch).
-            const { data: openPrs } = await github.rest.pulls.list({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              head: `${context.repo.owner}:${branch}`,
-              state: 'open'
-            });
-            if (openPrs.length > 0) {
-              console.log(`PR already open for ${tag}: #${openPrs[0].number} — skipping.`);
-              return;
-            }
-
-            const { data: ref } = await github.rest.git.getRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: 'heads/main'
-            });
-
-            // Clean up any stale branch from a prior failed run
-            // (no open PR points at it, so it's safe to delete).
-            try {
-              await github.rest.git.deleteRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: `heads/${branch}`
-              });
-              console.log(`Deleted stale branch ${branch}`);
-            } catch (e) {
-              // Branch didn't exist — that's fine
-            }
-
-            await github.rest.git.createRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: `refs/heads/${branch}`,
-              sha: ref.object.sha
-            });
-
-            await github.rest.repos.createOrUpdateFileContents({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              path: filename,
-              message: `Add ${tag} release notes to knowledge base`,
-              content: Buffer.from(fileContent).toString('base64'),
-              branch
-            });
-
-            const { data: pr } = await github.rest.pulls.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: `New release: Hermes Agent ${tag}`,
-              body: `Hermes Agent ${releaseName} was published on ${publishedAt}.\n\nThis PR adds the release notes to the research knowledge base at \`${filename}\`.\n\nAfter merge, the chunks rebuild action will automatically update the chatbot's knowledge.\n\n[View release on GitHub](https://github.com/NousResearch/hermes-agent/releases/tag/${tag})`,
-              head: branch,
-              base: 'main'
-            });
-
-            console.log(`PR #${pr.number} created for ${tag}`);
-
-            // Enable native auto-merge so the PR lands without a manual click.
-            // Content is copied verbatim from upstream RELEASE_v*.md (or the
-            // GitHub release body) — not LLM-generated — so the human review
-            // checkpoint here was guarding against zero hallucination risk.
-            //
-            // GitHub returns "Pull request is in unstable status" when
-            // enablePullRequestAutoMerge is called immediately after PR
-            // creation because mergeStateStatus is still UNKNOWN (merge
-            // state hasn't computed yet). This is exactly what kept PR #173
-            // (v0.13.0) and the 2026-05-17 burst orphan for hours behind a
-            // silent warning. Fix: poll for a non-UNKNOWN merge state
-            // before enabling, with a short max wait so we don't burn time.
-            // Tracking issue only opens if the state never settles OR the
-            // mutation still fails for a reason other than the race.
-            let autoMergeEnabled = false;
-            let mergeState = 'UNKNOWN';
-            // Poll until a TERMINAL merge state. The earlier fix broke on the
-            // first non-UNKNOWN reading, but UNSTABLE (checks still running) is
-            // non-UNKNOWN — enabling auto-merge during UNSTABLE is exactly what
-            // GitHub rejects with "Pull request is in unstable status", the
-            // recurring #332/#396/#450 failure. UNKNOWN/UNSTABLE/BEHIND are
-            // transient; wait for one of these terminal states or time out.
-            const TERMINAL = new Set(['CLEAN', 'HAS_HOOKS', 'BLOCKED', 'DIRTY']);
-            for (let i = 0; i < 24; i++) {
-              const { repository } = await github.graphql(
-                `query($owner: String!, $repo: String!, $num: Int!) {
-                  repository(owner: $owner, name: $repo) {
-                    pullRequest(number: $num) { mergeStateStatus }
-                  }
-                }`,
-                { owner: context.repo.owner, repo: context.repo.repo, num: pr.number }
-              );
-              mergeState = repository.pullRequest.mergeStateStatus;
-              if (mergeState && TERMINAL.has(mergeState)) break;
-              await new Promise(r => setTimeout(r, 5000));
-            }
-            console.log(`PR #${pr.number} mergeStateStatus settled to ${mergeState}`);
-
-            // Enable auto-merge, retrying the mutation on the transient
-            // "unstable status" rejection with backoff — the state can still
-            // flip to UNSTABLE between the poll and the mutation.
-            let lastErr = null;
-            for (let attempt = 0; attempt < 4; attempt++) {
-              try {
-                await github.graphql(
-                  `mutation($pullRequestId: ID!) {
-                    enablePullRequestAutoMerge(input: {
-                      pullRequestId: $pullRequestId,
-                      mergeMethod: MERGE
-                    }) {
-                      pullRequest { autoMergeRequest { enabledAt } }
-                    }
-                  }`,
-                  { pullRequestId: pr.node_id }
-                );
-                autoMergeEnabled = true;
-                console.log(`Auto-merge enabled on PR #${pr.number}`);
-                break;
-              } catch (e) {
-                lastErr = e;
-                if (!/unstable/i.test(e.message) || attempt === 3) break;
-                await new Promise(r => setTimeout(r, 10000 * (attempt + 1)));
-              }
-            }
-            if (!autoMergeEnabled) {
-              await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title: `[Workflow] Auto-merge failed on release PR #${pr.number}`,
-                body: `Could not enable auto-merge on release-notes PR #${pr.number} for ${tag}.\n\n**Merge state at attempt:** \`${mergeState}\`\n**Error:** \`${lastErr && lastErr.message}\`\n\n**Action:** review and merge the PR manually.`,
-                labels: ['workflow-issue']
-              });
-              core.warning(`Auto-merge failed on PR #${pr.number} (mergeState=${mergeState}); tracking issue opened.`);
-            }
-
-      - name: Bust stars API cache so site shows new version immediately
-        if: steps.check.outputs.new_release == 'true'
+      - name: Bust stars API cache after a release merge
+        if: steps.releases.outputs.merged == 'true'
         env:
           CRON_SECRET: ${{ secrets.CRON_SECRET }}
         run: |
-          # The /api/stars endpoint caches GitHub results in Redis with a 1hr
-          # TTL. Passing ?cron=1 bypasses the cache read and writes a fresh
-          # snapshot — so the masthead "Latest" stat picks up the new version
-          # on the next site visit rather than waiting up to an hour.
-          # Cache-bypass is now auth-gated; we send the same Bearer token
-          # that Vercel Cron sends on its scheduled invocations.
-          code=$(curl -s -o /dev/null -w "%{http_code}" \
+          code=$(curl --fail-with-body --silent --show-error -o /dev/null -w "%{http_code}" \
             -H "Authorization: Bearer ${CRON_SECRET}" \
             "https://hermesatlas.com/api/stars?cron=1")
           echo "Cache refresh returned HTTP $code"
-          if [ "$code" != "200" ]; then
-            echo "::warning::Cache bust returned non-200; site may briefly show stale version"
-          fi
+          test "$code" = "200"
 
       - name: Check for new official docs changes
         id: docs_check
         uses: actions/github-script@v7
         with:
           script: |
-            // Check if the docs website has been updated recently
-            // by looking at the website/ directory's last commit
             try {
               const { data: commits } = await github.rest.repos.listCommits({
                 owner: 'NousResearch',
@@ -339,35 +58,25 @@ jobs:
               });
 
               if (commits.length > 0) {
-                console.log(`Docs updated in last 24h: ${commits[0].sha.slice(0,7)} — "${commits[0].commit.message.split('\n')[0]}"`);
+                console.log(`Docs updated: ${commits[0].sha.slice(0, 7)} — ${commits[0].commit.message.split('\n')[0]}`);
                 core.setOutput('docs_updated', 'true');
                 core.setOutput('commit_msg', commits[0].commit.message.split('\n')[0]);
               } else {
-                console.log('No docs changes in last 24h');
                 core.setOutput('docs_updated', 'false');
               }
-            } catch (e) {
-              console.log('Could not check docs:', e.message);
-              core.setOutput('docs_updated', 'false');
+            } catch (error) {
+              core.setFailed(`Could not check official docs: ${error.message}`);
             }
 
       - name: Create issue for docs update
         if: steps.docs_check.outputs.docs_updated == 'true'
         env:
-          # Read from env to avoid JS string-injection issues with quote
-          # characters etc. in the upstream commit message (same pattern as
-          # the release-notes steps above).
           COMMIT_MSG: ${{ steps.docs_check.outputs.commit_msg }}
         uses: actions/github-script@v7
         with:
           script: |
             const msg = process.env.COMMIT_MSG || '';
             const today = new Date().toISOString().slice(0, 10);
-
-            // Get all open docs-update issues. These are informational only —
-            // a fresh one each day used to pile up (8 stale ones bulk-closed
-            // during 2026-05-01 triage). Now we close prior ones when we
-            // create today's, so at most one is open at a time.
             const { data: openIssues } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -376,42 +85,90 @@ jobs:
               per_page: 100
             });
 
-            // If today's already exists, leave it alone.
-            const todaysExists = openIssues.find(i => i.title.includes(today));
-            if (todaysExists) {
-              console.log(`Docs update issue already exists for today: #${todaysExists.number}`);
-              return;
-            }
+            if (openIssues.some(issue => issue.title.includes(today))) return;
 
-            // Close any prior open docs-update issues — this prevents the
-            // every-day pileup. Best-effort: a single close failure shouldn't
-            // block creating today's issue.
             for (const issue of openIssues) {
-              try {
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: issue.number,
-                  body: `Auto-closed — superseded by today's docs-update check. Daily docs-update issues are informational only.`
-                });
-                await github.rest.issues.update({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: issue.number,
-                  state: 'closed',
-                  state_reason: 'not_planned'
-                });
-                console.log(`Auto-closed prior docs-update issue #${issue.number}`);
-              } catch (e) {
-                console.log(`Could not close #${issue.number}: ${e.message}`);
-              }
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `Auto-closed — superseded by the ${today} docs-update check.`
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'not_planned'
+              });
             }
 
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: `[Docs] Official documentation updated (${today})`,
-              body: `The Hermes Agent official documentation was updated in the last 24 hours.\n\nLatest commit: "${msg}"\n\n**Action needed:** Review the changes at https://hermes-agent.nousresearch.com/docs and update the relevant research files if the changes are significant.\n\nSource: https://github.com/NousResearch/hermes-agent/tree/main/website/docs`,
+              body: `The official Hermes Agent documentation changed in the last 24 hours.\n\nLatest commit: "${msg}"\n\nSource: https://github.com/NousResearch/hermes-agent/tree/main/website/docs`,
               labels: ['docs-update']
             });
-            console.log('Created docs update issue');
+
+      - name: Close release-monitor alert after recovery
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = '[Workflow] release-monitor failed';
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'workflow-issue',
+              per_page: 100
+            });
+            const issue = issues.find(item => item.title === title);
+            if (!issue) return;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              body: `Recovered in ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}.`
+            });
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              state: 'closed',
+              state_reason: 'completed'
+            });
+
+      - name: Escalate release-monitor failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = '[Workflow] release-monitor failed';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = `Release ingestion failed and may be stale.\n\nRun: ${runUrl}\n\nThe workflow now fails on upstream API errors, unusable release notes, an unmergeable release PR, cache refresh failure, or downstream dispatch failure.`;
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'workflow-issue',
+              per_page: 100
+            });
+            const issue = issues.find(item => item.title === title);
+            if (issue) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['workflow-issue']
+              });
+            }

--- a/.github/workflows/release-monitor.yml
+++ b/.github/workflows/release-monitor.yml
@@ -32,17 +32,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node scripts/sync-releases.js
 
-      - name: Bust stars API cache after a release merge
-        if: steps.releases.outputs.merged == 'true'
-        env:
-          CRON_SECRET: ${{ secrets.CRON_SECRET }}
-        run: |
-          code=$(curl --fail-with-body --silent --show-error -o /dev/null -w "%{http_code}" \
-            -H "Authorization: Bearer ${CRON_SECRET}" \
-            "https://hermesatlas.com/api/stars?cron=1")
-          echo "Cache refresh returned HTTP $code"
-          test "$code" = "200"
-
       - name: Check for new official docs changes
         id: docs_check
         uses: actions/github-script@v7
@@ -147,7 +136,7 @@ jobs:
           script: |
             const title = '[Workflow] release-monitor failed';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const body = `Release ingestion failed and may be stale.\n\nRun: ${runUrl}\n\nThe workflow now fails on upstream API errors, unusable release notes, an unmergeable release PR, cache refresh failure, or downstream dispatch failure.`;
+            const body = `Release ingestion failed and may be stale.\n\nRun: ${runUrl}\n\nThe workflow now fails on upstream API errors, unusable release notes, an unmergeable release PR, downstream dispatch failure.`;
             const { data: issues } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/lib/release-sync.js
+++ b/lib/release-sync.js
@@ -1,0 +1,96 @@
+import path from "node:path";
+
+const CALENDAR_TAG_RE = /^v20\d{2}(?:\.\d+){2,}$/i;
+
+export function extractTrackedReleaseTags(researchFiles) {
+  const tags = new Set();
+
+  for (const file of researchFiles) {
+    const content = String(file.content || "");
+    for (const match of content.matchAll(/^\*\*Version:\*\*\s*(v20\d{2}(?:\.\d+){2,})\s*$/gmi)) {
+      tags.add(match[1]);
+    }
+    for (const match of content.matchAll(/releases\/tag\/(v20\d{2}(?:\.\d+){2,})/gi)) {
+      tags.add(match[1]);
+    }
+  }
+
+  return tags;
+}
+
+export function renderReleaseMarkdown(release) {
+  const tag = String(release?.tag_name || "").trim();
+  const publishedAt = String(release?.published_at || "").trim();
+  const body = String(release?.body || "").trim();
+
+  if (!CALENDAR_TAG_RE.test(tag)) {
+    throw new Error(`Invalid Hermes release tag: ${tag || "(missing)"}`);
+  }
+  if (!publishedAt || Number.isNaN(Date.parse(publishedAt))) {
+    throw new Error(`Release ${tag} has an invalid published_at value`);
+  }
+  if (body.length < 100) {
+    throw new Error(`Release ${tag} has no usable release notes (${body.length} chars)`);
+  }
+
+  return [
+    `# Hermes Agent ${tag} Release Notes`,
+    "",
+    `**Version:** ${tag}`,
+    `**Published:** ${publishedAt}`,
+    `**Source:** https://github.com/NousResearch/hermes-agent/releases/tag/${tag}`,
+    "",
+    body,
+    "",
+  ].join("\n");
+}
+
+export function planReleaseBatch({ upstreamReleases, researchFiles }) {
+  const trackedTags = extractTrackedReleaseTags(researchFiles);
+  const trackedPublishedTimes = researchFiles
+    .map((file) => String(file.content || "").match(/^\*\*Published:\*\*\s*([^\n]+)$/mi)?.[1])
+    .map((value) => Date.parse(value))
+    .filter(Number.isFinite);
+  const latestTrackedPublishedTime = trackedPublishedTimes.length
+    ? Math.max(...trackedPublishedTimes)
+    : Number.NEGATIVE_INFINITY;
+  const existingNumbers = researchFiles
+    .map((file) => path.basename(file.path || "").match(/^(\d+)-/)?.[1])
+    .filter(Boolean)
+    .map(Number);
+  let nextNumber = Math.max(29, ...existingNumbers) + 1;
+
+  const missing = upstreamReleases
+    .filter((release) => !release.draft && !release.prerelease)
+    .filter((release) => CALENDAR_TAG_RE.test(String(release.tag_name || "")))
+    .filter((release) => !trackedTags.has(release.tag_name))
+    // The Atlas intentionally does not carry every historical release. Treat
+    // the newest tracked publication as the ingestion watermark and capture
+    // every upstream release after it, including multiple same-day releases.
+    .filter((release) => Date.parse(release.published_at) > latestTrackedPublishedTime)
+    .sort((a, b) => Date.parse(a.published_at) - Date.parse(b.published_at));
+
+  const documents = missing.map((release) => {
+    const tagSlug = release.tag_name.replace(/^v/, "").replace(/\./g, "-");
+    return {
+      release,
+      path: `research/${nextNumber++}-release-${tagSlug}.md`,
+      content: renderReleaseMarkdown(release),
+    };
+  });
+
+  return { trackedTags, missing, documents };
+}
+
+export function releaseTagFromPrTitle(title) {
+  return String(title || "").match(/Hermes Agent\s+(v20\d{2}(?:\.\d+){2,})/i)?.[1] || null;
+}
+
+export function releaseBranchName(tag) {
+  const slug = String(tag || "")
+    .replace(/^v/i, "")
+    .replace(/[^0-9.]+/g, "")
+    .replace(/\./g, "-");
+  if (!slug) throw new Error("Cannot create a release branch without a tag");
+  return `release-notes-batch-${slug}`;
+}

--- a/research/49-release-2026-7-7.md
+++ b/research/49-release-2026-7-7.md
@@ -1,0 +1,28 @@
+# Hermes Agent v2026.7.7 Release Notes
+
+**Version:** v2026.7.7
+**Published:** 2026-07-08T01:15:00Z
+**Source:** https://github.com/NousResearch/hermes-agent/releases/tag/v2026.7.7
+
+# Hermes Agent v0.18.1 (v2026.7.7)
+
+**Release Date:** July 7, 2026
+
+> Patch release. This tag rolls up the ~660 PRs merged since v0.18.0 (July 1) — bug fixes, hardening, and in-progress feature work — into a stable tagged release for downstream consumers (Docker images, hosted deployments, PyPI installs).
+
+---
+
+## About this release
+
+This is an infrastructure-driven patch tag rather than a fully curated release. Since v0.18.0 shipped six days ago, main has accumulated roughly **667 commits across ~990 files (+89.5k/−10.4k lines)**, including installer/updater self-healing on Windows, dashboard and gateway fixes, WhatsApp dashboard pairing, MCP and provider fixes, and a large volume of stability work.
+
+**Full curated release notes for this window will ship with v0.19.0**, which will document everything from v0.18.0 onward — highlights, feature areas, and complete contributor credits. Nothing in this window is skipped; it's documented in the next minor release.
+
+## Updating
+
+```bash
+hermes update        # existing installs
+pip install -U hermes-agent
+```
+
+**Full Changelog**: [v2026.7.1...v2026.7.7](https://github.com/NousResearch/hermes-agent/compare/v2026.7.1...v2026.7.7)

--- a/research/50-release-2026-7-7-2.md
+++ b/research/50-release-2026-7-7-2.md
@@ -1,0 +1,28 @@
+# Hermes Agent v2026.7.7.2 Release Notes
+
+**Version:** v2026.7.7.2
+**Published:** 2026-07-08T03:11:22Z
+**Source:** https://github.com/NousResearch/hermes-agent/releases/tag/v2026.7.7.2
+
+# Hermes Agent v0.18.2 (v2026.7.7.2)
+
+**Release Date:** July 7, 2026
+
+> Same-day patch on top of v0.18.1, picking up the WhatsApp Baileys dependency fix needed for tagged-release Docker builds.
+
+---
+
+## What's in this patch
+
+- **fix(whatsapp): unpin Baileys from git commit, use published 7.0.0-rc13** ([#60643](https://github.com/NousResearch/hermes-agent/pull/60643)) — the WhatsApp bridge dependency now installs from the published npm release instead of a pinned git commit, making installs and Docker image builds reliable.
+
+Full curated release notes for the entire post-v0.18.0 window ship with v0.19.0.
+
+## Updating
+
+```bash
+hermes update        # existing installs
+pip install -U hermes-agent
+```
+
+**Full Changelog**: [v2026.7.7...v2026.7.7.2](https://github.com/NousResearch/hermes-agent/compare/v2026.7.7...v2026.7.7.2)

--- a/scripts/sync-releases.js
+++ b/scripts/sync-releases.js
@@ -1,0 +1,258 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  extractTrackedReleaseTags,
+  planReleaseBatch,
+  releaseBranchName,
+  releaseTagFromPrTitle,
+} from "../lib/release-sync.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "..");
+
+export class GitHubApiError extends Error {
+  constructor(message, status, responseBody) {
+    super(message);
+    this.name = "GitHubApiError";
+    this.status = status;
+    this.responseBody = responseBody;
+  }
+}
+
+export class GitHubClient {
+  constructor({ token, fetchImpl = fetch }) {
+    this.token = token;
+    this.fetchImpl = fetchImpl;
+  }
+
+  async request(method, apiPath, body) {
+    const response = await this.fetchImpl(`https://api.github.com${apiPath}`, {
+      method,
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${this.token}`,
+        "Content-Type": "application/json",
+        "User-Agent": "hermes-atlas-release-sync",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+
+    const text = await response.text();
+    const data = text ? JSON.parse(text) : null;
+    if (!response.ok) {
+      throw new GitHubApiError(
+        `${method} ${apiPath} failed (${response.status}): ${data?.message || text}`,
+        response.status,
+        data,
+      );
+    }
+    return data;
+  }
+}
+
+function walkMarkdown(dir) {
+  const files = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const absolute = path.join(dir, entry.name);
+    if (entry.isDirectory()) files.push(...walkMarkdown(absolute));
+    else if (entry.isFile() && entry.name.endsWith(".md")) files.push(absolute);
+  }
+  return files;
+}
+
+function readResearchFiles(root = ROOT) {
+  return walkMarkdown(path.join(root, "research")).map((absolute) => ({
+    path: path.relative(root, absolute).split(path.sep).join("/"),
+    content: fs.readFileSync(absolute, "utf-8"),
+  }));
+}
+
+async function listAllReleases(client) {
+  const releases = [];
+  for (let page = 1; page <= 10; page++) {
+    const batch = await client.request(
+      "GET",
+      `/repos/NousResearch/hermes-agent/releases?per_page=100&page=${page}`,
+    );
+    releases.push(...batch);
+    if (batch.length < 100) break;
+  }
+  return releases;
+}
+
+async function listOpenPulls(client, repository) {
+  return client.request("GET", `/repos/${repository}/pulls?state=open&per_page=100`);
+}
+
+async function closeTrackedReleasePrs(client, repository, trackedTags, { excludeNumber } = {}) {
+  const pulls = await listOpenPulls(client, repository);
+  for (const pr of pulls) {
+    if (pr.number === excludeNumber || !pr.head?.ref?.startsWith("release-notes-")) continue;
+    const tag = releaseTagFromPrTitle(pr.title);
+    if (!tag || !trackedTags.has(tag)) continue;
+
+    await client.request("POST", `/repos/${repository}/issues/${pr.number}/comments`, {
+      body: `Auto-closed: ${tag} is already present on main. This release PR is superseded by the synchronized release corpus.`,
+    });
+    await client.request("PATCH", `/repos/${repository}/pulls/${pr.number}`, { state: "closed" });
+    console.log(`Closed superseded release PR #${pr.number} (${tag})`);
+  }
+  return pulls;
+}
+
+async function createOrMoveBranch(client, repository, branch, sha) {
+  try {
+    await client.request("POST", `/repos/${repository}/git/refs`, {
+      ref: `refs/heads/${branch}`,
+      sha,
+    });
+  } catch (error) {
+    if (!(error instanceof GitHubApiError) || error.status !== 422) throw error;
+    await client.request("PATCH", `/repos/${repository}/git/refs/heads/${branch}`, {
+      sha,
+      force: true,
+    });
+  }
+}
+
+async function waitForMergeability(client, repository, pullNumber) {
+  let pull = null;
+  for (let attempt = 1; attempt <= 12; attempt++) {
+    pull = await client.request("GET", `/repos/${repository}/pulls/${pullNumber}`);
+    if (pull.mergeable !== null) return pull;
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+  }
+  throw new Error(`PR #${pullNumber} mergeability did not settle (last state: ${pull?.mergeable_state})`);
+}
+
+function setOutput(name, value) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (outputFile) fs.appendFileSync(outputFile, `${name}=${value}\n`);
+  console.log(`${name}=${value}`);
+}
+
+export async function syncReleases({
+  client,
+  repository,
+  researchFiles = readResearchFiles(),
+}) {
+  const upstreamReleases = await listAllReleases(client);
+  const plan = planReleaseBatch({ upstreamReleases, researchFiles });
+
+  await closeTrackedReleasePrs(client, repository, plan.trackedTags);
+
+  if (plan.documents.length === 0) {
+    console.log(`No missing releases (${plan.trackedTags.size} tags already tracked)`);
+    setOutput("new_release", "false");
+    setOutput("merged", "false");
+    return { merged: false, documents: [] };
+  }
+
+  const tags = plan.documents.map((document) => document.release.tag_name);
+  const latestTag = tags.at(-1);
+  console.log(`Missing ${tags.length} release(s): ${tags.join(", ")}`);
+
+  const mainRef = await client.request("GET", `/repos/${repository}/git/ref/heads/main`);
+  const baseCommit = await client.request("GET", `/repos/${repository}/git/commits/${mainRef.object.sha}`);
+
+  const tree = [];
+  for (const document of plan.documents) {
+    const blob = await client.request("POST", `/repos/${repository}/git/blobs`, {
+      content: document.content,
+      encoding: "utf-8",
+    });
+    tree.push({ path: document.path, mode: "100644", type: "blob", sha: blob.sha });
+  }
+
+  const newTree = await client.request("POST", `/repos/${repository}/git/trees`, {
+    base_tree: baseCommit.tree.sha,
+    tree,
+  });
+  const commit = await client.request("POST", `/repos/${repository}/git/commits`, {
+    message: `Add Hermes Agent release notes: ${tags.join(", ")}`,
+    tree: newTree.sha,
+    parents: [mainRef.object.sha],
+  });
+
+  const branch = releaseBranchName(latestTag);
+  const openPulls = await listOpenPulls(client, repository);
+  const existingPull = openPulls.find(
+    (pr) => pr.head?.ref?.startsWith("release-notes-") && releaseTagFromPrTitle(pr.title) === latestTag,
+  );
+
+  if (existingPull) {
+    await client.request(
+      "PATCH",
+      `/repos/${repository}/git/refs/heads/${existingPull.head.ref}`,
+      { sha: commit.sha, force: true },
+    );
+  } else {
+    await createOrMoveBranch(client, repository, branch, commit.sha);
+  }
+
+  const pull = existingPull || await client.request("POST", `/repos/${repository}/pulls`, {
+    title: `New release: Hermes Agent ${latestTag}`,
+    body: [
+      `Synchronizes ${tags.length} missing Hermes Agent release(s) into the Atlas knowledge base.`,
+      "",
+      ...plan.documents.map((document) => `- ${document.release.tag_name}: \`${document.path}\``),
+      "",
+      "This automation merges authoritative upstream release notes, then explicitly dispatches the RAG rebuild.",
+    ].join("\n"),
+    head: existingPull?.head.ref || branch,
+    base: "main",
+  });
+
+  const mergeablePull = await waitForMergeability(client, repository, pull.number);
+  if (!mergeablePull.mergeable) {
+    throw new Error(
+      `PR #${pull.number} is not mergeable (state=${mergeablePull.mergeable_state}); leaving it open for the next retry`,
+    );
+  }
+
+  const merge = await client.request("PUT", `/repos/${repository}/pulls/${pull.number}/merge`, {
+    sha: commit.sha,
+    merge_method: "merge",
+    commit_title: `Ingest Hermes Agent releases through ${latestTag}`,
+  });
+  if (!merge.merged) {
+    throw new Error(`GitHub did not merge PR #${pull.number}: ${merge.message || "unknown reason"}`);
+  }
+
+  const nowTracked = new Set([...plan.trackedTags, ...tags]);
+  await closeTrackedReleasePrs(client, repository, nowTracked, { excludeNumber: pull.number });
+
+  await client.request(
+    "POST",
+    `/repos/${repository}/actions/workflows/rebuild-chunks.yml/dispatches`,
+    { ref: "main" },
+  );
+
+  setOutput("new_release", "true");
+  setOutput("merged", "true");
+  setOutput("latest_tag", latestTag);
+  setOutput("pull_number", pull.number);
+  return { merged: true, documents: plan.documents, pullNumber: pull.number };
+}
+
+async function main() {
+  const token = process.env.GITHUB_TOKEN;
+  const repository = process.env.GITHUB_REPOSITORY;
+  if (!token) throw new Error("GITHUB_TOKEN is required");
+  if (!repository) throw new Error("GITHUB_REPOSITORY is required");
+
+  await syncReleases({ client: new GitHubClient({ token }), repository });
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error.stack || error);
+    process.exit(1);
+  });
+}
+
+export { extractTrackedReleaseTags };

--- a/tests/release-sync.test.js
+++ b/tests/release-sync.test.js
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  extractTrackedReleaseTags,
+  planReleaseBatch,
+  releaseBranchName,
+  releaseTagFromPrTitle,
+  renderReleaseMarkdown,
+} from "../lib/release-sync.js";
+import { syncReleases } from "../scripts/sync-releases.js";
+
+const release = (tag, publishedAt, version) => ({
+  tag_name: tag,
+  name: `Hermes Agent ${version}`,
+  published_at: publishedAt,
+  body: `# Hermes Agent ${version} (${tag})\n\n${"Authoritative release notes. ".repeat(5)}`,
+  draft: false,
+  prerelease: false,
+});
+
+test("extractTrackedReleaseTags reads exact release metadata and source URLs", () => {
+  const tags = extractTrackedReleaseTags([
+    {
+      path: "research/48-release-2026-7-1.md",
+      content: "**Version:** v2026.7.1\n**Source:** https://github.com/NousResearch/hermes-agent/releases/tag/v2026.7.1",
+    },
+    {
+      path: "research/unrelated.md",
+      content: "# Hermes Agent v0.18.0\n**Version:** v0.18.0",
+    },
+  ]);
+
+  assert.deepEqual([...tags], ["v2026.7.1"]);
+});
+
+test("planReleaseBatch ingests every missing release oldest to newest", () => {
+  const plan = planReleaseBatch({
+    upstreamReleases: [
+      release("v2026.7.7.2", "2026-07-08T03:11:22Z", "v0.18.2"),
+      release("v2026.7.7", "2026-07-08T01:15:00Z", "v0.18.1"),
+      release("v2026.7.1", "2026-07-01T20:08:06Z", "v0.18.0"),
+    ],
+    researchFiles: [{
+      path: "research/48-release-2026-7-1.md",
+      content: "**Version:** v2026.7.1\n**Published:** 2026-07-01T20:08:06Z",
+    }],
+  });
+
+  assert.deepEqual(plan.missing.map((item) => item.tag_name), ["v2026.7.7", "v2026.7.7.2"]);
+  assert.deepEqual(plan.documents.map((item) => item.path), [
+    "research/49-release-2026-7-7.md",
+    "research/50-release-2026-7-7-2.md",
+  ]);
+  assert.match(plan.documents[1].content, /Hermes Agent v0\.18\.2/);
+});
+
+test("planReleaseBatch is idempotent when all tags are already tracked", () => {
+  const upstream = release("v2026.7.7", "2026-07-08T01:15:00Z", "v0.18.1");
+  const plan = planReleaseBatch({
+    upstreamReleases: [upstream],
+    researchFiles: [{
+      path: "research/49-release-2026-7-7.md",
+      content: renderReleaseMarkdown(upstream),
+    }],
+  });
+  assert.equal(plan.documents.length, 0);
+});
+
+test("planReleaseBatch does not backfill intentional gaps before the watermark", () => {
+  const plan = planReleaseBatch({
+    upstreamReleases: [
+      release("v2026.7.7", "2026-07-08T01:15:00Z", "v0.18.1"),
+      release("v2026.3.12", "2026-03-12T12:00:00Z", "v0.8.0"),
+    ],
+    researchFiles: [{
+      path: "research/48-release-2026-7-1.md",
+      content: "**Version:** v2026.7.1\n**Published:** 2026-07-01T20:08:06Z",
+    }],
+  });
+
+  assert.deepEqual(plan.missing.map((item) => item.tag_name), ["v2026.7.7"]);
+});
+
+test("renderReleaseMarkdown fails rather than silently skipping empty notes", () => {
+  assert.throws(
+    () => renderReleaseMarkdown({ tag_name: "v2026.7.7", published_at: "2026-07-08T01:15:00Z", body: "short" }),
+    /no usable release notes/,
+  );
+});
+
+test("release PR helpers create stable retry keys", () => {
+  assert.equal(releaseTagFromPrTitle("New release: Hermes Agent v2026.7.7.2"), "v2026.7.7.2");
+  assert.equal(releaseBranchName("v2026.7.7.2"), "release-notes-batch-2026-7-7-2");
+});
+
+test("syncReleases reuses a stuck PR, merges the full batch, and dispatches the RAG rebuild", async () => {
+  const upstreamReleases = [
+    release("v2026.7.7.2", "2026-07-08T03:11:22Z", "v0.18.2"),
+    release("v2026.7.7", "2026-07-08T01:15:00Z", "v0.18.1"),
+  ];
+  const stuckPull = {
+    number: 494,
+    title: "New release: Hermes Agent v2026.7.7.2",
+    head: { ref: "release-notes-2026.7.7.2" },
+  };
+  const calls = [];
+  let blobNumber = 0;
+  let pullListNumber = 0;
+  const client = {
+    async request(method, apiPath, body) {
+      calls.push({ method, apiPath, body });
+      if (apiPath.includes("/releases?")) return upstreamReleases;
+      if (apiPath.endsWith("/pulls?state=open&per_page=100")) {
+        pullListNumber++;
+        return pullListNumber < 3 ? [stuckPull] : [];
+      }
+      if (apiPath.endsWith("/git/ref/heads/main")) return { object: { sha: "main-sha" } };
+      if (apiPath.endsWith("/git/commits/main-sha")) return { tree: { sha: "base-tree" } };
+      if (apiPath.endsWith("/git/blobs")) return { sha: `blob-${++blobNumber}` };
+      if (apiPath.endsWith("/git/trees")) return { sha: "new-tree" };
+      if (apiPath.endsWith("/git/commits")) return { sha: "release-commit" };
+      if (apiPath.endsWith("/git/refs/heads/release-notes-2026.7.7.2")) return {};
+      if (method === "GET" && apiPath.endsWith("/pulls/494")) {
+        return { ...stuckPull, mergeable: true, mergeable_state: "clean" };
+      }
+      if (method === "PUT" && apiPath.endsWith("/pulls/494/merge")) return { merged: true };
+      if (apiPath.endsWith("/actions/workflows/rebuild-chunks.yml/dispatches")) return null;
+      throw new Error(`Unexpected request: ${method} ${apiPath}`);
+    },
+  };
+
+  const result = await syncReleases({
+    client,
+    repository: "ksimback/hermes-ecosystem",
+    researchFiles: [{
+      path: "research/48-release-2026-7-1.md",
+      content: "**Version:** v2026.7.1\n**Published:** 2026-07-01T20:08:06Z",
+    }],
+  });
+
+  assert.equal(result.merged, true);
+  assert.equal(result.documents.length, 2);
+  assert.equal(calls.filter((call) => call.apiPath.endsWith("/git/blobs")).length, 2);
+  assert.ok(calls.some((call) => call.method === "PATCH" && call.body.force === true));
+  assert.ok(calls.some((call) => call.method === "PUT" && call.apiPath.endsWith("/pulls/494/merge")));
+  assert.ok(calls.some((call) => call.apiPath.endsWith("/actions/workflows/rebuild-chunks.yml/dispatches")));
+  assert.equal(calls.some((call) => call.method === "POST" && call.apiPath.endsWith("/pulls")), false);
+});


### PR DESCRIPTION
## What changed

- backfills the missing v0.18.1 and v0.18.2 release notes from authoritative upstream releases
- replaces latest-only polling with a watermark-based batch sync that ingests every release after the newest tracked publication, oldest to newest
- reuses and rewrites a stuck automation PR, merges it directly when mergeable, and fails the workflow instead of warning on merge failure
- explicitly dispatches `rebuild-chunks.yml` after token-authored merges
- explicitly dispatches `build-pages.yml` after the chunk/latest-release commit, because `GITHUB_TOKEN` pushes do not cascade into another workflow
- closes superseded release PRs and auto-closes the deduplicated release-monitor alert after recovery

## Root cause

The previous monitor fetched only the latest upstream release, returned early whenever a release PR already existed, and treated auto-merge failure as a successful workflow. That permanently skipped v0.18.1, left v0.18.2 in PR #494, and prevented downstream RAG/page updates from being triggered reliably.

## Validation

- `npm test` — 128/128 passed
- release-sync fake GitHub integration — reused PR #494, wrote two blobs, force-refreshed the branch, merged it, and dispatched `rebuild-chunks.yml`
- live read-only upstream comparison — no missing post-watermark releases; corpus latest tag equals upstream `v2026.7.7.2`
- workflow YAML parsing and Node syntax checks — passed
- `git diff --check` — passed

## Merge order and operational acceptance

Depends on #524; merge that first so the dispatched page build can complete. After this PR merges, require: the release monitor succeeds, PR #494 is auto-closed as superseded, the chunk rebuild succeeds, the page rebuild succeeds, and production reports v0.18.2 in `data/latest-release.json`, the homepage, and Ask the Atlas.