### PR TITLE
Dispatch smoke after bot-authored page builds

### DIFF
--- a/.github/workflows/build-pages.yml
+++ b/.github/workflows/build-pages.yml
@@ -23,6 +23,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
       issues: write
 
@@ -115,6 +116,18 @@ jobs:
       - name: Ping IndexNow with changed URLs
         if: steps.diff.outputs.changed == 'true'
         run: node scripts/indexnow-ping.js
+
+      # GITHUB_TOKEN-authored pushes do not emit another workflow's `push`
+      # event. Dispatch smoke explicitly with the exact generated commit so it
+      # can wait for that Vercel deployment before checking production.
+      - name: Dispatch post-deploy smoke
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run post-deploy-smoke.yml \
+            --ref main \
+            -f target_sha="$(git rev-parse HEAD)"
 
       - name: Close prior failure alert after recovery
         if: success()

--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -50,6 +50,10 @@ on:
         description: 'Number of project pages to sample'
         required: false
         default: '25'
+      target_sha:
+        description: 'Commit SHA whose Vercel deployment must be ready before smoke'
+        required: false
+        default: ''
 
 # Serialize - we don't want two smoke runs racing each other against the same
 # deploy. Cancel pending duplicate runs since only the latest deploy matters.
@@ -79,11 +83,13 @@ jobs:
       # completes. Poll for it. On workflow_dispatch we skip the wait because
       # the user-supplied base URL might already be live.
       - name: Wait for Vercel deploy to be ready
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || inputs.target_sha != ''
         uses: actions/github-script@v7
+        env:
+          TARGET_SHA: ${{ inputs.target_sha }}
         with:
           script: |
-            const sha = context.sha;
+            const sha = process.env.TARGET_SHA || context.sha;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const MAX_WAIT_MS = 10 * 60 * 1000; // 10 minutes
@@ -120,7 +126,7 @@ jobs:
       # before checking the semantic `stale`/`complete` contract, rather than
       # waiting up to six hours for the scheduled refresh.
       - name: Seed stars snapshot before semantic smoke
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || inputs.target_sha != ''
         env:
           GITHUB_TOKEN: ${{ github.token }}
           CRON_SECRET: ${{ secrets.CRON_SECRET }}

--- a/tests/automation-workflows.test.js
+++ b/tests/automation-workflows.test.js
@@ -39,6 +39,18 @@ test("page build regenerates from latest main after a rejected push", () => {
   assert.doesNotMatch(workflow, /git pull --rebase origin main/);
 });
 
+test("bot-authored page builds dispatch smoke for the exact deployed commit", () => {
+  const build = fs.readFileSync(".github/workflows/build-pages.yml", "utf-8");
+  const smoke = fs.readFileSync(".github/workflows/post-deploy-smoke.yml", "utf-8");
+
+  assert.match(build, /actions: write/);
+  assert.match(build, /Dispatch post-deploy smoke/);
+  assert.match(build, /-f target_sha="\$\(git rev-parse HEAD\)"/);
+  assert.match(smoke, /target_sha:/);
+  assert.match(smoke, /process\.env\.TARGET_SHA \|\| context\.sha/);
+  assert.match(smoke, /github\.event_name == 'push' \|\| inputs\.target_sha != ''/);
+});
+
 test("recoverable workflow alerts close after a green run", () => {
   for (const file of [
     ".github/workflows/build-pages.yml",


### PR DESCRIPTION
## Summary
- explicitly dispatch post-deploy smoke after a generated page commit
- pass the exact pushed SHA to the smoke workflow
- wait for that SHA's Vercel status and seed stars before semantic checks
- retain untargeted manual smoke runs for ad hoc URLs

## Root cause
GITHUB_TOKEN-authored build pushes do not emit a new push workflow event, so successful generated deployments were not automatically smoke-tested.

## Verification
- node --test tests/automation-workflows.test.js tests/smoke-test-prod.test.js (9 passed)
- npm test (184 passed)
- git diff --check