### PR TITLE
Add usage + serving-mix observability to Ask the Atlas (P0-5 + P0-7)

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -1,4 +1,4 @@
-import { kvIncr, kvExpireNx } from "../lib/redis.js";
+import { kvIncr, kvIncrBy, kvExpireNx } from "../lib/redis.js";
 import { combinedRetrievalScore, enrichChunkMetadata } from "../lib/rag-scoring.js";
 import { buildLatestReleaseBlock, detectLatestReleaseQuery } from "../lib/latest-release.js";
 import { parseChunkStore } from "../lib/chunk-store.js";
@@ -493,6 +493,10 @@ ${retrievedContext}${repoMetadataBlock}`;
         stream: true,
         max_tokens: MAX_TOKENS,
         temperature: 0.3,
+        // Ask OpenRouter to include token usage (and cost) in the final SSE
+        // chunk. That chunk may carry an empty choices array — the parser below
+        // tolerates it (it only reads choices[0] optionally).
+        usage: { include: true },
       }),
     });
 
@@ -517,6 +521,7 @@ ${retrievedContext}${repoMetadataBlock}`;
     let buffer = "";
     let totalContent = "";
     let actualModel = null; // Captured from OpenRouter SSE chunks
+    let usage = null; // Token usage from the final SSE chunk (usage.include)
 
     while (true) {
       const { done, value } = await reader.read();
@@ -548,6 +553,13 @@ ${retrievedContext}${repoMetadataBlock}`;
             actualModel = parsed.model;
           }
 
+          // Capture token usage — OpenRouter emits it on the final chunk (the
+          // one that may have an empty choices array). Overwrite so we keep the
+          // last/most-complete usage object seen.
+          if (parsed.usage) {
+            usage = parsed.usage;
+          }
+
           const content = parsed.choices?.[0]?.delta?.content;
           if (content) {
             totalContent += content;
@@ -572,6 +584,13 @@ ${retrievedContext}${repoMetadataBlock}`;
     }
 
     res.end();
