### PR TITLE
Regenerate pages when main moves during build

### DIFF
--- a/.github/workflows/build-pages.yml
+++ b/.github/workflows/build-pages.yml
@@ -75,34 +75,39 @@ jobs:
 
       - name: Commit updated pages
         if: steps.diff.outputs.changed == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
         run: |
           git config user.name "Hermes Atlas Bot"
           git config user.email "bot@hermesatlas.com"
           git commit -m "Rebuild project pages (${{ steps.diff.outputs.pages }} projects, ${{ steps.diff.outputs.lists }} lists)"
 
           # main can move during a multi-minute build (PR merge, another
-          # bot workflow committing) — vanilla `git push` then fails with
-          # `! [rejected] main -> main (fetch first)`. Retry up to 3 times,
-          # rebasing onto the new remote tip between attempts.
-          #
-          # Stash any unstaged working-tree changes before the rebase. Without
-          # this, the rebase aborts with "cannot pull with rebase: You have
-          # unstaged changes" if any build step writes a file outside the
-          # staged set — and the entire build's work gets thrown away silently
-          # (this is what cancelled all 5 burst-merge builds on 2026-05-15).
+          # bot workflow committing). Generated pages should never be rebased:
+          # almost every artifact changes together, so a new generated commit
+          # on main produces hundreds of conflicts. On rejection, discard only
+          # this ephemeral runner's generated commit, reset to the latest main,
+          # and deterministically regenerate from that complete input state.
           for attempt in 1 2 3; do
             if git push; then
               echo "Pushed on attempt $attempt"
               exit 0
             fi
-            echo "Push rejected (attempt $attempt) — rebasing onto new remote tip"
-            git stash --include-untracked --quiet || true
-            if ! git pull --rebase origin main; then
-              echo "Rebase failed — aborting"
-              git stash pop --quiet 2>/dev/null || true
-              exit 1
+            echo "Push rejected (attempt $attempt) — regenerating from latest main"
+            git fetch origin main
+            git reset --hard origin/main
+            git clean -fd
+            node scripts/generate-summaries.js
+            node scripts/build-pages.js
+            node scripts/stage-build-artifacts.js
+            if git diff --cached --quiet; then
+              echo "Latest main already contains the generated artifacts"
+              exit 0
             fi
-            git stash pop --quiet 2>/dev/null || true
+            PAGES=$(find projects -name '*.html' | wc -l)
+            LISTS=$(find lists -name '*.html' | wc -l)
+            git commit -m "Rebuild project pages ($PAGES projects, $LISTS lists)"
           done
           echo "Push failed after 3 attempts"
           exit 1

--- a/tests/automation-workflows.test.js
+++ b/tests/automation-workflows.test.js
@@ -28,6 +28,17 @@ test("knowledge rebuild has a scheduled reconciliation path", () => {
   assert.match(workflow, /workflow_dispatch:/);
 });
 
+test("page build regenerates from latest main after a rejected push", () => {
+  const workflow = fs.readFileSync(".github/workflows/build-pages.yml", "utf-8");
+  assert.match(workflow, /Push rejected \(attempt \$attempt\).*regenerating from latest main/);
+  assert.match(workflow, /git reset --hard origin\/main/);
+  assert.match(workflow, /git clean -fd/);
+  assert.match(workflow, /node scripts\/generate-summaries\.js/);
+  assert.match(workflow, /node scripts\/build-pages\.js/);
+  assert.match(workflow, /node scripts\/stage-build-artifacts\.js/);
+  assert.doesNotMatch(workflow, /git pull --rebase origin main/);
+});
+
 test("recoverable workflow alerts close after a green run", () => {
   for (const file of [
     ".github/workflows/build-pages.yml",


### PR DESCRIPTION
## Summary
- replace conflict-prone rebasing of generated output with a clean reset to latest main
- regenerate summaries and pages from the complete latest input state after push rejection
- clean stale untracked generated files and retain bounded retries
- add regression coverage

## Live failure reproduced
Build runs 29534981611 and 29535363779 generated successfully but failed while rebasing hundreds of generated artifacts after main advanced.

## Verification
- node --test tests/automation-workflows.test.js (5 passed)
- npm test (183 passed)
- git diff --check
- subsequent consolidated build 29535607505 succeeded from the latest main snapshot