### PR TITLE
Rebase recovered submissions onto current main

### DIFF
--- a/scripts/recover-repo-submissions.js
+++ b/scripts/recover-repo-submissions.js
@@ -64,6 +64,40 @@ function trackerTitle(pullNumber) {
   return `[Workflow] Validator PR #${pullNumber} needs manual review`;
 }
 
+async function refreshSubmissionBranch({
+  client,
+  repository,
+  pull,
+  mainSha,
+  mainTreeSha,
+  nextRepos,
+}) {
+  const blob = await client.request("POST", `/repos/${repository}/git/blobs`, {
+    content: `${JSON.stringify(nextRepos, null, 2)}\n`,
+    encoding: "utf-8",
+  });
+  const tree = await client.request("POST", `/repos/${repository}/git/trees`, {
+    base_tree: mainTreeSha,
+    tree: [{
+      path: "data/repos.json",
+      mode: "100644",
+      type: "blob",
+      sha: blob.sha,
+    }],
+  });
+  const commit = await client.request("POST", `/repos/${repository}/git/commits`, {
+    message: `Refresh validator PR #${pull.number} onto latest main`,
+    tree: tree.sha,
+    parents: [mainSha],
+  });
+  await client.request(
+    "PATCH",
+    `/repos/${repository}/git/refs/heads/${pull.head.ref}`,
+    { sha: commit.sha, force: true },
+  );
+  return commit.sha;
+}
+
 function expectedRepoKey(pull) {
   const match = String(pull.body || "").match(
     /https:\/\/github\.com\/([a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)/,
@@ -122,8 +156,11 @@ export async function recoverRepoSubmissions({ client, repository }) {
         throw new Error(`PR changes unexpected files: ${files.map((file) => file.filename).join(", ")}`);
       }
 
-      const [mainFile, branchFile] = await Promise.all([
-        getReposFile(client, repository, "main"),
+      const mainRef = await client.request("GET", `/repos/${repository}/git/ref/heads/main`);
+      const mainSha = mainRef.object.sha;
+      const [mainCommit, mainFile, branchFile] = await Promise.all([
+        client.request("GET", `/repos/${repository}/git/commits/${mainSha}`),
+        getReposFile(client, repository, mainSha),
         getReposFile(client, repository, pull.head.ref),
       ]);
       const mainRepos = decodeJsonFile(mainFile);
@@ -147,11 +184,13 @@ export async function recoverRepoSubmissions({ client, repository }) {
       }
 
       const nextRepos = mergeSubmissionCandidate(mainRepos, candidate);
-      await client.request("PUT", `/repos/${repository}/contents/data/repos.json`, {
-        message: `Refresh validator PR #${pull.number} onto latest main`,
-        content: Buffer.from(`${JSON.stringify(nextRepos, null, 2)}\n`).toString("base64"),
-        sha: branchFile.sha,
-        branch: pull.head.ref,
+      await refreshSubmissionBranch({
+        client,
+        repository,
+        pull,
+        mainSha,
+        mainTreeSha: mainCommit.tree.sha,
+        nextRepos,
       });
 
       const mergeable = await waitForMergeability(client, repository, pull.number);

--- a/tests/repo-submission.test.js
+++ b/tests/repo-submission.test.js
@@ -81,11 +81,16 @@ test("recoverRepoSubmissions refreshes a stale PR onto main before merging", asy
       if (apiPath.endsWith("/pulls?state=open&per_page=100")) return [pull];
       if (apiPath.endsWith("/issues?state=open&labels=workflow-issue&per_page=100")) return [];
       if (apiPath.endsWith("/pulls/516/files?per_page=100")) return [{ filename: "data/repos.json" }];
-      if (apiPath.endsWith("contents/data/repos.json?ref=main")) return { content: encoded(mainRepos), sha: "main-file" };
+      if (apiPath.endsWith("/git/ref/heads/main")) return { object: { sha: "main-sha" } };
+      if (apiPath.endsWith("/git/commits/main-sha")) return { tree: { sha: "main-tree" } };
+      if (apiPath.endsWith("contents/data/repos.json?ref=main-sha")) return { content: encoded(mainRepos), sha: "main-file" };
       if (apiPath.endsWith("contents/data/repos.json?ref=add-repo-example-candidate")) {
         return { content: encoded(branchRepos), sha: "branch-file" };
       }
-      if (method === "PUT" && apiPath.endsWith("/contents/data/repos.json")) return {};
+      if (method === "POST" && apiPath.endsWith("/git/blobs")) return { sha: "catalog-blob" };
+      if (method === "POST" && apiPath.endsWith("/git/trees")) return { sha: "refreshed-tree" };
+      if (method === "POST" && apiPath.endsWith("/git/commits")) return { sha: "refreshed-sha" };
+      if (method === "PATCH" && apiPath.endsWith("/git/refs/heads/add-repo-example-candidate")) return {};
       if (method === "GET" && apiPath.endsWith("/pulls/516")) {
         return { ...pull, mergeable: true, mergeable_state: "unstable", head: { ...pull.head, sha: "refreshed-sha" } };
       }
@@ -97,9 +102,13 @@ test("recoverRepoSubmissions refreshes a stale PR onto main before merging", asy
 
   const result = await recoverRepoSubmissions({ client, repository: "ksimback/hermes-ecosystem" });
   assert.equal(result.mergedCount, 1);
-  const update = calls.find((call) => call.method === "PUT" && call.apiPath.endsWith("/contents/data/repos.json"));
-  const refreshed = JSON.parse(Buffer.from(update.body.content, "base64").toString("utf-8"));
+  const update = calls.find((call) => call.method === "POST" && call.apiPath.endsWith("/git/blobs"));
+  const refreshed = JSON.parse(update.body.content);
   assert.deepEqual(refreshed.map((item) => item.repo), ["first", "newer-main", "candidate"]);
+  const commit = calls.find((call) => call.method === "POST" && call.apiPath.endsWith("/git/commits"));
+  assert.deepEqual(commit.body.parents, ["main-sha"]);
+  const refUpdate = calls.find((call) => call.method === "PATCH" && call.apiPath.includes("/git/refs/heads/"));
+  assert.deepEqual(refUpdate.body, { sha: "refreshed-sha", force: true });
   assert.ok(calls.some((call) => call.apiPath.endsWith("/pulls/516/merge")));
   assert.ok(calls.some((call) => call.apiPath.endsWith("/actions/workflows/build-pages.yml/dispatches")));
 });


### PR DESCRIPTION
## What changed
- rebuild each recovered submission branch with a Git commit parented directly on the current `main`
- use current `main` as the catalog and tree base
- force-move the bot branch to that clean commit before checking mergeability

## Root cause
Updating only `data/repos.json` through the Contents API changed the branch tip but retained its historical merge base. After PR #503 merged, GitHub still reported the other refreshed branches as `DIRTY` even though their catalog content had been reconstructed from current `main`.

## Validation
- `node --test tests/repo-submission.test.js` (5/5 passing)
- test now asserts that the recovery commit has current `main` as its sole parent and that the branch ref is force-moved to it
- live run 29528754624 proved candidate selection is fixed by merging #503, then reproduced the stale-merge-base failure on the remaining four PRs