### PR TITLE
Make repo submission automation self-contained

### DIFF
--- a/.github/workflows/validate-repo-suggestion.yml
+++ b/.github/workflows/validate-repo-suggestion.yml
@@ -12,6 +12,9 @@ env:
 on:
   issues:
     types: [opened, edited, labeled]
+  schedule:
+    - cron: '15 5 * * *'
+  workflow_dispatch:
 
 # Serialize validation runs. Without this, two concurrent submissions create
 # PRs that both branch from the same main SHA; merging the first leaves the
@@ -23,8 +26,10 @@ concurrency:
 
 jobs:
   validate:
+    if: github.event_name == 'issues'
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       issues: write
       contents: write
       pull-requests: write
@@ -351,6 +356,15 @@ jobs:
             if (!category || category === 'Not sure') {
               category = process.env.INFERRED_CATEGORY || 'Developer Tools';
             }
+            const { pathToFileURL } = require('url');
+            const validatorUrl = pathToFileURL(
+              `${process.env.GITHUB_WORKSPACE}/scripts/validate-repos-json.js`
+            ).href;
+            const { CANONICAL_CATEGORIES, validateRepos } = await import(validatorUrl);
+            if (!CANONICAL_CATEGORIES.includes(category)) {
+              console.log(`Ignoring non-canonical suggested category "${category}"; using inferred category.`);
+              category = process.env.INFERRED_CATEGORY || 'Developer Tools';
+            }
 
             // Always source repos.json from the LATEST main via API, not from
             // the workflow's local checkout. The checkout happens at the start
@@ -411,6 +425,14 @@ jobs:
 
             repos.push(newRepo);
 
+            // GITHUB_TOKEN-authored PRs do not fire pull_request workflows,
+            // so validate the exact candidate catalog before writing a branch.
+            const validationErrors = validateRepos(repos);
+            if (validationErrors.length > 0) {
+              core.setFailed(`Candidate repos.json is invalid:\n${validationErrors.join('\n')}`);
+              return;
+            }
+
             // Write updated repos.json
             const branch = `add-repo-${owner}-${repo}`.toLowerCase().replace(/[^a-z0-9-]/g, '-');
 
@@ -464,22 +486,16 @@ jobs:
               base: 'main'
             });
 
-            // Merge the validator PR inside this serialized workflow instead
-            // of delegating to native auto-merge immediately after PR creation.
-            // Native auto-merge has repeatedly rejected fresh validator PRs as
-            // "unstable" while preview/check contexts are still materializing;
-            // the job then exits, the next queued submission branches from the
-            // same main, and the open PR stack becomes DIRTY once any earlier
-            // add-repo PR lands. Keeping this workflow alive until checks are
-            // successful preserves the serialization invariant: the next repo
-            // submission only reads main after this one has either merged or
-            // produced a single deduped blocker issue.
+            // Merge inside this serialized workflow. The exact candidate was
+            // validated above; external contexts may still settle while
+            // GitHub computes mergeability, but bot-created PRs cannot launch
+            // a second GitHub Actions workflow through pull_request events.
             let mergedByWorkflow = false;
             let mergeState = 'UNKNOWN';
             let checkSummary = 'pending';
             let blockerReason = '';
 
