### PR TITLE
Fall back when GitHub REST pull listing is unavailable

### DIFF
--- a/.github/workflows/release-monitor.yml
+++ b/.github/workflows/release-monitor.yml
@@ -59,6 +59,14 @@ jobs:
               core.setFailed(`Could not check official docs: ${error.message}`);
             }
 
+      # Ingestion is the critical path. Dispatch it before the informational
+      # issue so a transient Issues API failure cannot leave the RAG corpus stale.
+      - name: Dispatch docs mirror refresh
+        if: steps.docs_check.outputs.docs_updated == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run refresh-docs.yml --ref main
+
       - name: Create issue for docs update
         if: steps.docs_check.outputs.docs_updated == 'true'
         env:
@@ -103,12 +111,6 @@ jobs:
               body: `The official Hermes Agent documentation changed in the last 24 hours.\n\nLatest commit: "${msg}"\n\nSource: https://github.com/NousResearch/hermes-agent/tree/main/website/docs`,
               labels: ['docs-update']
             });
-
-      - name: Dispatch docs mirror refresh
-        if: steps.docs_check.outputs.docs_updated == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh workflow run refresh-docs.yml --ref main
 
       - name: Close resolved legacy release alerts
         if: success()

--- a/scripts/sync-releases.js
+++ b/scripts/sync-releases.js
@@ -38,9 +38,9 @@ export class GitHubClient {
     this.retryDelayMs = retryDelayMs;
   }
 
-  async request(method, apiPath, body) {
+  async request(method, apiPath, body, { retryableRead = false } = {}) {
     const normalizedMethod = method.toUpperCase();
-    const attempts = normalizedMethod === "GET" ? this.maxReadAttempts : 1;
+    const attempts = normalizedMethod === "GET" || retryableRead ? this.maxReadAttempts : 1;
 
     for (let attempt = 1; attempt <= attempts; attempt++) {
       let response;
@@ -143,8 +143,36 @@ async function listAllReleases(client) {
   return releases;
 }
 
-async function listOpenPulls(client, repository) {
-  return client.request("GET", `/repos/${repository}/pulls?state=open&per_page=100`);
+export async function listOpenPulls(client, repository) {
+  try {
+    return await client.request("GET", `/repos/${repository}/pulls?state=open&per_page=100`);
+  } catch (error) {
+    if (!(error instanceof GitHubApiError) || error.status < 500) throw error;
+  }
+
+  console.warn("GitHub REST pull listing is unavailable — falling back to GraphQL");
+  const [owner, name] = repository.split("/");
+  const result = await client.request(
+    "POST",
+    "/graphql",
+    {
+      query: `query OpenPulls($owner: String!, $name: String!) {
+        repository(owner: $owner, name: $name) {
+          pullRequests(states: OPEN, first: 100) {
+            nodes { number title state headRefName }
+          }
+        }
+      }`,
+      variables: { owner, name },
+    },
+    { retryableRead: true },
+  );
+  return (result?.data?.repository?.pullRequests?.nodes || []).map((pull) => ({
+    number: pull.number,
+    title: pull.title,
+    state: pull.state?.toLowerCase(),
+    head: { ref: pull.headRefName },
+  }));
 }
 
 async function closeTrackedReleasePrs(client, repository, trackedTags, { excludeNumber } = {}) {

--- a/tests/automation-workflows.test.js
+++ b/tests/automation-workflows.test.js
@@ -66,6 +66,10 @@ test("daily docs detection triggers ingestion and resolves its notification", ()
   assert.match(monitor, /Dispatch docs mirror refresh/);
   assert.match(monitor, /gh workflow run refresh-docs\.yml --ref main/);
   assert.match(monitor, /if: steps\.docs_check\.outputs\.docs_updated == 'true'/);
+  assert.ok(
+    monitor.indexOf("Dispatch docs mirror refresh") < monitor.indexOf("Create issue for docs update"),
+    "docs ingestion must not wait on informational issue creation",
+  );
   assert.match(refresh, /Close processed docs-update notifications/);
   assert.match(refresh, /--label docs-update/);
   assert.match(refresh, /Official docs mirror is current after workflow run/);

--- a/tests/release-sync.test.js
+++ b/tests/release-sync.test.js
@@ -9,7 +9,7 @@ import {
   releaseTagFromPrTitle,
   renderReleaseMarkdown,
 } from "../lib/release-sync.js";
-import { GitHubApiError, GitHubClient, syncReleases } from "../scripts/sync-releases.js";
+import { GitHubApiError, GitHubClient, listOpenPulls, syncReleases } from "../scripts/sync-releases.js";
 
 const release = (tag, publishedAt, version) => ({
   tag_name: tag,
@@ -73,6 +73,38 @@ test("GitHubClient does not blindly retry mutating requests", async () => {
     (error) => error instanceof GitHubApiError && error.status === 503,
   );
   assert.equal(calls, 1);
+});
+
+test("release sync falls back to GraphQL when REST pull listing is unavailable", async () => {
+  const calls = [];
+  const client = {
+    async request(method, apiPath, body, options) {
+      calls.push({ method, apiPath, body, options });
+      if (method === "GET") {
+        throw new GitHubApiError("REST unavailable", 503, "<html>Unicorn</html>");
+      }
+      return {
+        data: {
+          repository: {
+            pullRequests: {
+              nodes: [{ number: 498, title: "Contributor PR", state: "OPEN", headRefName: "feature" }],
+            },
+          },
+        },
+      };
+    },
+  };
+
+  const pulls = await listOpenPulls(client, "ksimback/hermes-ecosystem");
+
+  assert.deepEqual(pulls, [{
+    number: 498,
+    title: "Contributor PR",
+    state: "open",
+    head: { ref: "feature" },
+  }]);
+  assert.equal(calls[1].apiPath, "/graphql");
+  assert.equal(calls[1].options.retryableRead, true);
 });
 
 test("extractTrackedReleaseTags reads exact release metadata and source URLs", () => {


### PR DESCRIPTION
## Summary
- fall back to a retryable GraphQL read when GitHub REST pull listing is unavailable
- normalize the GraphQL response into the existing release-sync contract
- dispatch critical docs ingestion before creating its informational issue
- prove both behaviors with targeted regression tests

## Live failure reproduced
Runs 29539985860 and 29540279552 exhausted retries on the REST open-pulls endpoint while the upstream releases and GraphQL PR endpoints remained healthy.

## Verification
- node --test tests/release-sync.test.js tests/automation-workflows.test.js (21/21)
- npm test (190/190)
- git diff --check -- scripts/sync-releases.js .github/workflows/release-monitor.yml tests/release-sync.test.js tests/automation-workflows.test.js