### PR TITLE
Recover stranded repo suggestions

### DIFF
--- a/.github/workflows/validate-repo-suggestion.yml
+++ b/.github/workflows/validate-repo-suggestion.yml
@@ -15,6 +15,11 @@ on:
   schedule:
     - cron: '15 5 * * *'
   workflow_dispatch:
+    inputs:
+      issue_number:
+        description: 'Specific repo-suggestion issue to validate (leave blank to run recovery)'
+        required: false
+        type: string
 
 # Serialize validation runs. Without this, two concurrent submissions create
 # PRs that both branch from the same main SHA; merging the first leaves the
@@ -26,7 +31,7 @@ concurrency:
 
 jobs:
   validate:
-    if: github.event_name == 'issues'
+    if: github.event_name == 'issues' || (github.event_name == 'workflow_dispatch' && inputs.issue_number != '')
     runs-on: ubuntu-latest
     permissions:
       actions: write
@@ -35,20 +40,59 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Load source issue
+        uses: actions/github-script@v7
+        env:
+          REQUESTED_ISSUE_NUMBER: ${{ inputs.issue_number }}
+        with:
+          script: |
+            let issue = context.payload.issue;
+            const requested = (process.env.REQUESTED_ISSUE_NUMBER || '').trim();
+
+            if (!issue && requested) {
+              const issueNumber = Number(requested);
+              if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+                core.setFailed(`Invalid issue_number input: ${requested}`);
+                return;
+              }
+              const response = await github.rest.issues.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber
+              });
+              issue = response.data;
+            }
+
+            if (!issue || issue.pull_request) {
+              core.setFailed('A repository issue is required');
+              return;
+            }
+
+            core.exportVariable('SOURCE_ISSUE_NUMBER', String(issue.number));
+            core.exportVariable('SOURCE_ISSUE_TITLE', issue.title || '');
+            core.exportVariable('SOURCE_ISSUE_BODY', issue.body || '');
+            core.exportVariable(
+              'SOURCE_ISSUE_LABELS',
+              JSON.stringify((issue.labels || []).map(label => typeof label === 'string' ? label : label.name))
+            );
+            console.log(`Loaded issue #${issue.number}: ${issue.title}`);
+
       - name: Decide whether this issue is a repo submission
         id: gate
         uses: actions/github-script@v7
         with:
           script: |
-            const title = context.payload.issue.title || '';
-            const labels = (context.payload.issue.labels || []).map(l => l.name);
-            const titleMatches = title.startsWith('[Repo]') || title.startsWith('[Submission]');
+            const title = process.env.SOURCE_ISSUE_TITLE || '';
+            const body = process.env.SOURCE_ISSUE_BODY || '';
+            const labels = JSON.parse(process.env.SOURCE_ISSUE_LABELS || '[]');
+            const titleMatches = /^\s*(?:\[(?:repo|submission|suggest a repo)\]|suggest(?:ion)?\b|add\b)/i.test(title);
+            const hasGitHubRepo = /https:\/\/github\.com\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+/.test(body);
             const labelMatches = labels.includes('repo-suggestion');
-            const shouldRun = titleMatches || labelMatches;
+            const shouldRun = labelMatches || (titleMatches && hasGitHubRepo);
 
             core.setOutput('should_run', shouldRun ? 'true' : 'false');
             core.setOutput('has_label', labelMatches ? 'true' : 'false');
-            console.log(`title=${title}, titleMatches=${titleMatches}, labelMatches=${labelMatches}, shouldRun=${shouldRun}`);
+            console.log(`title=${title}, titleMatches=${titleMatches}, hasGitHubRepo=${hasGitHubRepo}, labelMatches=${labelMatches}, shouldRun=${shouldRun}`);
 
       - name: Ensure repo-suggestion label is present
         if: steps.gate.outputs.should_run == 'true' && steps.gate.outputs.has_label != 'true'
@@ -58,10 +102,10 @@ jobs:
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.payload.issue.number,
+              issue_number: Number(process.env.SOURCE_ISSUE_NUMBER),
               labels: ['repo-suggestion']
             });
-            console.log(`Labeled #${context.payload.issue.number} as repo-suggestion`);
+            console.log(`Labeled #${process.env.SOURCE_ISSUE_NUMBER} as repo-suggestion`);
 
       - name: Checkout
         if: steps.gate.outputs.should_run == 'true'
