### PR TITLE
Split multi-repository suggestions safely

### DIFF
--- a/.github/workflows/validate-repo-suggestion.yml
+++ b/.github/workflows/validate-repo-suggestion.yml
@@ -86,13 +86,96 @@ jobs:
             const body = process.env.SOURCE_ISSUE_BODY || '';
             const labels = JSON.parse(process.env.SOURCE_ISSUE_LABELS || '[]');
             const titleMatches = /^\s*(?:\[(?:repo|submission|suggest a repo)\]|suggest(?:ion)?\b|add\b)/i.test(title);
-            const hasGitHubRepo = /https:\/\/github\.com\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+/.test(body);
+            const repoUrls = [...new Set(
+              [...body.matchAll(/https:\/\/github\.com\/[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+/g)]
+                .map(match => match[0].replace(/\/$/, ''))
+            )];
+            const hasGitHubRepo = repoUrls.length > 0;
+            const multiRepo = repoUrls.length > 1;
             const labelMatches = labels.includes('repo-suggestion');
-            const shouldRun = labelMatches || (titleMatches && hasGitHubRepo);
+            const shouldRun = !multiRepo && (labelMatches || (titleMatches && hasGitHubRepo));
 
             core.setOutput('should_run', shouldRun ? 'true' : 'false');
             core.setOutput('has_label', labelMatches ? 'true' : 'false');
-            console.log(`title=${title}, titleMatches=${titleMatches}, hasGitHubRepo=${hasGitHubRepo}, labelMatches=${labelMatches}, shouldRun=${shouldRun}`);
+            core.setOutput('multi_repo', multiRepo ? 'true' : 'false');
+            console.log(`title=${title}, titleMatches=${titleMatches}, repoCount=${repoUrls.length}, labelMatches=${labelMatches}, multiRepo=${multiRepo}, shouldRun=${shouldRun}`);
+
+      - name: Split multi-repo suggestion into atomic issues
+        if: steps.gate.outputs.multi_repo == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = process.env.SOURCE_ISSUE_BODY || '';
+            const sourceNumber = Number(process.env.SOURCE_ISSUE_NUMBER);
+            const repoUrls = [...new Set(
+              [...body.matchAll(/https:\/\/github\.com\/([a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)/g)]
+                .map(match => ({
+                  url: match[0].replace(/\/$/, ''),
+                  key: match[1].replace(/\/$/, '').toLowerCase()
+                }))
+                .map(repo => JSON.stringify(repo))
+            )].map(repo => JSON.parse(repo));
+
+            const { data: file } = await github.rest.repos.getContent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              path: 'data/repos.json',
+              ref: 'main'
+            });
+            const catalog = JSON.parse(Buffer.from(file.content, 'base64').toString('utf-8'));
+            const catalogKeys = new Set(catalog.map(repo => `${repo.owner}/${repo.repo}`.toLowerCase()));
+            const existing = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100
+            });
+            const created = [];
+            const skipped = [];
+
+            for (const candidate of repoUrls) {
+              if (catalogKeys.has(candidate.key)) {
+                skipped.push(`${candidate.key} (already cataloged)`);
+                continue;
+              }
+              const duplicate = existing.find(issue =>
+                !issue.pull_request &&
+                issue.number !== sourceNumber &&
+                String(issue.body || '').toLowerCase().includes(candidate.url.toLowerCase())
+              );
+              if (duplicate) {
+                skipped.push(`${candidate.key} (tracked in #${duplicate.number})`);
+                continue;
+              }
+              const [owner, repo] = candidate.key.split('/');
+              const { data: child } = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `[Repo] ${owner}/${repo} (split from #${sourceNumber})`,
+                body: `Repository: ${candidate.url}\n\nAutomatically split from multi-repository suggestion #${sourceNumber} so each repository receives an independent validation result.`
+              });
+              created.push(`#${child.number} (${candidate.key})`);
+            }
+
+            const summary = [
+              'Split this multi-repository suggestion into atomic validation issues.',
+              created.length ? `Created: ${created.join(', ')}` : 'Created: none',
+              skipped.length ? `Skipped: ${skipped.join(', ')}` : 'Skipped: none'
+            ].join('\n\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: sourceNumber,
+              body: summary
+            });
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: sourceNumber,
+              state: 'closed',
+              state_reason: 'completed'
+            });
+            console.log(summary);
 
       - name: Ensure repo-suggestion label is present
         if: steps.gate.outputs.should_run == 'true' && steps.gate.outputs.has_label != 'true'

