### PR TITLE
Reconcile recovered automation backlogs

### DIFF
--- a/.github/workflows/build-pages.yml
+++ b/.github/workflows/build-pages.yml
@@ -111,6 +111,16 @@ jobs:
         if: steps.diff.outputs.changed == 'true'
         run: node scripts/indexnow-ping.js
 
+      - name: Close prior failure alert after recovery
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue list --state open --label workflow-issue --search '"[Workflow] build-pages failed" in:title' --json number --jq '.[].number' |
+            while read issue; do
+              gh issue close "$issue" --comment "Recovered in workflow run ${GITHUB_RUN_ID}."
+            done
+
       # Escalate silent failures. This workflow runs daily and gates what is live
       # on hermesatlas.com; without this a failed run was only a red X in the
       # Actions tab. Opens (or comments on a deduped) workflow-issue.

--- a/.github/workflows/rebuild-chunks.yml
+++ b/.github/workflows/rebuild-chunks.yml
@@ -112,6 +112,16 @@ jobs:
             });
             console.log('Dispatched build-pages.yml after knowledge data update');
 
+      - name: Close prior failure alert after recovery
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue list --state open --label workflow-issue --search '"[Workflow] rebuild-chunks failed" in:title' --json number --jq '.[].number' |
+            while read issue; do
+              gh issue close "$issue" --comment "Recovered in workflow run ${GITHUB_RUN_ID}."
+            done
+
       # Escalate silent failures — this workflow rebuilds the RAG knowledge base
       # that Ask the Atlas answers from; a failed run was previously only a red X.
       - name: Escalate on failure

--- a/.github/workflows/refresh-docs.yml
+++ b/.github/workflows/refresh-docs.yml
@@ -73,6 +73,16 @@ jobs:
           echo "Push failed after 3 attempts"
           exit 1
 
+      - name: Close prior failure alert after recovery
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue list --state open --label workflow-issue --search '"[Workflow] refresh-docs failed" in:title' --json number --jq '.[].number' |
+            while read issue; do
+              gh issue close "$issue" --comment "Recovered in workflow run ${GITHUB_RUN_ID}."
+            done
+
       # Escalate silent failures — this workflow mirrors the official Hermes docs
       # into the KB; a failed run was previously only a red X in the Actions tab.
       - name: Escalate on failure

--- a/.github/workflows/release-monitor.yml
+++ b/.github/workflows/release-monitor.yml
@@ -100,6 +100,42 @@ jobs:
               labels: ['docs-update']
             });
 
+      - name: Close resolved legacy release alerts
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'workflow-issue',
+              per_page: 100
+            });
+            for (const issue of issues) {
+              const pullNumber = Number(issue.title.match(/^\[Workflow\] Auto-merge failed on release PR #(\d+)$/)?.[1]);
+              if (!pullNumber) continue;
+              const { data: pull } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pullNumber
+              });
+              if (pull.state === 'open') continue;
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `Auto-closed: release PR #${pullNumber} is ${pull.state}.`
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'completed'
+              });
+            }
+
       - name: Close release-monitor alert after recovery
         if: success()
         uses: actions/github-script@v7

--- a/.github/workflows/rotate-featured.yml
+++ b/.github/workflows/rotate-featured.yml
@@ -56,6 +56,16 @@ jobs:
           echo "Push failed after 3 attempts"
           exit 1
 
+      - name: Close prior failure alert after recovery
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue list --state open --label workflow-issue --search '"[Workflow] rotate-featured failed" in:title' --json number --jq '.[].number' |
+            while read issue; do
+              gh issue close "$issue" --comment "Recovered in workflow run ${GITHUB_RUN_ID}."
+            done
+
       - name: Escalate on failure
         if: failure()
         uses: actions/github-script@v7

--- a/.github/workflows/smoke-test-pr.yml
+++ b/.github/workflows/smoke-test-pr.yml
@@ -41,7 +41,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
       statuses: read
 
     steps:

