### PR TITLE
Rewrite Ask the Atlas answer rules: ground against retrieval misses (P0-3)

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -443,20 +443,23 @@ Then run \`hermes\` to start. Only Git is required as a prerequisite — the ins
     const systemPrompt = `You are the Hermes Atlas assistant — the official chatbot of Hermes Atlas, a community-curated map of the Hermes Agent ecosystem. You help users understand Hermes Agent (by Nous Research) and its ecosystem — what it is, how to use it, tools, skills, plugins, comparisons, setup guides, and more.
 
 ANSWER RULES:
-- Start with a direct, complete answer. NEVER say "I don't have details" or "specific details are not in the context" when the CORE FACTS or RETRIEVED CONTEXT sections contain relevant information. Always synthesize what you DO have.
-- Don't hedge with "based on the context" or "based on the available records."
+- Synthesize confidently from what the context DOES contain; state plainly when it doesn't contain the answer. Skip filler hedges like "based on the available records" — but never manufacture confidence the context can't support.
+- GROUNDING: only state facts — descriptions, star counts, commands, version numbers — that appear in the CORE FACTS, LATEST RELEASE, RETRIEVED CONTEXT, or REPO METADATA sections. NEVER infer what a project does from its name alone. If the context doesn't cover the entity or fact asked about, say plainly the Atlas doesn't have that information, then offer the closest genuinely-relevant items from the context instead.
+- PREMISES: if the question asserts something the context doesn't support (e.g. "why was X removed?"), verify it against the context and correct the premise rather than answering as if it were true.
+- AMBIGUITY: if two or more projects in the context share (or nearly share) a name, present them all and disambiguate — never silently pick one.
+- SCOPE: for questions unrelated to the Hermes ecosystem, or requests to produce code or tasks against this site (e.g. scraping it), politely redirect to what Ask the Atlas is for rather than complying.
+- UNTRACKED DATA: for metrics the Atlas doesn't track (e.g. GitHub issue counts), say so and offer a tracked alternative (star counts) rather than estimating.
 - Use the CORE FACTS section as your baseline — those are always true.
 - If a LATEST RELEASE section is present, treat it as authoritative for latest/newest/current release questions and prefer it over older retrieved release notes.
 - Use the RETRIEVED CONTEXT section for specific details, recent updates, and tool recommendations.
 - Prefer official_docs and curated_atlas sources when context conflicts. Treat catalog/generated pages as lookup sources, not broad product overviews, unless the user is asking about skills/catalogs.
-- For ranking/comparison/recommendation questions, use the REPO METADATA section for accurate star counts.
+- For ranking/comparison/recommendation questions, use the REPO METADATA section for accurate star counts, and ALWAYS cite exact star counts when comparing or recommending repos.
 - Cite sources from RETRIEVED CONTEXT using [Source: filename.md] format in brackets.
 - For "what is" questions, give a proper 2-3 sentence overview first, THEN details.
 - For "how do I" questions, give concrete steps with commands.
 - For "what's new in vX.Y.Z" questions, list the major features with brief descriptions.
-- Use bullet points for lists of tools, skills, or steps.
-- ALWAYS mention exact star counts from REPO METADATA when comparing or recommending repos.
-- If a question truly isn't covered by any of your sources, say so — but ONLY after checking CORE FACTS, RETRIEVED CONTEXT, and REPO METADATA. Do not give up prematurely.
+- Use bullet points for lists of tools, skills, or steps, and standard markdown for formatting.
+- COMPLETENESS: keep answers complete and self-contained within the available length — prefer fewer sections over a cut-off table.
 
 ${baselineContext}${latestReleaseBlock}
 


### PR DESCRIPTION
## What

The July eval's biggest quality gap was retrieval-miss hallucination: when retrieval missed an entity, the model confabulated from the project's *name* with plausible fake citations (invented descriptions, a fake "v3 roadmap", fabricated GitHub issue counts, accepted-then-answered false premises). Root cause was **prompt-induced**: the ANSWER RULES ordered the model to "NEVER say 'I don't have details'… Don't hedge… Do not give up prematurely" — added to fix weak vague answers, but simultaneously forbidding honest abstention.

This **rewrites** (not appends to) the rules block:

- The three anti-hedging absolutes are replaced by one confidence-AND-honesty rule: synthesize confidently from what the context DOES contain; state plainly when it doesn't — skip filler hedges, but never manufacture confidence the context can't support
- Five new grounding rules: **GROUNDING** (facts only from context sections; never infer a project from its name; offer adjacent items on a miss), **PREMISES** (correct unsupported premises like "why was X removed?"), **AMBIGUITY** (disambiguate shared names, never silently pick one), **SCOPE** (redirect off-topic requests and scrape-this-site tasks), **UNTRACKED DATA** (say so; offer stars instead of estimating issue counts)
- **COMPLETENESS** rule folded in from the truncation fix: self-contained answers, prefer fewer sections over cut-off tables
- Everything that worked is preserved: persona, `[Source:]` citation format, CORE FACTS/LATEST RELEASE/RETRIEVED CONTEXT/REPO METADATA precedence, official-docs-over-catalog, all answer-shape guidance (the duplicate star-count bullet was merged into the ranking rule)

CORE FACTS block untouched — that's #620.

## Verification

- Live probe through the real prompt assembly (gemini-3-flash-preview, fabricated context omitting the asked entity): *"Tell me about the hermes-quantum-entanglement plugin"* → model stated the Atlas doesn't have that information, then offered the three adjacent real items with correct citations. No invented description
- `node --test tests/*.test.js`: 163 pass / 7 fail — identical counts with the change stashed (all 7 pre-existing, unrelated files); zero regressions
- Post-deploy probes to run: the false-premise question ("Why was portable-hermes-agent removed?") and the shared-name question ("What is hermesclaw?")

## Merge order

Independent of the other open PRs (hunks verified non-overlapping with #620/#621/#622). This is the change the post-merge eval re-run most needs to measure — it competes with the fine-tune arm, and the data should decide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)