### PR TITLE
Dispatch RAG rebuild after docs refresh

### DIFF
--- a/.github/workflows/refresh-docs.yml
+++ b/.github/workflows/refresh-docs.yml
@@ -23,6 +23,7 @@ jobs:
   refresh:
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
       issues: write
 
@@ -72,6 +73,15 @@ jobs:
           done
           echo "Push failed after 3 attempts"
           exit 1
+
+      # GITHUB_TOKEN-authored pushes do not emit the rebuild workflow's push
+      # event. Start ingestion explicitly after the refreshed mirror is safely
+      # on main so new official documentation reaches the RAG corpus.
+      - name: Dispatch knowledge-base rebuild
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run rebuild-chunks.yml --ref main
 
       - name: Close prior failure alert after recovery
         if: success()

--- a/tests/automation-workflows.test.js
+++ b/tests/automation-workflows.test.js
@@ -51,6 +51,14 @@ test("bot-authored page builds dispatch smoke for the exact deployed commit", ()
   assert.match(smoke, /github\.event_name == 'push' \|\| inputs\.target_sha != ''/);
 });
 
+test("docs mirror explicitly dispatches RAG ingestion after bot-authored pushes", () => {
+  const workflow = fs.readFileSync(".github/workflows/refresh-docs.yml", "utf-8");
+  assert.match(workflow, /actions: write/);
+  assert.match(workflow, /Dispatch knowledge-base rebuild/);
+  assert.match(workflow, /gh workflow run rebuild-chunks\.yml --ref main/);
+  assert.match(workflow, /if: steps\.diff\.outputs\.changed == 'true'/);
+});
+
 test("recoverable workflow alerts close after a green run", () => {
   for (const file of [
     ".github/workflows/build-pages.yml",


### PR DESCRIPTION
## Summary
- grant the docs mirror permission to dispatch workflows
- explicitly start the RAG chunk rebuild after a successful bot-authored docs push
- cover the handoff with an automation regression test

## Why
Refresh Hermes Docs Mirror run 29538787543 updated 43 mirrored documentation files and pushed them to main, but no knowledge-base rebuild started. GitHub intentionally suppresses workflow events caused by GITHUB_TOKEN pushes, so relying on the rebuild workflow push trigger left the new docs out of RAG.

## Verification
- node --test tests/automation-workflows.test.js (7/7)
- npm test (185/185)
- git diff --check -- .github/workflows/refresh-docs.yml tests/automation-workflows.test.js