### PR TITLE
Decouple docs refresh from release API availability

### DIFF
--- a/.github/workflows/release-monitor.yml
+++ b/.github/workflows/release-monitor.yml
@@ -28,9 +28,18 @@ jobs:
 
       - name: Synchronize every missing Hermes Agent release
         id: releases
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node scripts/sync-releases.js
+
+      # The mirror is idempotent and owns its own change detection. Dispatch it
+      # before API-based notifications so release or Issues API outages cannot
+      # block official docs from reaching the RAG corpus.
+      - name: Dispatch docs mirror refresh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run refresh-docs.yml --ref main
 
       - name: Check for new official docs changes
         id: docs_check
@@ -58,14 +67,6 @@ jobs:
             } catch (error) {
               core.setFailed(`Could not check official docs: ${error.message}`);
             }
-
-      # Ingestion is the critical path. Dispatch it before the informational
-      # issue so a transient Issues API failure cannot leave the RAG corpus stale.
-      - name: Dispatch docs mirror refresh
-        if: steps.docs_check.outputs.docs_updated == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh workflow run refresh-docs.yml --ref main
 
       - name: Create issue for docs update
         if: steps.docs_check.outputs.docs_updated == 'true'
@@ -113,7 +114,7 @@ jobs:
             });
 
       - name: Close resolved legacy release alerts
-        if: success()
+        if: steps.releases.outcome == 'success' && success()
         uses: actions/github-script@v7
         with:
           retries: 3
@@ -151,7 +152,7 @@ jobs:
             }
 
       - name: Close release-monitor alert after recovery
-        if: success()
+        if: steps.releases.outcome == 'success' && success()
         uses: actions/github-script@v7
         with:
           retries: 3
@@ -180,6 +181,12 @@ jobs:
               state: 'closed',
               state_reason: 'completed'
             });
+
+      - name: Preserve release synchronization failure
+        if: steps.releases.outcome == 'failure'
+        run: |
+          echo "Release synchronization failed; docs refresh was dispatched independently."
+          exit 1
 
       - name: Escalate release-monitor failure
         if: failure()

--- a/tests/automation-workflows.test.js
+++ b/tests/automation-workflows.test.js
@@ -59,17 +59,19 @@ test("docs mirror explicitly dispatches RAG ingestion after bot-authored pushes"
   assert.match(workflow, /if: steps\.diff\.outputs\.changed == 'true'/);
 });
 
-test("daily docs detection triggers ingestion and resolves its notification", () => {
+test("daily monitor dispatches docs ingestion independently and resolves its notification", () => {
   const monitor = fs.readFileSync(".github/workflows/release-monitor.yml", "utf-8");
   const refresh = fs.readFileSync(".github/workflows/refresh-docs.yml", "utf-8");
 
   assert.match(monitor, /Dispatch docs mirror refresh/);
   assert.match(monitor, /gh workflow run refresh-docs\.yml --ref main/);
-  assert.match(monitor, /if: steps\.docs_check\.outputs\.docs_updated == 'true'/);
   assert.ok(
-    monitor.indexOf("Dispatch docs mirror refresh") < monitor.indexOf("Create issue for docs update"),
-    "docs ingestion must not wait on informational issue creation",
+    monitor.indexOf("Dispatch docs mirror refresh") < monitor.indexOf("Check for new official docs changes"),
+    "docs ingestion must not wait on release-independent API checks",
   );
+  assert.match(monitor, /id: releases\s+continue-on-error: true/);
+  assert.match(monitor, /Preserve release synchronization failure/);
+  assert.match(monitor, /if: steps\.releases\.outcome == 'failure'/);
   assert.match(refresh, /Close processed docs-update notifications/);
   assert.match(refresh, /--label docs-update/);
   assert.match(refresh, /Official docs mirror is current after workflow run/);


### PR DESCRIPTION
## Summary
- dispatch the idempotent docs mirror before any optional API detection or notification step
- allow release synchronization to record a failure without stopping docs ingestion
- restore that release failure at the end so monitoring remains fail-loud
- only close release alerts when release synchronization actually succeeded

## Why
A live GitHub pulls API outage caused release reconciliation to fail before the docs mirror could be dispatched. Docs freshness and release availability are independent maintenance contracts and must not block one another.

## Verification
- node --test tests/automation-workflows.test.js (9/9)
- npm test (190/190)
- git diff --check -- .github/workflows/release-monitor.yml tests/automation-workflows.test.js