@@ -79,7 +123,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const body = context.payload.issue.body || '';
+            const body = process.env.SOURCE_ISSUE_BODY || '';
 
             // Extract GitHub URL from the issue body
             const urlMatch = body.match(/https:\/\/github\.com\/([a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)/);
@@ -310,7 +354,7 @@ jobs:
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: Number(process.env.SOURCE_ISSUE_NUMBER),
               body: report
             });
 
@@ -322,14 +366,14 @@ jobs:
             await github.rest.issues.update({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: Number(process.env.SOURCE_ISSUE_NUMBER),
               state: 'closed',
               state_reason: 'not_planned'
             });
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: Number(process.env.SOURCE_ISSUE_NUMBER),
               body: 'Auto-closing — this repo is already in the ecosystem map. Reopen if you believe this is a mistake.'
             });
 
@@ -398,13 +442,13 @@ jobs:
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.issue.number,
+                issue_number: Number(process.env.SOURCE_ISSUE_NUMBER),
                 body: `[${owner}/${repo}](${htmlUrl}) is already in the Atlas ecosystem — no PR needed. Closing.`
               });
               await github.rest.issues.update({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.issue.number,
+                issue_number: Number(process.env.SOURCE_ISSUE_NUMBER),
                 state: 'closed',
                 state_reason: 'completed'
               });
@@ -470,7 +514,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               path: 'data/repos.json',
-              message: `Add ${owner}/${repo} to ecosystem map\n\nSuggested in #${context.issue.number}`,
+              message: `Add ${owner}/${repo} to ecosystem map\n\nSuggested in #${process.env.SOURCE_ISSUE_NUMBER}`,
               content: Buffer.from(JSON.stringify(repos, null, 2) + '\n').toString('base64'),
               sha: file.sha,
               branch
@@ -481,7 +525,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: `Add ${owner}/${repo} (${stars} stars) to ${category}`,
-              body: `Adds [${owner}/${repo}](${htmlUrl}) to the ecosystem map.\n\n**Stars:** ${stars}\n**Category:** ${category}\n**Description:** ${description}\n\nCloses #${context.issue.number}\n\n> Note: This PR only updates repos.json. The HTML map will need a manual update to include the new chip, or will be picked up in the next full refresh.`,
+              body: `Adds [${owner}/${repo}](${htmlUrl}) to the ecosystem map.\n\n**Stars:** ${stars}\n**Category:** ${category}\n**Description:** ${description}\n\nCloses #${process.env.SOURCE_ISSUE_NUMBER}\n\n> Note: This PR only updates repos.json. The HTML map will need a manual update to include the new chip, or will be picked up in the next full refresh.`,
               head: branch,
               base: 'main'
             });
@@ -628,12 +672,12 @@ jobs:
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: Number(process.env.SOURCE_ISSUE_NUMBER),
               body: `PR created: #${pr.number}\n\nOnce merged, this repo will appear in the ecosystem map.${mergeNote}`
             });
 
   recover-open-prs:
-    if: github.event_name != 'issues'
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.issue_number == '')
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/scripts/recover-repo-submissions.js
+++ b/scripts/recover-repo-submissions.js
@@ -107,6 +107,17 @@ function repoKeyFromText(text) {
   return match ? match[1].replace(/\/$/, "").toLowerCase() : "";
 }
 
