### PR TITLE
Ingest official docs when changes are detected

### DIFF
--- a/.github/workflows/refresh-docs.yml
+++ b/.github/workflows/refresh-docs.yml
@@ -5,8 +5,8 @@ env:
 
 # Pulls the latest content from hermes-agent.nousresearch.com/docs into
 # research/docs/. Idempotent: only files whose upstream content changed are
-# rewritten. The push then triggers rebuild-chunks.yml downstream, so the
-# embedded knowledge base stays in sync without manual intervention.
+# rewritten. Changed mirrors explicitly dispatch rebuild-chunks.yml downstream,
+# so the embedded knowledge base stays in sync without manual intervention.
 
 concurrency:
   group: refresh-docs
@@ -82,6 +82,16 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh workflow run rebuild-chunks.yml --ref main
+
+      - name: Close processed docs-update notifications
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue list --state open --label docs-update --json number --jq '.[].number' |
+            while read issue; do
+              gh issue close "$issue" --comment "Official docs mirror is current after workflow run ${GITHUB_RUN_ID}."
+            done
 
       - name: Close prior failure alert after recovery
         if: success()

--- a/.github/workflows/release-monitor.yml
+++ b/.github/workflows/release-monitor.yml
@@ -100,6 +100,12 @@ jobs:
               labels: ['docs-update']
             });
 
+      - name: Dispatch docs mirror refresh
+        if: steps.docs_check.outputs.docs_updated == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run refresh-docs.yml --ref main
+
       - name: Close resolved legacy release alerts
         if: success()
         uses: actions/github-script@v7

--- a/tests/automation-workflows.test.js
+++ b/tests/automation-workflows.test.js
@@ -59,6 +59,18 @@ test("docs mirror explicitly dispatches RAG ingestion after bot-authored pushes"
   assert.match(workflow, /if: steps\.diff\.outputs\.changed == 'true'/);
 });
 
+test("daily docs detection triggers ingestion and resolves its notification", () => {
+  const monitor = fs.readFileSync(".github/workflows/release-monitor.yml", "utf-8");
+  const refresh = fs.readFileSync(".github/workflows/refresh-docs.yml", "utf-8");
+
+  assert.match(monitor, /Dispatch docs mirror refresh/);
+  assert.match(monitor, /gh workflow run refresh-docs\.yml --ref main/);
+  assert.match(monitor, /if: steps\.docs_check\.outputs\.docs_updated == 'true'/);
+  assert.match(refresh, /Close processed docs-update notifications/);
+  assert.match(refresh, /--label docs-update/);
+  assert.match(refresh, /Official docs mirror is current after workflow run/);
+});
+
 test("recoverable workflow alerts close after a green run", () => {
   for (const file of [
     ".github/workflows/build-pages.yml",


### PR DESCRIPTION
## Summary
- dispatch the docs mirror immediately when the daily monitor detects upstream documentation changes
- close docs-update notifications only after the mirror workflow succeeds
- keep the weekly refresh as a reconciliation fallback
- cover the complete alert-to-ingestion handoff with regression assertions

## Verification
- node --test tests/automation-workflows.test.js (8/8)
- npm test (186/186)
- git diff --check -- .github/workflows/release-monitor.yml .github/workflows/refresh-docs.yml tests/automation-workflows.test.js