### PR TITLE
Keep healthy release checks green during PR API outages

### DIFF
--- a/scripts/sync-releases.js
+++ b/scripts/sync-releases.js
@@ -232,9 +232,16 @@ export async function syncReleases({
   const plan = planReleaseBatch({ upstreamReleases, researchFiles });
   const upstreamLatest = latestStableRelease(upstreamReleases);
 
-  await closeTrackedReleasePrs(client, repository, plan.trackedTags);
-
   if (plan.documents.length === 0) {
+    try {
+      await closeTrackedReleasePrs(client, repository, plan.trackedTags);
+    } catch (error) {
+      if (!(error instanceof GitHubApiError) || error.status < 500) throw error;
+      console.warn(
+        "Release corpus is current, but superseded release PR cleanup is temporarily unavailable; " +
+        "deferring cleanup to the next reconciliation",
+      );
+    }
     console.log(`No missing releases (${plan.trackedTags.size} tags already tracked)`);
     const artifactTag = String(latestReleaseData?.tag || "");
     const artifactStale = upstreamLatest && artifactTag !== upstreamLatest.tag_name;
@@ -251,6 +258,8 @@ export async function syncReleases({
     setOutput("latest_tag", upstreamLatest?.tag_name || "");
     return { merged: false, documents: [], rebuildDispatched: Boolean(artifactStale) };
   }
+
+  await closeTrackedReleasePrs(client, repository, plan.trackedTags);
 
   const tags = plan.documents.map((document) => document.release.tag_name);
   const latestTag = tags.at(-1);

--- a/tests/release-sync.test.js
+++ b/tests/release-sync.test.js
@@ -200,6 +200,34 @@ test("syncReleases dispatches a rebuild when the corpus is current but the relea
   assert.ok(calls.some((call) => call.method === "PATCH" && call.apiPath.endsWith("/pulls/494")));
 });
 
+test("syncReleases defers PR cleanup when the current release corpus is healthy", async () => {
+  const upstream = release("v2026.7.7.2", "2026-07-08T03:11:22Z", "v0.18.2");
+  const calls = [];
+  const client = {
+    async request(method, apiPath) {
+      calls.push({ method, apiPath });
+      if (apiPath.includes("/releases?")) return [upstream];
+      if (apiPath.endsWith("/pulls?state=open&per_page=100") || apiPath === "/graphql") {
+        throw new GitHubApiError("GitHub unavailable", 503, "<html>Unicorn</html>");
+      }
+      throw new Error(`Unexpected request: ${method} ${apiPath}`);
+    },
+  };
+
+  const result = await syncReleases({
+    client,
+    repository: "ksimback/hermes-ecosystem",
+    researchFiles: [{
+      path: "research/50-release-2026-7-7-2.md",
+      content: renderReleaseMarkdown(upstream),
+    }],
+    latestReleaseData: { tag: "v2026.7.7.2" },
+  });
+
+  assert.deepEqual(result, { merged: false, documents: [], rebuildDispatched: false });
+  assert.equal(calls.some((call) => call.apiPath === "/graphql"), true);
+});
+
 test("planReleaseBatch does not backfill intentional gaps before the watermark", () => {
   const plan = planReleaseBatch({
     upstreamReleases: [


### PR DESCRIPTION
## Summary
- make superseded release-PR cleanup best-effort when the release corpus is already current
- keep new-release ingestion fail-closed when PR state is required to avoid duplicates
- add regression coverage for simultaneous REST and GraphQL PR-list outages

## Why
GitHub's upstream release endpoint and the Atlas corpus can both be healthy while repository PR-list APIs are temporarily unavailable. That optional cleanup must not turn a correct steady-state freshness check red.

## Verification
- `node --test tests/release-sync.test.js` ? 13/13 passed
- `npm test` ? 191/191 passed
- `git diff --check` ? clean