### PR TITLE
Retry malformed OpenRouter JSON

### DIFF
--- a/lib/openrouter.js
+++ b/lib/openrouter.js
@@ -12,6 +12,7 @@ const FALLBACK_MODELS = [
 // Total max wait is ~7s — small enough not to balloon CI runtime, large
 // enough to ride out a typical 429 burst or brief upstream blip.
 const RETRY_DELAYS_MS = [1000, 2000, 4000];
+const JSON_RETRY_DELAYS_MS = [250, 750];
 
 async function callOpenRouterOnce({ system, user, apiKey, modelChain, maxTokens }) {
   const res = await fetch("https://openrouter.ai/api/v1/chat/completions", {
@@ -105,20 +106,35 @@ export async function callOpenRouter({
  * @param {Object} options - Same as callOpenRouter
  * @returns {Promise<Object>} Parsed JSON object
  */
-export async function callOpenRouterJSON(options) {
-  const raw = await callOpenRouter(options);
+export async function callOpenRouterJSON({
+  jsonRetryDelaysMs = JSON_RETRY_DELAYS_MS,
+  ...options
+}) {
+  let lastError;
+  for (let attempt = 0; attempt <= jsonRetryDelaysMs.length; attempt++) {
+    const raw = await callOpenRouter(options);
 
-  // Strip markdown fences if the model wraps output in ```json ... ```
-  const cleaned = raw
-    .replace(/^```(?:json)?\s*/i, "")
-    .replace(/\s*```\s*$/, "")
-    .trim();
+    // Strip markdown fences if the model wraps output in ```json ... ```
+    const cleaned = raw
+      .replace(/^```(?:json)?\s*/i, "")
+      .replace(/\s*```\s*$/, "")
+      .trim();
 
-  try {
-    return JSON.parse(cleaned);
-  } catch (e) {
-    throw new Error(
-      `Failed to parse JSON from OpenRouter response: ${e.message}\nRaw: ${raw.slice(0, 300)}`
-    );
+    try {
+      return JSON.parse(cleaned);
+    } catch (error) {
+      lastError = new Error(
+        `Failed to parse JSON from OpenRouter response: ${error.message}\nRaw: ${raw.slice(0, 300)}`
+      );
+      if (attempt === jsonRetryDelaysMs.length) throw lastError;
+
+      const delay = jsonRetryDelaysMs[attempt];
+      console.warn(
+        `OpenRouter returned invalid JSON — regenerating in ${delay}ms ` +
+        `(attempt ${attempt + 2}/${jsonRetryDelaysMs.length + 1})`,
+      );
+      if (delay > 0) await new Promise((resolve) => setTimeout(resolve, delay));
+    }
   }
+  throw lastError;
 }

--- a/tests/openrouter.test.js
+++ b/tests/openrouter.test.js
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { callOpenRouterJSON } from "../lib/openrouter.js";
+
+function openRouterResponse(content) {
+  return {
+    ok: true,
+    async json() {
+      return { choices: [{ message: { content } }] };
+    },
+  };
+}
+
+test("callOpenRouterJSON regenerates truncated JSON", async () => {
+  const originalFetch = globalThis.fetch;
+  const responses = [
+    openRouterResponse('{"summary":"truncated'),
+    openRouterResponse('{"summary":"complete"}'),
+  ];
+  let calls = 0;
+  globalThis.fetch = async () => responses[calls++];
+
+  try {
+    const result = await callOpenRouterJSON({
+      system: "system",
+      user: "user",
+      apiKey: "test",
+      jsonRetryDelaysMs: [0, 0],
+    });
+    assert.deepEqual(result, { summary: "complete" });
+    assert.equal(calls, 2);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("callOpenRouterJSON fails after bounded regeneration attempts", async () => {
+  const originalFetch = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls++;
+    return openRouterResponse('{"still":"truncated');
+  };
+
+  try {
+    await assert.rejects(
+      callOpenRouterJSON({
+        system: "system",
+        user: "user",
+        apiKey: "test",
+        jsonRetryDelaysMs: [0, 0],
+      }),
+      /Failed to parse JSON from OpenRouter response/,
+    );
+    assert.equal(calls, 3);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## What changed
- retry malformed/truncated JSON responses twice with short bounded delays
- preserve the existing HTTP/network retry behavior
- fail loudly with the final raw-response excerpt after the bounded attempts

## Root cause
Build-pages run 29529076253 regenerated all four new project summaries, then failed because OpenRouter truncated the `top-skills` list JSON. The shared helper retried transport errors but treated a transient malformed model response as terminal, blocking all page generation and downstream deploy verification.

## Validation
- `node --test tests/openrouter.test.js` (2/2 passing)
- `node --test tests/summary-pruning.test.js` (5/5 passing)
- published Git blobs match the tested normalized files