--- a/scripts/recover-repo-submissions.js
+++ b/scripts/recover-repo-submissions.js
@@ -101,10 +101,15 @@ async function refreshSubmissionBranch({
 }
 
 function repoKeyFromText(text) {
-  const match = String(text || "").match(
-    /https:\/\/github\.com\/([a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)/,
-  );
-  return match ? match[1].replace(/\/$/, "").toLowerCase() : "";
+  return repoKeysFromText(text)[0] || "";
+}
+
+function repoKeysFromText(text) {
+  return [...new Set(
+    [...String(text || "").matchAll(
+      /https:\/\/github\.com\/([a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+)/g,
+    )].map((match) => match[1].replace(/\/$/, "").toLowerCase()),
+  )];
 }
 
 export function isUnprocessedSuggestion(issue) {
@@ -113,9 +118,10 @@ export function isUnprocessedSuggestion(issue) {
     typeof label === "string" ? label : label.name,
   );
   if (labels.includes("repo-suggestion")) return false;
+  const repoKeys = repoKeysFromText(issue.body);
   const titleMatches = /^\s*(?:\[(?:repo|submission|suggest a repo)\]|suggest(?:ion)?\b|add\b)/i
     .test(String(issue.title || ""));
-  return titleMatches && Boolean(repoKeyFromText(issue.body));
+  return repoKeys.length > 1 || (titleMatches && repoKeys.length === 1);
 }
 
 function expectedRepoKey(pull) {
@@ -300,9 +306,11 @@ export async function recoverRepoSubmissions({ client, repository }) {
       `/repos/${repository}/actions/workflows/validate-repo-suggestion.yml/dispatches`,
       { ref: "main", inputs: { issue_number: String(stranded.number) } },
     );
-    await client.request("POST", `/repos/${repository}/issues/${stranded.number}/labels`, {
-      labels: ["repo-suggestion"],
-    });
+    if (repoKeysFromText(stranded.body).length === 1) {
+      await client.request("POST", `/repos/${repository}/issues/${stranded.number}/labels`, {
+        labels: ["repo-suggestion"],
+      });
+    }
     console.log(`Dispatched validation recovery for stranded issue #${stranded.number}`);
   }
 

--- a/tests/repo-submission.test.js
+++ b/tests/repo-submission.test.js
@@ -78,6 +78,10 @@ test("isUnprocessedSuggestion recognizes legacy repo titles without sweeping unr
   assert.equal(isUnprocessedSuggestion(issue("Add obra/superpowers", url)), true);
   assert.equal(isUnprocessedSuggestion(issue("Suggest a Hermes plugin", url)), true);
   assert.equal(isUnprocessedSuggestion(issue("[Suggest a Repo] agentcairn", url)), true);
+  assert.equal(
+    isUnprocessedSuggestion(issue("Three Hermes plugins", `${url}\nhttps://github.com/example/two`)),
+    true,
+  );
   assert.equal(isUnprocessedSuggestion(issue("Content newsletter", url)), false);
   assert.equal(isUnprocessedSuggestion(issue("Add content newsletter", "No repository URL")), false);
   assert.equal(
@@ -227,6 +231,33 @@ test("recoverRepoSubmissions dispatches the oldest stranded suggestion", async (
   assert.ok(!calls.some((call) => call.apiPath.endsWith("/issues/326/labels")));
 });
 
+test("recoverRepoSubmissions leaves multi-repo parents unlabeled for the splitter", async () => {
+  const calls = [];
+  const multi = {
+    number: 435,
+    state: "open",
+    created_at: "2026-06-01T00:00:00Z",
+    title: "Three Hermes plugins",
+    body: "https://github.com/example/one\nhttps://github.com/example/two",
+    labels: [],
+  };
+  const client = {
+    async request(method, apiPath, body) {
+      calls.push({ method, apiPath, body });
+      if (apiPath.endsWith("/pulls?state=open&per_page=100")) return [];
+      if (apiPath.endsWith("/issues?state=open&labels=workflow-issue&per_page=100")) return [];
+      if (apiPath.endsWith("/issues?state=open&labels=repo-suggestion&per_page=100")) return [];
+      if (apiPath.endsWith("/issues?state=open&per_page=100")) return [multi];
+      if (method === "POST" && apiPath.endsWith("/actions/workflows/validate-repo-suggestion.yml/dispatches")) return null;
+      throw new Error(`Unexpected request: ${method} ${apiPath}`);
+    },
+  };
+
+  const result = await recoverRepoSubmissions({ client, repository: "ksimback/hermes-ecosystem" });
+  assert.equal(result.dispatchedIssue, 435);
+  assert.ok(!calls.some((call) => call.apiPath.endsWith("/issues/435/labels")));
+});
+
 test("validator workflow does not wait for impossible bot-triggered CheckRuns", () => {
   const workflow = fs.readFileSync(".github/workflows/validate-repo-suggestion.yml", "utf-8");
   assert.match(workflow, /CANONICAL_CATEGORIES, validateRepos \} = await import/);
@@ -240,5 +271,6 @@ test("validator workflow does not wait for impossible bot-triggered CheckRuns", 
   assert.match(workflow, /state_reason: 'completed'/);
   assert.match(workflow, /canonical_owner/);
   assert.match(workflow, /steps\.metadata\.outputs\.canonical_owner/);
+  assert.match(workflow, /Split multi-repo suggestion into atomic issues/);
   assert.doesNotMatch(workflow, /const REQUIRED = \['validate', 'smoke'\]/);
 });


### PR DESCRIPTION
## Summary
- detect multi-repository issues before single-repo extraction
- create one atomic child issue for every uncataloged, untracked repository
- close the parent only after child tracking exists
- let scheduled recovery discover multi-repo parents without mislabeling them

## Live failure reproduced
#435 contains three repositories, while duplicate #473 closed after validating only the first. Two repositories were therefore never reviewed.

## Verification
- node --test tests/repo-submission.test.js (10 passed)
- npm test (182 passed)
- git diff --check