### PR TITLE
Close recovered production smoke alerts

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -146,6 +146,36 @@ jobs:
             --continue \
             | tee smoke-output.txt
 
+      - name: Close smoke alert after recovery
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = 'Smoke test failure on production';
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'workflow-issue',
+              per_page: 100,
+            });
+            const issue = issues.find(item => item.title === title);
+            if (!issue) return;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              body: `Recovered in ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}.`,
+            });
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              state: 'closed',
+              state_reason: 'completed',
+            });
+
       - name: Post commit status (success)
         if: success() && github.event_name == 'push'
         uses: actions/github-script@v7

--- a/tests/post-deploy-smoke-workflow.test.js
+++ b/tests/post-deploy-smoke-workflow.test.js
@@ -18,3 +18,11 @@ test("post-deploy smoke seeds stars before enforcing semantic freshness", () => 
   assert.ok(smoke > seed, "snapshot seed must complete before semantic smoke starts");
   assert.match(workflow, /if: github\.event_name == 'push'[\s\S]*?GITHUB_TOKEN: \$\{\{ github\.token \}\}[\s\S]*?CRON_SECRET: \$\{\{ secrets\.CRON_SECRET \}\}[\s\S]*?node scripts\/push-stars-snapshot\.js/);
 });
+
+test("post-deploy smoke closes the one active alert after recovery", () => {
+  const smoke = workflow.indexOf("- name: Run smoke test");
+  const recovery = workflow.indexOf("Close smoke alert after recovery");
+
+  assert.ok(recovery > smoke, "recovery close must run only after smoke succeeds");
+  assert.match(workflow, /if: success\(\)[\s\S]*?title = 'Smoke test failure on production'[\s\S]*?labels: 'workflow-issue'[\s\S]*?state: 'closed'[\s\S]*?state_reason: 'completed'/);
+});


### PR DESCRIPTION
## Close recovered production-smoke alerts

A successful post-deploy smoke run now closes the single open `Smoke test failure on production` issue, with a comment linking to the recovery run. This prevents resolved transient incidents from remaining open indefinitely.

### Verification
- `node --test tests/post-deploy-smoke-workflow.test.js` — 2/2 passed.
- Workflow YAML parse — passed.
- `npm test` — 167/167 passed.

Merging this PR triggers the end-to-end recovery proof: the successful post-deploy smoke should close issue #535.