-            for (let i = 0; i < 60; i++) {
+            for (let i = 0; i < 24; i++) {
               const { repository } = await github.graphql(
                 `query($owner: String!, $repo: String!, $num: Int!) {
                   repository(owner: $owner, name: $repo) {
@@ -524,19 +540,12 @@ jobs:
                 ? `${contexts.length - blocking.length}/${contexts.length} passing`
                 : 'no check contexts yet';
 
-              // Require the data-integrity gates to have actually run and passed
-              // before merging. The old gate merged as soon as ANY context was
-              // green with none blocking — so a PR whose only posted check was
-              // the fast Vercel status merged in ~30s, before `validate`
-              // (repos.json schema + duplicate/category checks) and `smoke`
-              // even registered. That is how the duplicate + bad-category
-              // entries slipped in. Wait for both named CheckRuns to complete
-              // SUCCESS.
-              const REQUIRED = ['validate', 'smoke'];
-              const requiredGreen = REQUIRED.every(name => {
-                const c = contexts.find(x => x.__typename === 'CheckRun' && x.name === name);
-                return c && c.status === 'COMPLETED' && ['SUCCESS', 'SKIPPED', 'NEUTRAL'].includes(c.conclusion);
-              });
+              // Bot-authored pull requests cannot emit the pull_request event,
+              // so `validate` and `smoke` CheckRuns will never appear. The
+              // exact candidate catalog was validated in-process before the
+              // branch was written; external contexts (for example Vercel)
+              // still must not be pending or failed.
+              const requiredGreen = true;
 
               console.log(`PR #${pr.number}: mergeState=${mergeState}, mergeable=${pull.mergeable}, checks=${checkSummary}, requiredGreen=${requiredGreen}`);
 
@@ -548,17 +557,18 @@ jobs:
                 blockerReason = 'PR is dirty/conflicted';
                 break;
               }
-              if (requiredGreen && blocking.length === 0 && ['CLEAN', 'HAS_HOOKS'].includes(mergeState)) {
+              if (requiredGreen && blocking.length === 0 && ['CLEAN', 'HAS_HOOKS', 'UNSTABLE'].includes(mergeState)) {
                 try {
-                  await github.rest.pulls.merge({
+                  const { data: merge } = await github.rest.pulls.merge({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     pull_number: pr.number,
                     merge_method: 'squash',
                     commit_title: `Add ${owner}/${repo} to Atlas ecosystem (#${pr.number})`
                   });
+                  if (!merge.merged) throw new Error(merge.message || 'GitHub declined the merge');
                   mergedByWorkflow = true;
-                  console.log(`Merged PR #${pr.number} after checks passed.`);
+                  console.log(`Merged PR #${pr.number} after candidate validation.`);
                   break;
                 } catch (e) {
                   blockerReason = `Merge API failed: ${e.message}`;
@@ -566,12 +576,12 @@ jobs:
                 }
               }
 
-              await new Promise(r => setTimeout(r, 30000));
+              await new Promise(r => setTimeout(r, 5000));
             }
 
             if (!mergedByWorkflow) {
               if (!blockerReason) {
-                blockerReason = `Timed out waiting for mergeable green PR; mergeState=${mergeState}, checks=${checkSummary}`;
+                blockerReason = `Timed out waiting for a mergeable PR; mergeState=${mergeState}, checks=${checkSummary}`;
               }
 
               const issueTitle = `[Workflow] Validator PR #${pr.number} needs manual review`;
@@ -596,12 +606,24 @@ jobs:
                   body: `Still blocked.\n\n${body}`
                 });
               }
-              core.warning(`PR #${pr.number} did not auto-merge: ${blockerReason}`);
+              core.setFailed(`PR #${pr.number} did not auto-merge: ${blockerReason}`);
+            }
+
+            if (mergedByWorkflow) {
+              // A merge made with GITHUB_TOKEN does not fire a push-triggered
+              // workflow. Start the deterministic site refresh explicitly.
+              await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'build-pages.yml',
+                ref: 'main'
+              });
+              console.log('Dispatched build-pages.yml after repo merge');
             }
 
             // Comment on the source issue with the PR link and outcome.
             const mergeNote = mergedByWorkflow
-              ? '\n\nThe validator workflow merged the PR after checks passed.'
+              ? '\n\nThe validator workflow validated and merged the PR, then dispatched the site rebuild.'
               : '\n\nThe PR was created, but did not auto-merge; a deduped workflow issue tracks manual review.';
             await github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -609,3 +631,26 @@ jobs:
               issue_number: context.issue.number,
               body: `PR created: #${pr.number}\n\nOnce merged, this repo will appear in the ecosystem map.${mergeNote}`
             });
+
+  recover-open-prs:
+    if: github.event_name != 'issues'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Refresh and merge stuck repo-submission PRs sequentially
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/recover-repo-submissions.js

