### PR TITLE
Add MongrelDB-Hermes to memory providers

### DIFF
--- a/data/repos.json
+++ b/data/repos.json
@@ -2028,5 +2028,15 @@
     "url": "https://github.com/IVRZ-da/agentiker-scout",
     "official": false,
     "category": "Plugins & Extensions"
+  },
+  {
+    "owner": "visorcraft",
+    "repo": "MongrelDB-Hermes",
+    "name": "MongrelDB-Hermes",
+    "description": "AI-native long-term memory for Hermes Agent with AES-256-GCM encryption at rest, dense HNSW ANN, sparse and exact-text recall, metadata/range filters, and MinHash dedup, backed by an embedded or multi-client server columnar SQL database with 35 language bindings.",
+    "stars": 0,
+    "url": "https://github.com/visorcraft/MongrelDB-Hermes",
+    "official": false,
+    "category": "Memory & Context"
   }
 ]

--- a/index.html
+++ b/index.html
@@ -773,7 +773,7 @@
     <div class="cat-num">§04</div>
     <h2 class="cat-title">Memory &amp; context</h2>
     <p class="cat-desc">Long-term semantic memory, graph-based retrieval, cross-session persistence.</p>
-    <div class="cat-count"><span class="cat-count-n">30</span> repos</div>
+    <div class="cat-count"><span class="cat-count-n">31</span> repos</div>
   </div>
   <div class="cat-list">
     <a class="repo-row" href="/projects/mem0ai/mem0" data-github="https://github.com/mem0ai/mem0" data-desc="Universal memory layer for AI Agents — official Hermes Agent memory provider, managed cloud or Apache-2.0 self-hosted OSS">
@@ -1013,6 +1013,14 @@
       <div class="repo-body">
         <div class="repo-name"><span class="org">sourcevault-ai /</span> sourcevault-code-tools</div>
         <div class="repo-desc">Hermes Agent plugin — private local code memory for your repos (semantic search, file reads, grounded Q&amp;A).</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/visorcraft/MongrelDB-Hermes" data-github="https://github.com/visorcraft/MongrelDB-Hermes" data-desc="AI-native long-term memory for Hermes Agent with AES-256-GCM encryption at rest, dense HNSW ANN, sparse and exact-text recall, metadata/range filters, and MinHash dedup, backed by an embedded or multi-client server columnar SQL database with 35 language bindings.">
+      <div class="repo-stars">★ 0</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">visorcraft /</span> MongrelDB-Hermes</div>
+        <div class="repo-desc">AI-native long-term memory for Hermes Agent with AES-256-GCM encryption at rest, dense HNSW ANN, sparse and exact-text recall, metadata/range filters, and MinHash dedup, backed by an embedded or multi-client server columnar SQL database with 35 language bindings.</div>
       </div>
       <div class="repo-delta">— / wk</div>
     </a>


### PR DESCRIPTION
## What changed

Adds [visorcraft/MongrelDB-Hermes](https://github.com/visorcraft/MongrelDB-Hermes) to the Memory & Context catalog and homepage with a factual, standalone description.

## Why

MongrelDB-Hermes is an installable exclusive memory provider built specifically for Hermes Agent. It provides AES-256-GCM encryption at rest, dense HNSW ANN, sparse and exact-text recall, metadata and range filtering, and MinHash deduplication through one embedded or multi-client server columnar SQL database with 35 language bindings.

After merge, the existing page-build workflow will generate the project page, Best Memory Providers entry, sitemap entry, and README-backed summary.

The repository is new and currently has 0 stars. Please consider it under the notable-project exception because it is a released, working Hermes integration rather than a generic database listing.

## Validation

- `node scripts/validate-repos-json.js`
- `npm test` after generating pages in a disposable worktree: 183/183 passed
