### PR TITLE
Raise chat answer cap to 1200 tokens + force reasoning off (P0-2)

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -248,7 +248,7 @@ const FALLBACK_MODELS = (process.env.OPENROUTER_FALLBACK_MODELS ||
   "mistralai/mistral-small-2603"
 ).split(",").map(s => s.trim()).filter(Boolean).slice(0, 2);
 
-const MAX_TOKENS = parseInt(process.env.CHAT_MAX_TOKENS || "800");
+const MAX_TOKENS = parseInt(process.env.CHAT_MAX_TOKENS || "1200");
 
 // Per-IP rate limits
 const RATE_LIMIT_HOUR = parseInt(process.env.CHAT_RATE_LIMIT || "15"); // per hour per IP
@@ -507,6 +507,14 @@ ${retrievedContext}${repoMetadataBlock}`;
         stream: true,
         max_tokens: MAX_TOKENS,
         temperature: 0.3,
+        // Force reasoning OFF. Our SSE parser reads only delta.content; a
+        // reasoning-capable model streams to delta.reasoning (empty answer to
+        // us) or burns the whole token budget on hidden thinking. `enabled:
+        // false` stops the generation entirely — unlike `exclude: true`, which
+        // only hides reasoning from the response while still billing for it.
+        // Also insures against the unpinned preview alias silently shipping a
+        // reasoning-on provider revision.
+        reasoning: { enabled: false },
       }),
     });
 


### PR DESCRIPTION
## What

Stacked on #622 (paid waterfall) — merge that first; GitHub will retarget this to `main` automatically.

- `CHAT_MAX_TOKENS` default 800 → 1200. The eval measured ~3% of answers truncated mid-sentence or mid-table at 800 (answers average ~550 tokens with a long tail that hits the cap). Env override unchanged
- `reasoning: { enabled: false }` on the main chat request. Our SSE parser reads only `delta.content`; a reasoning-capable model either streams to `delta.reasoning` (empty answer to us) or silently burns the entire token budget on hidden thinking — the eval measured runs billing ~800 completion tokens while delivering a 40-character answer. This is also the `vercel-function-reviewer`'s requested insurance against the unpinned preview alias silently shipping a reasoning-on provider revision, and a hard prerequisite for the deferred DeepSeek swap (P1-1)
- Query-rewrite call untouched (its model list is separately curated and non-reasoning-only)

## Doc note on the reasoning param

OpenRouter's docs are explicit that `exclude: true` still *generates* (and bills) reasoning and only hides it — wrong tool. `enabled: false` is the disable form (parallel to the documented `effort: "none"` = "disables reasoning entirely"), though the docs don't spell out its semantics in prose. Live call confirms it's accepted without error on the current waterfall. If P1-1 ever lands a reasoning-capable model, re-verify suppression on that model specifically.

## Verification

- Live streaming call with the branch's models array + `reasoning: { enabled: false }`: HTTP 200, incremental `delta.content`, served by `google/gemini-3-flash-preview`, no unsupported-parameter error
- `node --test tests/*.test.js`: 163 pass / 7 fail — verified pre-existing via stash (same failures without this change)

## Merge-order note

After #621 (usage logging) merges, this PR's request-body hunk sits adjacent to its `usage: { include: true }` line — if git reports a trivial conflict on the retarget, ping me and I'll rebase it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)