### PR TITLE
Preserve recovery HTTP status

### DIFF
--- a/scripts/recover-repo-submissions.js
+++ b/scripts/recover-repo-submissions.js
@@ -29,7 +29,9 @@ export class GitHubClient {
     const text = await response.text();
     const data = text ? JSON.parse(text) : null;
     if (!response.ok) {
-      throw new Error(`${method} ${apiPath} failed (${response.status}): ${data?.message || text}`);
+      const error = new Error(`${method} ${apiPath} failed (${response.status}): ${data?.message || text}`);
+      error.status = response.status;
+      throw error;
     }
     return data;
   }

--- a/tests/repo-submission.test.js
+++ b/tests/repo-submission.test.js
@@ -6,7 +6,7 @@ import {
   findSubmissionCandidate,
   mergeSubmissionCandidate,
 } from "../lib/repo-submission.js";
-import { recoverRepoSubmissions } from "../scripts/recover-repo-submissions.js";
+import { GitHubClient, recoverRepoSubmissions } from "../scripts/recover-repo-submissions.js";
 
 const repo = (owner, name, category = "Developer Tools") => ({
   owner,
@@ -27,6 +27,22 @@ test("findSubmissionCandidate isolates the one branch-only repo", () => {
   assert.throws(
     () => findSubmissionCandidate([existing], [existing, candidate, repo("example", "second")]),
     /Expected one repo addition/,
+  );
+});
+
+test("GitHubClient preserves HTTP status for recovery decisions", async () => {
+  const client = new GitHubClient({
+    token: "test",
+    fetchImpl: async () => ({
+      ok: false,
+      status: 404,
+      async text() { return JSON.stringify({ message: "Not Found" }); },
+    }),
+  });
+
+  await assert.rejects(
+    client.request("GET", "/repos/example/deleted"),
+    (error) => error.status === 404 && /Not Found/.test(error.message),
   );
 });
 


### PR DESCRIPTION
## What changed
- attach the HTTP status to recovery-client errors
- add a direct regression test for 404 preservation

## Root cause
The suggestion reconciler correctly distinguishes a deleted repo by `error.status === 404`, but `GitHubClient.request` threw a plain Error and discarded the response status. Live run 29532796951 therefore failed safely when it reached the one deleted submission after closing the cataloged backlog.

## Validation
- `node --test tests/repo-submission.test.js` — 7/7 passing
- live run 29532796951 reproduced the missing-status path
- both published Git blobs match the tested normalized files