### PR TITLE
Close successfully validated suggestion issues

### DIFF
--- a/.github/workflows/validate-repo-suggestion.yml
+++ b/.github/workflows/validate-repo-suggestion.yml
@@ -676,6 +676,21 @@ jobs:
               body: `PR created: #${pr.number}\n\nOnce merged, this repo will appear in the ecosystem map.${mergeNote}`
             });
 
+            // GitHub does not reliably apply `Closes #...` from PR bodies when
+            // a GITHUB_TOKEN-authored PR is squash-merged by the same token.
+            // Close the source issue explicitly after the merge succeeds so
+            // the public backlog reflects the actual catalog state promptly.
+            if (mergedByWorkflow) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: Number(process.env.SOURCE_ISSUE_NUMBER),
+                state: 'closed',
+                state_reason: 'completed'
+              });
+              console.log(`Closed source issue #${process.env.SOURCE_ISSUE_NUMBER}`);
+            }
+
   recover-open-prs:
     if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.issue_number == '')
     runs-on: ubuntu-latest

--- a/tests/repo-submission.test.js
+++ b/tests/repo-submission.test.js
@@ -236,5 +236,7 @@ test("validator workflow does not wait for impossible bot-triggered CheckRuns", 
   assert.match(workflow, /issue_number:/);
   assert.match(workflow, /SOURCE_ISSUE_NUMBER/);
   assert.match(workflow, /titleMatches && hasGitHubRepo/);
+  assert.match(workflow, /Closed source issue/);
+  assert.match(workflow, /state_reason: 'completed'/);
   assert.doesNotMatch(workflow, /const REQUIRED = \['validate', 'smoke'\]/);
 });


### PR DESCRIPTION
## Summary
- explicitly close the source issue after a token-authored validator PR merges
- keep failed/manual-review submissions open
- add regression assertions

## Live failure reproduced
Issue #293 remained open after validator PR #546 merged and dispatched its site rebuild.

## Verification
- node --test tests/repo-submission.test.js (9 passed)
- npm test (181 passed)
- git diff --check