+export function isUnprocessedSuggestion(issue) {
+  if (!issue || issue.pull_request || issue.state === "closed") return false;
+  const labels = (issue.labels || []).map((label) =>
+    typeof label === "string" ? label : label.name,
+  );
+  if (labels.includes("repo-suggestion")) return false;
+  const titleMatches = /^\s*(?:\[(?:repo|submission|suggest a repo)\]|suggest(?:ion)?\b|add\b)/i
+    .test(String(issue.title || ""));
+  return titleMatches && Boolean(repoKeyFromText(issue.body));
+}
+
 function expectedRepoKey(pull) {
   const key = repoKeyFromText(pull.body);
   if (!key) {
@@ -183,10 +194,11 @@ async function ensureTracker(client, repository, trackers, pull, reason) {
 }
 
 export async function recoverRepoSubmissions({ client, repository }) {
-  const [allPulls, issueList, suggestionIssues] = await Promise.all([
+  const [allPulls, issueList, suggestionIssues, allOpenIssues] = await Promise.all([
     client.request("GET", `/repos/${repository}/pulls?state=open&per_page=100`),
     client.request("GET", `/repos/${repository}/issues?state=open&labels=workflow-issue&per_page=100`),
     client.request("GET", `/repos/${repository}/issues?state=open&labels=repo-suggestion&per_page=100`),
+    client.request("GET", `/repos/${repository}/issues?state=open&per_page=100`),
   ]);
   const pulls = allPulls
     .filter((pull) => pull.head?.ref?.startsWith("add-repo-"))
@@ -274,6 +286,26 @@ export async function recoverRepoSubmissions({ client, repository }) {
 
   await reconcileSuggestionIssues(client, repository, suggestionIssues);
 
+  // Issue events can be missed, and older issue templates used titles such as
+  // "Suggest ..." or "Add ..." without applying repo-suggestion. Dispatch one
+  // oldest stranded submission per scheduled recovery. The shared workflow
+  // concurrency queue runs the child validation after this recovery finishes,
+  // while the next daily run provides bounded retry behavior.
+  const stranded = allOpenIssues
+    .filter(isUnprocessedSuggestion)
+    .sort((a, b) => Date.parse(a.created_at) - Date.parse(b.created_at))[0];
+  if (stranded) {
+    await client.request(
+      "POST",
+      `/repos/${repository}/actions/workflows/validate-repo-suggestion.yml/dispatches`,
+      { ref: "main", inputs: { issue_number: String(stranded.number) } },
+    );
+    await client.request("POST", `/repos/${repository}/issues/${stranded.number}/labels`, {
+      labels: ["repo-suggestion"],
+    });
+    console.log(`Dispatched validation recovery for stranded issue #${stranded.number}`);
+  }
+
   if (mergedCount > 0) {
     await client.request(
       "POST",
@@ -286,7 +318,7 @@ export async function recoverRepoSubmissions({ client, repository }) {
   }
 
   console.log(`Repo-submission recovery complete: ${mergedCount} merged`);
-  return { mergedCount };
+  return { mergedCount, dispatchedIssue: stranded?.number || null };
 }
 
 async function main() {

--- a/tests/repo-submission.test.js
+++ b/tests/repo-submission.test.js
@@ -6,7 +6,11 @@ import {
   findSubmissionCandidate,
   mergeSubmissionCandidate,
 } from "../lib/repo-submission.js";
-import { GitHubClient, recoverRepoSubmissions } from "../scripts/recover-repo-submissions.js";
+import {
+  GitHubClient,
+  isUnprocessedSuggestion,
+  recoverRepoSubmissions,
+} from "../scripts/recover-repo-submissions.js";
 
 const repo = (owner, name, category = "Developer Tools") => ({
   owner,
@@ -61,6 +65,27 @@ test("findSubmissionCandidate selects the PR-owned repo when a stale branch has 
   );
 });
 
+test("isUnprocessedSuggestion recognizes legacy repo titles without sweeping unrelated issues", () => {
+  const issue = (title, body, labels = []) => ({
+    number: 293,
+    state: "open",
+    title,
+    body,
+    labels,
+  });
+  const url = "https://github.com/obra/superpowers";
+
+  assert.equal(isUnprocessedSuggestion(issue("Add obra/superpowers", url)), true);
+  assert.equal(isUnprocessedSuggestion(issue("Suggest a Hermes plugin", url)), true);
+  assert.equal(isUnprocessedSuggestion(issue("[Suggest a Repo] agentcairn", url)), true);
+  assert.equal(isUnprocessedSuggestion(issue("Content newsletter", url)), false);
+  assert.equal(isUnprocessedSuggestion(issue("Add content newsletter", "No repository URL")), false);
+  assert.equal(
+    isUnprocessedSuggestion(issue("Add obra/superpowers", url, [{ name: "repo-suggestion" }])),
+    false,
+  );
+});
+
 test("mergeSubmissionCandidate preserves current main and validates the candidate", () => {
   const main = [repo("example", "first"), repo("example", "second")];
   const next = mergeSubmissionCandidate(main, repo("example", "third"));
@@ -97,6 +122,7 @@ test("recoverRepoSubmissions refreshes a stale PR onto main before merging", asy
       if (apiPath.endsWith("/pulls?state=open&per_page=100")) return [pull];
       if (apiPath.endsWith("/issues?state=open&labels=workflow-issue&per_page=100")) return [];
       if (apiPath.endsWith("/issues?state=open&labels=repo-suggestion&per_page=100")) return [];
+      if (apiPath.endsWith("/issues?state=open&per_page=100")) return [];
       if (apiPath.endsWith("/pulls/516/files?per_page=100")) return [{ filename: "data/repos.json" }];
       if (apiPath.endsWith("/git/ref/heads/main")) return { object: { sha: "main-sha" } };
       if (apiPath.endsWith("/git/commits/main-sha")) return { tree: { sha: "main-tree" } };
@@ -144,6 +170,7 @@ test("recoverRepoSubmissions closes cataloged and deleted suggestion issues", as
       if (apiPath.endsWith("/pulls?state=open&per_page=100")) return [];
       if (apiPath.endsWith("/issues?state=open&labels=workflow-issue&per_page=100")) return [];
       if (apiPath.endsWith("/issues?state=open&labels=repo-suggestion&per_page=100")) return suggestions;
+      if (apiPath.endsWith("/issues?state=open&per_page=100")) return [];
       if (apiPath.endsWith("contents/data/repos.json?ref=main")) return { content: encoded(catalog) };
       if (method === "GET" && apiPath.endsWith("/repos/example/deleted")) {
         const error = new Error("Not Found");
@@ -162,11 +189,52 @@ test("recoverRepoSubmissions closes cataloged and deleted suggestion issues", as
   assert.deepEqual(closures.map((call) => call.body.state_reason), ["completed", "not_planned"]);
 });
 
+test("recoverRepoSubmissions dispatches the oldest stranded suggestion", async () => {
+  const calls = [];
+  const oldIssue = {
+    number: 293,
+    state: "open",
+    created_at: "2026-05-01T00:00:00Z",
+    title: "Add obra/superpowers",
+    body: "https://github.com/obra/superpowers",
+    labels: [],
+  };
+  const newerIssue = {
+    ...oldIssue,
+    number: 326,
+    created_at: "2026-05-02T00:00:00Z",
+    title: "Add zero-sq/space0-mcp",
+    body: "https://github.com/zero-sq/space0-mcp",
+  };
+  const client = {
+    async request(method, apiPath, body) {
+      calls.push({ method, apiPath, body });
+      if (apiPath.endsWith("/pulls?state=open&per_page=100")) return [];
+      if (apiPath.endsWith("/issues?state=open&labels=workflow-issue&per_page=100")) return [];
+      if (apiPath.endsWith("/issues?state=open&labels=repo-suggestion&per_page=100")) return [];
+      if (apiPath.endsWith("/issues?state=open&per_page=100")) return [newerIssue, oldIssue];
+      if (method === "POST" && apiPath.endsWith("/actions/workflows/validate-repo-suggestion.yml/dispatches")) return null;
+      if (method === "POST" && apiPath.endsWith("/issues/293/labels")) return [];
+      throw new Error(`Unexpected request: ${method} ${apiPath}`);
+    },
+  };
+
+  const result = await recoverRepoSubmissions({ client, repository: "ksimback/hermes-ecosystem" });
+  assert.equal(result.dispatchedIssue, 293);
+  const dispatch = calls.find((call) => call.apiPath.endsWith("/dispatches"));
+  assert.deepEqual(dispatch.body.inputs, { issue_number: "293" });
+  assert.ok(calls.some((call) => call.apiPath.endsWith("/issues/293/labels")));
+  assert.ok(!calls.some((call) => call.apiPath.endsWith("/issues/326/labels")));
+});
+
 test("validator workflow does not wait for impossible bot-triggered CheckRuns", () => {
   const workflow = fs.readFileSync(".github/workflows/validate-repo-suggestion.yml", "utf-8");
   assert.match(workflow, /CANONICAL_CATEGORIES, validateRepos \} = await import/);
   assert.match(workflow, /\['CLEAN', 'HAS_HOOKS', 'UNSTABLE'\]/);
   assert.match(workflow, /createWorkflowDispatch/);
   assert.match(workflow, /recover-open-prs:/);
+  assert.match(workflow, /issue_number:/);
+  assert.match(workflow, /SOURCE_ISSUE_NUMBER/);
+  assert.match(workflow, /titleMatches && hasGitHubRepo/);
   assert.doesNotMatch(workflow, /const REQUIRED = \['validate', 'smoke'\]/);
 });


### PR DESCRIPTION
## Summary
- accept legacy Add/Suggest repo issue titles when they contain a GitHub repository URL
- allow direct issue-number workflow dispatch for deterministic recovery
- sweep one oldest stranded suggestion per scheduled recovery run
- preserve serialized validation and add regression coverage

## Verification
- node --test tests/repo-submission.test.js tests/automation-workflows.test.js (13 passed)
- npm test (181 passed)
- git diff --check