### PR TITLE
Remove free-tier models from Ask the Atlas chat waterfall (P0-1 + P0-7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ OPENROUTER_API_KEY=sk-or-... node scripts/test-rag.js
 | `GITHUB_TOKEN` | Fine-grained PAT, public repos read-only | For 5000/hr rate limit (60/hr without) |
 | `OPENROUTER_API_KEY` | LLM API key for chat | Yes |
 | `REDIS_URL` | Redis Cloud connection string | Yes (for cache + history) |
-| `OPENROUTER_MODEL` | Override primary LLM model | No (default: `google/gemma-4-31b-it:free`) |
-| `OPENROUTER_FALLBACK_MODELS` | Comma-separated fallback chain | No |
+| `OPENROUTER_MODEL` | Override primary LLM model | No (default: `google/gemini-3-flash-preview`) |
+| `OPENROUTER_FALLBACK_MODELS` | Comma-separated fallback chain | No (default: `google/gemini-3.1-flash-lite-preview,mistralai/mistral-small-2603`) |
 
 ## Contributing
 

--- a/api/chat.js
+++ b/api/chat.js
@@ -228,10 +228,24 @@ const OPENROUTER_KEY = process.env.OPENROUTER_API_KEY;
 // Nemotron 3 Super) either stream to `delta.reasoning` instead of `delta.content`
 // (returning empty content to our parser) or leak reasoning text into their
 // content output.
-const PRIMARY_MODEL = process.env.OPENROUTER_MODEL || "google/gemma-4-31b-it:free";
+//
+// PAID DEFAULTS (2026-07-23): the chat waterfall deliberately excludes free-tier
+// models. The free gemma-4-31b:free either failed ~91% of calls (mid-July) or,
+// once recovered, served ~91% of traffic at a measured ~0.86-pt quality cost
+// (8.28 vs 9.14 on a 100-question graded eval) because it refuses answerable
+// long-tail questions. lib/openrouter.js keeps a SEPARATE free-tier waterfall for
+// batch summaries (a cost tradeoff, hallucination-audited) — keep the two in sync
+// in awareness of each other.
+//
+// PIN NOTE (2026-07-23): OpenRouter exposes no separately-routable dated variant
+// of gemini-3-flash-preview (the dated form appears only as canonical_slug
+// metadata), so we use the unpinned alias. Unpinned preview aliases inherit
+// provider updates silently — mid-July an identical config scored 8.16 → 9.14
+// after an unannounced provider revision. Re-pin here if a dated slug is listed.
+const PRIMARY_MODEL = process.env.OPENROUTER_MODEL || "google/gemini-3-flash-preview";
 const FALLBACK_MODELS = (process.env.OPENROUTER_FALLBACK_MODELS ||
-  "google/gemma-4-26b-a4b-it:free," +
-  "google/gemini-3-flash-preview"
+  "google/gemini-3.1-flash-lite-preview," +
+  "mistralai/mistral-small-2603"
 ).split(",").map(s => s.trim()).filter(Boolean).slice(0, 2);
 
 const MAX_TOKENS = parseInt(process.env.CHAT_MAX_TOKENS || "800");

--- a/lib/openrouter.js
+++ b/lib/openrouter.js
@@ -2,6 +2,12 @@
  * Shared OpenRouter LLM call helper with model fallback chain.
  */
 
+// NOTE: This free-tier waterfall is used ONLY by batch summary scripts
+// (scripts/generate-summaries.js, scripts/audit-summaries.js). Free tier is a
+// deliberate cost tradeoff here — those outputs are hallucination-audited before
+// shipping. The interactive chat path (api/chat.js) deliberately uses PAID
+// defaults instead, after a measured ~0.86-pt free-tier quality drain on graded
+// evals (July 2026). Update the two in awareness of each other.
 const PRIMARY_MODEL = "google/gemma-4-31b-it:free";
 const FALLBACK_MODELS = [
   "google/gemma-4-26b-a4b-it:free",


### PR DESCRIPTION
## What

The chat waterfall defaulted to free-tier gemma first. Measured two ways, both bad: mid-July the free tier failed ~91% of calls (dead weight, everything fell through to gemini); after it recovered it served ~91% of traffic at a measured **~0.86-point quality cost** (8.28 vs 9.14 on the 100-question graded eval) because free gemma refuses answerable long-tail questions the paid model handles.

- `PRIMARY_MODEL` default: `google/gemma-4-31b-it:free` → `google/gemini-3-flash-preview`
- `FALLBACK_MODELS` default: → `google/gemini-3.1-flash-lite-preview, mistralai/mistral-small-2603` (both already vetted non-reasoning paid models used by this file's query rewriter)
- Env overrides (`OPENROUTER_MODEL`/`OPENROUTER_FALLBACK_MODELS`) and max-3 waterfall structure unchanged; README defaults updated
- **Pin check (P0-7)**: OpenRouter exposes no separately-routable dated variant of gemini-3-flash-preview (the dated form exists only as `canonical_slug` metadata), so the alias stays, with a dated comment documenting the silent-provider-revision risk (this bit us mid-July: identical config scored 8.16 → 9.14 after an unannounced revision)
- `lib/openrouter.js` keeps its separate free-tier waterfall for hallucination-audited batch summaries (deliberate cost tradeoff) — now cross-referenced in comments so the two can't drift apart unnoticed

Grep confirmed no chat-path code assumes the removed `:free` slugs exist (remaining references are the intentional batch path + provenance stamps).

## Cost note

At current rate limits (2,000 requests/day global cap) worst case is ~$8/day at the eval-measured $4.21/1k questions; realistic traffic is far below the cap.

## Review

Passed the `vercel-function-reviewer` gate: no blockers. One advisory: the residual risk is a provider silently shipping a reasoning-on-by-default revision to the unpinned preview alias (our parser reads only `delta.content`). The follow-up PR (P0-2, stacked on this branch) adds `reasoning: { enabled: false }` as explicit insurance.

## Merge order

Reviewer recommends the usage-logging PR merges **first** so the serving-mix counter is live when defaults change. Hunks verified disjoint — no conflicts either way.

## Verification

- `node --test tests/*.test.js`: 186 pass, 0 fail
- Live streaming call with the new models array: `model` field returned `google/gemini-3-flash-preview`, non-empty `delta.content` streamed
- Post-merge: confirm one live chat on hermesatlas.com streams and the `__META__` trailer reports the paid model

🤖 Generated with [Claude Code](https://claude.com/claude-code)