### PR TITLE
Make release automation self-healing

### DIFF
--- a/.github/workflows/audit-summaries.yml
+++ b/.github/workflows/audit-summaries.yml
@@ -4,7 +4,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 concurrency:
-  group: main-bot-push
+  group: audit-summaries
   cancel-in-progress: false
 
 on:

--- a/.github/workflows/build-pages.yml
+++ b/.github/workflows/build-pages.yml
@@ -4,7 +4,7 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 concurrency:
-  group: main-bot-push
+  group: build-pages
   cancel-in-progress: false
 
 on:

--- a/.github/workflows/rebuild-chunks.yml
+++ b/.github/workflows/rebuild-chunks.yml
@@ -4,10 +4,14 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 concurrency:
-  group: main-bot-push
+  group: rebuild-chunks
   cancel-in-progress: false
 
 on:
+  schedule:
+    # Daily reconciliation after release-monitor. Push/dispatch events remain
+    # the fast path; this catches a missed or externally cancelled event.
+    - cron: '20 6 * * *'
   push:
     branches: [main]
     paths:

--- a/.github/workflows/refresh-docs.yml
+++ b/.github/workflows/refresh-docs.yml
@@ -9,7 +9,7 @@ env:
 # embedded knowledge base stays in sync without manual intervention.
 
 concurrency:
-  group: main-bot-push
+  group: refresh-docs
   cancel-in-progress: false
 
 on:

--- a/.github/workflows/rotate-featured.yml
+++ b/.github/workflows/rotate-featured.yml
@@ -7,7 +7,7 @@ name: Rotate featured pick
 # adjusting the picker's band.
 
 concurrency:
-  group: main-bot-push
+  group: rotate-featured
   cancel-in-progress: false
 
 on:

--- a/TESTING.md
+++ b/TESTING.md
@@ -10,7 +10,7 @@ deploy).
 | When | What runs | What it catches |
 |---|---|---|
 | Pre-merge | Existing workflows (`audit-repos`, `validate-repo-suggestion`, Vercel preview build) | Schema errors, dead repos, build failures, bad submissions |
-| Post-deploy | `post-deploy-smoke.yml` ← **new** | Drift between `data/repos.json` and rendered HTML, missing project pages, broken sitemap/RSS, 404s on critical pages, broken internal links |
+| Post-deploy | `post-deploy-smoke.yml` | Stale release data, unhealthy chat/stars/OG contracts, drift between `data/repos.json` and rendered HTML, missing project pages, broken sitemap/RSS, 404s, and broken internal links |
 
 The post-deploy smoke test runs automatically on every push to `main` that
 touches site-affecting files. Results show up as a commit status next to
@@ -55,6 +55,15 @@ Hits `/`, `/guide/`, `/lists/`, `/reports/`, `/privacy/`, `/sitemap.xml`,
 - A build skipping a top-level page
 - Vercel routing config (`vercel.json`) regressing
 - A page rename that wasn't propagated to the menu
+
+### Public API and release contracts are semantically healthy
+
+Checks Ask the Atlas, stars, star history, and OG image responses rather than
+accepting HTTP 200 alone. On production it also compares
+`/data/latest-release.json` with the latest stable calendar-tagged release from
+`NousResearch/hermes-agent`; preview runs compare the deployed artifact with the
+PR checkout. This catches a release that reached `research/` but never reached
+the RAG artifact or generated site.
 
 ### 2. Homepage category counts match `data/repos.json`
 
@@ -141,7 +150,7 @@ These run on PRs and pushes:
 | `audit-repos.yml` | Periodic dead-repo check (GraphQL against GitHub) |
 | `audit-summaries.yml` | Weekly LLM audit of generated summaries against current READMEs |
 | `build-pages.yml` | Rebuilds project pages on push to `main` |
-| `rebuild-chunks.yml` | Rebuilds the RAG chunks corpus |
+| `rebuild-chunks.yml` | Rebuilds the RAG chunks corpus on source changes/dispatch and reconciles daily at 06:20 UTC |
 | Vercel preview build | Catches build/deploy failures on PRs before merge |
 
 ## Recommended next-step hardening

