### PR TITLE
Isolate release freshness from notification outages

### DIFF
--- a/.github/workflows/release-monitor.yml
+++ b/.github/workflows/release-monitor.yml
@@ -45,6 +45,7 @@ jobs:
 
       - name: Check for new official docs changes
         id: docs_check
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           retries: 3
@@ -71,6 +72,7 @@ jobs:
             }
 
       - name: Create issue for docs update
+        continue-on-error: true
         if: steps.docs_check.outputs.docs_updated == 'true'
         env:
           COMMIT_MSG: ${{ steps.docs_check.outputs.commit_msg }}
@@ -116,6 +118,7 @@ jobs:
             });
 
       - name: Close resolved legacy release alerts
+        continue-on-error: true
         if: steps.releases.outcome == 'success' && success()
         uses: actions/github-script@v7
         with:
@@ -154,6 +157,7 @@ jobs:
             }
 
       - name: Close release-monitor alert after recovery
+        continue-on-error: true
         if: steps.releases.outcome == 'success' && success()
         uses: actions/github-script@v7
         with:
@@ -191,7 +195,7 @@ jobs:
           exit 1
 
       - name: Escalate release-monitor failure
-        if: failure()
+        if: steps.releases.outcome == 'failure'
         uses: actions/github-script@v7
         with:
           retries: 3

--- a/tests/automation-workflows.test.js
+++ b/tests/automation-workflows.test.js
@@ -89,6 +89,27 @@ test("release monitor retries transient GitHub API failures", () => {
   assert.match(monitor, /cron: '17 \*\/6 \* \* \*'/);
 });
 
+test("release monitor does not fail freshness on optional notification outages", () => {
+  const monitor = fs.readFileSync(".github/workflows/release-monitor.yml", "utf-8");
+  for (const step of [
+    "Check for new official docs changes",
+    "Create issue for docs update",
+    "Close resolved legacy release alerts",
+    "Close release-monitor alert after recovery",
+  ]) {
+    const start = monitor.indexOf(`- name: ${step}`);
+    const next = monitor.indexOf("\n      - name:", start + 1);
+    const block = monitor.slice(start, next === -1 ? undefined : next);
+    assert.ok(start >= 0, `${step} exists`);
+    assert.match(block, /continue-on-error: true/, `${step} is informational housekeeping`);
+  }
+  assert.match(
+    monitor,
+    /- name: Escalate release-monitor failure\s+if: steps\.releases\.outcome == 'failure'/,
+  );
+  assert.doesNotMatch(monitor, /- name: Escalate release-monitor failure\s+if: failure\(\)/);
+});
+
 test("recoverable workflow alerts close after a green run", () => {
   for (const file of [
     ".github/workflows/build-pages.yml",


### PR DESCRIPTION
## Summary
- keep docs-change notifications and resolved-alert cleanup best-effort
- escalate only when authoritative release synchronization fails
- preserve hard failure for release ingestion and docs-refresh dispatch
- add workflow regression coverage for notification API outages

## Live evidence
During GitHub's repository API degradation, the exact-main release sync and docs refresh completed their authoritative work, while the informational docs check and failure-alert issue call returned Unicorn errors. Those notification failures should not misreport release freshness as broken.

## Verification
- `node --test tests/automation-workflows.test.js` ? 10/10 passed
- `npm test` ? 192/192 passed
- `git diff --check` ? clean