--- a/scripts/recover-repo-submissions.js
+++ b/scripts/recover-repo-submissions.js
@@ -98,14 +98,61 @@ async function refreshSubmissionBranch({
   return commit.sha;
 }
 
-function expectedRepoKey(pull) {
-  const match = String(pull.body || "").match(
+function repoKeyFromText(text) {
+  const match = String(text || "").match(
     /https:\/\/github\.com\/([a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)/,
   );
-  if (!match) {
+  return match ? match[1].replace(/\/$/, "").toLowerCase() : "";
+}
+
+function expectedRepoKey(pull) {
+  const key = repoKeyFromText(pull.body);
+  if (!key) {
     throw new Error("Could not identify the submitted repository from the PR body");
   }
-  return match[1].replace(/\/$/, "").toLowerCase();
+  return key;
+}
+
+async function closeSuggestion(client, repository, issue, body, stateReason) {
+  await comment(client, repository, issue.number, body);
+  await client.request("PATCH", `/repos/${repository}/issues/${issue.number}`, {
+    state: "closed",
+    state_reason: stateReason,
+  });
+}
+
+async function reconcileSuggestionIssues(client, repository, suggestionIssues) {
+  if (suggestionIssues.length === 0) return;
+  const mainFile = await getReposFile(client, repository, "main");
+  const catalogKeys = new Set(decodeJsonFile(mainFile).map(repoKey));
+
+  for (const issue of suggestionIssues) {
+    const key = repoKeyFromText(issue.body);
+    if (!key) continue;
+    if (catalogKeys.has(key)) {
+      await closeSuggestion(
+        client,
+        repository,
+        issue,
+        `Auto-closed: ${key} is present in the current Atlas catalog.`,
+        "completed",
+      );
+      continue;
+    }
+
+    try {
+      await client.request("GET", `/repos/${key}`);
+    } catch (error) {
+      if (error.status !== 404) throw error;
+      await closeSuggestion(
+        client,
+        repository,
+        issue,
+        `Auto-closed: https://github.com/${key} no longer exists (GitHub returned 404).`,
+        "not_planned",
+      );
+    }
+  }
 }
 
 async function closeTracker(client, repository, tracker) {
@@ -134,9 +181,10 @@ async function ensureTracker(client, repository, trackers, pull, reason) {
 }
 
 export async function recoverRepoSubmissions({ client, repository }) {
-  const [allPulls, issueList] = await Promise.all([
+  const [allPulls, issueList, suggestionIssues] = await Promise.all([
     client.request("GET", `/repos/${repository}/pulls?state=open&per_page=100`),
     client.request("GET", `/repos/${repository}/issues?state=open&labels=workflow-issue&per_page=100`),
+    client.request("GET", `/repos/${repository}/issues?state=open&labels=repo-suggestion&per_page=100`),
   ]);
   const pulls = allPulls
     .filter((pull) => pull.head?.ref?.startsWith("add-repo-"))
@@ -221,6 +269,8 @@ export async function recoverRepoSubmissions({ client, repository }) {
       await closeTracker(client, repository, issue);
     }
   }
+
+  await reconcileSuggestionIssues(client, repository, suggestionIssues);
 
   if (mergedCount > 0) {
     await client.request(

--- a/tests/automation-workflows.test.js
+++ b/tests/automation-workflows.test.js
@@ -27,3 +27,25 @@ test("knowledge rebuild has a scheduled reconciliation path", () => {
   assert.match(workflow, /schedule:[\s\S]{0,300}- cron: '20 6 \* \* \*'/);
   assert.match(workflow, /workflow_dispatch:/);
 });
+
+test("recoverable workflow alerts close after a green run", () => {
+  for (const file of [
+    ".github/workflows/build-pages.yml",
+    ".github/workflows/rebuild-chunks.yml",
+    ".github/workflows/refresh-docs.yml",
+    ".github/workflows/rotate-featured.yml",
+  ]) {
+    const workflow = fs.readFileSync(file, "utf-8");
+    assert.match(workflow, /Close prior failure alert after recovery/, file);
+    assert.match(workflow, /if: success\(\)/, file);
+  }
+});
+
+test("PR smoke can report failures and release monitor closes resolved legacy alerts", () => {
+  const smoke = fs.readFileSync(".github/workflows/smoke-test-pr.yml", "utf-8");
+  assert.match(smoke, /pull-requests: write/);
+
+  const release = fs.readFileSync(".github/workflows/release-monitor.yml", "utf-8");
+  assert.match(release, /Close resolved legacy release alerts/);
+  assert.match(release, /Auto-merge failed on release PR/);
+});

--- a/tests/repo-submission.test.js
+++ b/tests/repo-submission.test.js
@@ -80,6 +80,7 @@ test("recoverRepoSubmissions refreshes a stale PR onto main before merging", asy
       calls.push({ method, apiPath, body });
       if (apiPath.endsWith("/pulls?state=open&per_page=100")) return [pull];
       if (apiPath.endsWith("/issues?state=open&labels=workflow-issue&per_page=100")) return [];
+      if (apiPath.endsWith("/issues?state=open&labels=repo-suggestion&per_page=100")) return [];
       if (apiPath.endsWith("/pulls/516/files?per_page=100")) return [{ filename: "data/repos.json" }];
       if (apiPath.endsWith("/git/ref/heads/main")) return { object: { sha: "main-sha" } };
       if (apiPath.endsWith("/git/commits/main-sha")) return { tree: { sha: "main-tree" } };
@@ -111,6 +112,38 @@ test("recoverRepoSubmissions refreshes a stale PR onto main before merging", asy
   assert.deepEqual(refUpdate.body, { sha: "refreshed-sha", force: true });
   assert.ok(calls.some((call) => call.apiPath.endsWith("/pulls/516/merge")));
   assert.ok(calls.some((call) => call.apiPath.endsWith("/actions/workflows/build-pages.yml/dispatches")));
+});
+
+test("recoverRepoSubmissions closes cataloged and deleted suggestion issues", async () => {
+  const catalog = [repo("example", "cataloged")];
+  const suggestions = [
+    { number: 100, body: "Repo: https://github.com/example/cataloged" },
+    { number: 101, body: "Repo: https://github.com/example/deleted" },
+  ];
+  const calls = [];
+  const encoded = (value) => Buffer.from(JSON.stringify(value)).toString("base64");
+  const client = {
+    async request(method, apiPath, body) {
+      calls.push({ method, apiPath, body });
+      if (apiPath.endsWith("/pulls?state=open&per_page=100")) return [];
+      if (apiPath.endsWith("/issues?state=open&labels=workflow-issue&per_page=100")) return [];
+      if (apiPath.endsWith("/issues?state=open&labels=repo-suggestion&per_page=100")) return suggestions;
+      if (apiPath.endsWith("contents/data/repos.json?ref=main")) return { content: encoded(catalog) };
+      if (method === "GET" && apiPath.endsWith("/repos/example/deleted")) {
+        const error = new Error("Not Found");
+        error.status = 404;
+        throw error;
+      }
+      if (method === "POST" && apiPath.match(/\/issues\/10[01]\/comments$/)) return {};
+      if (method === "PATCH" && apiPath.match(/\/issues\/10[01]$/)) return {};
+      throw new Error(`Unexpected request: ${method} ${apiPath}`);
+    },
+  };
+
+  const result = await recoverRepoSubmissions({ client, repository: "ksimback/hermes-ecosystem" });
+  assert.equal(result.mergedCount, 0);
+  const closures = calls.filter((call) => call.method === "PATCH" && call.apiPath.match(/\/issues\/10[01]$/));
+  assert.deepEqual(closures.map((call) => call.body.state_reason), ["completed", "not_planned"]);
 });
 
 test("validator workflow does not wait for impossible bot-triggered CheckRuns", () => {


### PR DESCRIPTION
## What changed
- reconcile open `repo-suggestion` issues against the current catalog and close completed or deleted submissions
- close recovered failure alerts after successful build-pages, chunk rebuild, docs refresh, and featured rotation runs
- close legacy release auto-merge alerts after their PRs are no longer open
- grant PR preview smoke the permission needed to post failure comments
- add regression tests for queue reconciliation, alert recovery, and reporter permissions

## Root cause
The automation completed the work but left its bookkeeping open. API merges did not reliably apply `Closes #...`, success paths opened no recovery closure for several workflow alerts, and PR smoke used the issues endpoint with only read access to pull requests. This made the issue count and alert queue look persistently unhealthy even after successful recovery.

## Validation
- `node --test tests/repo-submission.test.js tests/automation-workflows.test.js` — 10/10 passing
- source reconciliation is bounded to issues already labeled `repo-suggestion`; it closes only catalog matches or GitHub 404s
- all nine published Git blobs match the normalized tested files