### PR TITLE
Reconcile releases every six hours

### DIFF
--- a/.github/workflows/release-monitor.yml
+++ b/.github/workflows/release-monitor.yml
@@ -5,7 +5,9 @@ env:
 
 on:
   schedule:
-    - cron: '0 6 * * *'
+    # Idempotent reconciliation every six hours. This bounds recovery time when
+    # GitHub's API is temporarily unavailable during one scheduled run.
+    - cron: '17 */6 * * *'
   workflow_dispatch:
 
 jobs:

--- a/tests/automation-workflows.test.js
+++ b/tests/automation-workflows.test.js
@@ -86,6 +86,7 @@ test("release monitor retries transient GitHub API failures", () => {
   assert.equal(githubScriptSteps.length, 5);
   assert.equal(retrySettings.length, githubScriptSteps.length);
   assert.equal(retryExemptions.length, githubScriptSteps.length);
+  assert.match(monitor, /cron: '17 \*\/6 \* \* \*'/);
 });
 
 test("recoverable workflow alerts close after a green run", () => {


### PR DESCRIPTION
## Summary
- run the idempotent release/docs reconciliation every six hours instead of once daily
- bound recovery time after transient GitHub API outages
- lock the cadence in workflow regression coverage

## Verification
- `node --test tests/automation-workflows.test.js` ? 9/9 passed
- `npm test` ? 190/190 passed
- `git diff --check` ? clean
- canonical production smoke from clean `origin/main` ? 32/32 passed