### PR TITLE
Seed stars before semantic post-deploy smoke

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -115,6 +115,17 @@ jobs:
             }
             core.setFailed(`Timed out waiting for Vercel deploy (10min)`);
 
+      # A catalog deployment can invalidate the previous snapshot (for example,
+      # after a removed repository is pruned). Seed a validated replacement
+      # before checking the semantic `stale`/`complete` contract, rather than
+      # waiting up to six hours for the scheduled refresh.
+      - name: Seed stars snapshot before semantic smoke
+        if: github.event_name == 'push'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+        run: node scripts/push-stars-snapshot.js
+
       - name: Run smoke test
         id: smoke
         # Pass dispatch inputs via env, never interpolated straight into the

--- a/tests/post-deploy-smoke-workflow.test.js
+++ b/tests/post-deploy-smoke-workflow.test.js
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const workflow = await readFile(
+  path.join(ROOT, ".github", "workflows", "post-deploy-smoke.yml"),
+  "utf8",
+);
+
+test("post-deploy smoke seeds stars before enforcing semantic freshness", () => {
+  const seed = workflow.indexOf("Seed stars snapshot before semantic smoke");
+  const smoke = workflow.indexOf("- name: Run smoke test");
+
+  assert.ok(seed >= 0, "workflow must seed the snapshot after a push deploy");
+  assert.ok(smoke > seed, "snapshot seed must complete before semantic smoke starts");
+  assert.match(workflow, /if: github\.event_name == 'push'[\s\S]*?GITHUB_TOKEN: \$\{\{ github\.token \}\}[\s\S]*?CRON_SECRET: \$\{\{ secrets\.CRON_SECRET \}\}[\s\S]*?node scripts\/push-stars-snapshot\.js/);
+});


### PR DESCRIPTION
## Fix post-deploy semantic-smoke ordering

The first deployment of #529 correctly failed the new semantic star checks: the catalog had changed from 185 to 184 repos, invalidating the old snapshot, while the scheduled refresh had not yet run.

This PR seeds a validated snapshot with the existing `push-stars-snapshot.js` publisher after Vercel confirms a push deployment and before semantic smoke runs. It uses the existing GitHub token and `CRON_SECRET`, so a catalog-changing deployment cannot race the six-hour schedule.

### Verification
- `node --test tests/post-deploy-smoke-workflow.test.js` — passed.
- Workflow YAML parse — passed.
- `npm test` — 166/166 passed.
- Existing post-deploy smoke rerun after seeding — passed.

After merge, the push-triggered post-deploy job itself is the end-to-end verification target.