### PR TITLE
Retry transient GitHub failures in release monitoring

### DIFF
--- a/.github/workflows/release-monitor.yml
+++ b/.github/workflows/release-monitor.yml
@@ -36,6 +36,8 @@ jobs:
         id: docs_check
         uses: actions/github-script@v7
         with:
+          retries: 3
+          retry-exempt-status-codes: 400,401,403,404,422
           script: |
             try {
               const { data: commits } = await github.rest.repos.listCommits({
@@ -63,6 +65,8 @@ jobs:
           COMMIT_MSG: ${{ steps.docs_check.outputs.commit_msg }}
         uses: actions/github-script@v7
         with:
+          retries: 3
+          retry-exempt-status-codes: 400,401,403,404,422
           script: |
             const msg = process.env.COMMIT_MSG || '';
             const today = new Date().toISOString().slice(0, 10);
@@ -110,6 +114,8 @@ jobs:
         if: success()
         uses: actions/github-script@v7
         with:
+          retries: 3
+          retry-exempt-status-codes: 400,401,403,404,422
           script: |
             const { data: issues } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
@@ -146,6 +152,8 @@ jobs:
         if: success()
         uses: actions/github-script@v7
         with:
+          retries: 3
+          retry-exempt-status-codes: 400,401,403,404,422
           script: |
             const title = '[Workflow] release-monitor failed';
             const { data: issues } = await github.rest.issues.listForRepo({
@@ -175,6 +183,8 @@ jobs:
         if: failure()
         uses: actions/github-script@v7
         with:
+          retries: 3
+          retry-exempt-status-codes: 400,401,403,404,422
           script: |
             const title = '[Workflow] release-monitor failed';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;

--- a/scripts/sync-releases.js
+++ b/scripts/sync-releases.js
@@ -24,34 +24,76 @@ export class GitHubApiError extends Error {
 }
 
 export class GitHubClient {
-  constructor({ token, fetchImpl = fetch }) {
+  constructor({
+    token,
+    fetchImpl = fetch,
+    sleepImpl = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+    maxReadAttempts = 4,
+    retryDelayMs = 1000,
+  }) {
     this.token = token;
     this.fetchImpl = fetchImpl;
+    this.sleepImpl = sleepImpl;
+    this.maxReadAttempts = maxReadAttempts;
+    this.retryDelayMs = retryDelayMs;
   }
 
   async request(method, apiPath, body) {
-    const response = await this.fetchImpl(`https://api.github.com${apiPath}`, {
-      method,
-      headers: {
-        Accept: "application/vnd.github+json",
-        Authorization: `Bearer ${this.token}`,
-        "Content-Type": "application/json",
-        "User-Agent": "hermes-atlas-release-sync",
-        "X-GitHub-Api-Version": "2022-11-28",
-      },
-      body: body === undefined ? undefined : JSON.stringify(body),
-    });
+    const normalizedMethod = method.toUpperCase();
+    const attempts = normalizedMethod === "GET" ? this.maxReadAttempts : 1;
 
-    const text = await response.text();
-    const data = text ? JSON.parse(text) : null;
-    if (!response.ok) {
-      throw new GitHubApiError(
-        `${method} ${apiPath} failed (${response.status}): ${data?.message || text}`,
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+      let response;
+      try {
+        response = await this.fetchImpl(`https://api.github.com${apiPath}`, {
+          method: normalizedMethod,
+          headers: {
+            Accept: "application/vnd.github+json",
+            Authorization: `Bearer ${this.token}`,
+            "Content-Type": "application/json",
+            "User-Agent": "hermes-atlas-release-sync",
+            "X-GitHub-Api-Version": "2022-11-28",
+          },
+          body: body === undefined ? undefined : JSON.stringify(body),
+        });
+      } catch (error) {
+        if (attempt >= attempts) throw error;
+        const delay = this.retryDelayMs * attempt;
+        console.warn(`GitHub read failed — retrying in ${delay}ms (attempt ${attempt + 1}/${attempts})`);
+        await this.sleepImpl(delay);
+        continue;
+      }
+
+      const text = await response.text();
+      let data = null;
+      if (text) {
+        try {
+          data = JSON.parse(text);
+        } catch {
+          data = text;
+        }
+      }
+      if (response.ok) return data;
+
+      const message = data && typeof data === "object" ? data.message : text;
+      const error = new GitHubApiError(
+        `${normalizedMethod} ${apiPath} failed (${response.status}): ${message}`,
         response.status,
         data,
       );
+      const retryable = response.status === 429 || response.status >= 500;
+      if (!retryable || attempt >= attempts) throw error;
+
+      const retryAfterSeconds = Number(response.headers?.get?.("retry-after"));
+      const delay = Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0
+        ? retryAfterSeconds * 1000
+        : this.retryDelayMs * attempt;
+      console.warn(
+        `GitHub returned ${response.status} — retrying read in ${delay}ms ` +
+        `(attempt ${attempt + 1}/${attempts})`,
+      );
+      await this.sleepImpl(delay);
     }
-    return data;
   }
 }
 

--- a/tests/automation-workflows.test.js
+++ b/tests/automation-workflows.test.js
@@ -71,6 +71,17 @@ test("daily docs detection triggers ingestion and resolves its notification", ()
   assert.match(refresh, /Official docs mirror is current after workflow run/);
 });
 
+test("release monitor retries transient GitHub API failures", () => {
+  const monitor = fs.readFileSync(".github/workflows/release-monitor.yml", "utf-8");
+  const githubScriptSteps = monitor.match(/uses: actions\/github-script@v7/g) || [];
+  const retrySettings = monitor.match(/^\s+retries: 3$/gm) || [];
+  const retryExemptions = monitor.match(/^\s+retry-exempt-status-codes: 400,401,403,404,422$/gm) || [];
+
+  assert.equal(githubScriptSteps.length, 5);
+  assert.equal(retrySettings.length, githubScriptSteps.length);
+  assert.equal(retryExemptions.length, githubScriptSteps.length);
+});
+
 test("recoverable workflow alerts close after a green run", () => {
   for (const file of [
     ".github/workflows/build-pages.yml",

--- a/tests/release-sync.test.js
+++ b/tests/release-sync.test.js
@@ -9,7 +9,7 @@ import {
   releaseTagFromPrTitle,
   renderReleaseMarkdown,
 } from "../lib/release-sync.js";
-import { syncReleases } from "../scripts/sync-releases.js";
+import { GitHubApiError, GitHubClient, syncReleases } from "../scripts/sync-releases.js";
 
 const release = (tag, publishedAt, version) => ({
   tag_name: tag,
@@ -18,6 +18,61 @@ const release = (tag, publishedAt, version) => ({
   body: `# Hermes Agent ${version} (${tag})\n\n${"Authoritative release notes. ".repeat(5)}`,
   draft: false,
   prerelease: false,
+});
+
+test("GitHubClient retries transient read failures including non-JSON 503 bodies", async () => {
+  const responses = [
+    {
+      ok: false,
+      status: 503,
+      headers: { get: () => null },
+      text: async () => "<html><title>Unicorn!</title></html>",
+    },
+    {
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      text: async () => JSON.stringify([{ tag_name: "v2026.7.7.2" }]),
+    },
+  ];
+  const delays = [];
+  let calls = 0;
+  const client = new GitHubClient({
+    token: "test-token",
+    fetchImpl: async () => responses[calls++],
+    sleepImpl: async (delay) => delays.push(delay),
+    retryDelayMs: 25,
+  });
+
+  const result = await client.request("GET", "/repos/NousResearch/hermes-agent/releases");
+
+  assert.deepEqual(result, [{ tag_name: "v2026.7.7.2" }]);
+  assert.equal(calls, 2);
+  assert.deepEqual(delays, [25]);
+});
+
+test("GitHubClient does not blindly retry mutating requests", async () => {
+  let calls = 0;
+  const client = new GitHubClient({
+    token: "test-token",
+    fetchImpl: async () => {
+      calls++;
+      return {
+        ok: false,
+        status: 503,
+        headers: { get: () => null },
+        text: async () => "<html><title>Unicorn!</title></html>",
+      };
+    },
+    sleepImpl: async () => assert.fail("mutation retry must not sleep"),
+    retryDelayMs: 0,
+  });
+
+  await assert.rejects(
+    client.request("POST", "/repos/ksimback/hermes-ecosystem/issues", { title: "test" }),
+    (error) => error instanceof GitHubApiError && error.status === 503,
+  );
+  assert.equal(calls, 1);
 });
 
 test("extractTrackedReleaseTags reads exact release metadata and source URLs", () => {


### PR DESCRIPTION
## Summary
- retry transient network, 429, and 5xx failures for idempotent GitHub release reads
- safely handle GitHub HTML error pages instead of throwing during JSON parsing
- keep mutation requests single-attempt to avoid duplicate PRs, issues, or comments
- enable three retries on every actions/github-script step in the daily monitor

## Live failure reproduced
Daily Release Monitor run 29539985860 failed on a GitHub 503 HTML Unicorn response before the docs handoff could run.

## Verification
- node --test tests/release-sync.test.js tests/automation-workflows.test.js (20/20)
- npm test (189/189)
- git diff --check -- scripts/sync-releases.js .github/workflows/release-monitor.yml tests/release-sync.test.js tests/automation-workflows.test.js