### PR TITLE
Recover stale repo submission PRs safely

### DIFF
--- a/lib/repo-submission.js
+++ b/lib/repo-submission.js
@@ -7,9 +7,21 @@ export function repoKey(repo) {
   return `${repo?.owner || ""}/${repo?.repo || ""}`.toLowerCase();
 }
 
-export function findSubmissionCandidate(mainRepos, branchRepos) {
+export function findSubmissionCandidate(mainRepos, branchRepos, expectedKey = "") {
   const mainKeys = new Set(mainRepos.map(repoKey));
   const additions = branchRepos.filter((repo) => !mainKeys.has(repoKey(repo)));
+
+  if (expectedKey) {
+    const normalizedExpected = expectedKey.toLowerCase();
+    const expected = additions.find((repo) => repoKey(repo) === normalizedExpected);
+    if (expected) return expected;
+    if (mainKeys.has(normalizedExpected)) return null;
+    throw new Error(
+      `Expected submission ${expectedKey} was not present in the PR branch; ` +
+      `branch-only entries: ${additions.map(repoKey).join(", ") || "none"}`,
+    );
+  }
+
   if (additions.length > 1) {
     throw new Error(`Expected one repo addition, found ${additions.length}`);
   }

--- a/scripts/recover-repo-submissions.js
+++ b/scripts/recover-repo-submissions.js
@@ -64,6 +64,16 @@ function trackerTitle(pullNumber) {
   return `[Workflow] Validator PR #${pullNumber} needs manual review`;
 }
 
+function expectedRepoKey(pull) {
+  const match = String(pull.body || "").match(
+    /https:\/\/github\.com\/([a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)/,
+  );
+  if (!match) {
+    throw new Error("Could not identify the submitted repository from the PR body");
+  }
+  return match[1].replace(/\/$/, "").toLowerCase();
+}
+
 async function closeTracker(client, repository, tracker) {
   if (!tracker) return;
   await comment(client, repository, tracker.number, "Recovered automatically; the validator PR is no longer blocked.");
@@ -118,7 +128,16 @@ export async function recoverRepoSubmissions({ client, repository }) {
       ]);
       const mainRepos = decodeJsonFile(mainFile);
       const branchRepos = decodeJsonFile(branchFile);
-      const candidate = findSubmissionCandidate(mainRepos, branchRepos);
+      // Old validator branches can contain a legitimate entry that was later
+      // removed from main. That makes a raw branch-vs-main diff contain more
+      // than one addition. Select the repository named by the bot-authored PR
+      // body, then rebuild the branch from current main so historical baggage
+      // cannot be reintroduced.
+      const candidate = findSubmissionCandidate(
+        mainRepos,
+        branchRepos,
+        expectedRepoKey(pull),
+      );
 
       if (!candidate) {
         await comment(client, repository, pull.number, "Auto-closing: this repo is already present on main.");

--- a/tests/repo-submission.test.js
+++ b/tests/repo-submission.test.js
@@ -30,6 +30,21 @@ test("findSubmissionCandidate isolates the one branch-only repo", () => {
   );
 });
 
+test("findSubmissionCandidate selects the PR-owned repo when a stale branch has extra history", () => {
+  const main = [repo("example", "existing")];
+  const removedFromMain = repo("example", "removed-later");
+  const candidate = repo("example", "candidate");
+
+  assert.deepEqual(
+    findSubmissionCandidate(
+      main,
+      [main[0], removedFromMain, candidate],
+      "example/candidate",
+    ),
+    candidate,
+  );
+});
+
 test("mergeSubmissionCandidate preserves current main and validates the candidate", () => {
   const main = [repo("example", "first"), repo("example", "second")];
   const next = mergeSubmissionCandidate(main, repo("example", "third"));
@@ -52,6 +67,7 @@ test("recoverRepoSubmissions refreshes a stale PR onto main before merging", asy
   const pull = {
     number: 516,
     created_at: "2026-07-12T00:00:00Z",
+    body: "Adds [example/candidate](https://github.com/example/candidate) to the ecosystem map.",
     head: {
       ref: "add-repo-example-candidate",
       repo: { full_name: "ksimback/hermes-ecosystem" },


### PR DESCRIPTION
## What changed
- identify the submitted repository from the bot-authored PR body
- rebuild stale validator branches from current `main` using only that candidate
- preserve fail-closed behavior when the expected repository cannot be identified

## Root cause
Historical validator branches all carry a second entry (`ellickjohnson/portainer-stack-hermes`) that was later removed from `main`. The recovery job treated every branch-only entry as a new candidate, saw two additions, and refused all five PRs.

## Validation
- `node --test tests/repo-submission.test.js` (5/5 passing)
- live workflow run 29528444642 reproduced the fail-closed behavior on PRs #503, #509, #512, #516, and #533 before any merge
- remote Git blob SHAs match the normalized local objects for all three files