--- a/lib/repo-submission.js
+++ b/lib/repo-submission.js
@@ -1,0 +1,41 @@
+import {
+  CANONICAL_CATEGORIES,
+  validateRepos,
+} from "../scripts/validate-repos-json.js";
+
+export function repoKey(repo) {
+  return `${repo?.owner || ""}/${repo?.repo || ""}`.toLowerCase();
+}
+
+export function findSubmissionCandidate(mainRepos, branchRepos) {
+  const mainKeys = new Set(mainRepos.map(repoKey));
+  const additions = branchRepos.filter((repo) => !mainKeys.has(repoKey(repo)));
+  if (additions.length > 1) {
+    throw new Error(`Expected one repo addition, found ${additions.length}`);
+  }
+  return additions[0] || null;
+}
+
+export function mergeSubmissionCandidate(mainRepos, candidate) {
+  if (!candidate) return [...mainRepos];
+  const normalizedCandidate = normalizeSubmissionCandidate(candidate);
+  const key = repoKey(normalizedCandidate);
+  if (mainRepos.some((repo) => repoKey(repo) === key)) return [...mainRepos];
+
+  const next = [...mainRepos, normalizedCandidate];
+  const errors = validateRepos(next);
+  if (errors.length > 0) {
+    throw new Error(`Candidate repos.json is invalid:\n${errors.join("\n")}`);
+  }
+  return next;
+}
+
+export function normalizeSubmissionCandidate(candidate) {
+  const rawCategory = String(candidate?.category || "").trim();
+  const canonicalCategory = CANONICAL_CATEGORIES.find(
+    (category) => rawCategory === category || rawCategory.startsWith(`${category} `),
+  );
+  return canonicalCategory && canonicalCategory !== rawCategory
+    ? { ...candidate, category: canonicalCategory }
+    : { ...candidate };
+}