--- a/lib/release-sync.js
+++ b/lib/release-sync.js
@@ -82,6 +82,14 @@ export function planReleaseBatch({ upstreamReleases, researchFiles }) {
   return { trackedTags, missing, documents };
 }
 
+export function latestStableRelease(upstreamReleases) {
+  return upstreamReleases
+    .filter((release) => !release.draft && !release.prerelease)
+    .filter((release) => CALENDAR_TAG_RE.test(String(release.tag_name || "")))
+    .filter((release) => Number.isFinite(Date.parse(release.published_at)))
+    .sort((a, b) => Date.parse(b.published_at) - Date.parse(a.published_at))[0] || null;
+}
+
 export function releaseTagFromPrTitle(title) {
   return String(title || "").match(/Hermes Agent\s+(v20\d{2}(?:\.\d+){2,})/i)?.[1] || null;
 }

--- a/scripts/smoke-test-prod.js
+++ b/scripts/smoke-test-prod.js
@@ -95,6 +95,8 @@ const VERBOSE = flag("verbose");
 const PREVIEW_MODE = flag("preview");
 const USER_AGENT = "HermesAtlas-SmokeTest/1.0";
 const BYPASS_SECRET = process.env.VERCEL_AUTOMATION_BYPASS_SECRET || "";
+const HERMES_RELEASES_URL = process.env.HERMES_RELEASES_URL ||
+  "https://api.github.com/repos/NousResearch/hermes-agent/releases?per_page=20";
 
 // Acknowledged failures: substring-matched against the `check` name. Anything
 // matched becomes a WARN instead of a FAIL (still printed, doesn't affect exit
@@ -224,6 +226,9 @@ function sample(arr, n) {
 const repos = JSON.parse(
   await fs.readFile(path.join(ROOT, "data/repos.json"), "utf8")
 );
+const checkoutLatestRelease = JSON.parse(
+  await fs.readFile(path.join(ROOT, "data/latest-release.json"), "utf8")
+);
 
 // Preview mode: a preview deploy serves exactly this commit, so an entry
 // whose project page hasn't been generated yet (a repo-add PR; build-pages
@@ -320,6 +325,52 @@ await section("2. Public API contracts are semantically healthy", async () => {
     pass("Ask the Atlas", `HTTP ${chat.status}, non-empty response`);
   } else {
     fail("Ask the Atlas", `HTTP ${chat.status}${chat.ok ? ", empty response" : ""}`, `${BASE}/api/chat`);
+  }
+
+  const releaseArtifactResponse = await fetchWithTimeout(`${BASE}/data/latest-release.json`);
+  if (!releaseArtifactResponse.ok) {
+    fail("latest release freshness", `artifact HTTP ${releaseArtifactResponse.status}`, `${BASE}/data/latest-release.json`);
+  } else {
+    const releaseArtifact = await readJson(releaseArtifactResponse, "latest release freshness");
+    if (releaseArtifact) {
+      if (PREVIEW_MODE) {
+        if (releaseArtifact.tag === checkoutLatestRelease.tag) {
+          pass("latest release freshness", `preview matches checkout ${releaseArtifact.tag}`);
+        } else {
+          fail(
+            "latest release freshness",
+            `preview has ${releaseArtifact.tag || "no tag"}; checkout has ${checkoutLatestRelease.tag || "no tag"}`,
+            `${BASE}/data/latest-release.json`,
+          );
+        }
+      } else {
+        const upstreamResponse = await fetchWithTimeout(HERMES_RELEASES_URL, {
+          headers: { Accept: "application/vnd.github+json" },
+        });
+        if (!upstreamResponse.ok) {
+          fail("latest release freshness", `upstream HTTP ${upstreamResponse.status}`, HERMES_RELEASES_URL);
+        } else {
+          const upstreamReleases = await readJson(upstreamResponse, "latest release freshness");
+          const upstreamLatest = Array.isArray(upstreamReleases)
+            ? upstreamReleases
+              .filter((release) => !release.draft && !release.prerelease)
+              .filter((release) => /^v20\d{2}(?:\.\d+){2,}$/i.test(String(release.tag_name || "")))
+              .sort((a, b) => Date.parse(b.published_at) - Date.parse(a.published_at))[0]
+            : null;
+          if (!upstreamLatest) {
+            fail("latest release freshness", "upstream returned no stable calendar-tagged release", HERMES_RELEASES_URL);
+          } else if (releaseArtifact.tag === upstreamLatest.tag_name) {
+            pass("latest release freshness", `${releaseArtifact.version} (${releaseArtifact.tag})`);
+          } else {
+            fail(
+              "latest release freshness",
+              `production has ${releaseArtifact.tag || "no tag"}; upstream has ${upstreamLatest.tag_name}`,
+              `${BASE}/data/latest-release.json`,
+            );
+          }
+        }
+      }
+    }
   }
 
   const stars = await fetchWithTimeout(`${BASE}/api/stars`);

--- a/scripts/sync-releases.js
+++ b/scripts/sync-releases.js
@@ -5,6 +5,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   extractTrackedReleaseTags,
+  latestStableRelease,
   planReleaseBatch,
   releaseBranchName,
   releaseTagFromPrTitle,
@@ -69,6 +70,22 @@ function readResearchFiles(root = ROOT) {
     path: path.relative(root, absolute).split(path.sep).join("/"),
     content: fs.readFileSync(absolute, "utf-8"),
   }));