+
+    // Observability — runs AFTER res.end() so it can never break or delay the
+    // user's response. recordChatUsage swallows all errors internally, so a
+    // Redis hiccup is non-fatal by construction (unlike the fail-closed rate
+    // limiter above). We await it so the writes finish before the lambda
+    // freezes, but nothing it does can throw into the response path.
+    await recordChatUsage(actualModel, usage);
   } catch (err) {
     // Client disconnected mid-stream — expected, not an error worth logging or
     // writing (the socket is already gone).
@@ -585,6 +604,54 @@ ${retrievedContext}${repoMetadataBlock}`;
       res.write("\n\n[Error: " + (err.message || "Internal error") + "]");
       res.end();
     } catch {}
+  }
+}
+
+// Lightweight, fully non-fatal observability for a completed chat request.
+// Emits one structured log line and bumps two Redis counters (serving-mix +
+// token totals) so production model drift and token spend are visible. NEVER
+// throws: every failure is swallowed here so it can't affect the response,
+// which has already been flushed via res.end() before this runs.
+async function recordChatUsage(actualModel, usage) {
+  try {
+    if (!actualModel) return; // Nothing to attribute the request to.
+
+    const promptTokens = usage?.prompt_tokens ?? null;
+    const completionTokens = usage?.completion_tokens ?? null;
+    const cost = usage?.cost; // OpenRouter-provided; may be undefined.
+
+    // One structured log line. No message content, no PII — Vercel captures
+    // function logs. Cost is included only when OpenRouter provided it.
+    const logPayload = {
+      model: actualModel,
+      prompt_tokens: promptTokens,
+      completion_tokens: completionTokens,
+    };
+    if (typeof cost === "number") logPayload.cost = cost;
+    console.log(`[chat-usage] ${JSON.stringify(logPayload)}`);
+
+    // Serving-mix + token counters in Redis. TTL ~45 days so the daily keys
+    // self-expire. All writes are non-fatal (helpers return null on error).
+    const today = new Date().toISOString().slice(0, 10);
+    const TTL_45_DAYS = 45 * 86400;
+
+    // chat:model:{today}:{model} — one per completed request (serving mix).
+    const modelKey = `chat:model:${today}:${actualModel}`;
+    if ((await kvIncr(modelKey)) !== null) {
+      await kvExpireNx(modelKey, TTL_45_DAYS);
+    }
+
+    // chat:tokens:{today}:{model} — total prompt+completion tokens.
+    const totalTokens = (promptTokens || 0) + (completionTokens || 0);
+    if (totalTokens > 0) {
+      const tokensKey = `chat:tokens:${today}:${actualModel}`;
+      if ((await kvIncrBy(tokensKey, totalTokens)) !== null) {
+        await kvExpireNx(tokensKey, TTL_45_DAYS);
+      }
+    }
+  } catch (err) {
+    // Observability must never affect the request. Log and move on.
+    console.error("[chat-usage] recording error:", err.message);
   }
 }
 

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -94,6 +94,19 @@ export async function kvIncr(key) {
 }
 
 /**
+ * Increment a counter in Redis by n. Returns the new value, or null on error.
+ */
+export async function kvIncrBy(key, n) {
+  try {
+    const client = await getRedis();
+    return await client.incrBy(key, n);
+  } catch (err) {
+    console.error(`kvIncrBy(${key}) error:`, err.message);
+    return null;
+  }
+}
+
+/**
  * Set TTL (expiration) on a key in seconds.
  */
 export async function kvExpire(key, seconds) {

--- a/tests/redis.test.js
+++ b/tests/redis.test.js
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { kvIncrBy } from "../lib/redis.js";
+
+// kvIncrBy must be non-fatal: when Redis is unavailable it returns null rather
+// than throwing. This is the contract the chat-usage observability relies on so
+// a Redis hiccup can never break the user's response.
+test("kvIncrBy returns null when Redis is unavailable", async () => {
+  const original = process.env.REDIS_URL;
+  delete process.env.REDIS_URL; // getRedis() throws → kvIncrBy swallows → null
+  try {
+    const result = await kvIncrBy("chat:tokens:test", 42);
+    assert.equal(result, null);
+  } finally {
+    if (original !== undefined) process.env.REDIS_URL = original;
+  }
+});


### PR DESCRIPTION
## What

The chat endpoint streamed from OpenRouter but recorded neither token usage nor which model actually served each request — production model drift flipped the serving mix twice in July (~100% gemini → 91% free-tier gemma) and nothing surfaced it.

- `usage: { include: true }` on the streaming request; `parsed.usage` captured from the final SSE chunk (tolerates its empty `choices` array — verified live)
- One structured `[chat-usage]` console line per request: model, prompt/completion tokens, cost when OpenRouter provides it. No message content, no PII
- Redis daily counters via the existing `kvIncr`/`kvExpireNx` idiom: `chat:model:{date}:{model}` (serving mix) and `chat:tokens:{date}:{model}` (token totals), 45-day TTL. New `kvIncrBy` helper in `lib/redis.js` mirroring `kvIncr`'s null-on-error contract, with a unit test
- **Non-fatal by construction**: recording runs after `res.end()`, fully try/catch-wrapped — a Redis outage logs a warning and nothing else (deliberately the opposite of the fail-closed rate limiter)

## Review

Passed the `vercel-function-reviewer` gate: no blockers. Verified: post-`res.end()` await is correct for the Vercel lambda lifecycle; abort path skips recording cleanly; new keys don't collide with `chat:ip:*`/`chat:global:*` rate-limit namespaces; no secret/PII leakage.

One advisory to keep in mind when reading dashboards: the counters count **completed** requests — errored/aborted requests intentionally record nothing, so the mix is "who answered," not total attempts.

## Merge order

Part of the Ask-the-Atlas improvement pack. Reviewer recommends this merges **before** the paid-waterfall PR so the serving-mix counter is live when the default models change. Hunks are disjoint from the other open PRs (verified — no conflicts).

## Verification

- `node --test tests/*.test.js`: 187 pass, 0 fail (includes new redis test)
- Live streaming call with `usage:{include:true}`: usage arrived in final SSE chunk (`prompt_tokens:8, completion_tokens:4, cost:0`), existing parser unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)