--- a/scripts/recover-repo-submissions.js
+++ b/scripts/recover-repo-submissions.js
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  findSubmissionCandidate,
+  mergeSubmissionCandidate,
+  repoKey,
+} from "../lib/repo-submission.js";
+
+export class GitHubClient {
+  constructor({ token, fetchImpl = fetch }) {
+    this.token = token;
+    this.fetchImpl = fetchImpl;
+  }
+
+  async request(method, apiPath, body) {
+    const response = await this.fetchImpl(`https://api.github.com${apiPath}`, {
+      method,
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${this.token}`,
+        "Content-Type": "application/json",
+        "User-Agent": "hermes-atlas-repo-recovery",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    const text = await response.text();
+    const data = text ? JSON.parse(text) : null;
+    if (!response.ok) {
+      throw new Error(`${method} ${apiPath} failed (${response.status}): ${data?.message || text}`);
+    }
+    return data;
+  }
+}
+
+function decodeJsonFile(file) {
+  return JSON.parse(Buffer.from(file.content, "base64").toString("utf-8"));
+}
+
+async function getReposFile(client, repository, ref) {
+  return client.request(
+    "GET",
+    `/repos/${repository}/contents/data/repos.json?ref=${encodeURIComponent(ref)}`,
+  );
+}
+
+async function waitForMergeability(client, repository, pullNumber) {
+  let pull = null;
+  for (let attempt = 1; attempt <= 12; attempt++) {
+    pull = await client.request("GET", `/repos/${repository}/pulls/${pullNumber}`);
+    if (pull.mergeable !== null) return pull;
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+  }
+  throw new Error(`PR #${pullNumber} mergeability did not settle (state=${pull?.mergeable_state})`);
+}
+
+async function comment(client, repository, issueNumber, body) {
+  await client.request("POST", `/repos/${repository}/issues/${issueNumber}/comments`, { body });
+}
+
+function trackerTitle(pullNumber) {
+  return `[Workflow] Validator PR #${pullNumber} needs manual review`;
+}
+
+async function closeTracker(client, repository, tracker) {
+  if (!tracker) return;
+  await comment(client, repository, tracker.number, "Recovered automatically; the validator PR is no longer blocked.");
+  await client.request("PATCH", `/repos/${repository}/issues/${tracker.number}`, {
+    state: "closed",
+    state_reason: "completed",
+  });
+}
+
+async function ensureTracker(client, repository, trackers, pull, reason) {
+  const title = trackerTitle(pull.number);
+  const existing = trackers.get(title);
+  const body = `Validator recovery could not merge PR #${pull.number}.\n\n**Reason:** \`${reason}\`\n\nThe recovery job will retry on its next run.`;
+  if (existing) {
+    await comment(client, repository, existing.number, body);
+    return;
+  }
+  const issue = await client.request("POST", `/repos/${repository}/issues`, {
+    title,
+    body,
+    labels: ["workflow-issue"],
+  });
+  trackers.set(title, issue);
+}
+
+export async function recoverRepoSubmissions({ client, repository }) {
+  const [allPulls, issueList] = await Promise.all([
+    client.request("GET", `/repos/${repository}/pulls?state=open&per_page=100`),
+    client.request("GET", `/repos/${repository}/issues?state=open&labels=workflow-issue&per_page=100`),
+  ]);
+  const pulls = allPulls
+    .filter((pull) => pull.head?.ref?.startsWith("add-repo-"))
+    .filter((pull) => pull.head?.repo?.full_name === repository)
+    .sort((a, b) => Date.parse(a.created_at) - Date.parse(b.created_at));
+  const trackers = new Map(issueList.map((issue) => [issue.title, issue]));
+  const failures = [];
+  let mergedCount = 0;
+
+  for (const pull of pulls) {
+    try {
+      const files = await client.request(
+        "GET",
+        `/repos/${repository}/pulls/${pull.number}/files?per_page=100`,
+      );
+      if (files.length !== 1 || files[0].filename !== "data/repos.json") {
+        throw new Error(`PR changes unexpected files: ${files.map((file) => file.filename).join(", ")}`);
+      }
+
+      const [mainFile, branchFile] = await Promise.all([
+        getReposFile(client, repository, "main"),
+        getReposFile(client, repository, pull.head.ref),
+      ]);
+      const mainRepos = decodeJsonFile(mainFile);
+      const branchRepos = decodeJsonFile(branchFile);
+      const candidate = findSubmissionCandidate(mainRepos, branchRepos);
+
+      if (!candidate) {
+        await comment(client, repository, pull.number, "Auto-closing: this repo is already present on main.");
+        await client.request("PATCH", `/repos/${repository}/pulls/${pull.number}`, { state: "closed" });
+        await closeTracker(client, repository, trackers.get(trackerTitle(pull.number)));
+        continue;
+      }
+
+      const nextRepos = mergeSubmissionCandidate(mainRepos, candidate);
+      await client.request("PUT", `/repos/${repository}/contents/data/repos.json`, {
+        message: `Refresh validator PR #${pull.number} onto latest main`,
+        content: Buffer.from(`${JSON.stringify(nextRepos, null, 2)}\n`).toString("base64"),
+        sha: branchFile.sha,
+        branch: pull.head.ref,
+      });
+
+      const mergeable = await waitForMergeability(client, repository, pull.number);
+      if (!mergeable.mergeable) {
+        throw new Error(`PR is not mergeable after refresh (state=${mergeable.mergeable_state})`);
+      }
+      const merge = await client.request("PUT", `/repos/${repository}/pulls/${pull.number}/merge`, {
+        sha: mergeable.head.sha,
+        merge_method: "squash",
+        commit_title: `Add ${candidate.owner}/${candidate.repo} to Atlas ecosystem (#${pull.number})`,
+      });
+      if (!merge.merged) throw new Error(merge.message || "GitHub declined the merge");
+
+      mergedCount++;
+      await closeTracker(client, repository, trackers.get(trackerTitle(pull.number)));
+      console.log(`Recovered and merged PR #${pull.number}: ${repoKey(candidate)}`);
+    } catch (error) {
+      failures.push(`#${pull.number}: ${error.message}`);
+      await ensureTracker(client, repository, trackers, pull, error.message);
+    }
+  }
+
+  // Close tracker issues for PRs that are no longer open (for example #507).
+  const openNumbers = new Set(pulls.map((pull) => pull.number));
+  for (const issue of trackers.values()) {
+    const pullNumber = Number(issue.title.match(/^\[Workflow\] Validator PR #(\d+)/)?.[1]);
+    if (pullNumber && !openNumbers.has(pullNumber)) {
+      await closeTracker(client, repository, issue);
+    }
+  }
+
+  if (mergedCount > 0) {
+    await client.request(
+      "POST",
+      `/repos/${repository}/actions/workflows/build-pages.yml/dispatches`,
+      { ref: "main" },
+    );
+  }
+  if (failures.length > 0) {
+    throw new Error(`Repo-submission recovery incomplete:\n${failures.join("\n")}`);
+  }
+
+  console.log(`Repo-submission recovery complete: ${mergedCount} merged`);
+  return { mergedCount };
+}
+
+async function main() {
+  const token = process.env.GITHUB_TOKEN;
+  const repository = process.env.GITHUB_REPOSITORY;
+  if (!token) throw new Error("GITHUB_TOKEN is required");
+  if (!repository) throw new Error("GITHUB_REPOSITORY is required");
+  await recoverRepoSubmissions({ client: new GitHubClient({ token }), repository });
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error.stack || error);
+    process.exit(1);
+  });
+}

--- a/tests/repo-submission.test.js
+++ b/tests/repo-submission.test.js
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { test } from "node:test";
+
+import {
+  findSubmissionCandidate,
+  mergeSubmissionCandidate,
+} from "../lib/repo-submission.js";
+import { recoverRepoSubmissions } from "../scripts/recover-repo-submissions.js";
+
+const repo = (owner, name, category = "Developer Tools") => ({
+  owner,
+  repo: name,
+  name,
+  description: `${name} for Hermes Agent`,
+  stars: 10,
+  url: `https://github.com/${owner}/${name}`,
+  official: false,
+  category,
+});
+
+test("findSubmissionCandidate isolates the one branch-only repo", () => {
+  const existing = repo("example", "existing");
+  const candidate = repo("example", "candidate");
+  assert.deepEqual(findSubmissionCandidate([existing], [existing, candidate]), candidate);
+  assert.equal(findSubmissionCandidate([existing, candidate], [existing, candidate]), null);
+  assert.throws(
+    () => findSubmissionCandidate([existing], [existing, candidate, repo("example", "second")]),
+    /Expected one repo addition/,
+  );
+});
+
+test("mergeSubmissionCandidate preserves current main and validates the candidate", () => {
+  const main = [repo("example", "first"), repo("example", "second")];
+  const next = mergeSubmissionCandidate(main, repo("example", "third"));
+  assert.deepEqual(next.map((item) => item.repo), ["first", "second", "third"]);
+  const repaired = mergeSubmissionCandidate(
+    main,
+    repo("example", "repaired", "Memory & Context on plugin performance"),
+  );
+  assert.equal(repaired.at(-1).category, "Memory & Context");
+  assert.throws(
+    () => mergeSubmissionCandidate(main, repo("example", "bad", "Not a category")),
+    /category must be one of/,
+  );
+});
+
+test("recoverRepoSubmissions refreshes a stale PR onto main before merging", async () => {
+  const mainRepos = [repo("example", "first"), repo("example", "newer-main")];
+  const candidate = repo("example", "candidate");
+  const branchRepos = [repo("example", "first"), candidate];
+  const pull = {
+    number: 516,
+    created_at: "2026-07-12T00:00:00Z",
+    head: {
+      ref: "add-repo-example-candidate",
+      repo: { full_name: "ksimback/hermes-ecosystem" },
+    },
+  };
+  const calls = [];
+  const encoded = (value) => Buffer.from(JSON.stringify(value)).toString("base64");
+  const client = {
+    async request(method, apiPath, body) {
+      calls.push({ method, apiPath, body });
+      if (apiPath.endsWith("/pulls?state=open&per_page=100")) return [pull];
+      if (apiPath.endsWith("/issues?state=open&labels=workflow-issue&per_page=100")) return [];
+      if (apiPath.endsWith("/pulls/516/files?per_page=100")) return [{ filename: "data/repos.json" }];
+      if (apiPath.endsWith("contents/data/repos.json?ref=main")) return { content: encoded(mainRepos), sha: "main-file" };
+      if (apiPath.endsWith("contents/data/repos.json?ref=add-repo-example-candidate")) {
+        return { content: encoded(branchRepos), sha: "branch-file" };
+      }
+      if (method === "PUT" && apiPath.endsWith("/contents/data/repos.json")) return {};
+      if (method === "GET" && apiPath.endsWith("/pulls/516")) {
+        return { ...pull, mergeable: true, mergeable_state: "unstable", head: { ...pull.head, sha: "refreshed-sha" } };
+      }
+      if (method === "PUT" && apiPath.endsWith("/pulls/516/merge")) return { merged: true };
+      if (apiPath.endsWith("/actions/workflows/build-pages.yml/dispatches")) return null;
+      throw new Error(`Unexpected request: ${method} ${apiPath}`);
+    },
+  };
+
+  const result = await recoverRepoSubmissions({ client, repository: "ksimback/hermes-ecosystem" });
+  assert.equal(result.mergedCount, 1);
+  const update = calls.find((call) => call.method === "PUT" && call.apiPath.endsWith("/contents/data/repos.json"));
+  const refreshed = JSON.parse(Buffer.from(update.body.content, "base64").toString("utf-8"));
+  assert.deepEqual(refreshed.map((item) => item.repo), ["first", "newer-main", "candidate"]);
+  assert.ok(calls.some((call) => call.apiPath.endsWith("/pulls/516/merge")));
+  assert.ok(calls.some((call) => call.apiPath.endsWith("/actions/workflows/build-pages.yml/dispatches")));
+});
+
+test("validator workflow does not wait for impossible bot-triggered CheckRuns", () => {
+  const workflow = fs.readFileSync(".github/workflows/validate-repo-suggestion.yml", "utf-8");
+  assert.match(workflow, /CANONICAL_CATEGORIES, validateRepos \} = await import/);
+  assert.match(workflow, /\['CLEAN', 'HAS_HOOKS', 'UNSTABLE'\]/);
+  assert.match(workflow, /createWorkflowDispatch/);
+  assert.match(workflow, /recover-open-prs:/);
+  assert.doesNotMatch(workflow, /const REQUIRED = \['validate', 'smoke'\]/);
+});


### PR DESCRIPTION
## What changed

- validates the exact candidate `repos.json` inside the issue-triggered workflow, where bot-created PRs can actually be evaluated
- accepts GitHub's `UNSTABLE` merge state when all posted external contexts are green and the in-process catalog validation passed
- fails the workflow on merge failure instead of opening a warning while returning success
- explicitly dispatches `build-pages.yml` after a token-authored merge
- rejects non-canonical suggested categories and falls back to the inferred category
- adds a scheduled/manual recovery job that refreshes each stuck `add-repo-*` PR onto current main, validates it, merges sequentially, closes stale tracker issues, and rebuilds the site once

## Root cause

The validator created PRs with `GITHUB_TOKEN`, then waited for `validate` and `smoke` CheckRuns that can only be created by a `pull_request` event. GitHub intentionally suppresses that cascade, so the required checks never existed and every run timed out green with a manual-review issue.

## Validation

- `npm test` — 125/125 passed
- fake stale-branch recovery integration — preserved newer main entries, appended one candidate, merged, and dispatched the page build
- workflow YAML and JavaScript syntax checks — passed
- live read-only audit of PRs #503, #509, #512, and #516 — each changes only `data/repos.json` and resolves to exactly one valid candidate after canonical category normalization
- `git diff --check` — passed

## Merge order and operational acceptance

Merge #524 first so the dispatched page build is healthy. Then merge this PR and manually dispatch **Validate Repo Suggestion** once. Acceptance: PRs #503/#509/#512/#516 are merged sequentially (or closed only if already present), issues #504/#508/#510/#514/#517 are closed as recovered/stale, the catalog contains all four repos without duplicates, and the page build succeeds.