+}
+
+function readLatestRelease(root = ROOT) {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(root, "data", "latest-release.json"), "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+async function dispatchRebuild(client, repository) {
+  await client.request(
+    "POST",
+    `/repos/${repository}/actions/workflows/rebuild-chunks.yml/dispatches`,
+    { ref: "main" },
+  );
 }
 
 async function listAllReleases(client) {
@@ -139,17 +156,30 @@ export async function syncReleases({
   client,
   repository,
   researchFiles = readResearchFiles(),
+  latestReleaseData = readLatestRelease(),
 }) {
   const upstreamReleases = await listAllReleases(client);
   const plan = planReleaseBatch({ upstreamReleases, researchFiles });
+  const upstreamLatest = latestStableRelease(upstreamReleases);
 
   await closeTrackedReleasePrs(client, repository, plan.trackedTags);
 
   if (plan.documents.length === 0) {
     console.log(`No missing releases (${plan.trackedTags.size} tags already tracked)`);
+    const artifactTag = String(latestReleaseData?.tag || "");
+    const artifactStale = upstreamLatest && artifactTag !== upstreamLatest.tag_name;
+    if (artifactStale) {
+      console.log(
+        `Release corpus is current but latest-release.json is stale ` +
+        `(${artifactTag || "missing"} != ${upstreamLatest.tag_name}); dispatching rebuild`,
+      );
+      await dispatchRebuild(client, repository);
+    }
     setOutput("new_release", "false");
     setOutput("merged", "false");
-    return { merged: false, documents: [] };
+    setOutput("rebuild_dispatched", artifactStale ? "true" : "false");
+    setOutput("latest_tag", upstreamLatest?.tag_name || "");
+    return { merged: false, documents: [], rebuildDispatched: Boolean(artifactStale) };
   }
 
   const tags = plan.documents.map((document) => document.release.tag_name);
@@ -226,14 +256,11 @@ export async function syncReleases({
   const nowTracked = new Set([...plan.trackedTags, ...tags]);
   await closeTrackedReleasePrs(client, repository, nowTracked, { excludeNumber: pull.number });
 
-  await client.request(
-    "POST",
-    `/repos/${repository}/actions/workflows/rebuild-chunks.yml/dispatches`,
-    { ref: "main" },
-  );
+  await dispatchRebuild(client, repository);
 
   setOutput("new_release", "true");
   setOutput("merged", "true");
+  setOutput("rebuild_dispatched", "true");
   setOutput("latest_tag", latestTag);
   setOutput("pull_number", pull.number);
   return { merged: true, documents: plan.documents, pullNumber: pull.number };

--- a/tests/automation-workflows.test.js
+++ b/tests/automation-workflows.test.js
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+const workflowFiles = [
+  ".github/workflows/build-pages.yml",
+  ".github/workflows/rebuild-chunks.yml",
+  ".github/workflows/refresh-docs.yml",
+  ".github/workflows/audit-summaries.yml",
+  ".github/workflows/rotate-featured.yml",
+];
+
+test("main-writing workflows have independent concurrency queues", () => {
+  const groups = workflowFiles.map((file) => {
+    const workflow = fs.readFileSync(file, "utf-8");
+    const group = workflow.match(/concurrency:\s*\n\s*group:\s*([^\n]+)/)?.[1]?.trim();
+    assert.ok(group, `${file} has a concurrency group`);
+    assert.doesNotMatch(group, /main-bot-push/, `${file} must not use the shared eviction-prone queue`);
+    return group;
+  });
+
+  assert.equal(new Set(groups).size, groups.length, "every main-writing workflow has its own queue");
+});
+
+test("knowledge rebuild has a scheduled reconciliation path", () => {
+  const workflow = fs.readFileSync(".github/workflows/rebuild-chunks.yml", "utf-8");
+  assert.match(workflow, /schedule:[\s\S]{0,300}- cron: '20 6 \* \* \*'/);
+  assert.match(workflow, /workflow_dispatch:/);
+});

--- a/tests/release-sync.test.js
+++ b/tests/release-sync.test.js
@@ -3,6 +3,7 @@ import { test } from "node:test";
 
 import {
   extractTrackedReleaseTags,
+  latestStableRelease,
   planReleaseBatch,
   releaseBranchName,
   releaseTagFromPrTitle,
@@ -65,6 +66,51 @@ test("planReleaseBatch is idempotent when all tags are already tracked", () => {
     }],
   });
   assert.equal(plan.documents.length, 0);
+});
+
+test("latestStableRelease ignores drafts and prereleases", () => {
+  const stable = release("v2026.7.7.2", "2026-07-08T03:11:22Z", "v0.18.2");
+  assert.equal(latestStableRelease([
+    { ...release("v2026.7.8", "2026-07-09T00:00:00Z", "v0.19.0"), prerelease: true },
+    { ...release("v2026.7.9", "2026-07-10T00:00:00Z", "v0.19.1"), draft: true },
+    stable,
+  ]), stable);
+});
+
+test("syncReleases dispatches a rebuild when the corpus is current but the release artifact is stale", async () => {
+  const upstream = release("v2026.7.7.2", "2026-07-08T03:11:22Z", "v0.18.2");
+  const stalePull = {
+    number: 494,
+    title: "New release: Hermes Agent v2026.7.7.2",
+    head: { ref: "release-notes-2026.7.7.2" },
+  };
+  const calls = [];
+  const client = {
+    async request(method, apiPath, body) {
+      calls.push({ method, apiPath, body });
+      if (apiPath.includes("/releases?")) return [upstream];
+      if (apiPath.endsWith("/pulls?state=open&per_page=100")) return [stalePull];
+      if (method === "POST" && apiPath.endsWith("/issues/494/comments")) return {};
+      if (method === "PATCH" && apiPath.endsWith("/pulls/494")) return {};
+      if (apiPath.endsWith("/actions/workflows/rebuild-chunks.yml/dispatches")) return null;
+      throw new Error(`Unexpected request: ${method} ${apiPath}`);
+    },
+  };
+
+  const result = await syncReleases({
+    client,
+    repository: "ksimback/hermes-ecosystem",
+    researchFiles: [{
+      path: "research/50-release-2026-7-7-2.md",
+      content: renderReleaseMarkdown(upstream),
+    }],
+    latestReleaseData: { tag: "v2026.7.1" },
+  });
+
+  assert.equal(result.merged, false);
+  assert.equal(result.rebuildDispatched, true);
+  assert.ok(calls.some((call) => call.apiPath.endsWith("/actions/workflows/rebuild-chunks.yml/dispatches")));
+  assert.ok(calls.some((call) => call.method === "PATCH" && call.apiPath.endsWith("/pulls/494")));
 });
 
 test("planReleaseBatch does not backfill intentional gaps before the watermark", () => {

--- a/tests/smoke-test-prod.test.js
+++ b/tests/smoke-test-prod.test.js
@@ -29,7 +29,10 @@ function runSmoke(base) {
   return new Promise((resolve, reject) => {
     const child = spawn(process.execPath, [
       "scripts/smoke-test-prod.js", "--base", base, "--sample", "0", "--recent-days", "-1", "--concurrency", "1", "--timeout", "2000", "--continue",
-    ], { cwd: ROOT });
+    ], {
+      cwd: ROOT,
+      env: { ...process.env, HERMES_RELEASES_URL: `${base}/upstream-releases` },
+    });
     let output = "";
     child.stdout.on("data", (data) => { output += data; });
     child.stderr.on("data", (data) => { output += data; });
@@ -38,7 +41,7 @@ function runSmoke(base) {
   });
 }
 
-async function withAtlasFixture({ stars = {} } = {}) {
+async function withAtlasFixture({ stars = {}, releaseTag = "v2026.7.7.2" } = {}) {
   const seenTwitterbot = [];
   const server = createServer((req, res) => {
     const base = `http://${req.headers.host}`;
@@ -53,6 +56,20 @@ async function withAtlasFixture({ stars = {} } = {}) {
     if (url.pathname === "/sitemap.xml") return send(200, "application/xml", sitemap(base));
     if (url.pathname === "/rss.xml") return send(200, "application/xml", "<rss><channel><item>ok</item></channel></rss>");
     if (url.pathname === "/llms.txt") return send(200, "text/plain", `Hermes Atlas has ${repos.length}+ tools.`);
+    if (url.pathname === "/data/latest-release.json") {
+      return send(200, "application/json", JSON.stringify({
+        version: releaseTag === "v2026.7.7.2" ? "v0.18.2" : "v0.18.0",
+        tag: releaseTag,
+      }));
+    }
+    if (url.pathname === "/upstream-releases") {
+      return send(200, "application/json", JSON.stringify([{
+        tag_name: "v2026.7.7.2",
+        published_at: "2026-07-08T03:11:22Z",
+        draft: false,
+        prerelease: false,
+      }]));
+    }
     if (url.pathname === "/api/chat") return send(200, "text/event-stream", "data: Hermes Agent is ready.\n\n");
     if (url.pathname === "/api/stars") {
       const response = {
@@ -109,4 +126,11 @@ test("production smoke rejects a stale stars response even when HTTP is 200", as
   });
   assert.equal(code, 1, output);
   assert.match(output, /FAIL\s+stars freshness/);
+});
+
+test("production smoke rejects a stale release artifact even when HTTP is 200", async () => {
+  const { code, output } = await withAtlasFixture({ releaseTag: "v2026.7.1" });
+  assert.equal(code, 1, output);
+  assert.match(output, /FAIL\s+latest release freshness/);
+  assert.match(output, /production has v2026\.7\.1; upstream has v2026\.7\.7\.2/);
 });


### PR DESCRIPTION
## What changed
- give each main-writing workflow its own concurrency queue so unrelated jobs cannot evict one another
- add a daily 06:20 UTC knowledge-base reconciliation run
- redispatch the RAG rebuild when release markdown is current but `latest-release.json` is stale
- close superseded release PRs during no-op release checks
- make production smoke compare the deployed release artifact with the latest stable upstream Hermes release
- document and test the new release contract

## Root cause
`build-pages`, `rebuild-chunks`, docs refresh, summary audit, and featured rotation all shared the `main-bot-push` concurrency key. GitHub keeps only one pending run per key, so the page build queued after the P0 merges cancelled both chunk rebuilds before either received a job. The release monitor then saw the v0.18.1/v0.18.2 markdown on `main` and reported success, but it had no reconciliation check for the stale generated release artifact.

## Validation
- `npm test` — 173/173 passing
- isolated release/workflow/smoke suites — 14/14 passing
- live production smoke with the new contract fails specifically on `v2026.7.1` versus upstream `v2026.7.7.2`, proving it catches the incident
- all 12 published Git blobs match the normalized tested files