### PR TITLE
Raise chat answer cap to 1200 tokens + force reasoning off (P0-2)

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -248,7 +248,7 @@ const FALLBACK_MODELS = (process.env.OPENROUTER_FALLBACK_MODELS ||
   "mistralai/mistral-small-2603"
 ).split(",").map(s => s.trim()).filter(Boolean).slice(0, 2);
 
-const MAX_TOKENS = parseInt(process.env.CHAT_MAX_TOKENS || "800");
+const MAX_TOKENS = parseInt(process.env.CHAT_MAX_TOKENS || "1200");
 
 // Per-IP rate limits
 const RATE_LIMIT_HOUR = parseInt(process.env.CHAT_RATE_LIMIT || "15"); // per hour per IP
@@ -514,6 +514,14 @@ ${retrievedContext}${repoMetadataBlock}`;
         // chunk. That chunk may carry an empty choices array — the parser below
         // tolerates it (it only reads choices[0] optionally).
         usage: { include: true },
+        // Force reasoning OFF. Our SSE parser reads only delta.content; a
+        // reasoning-capable model streams to delta.reasoning (empty answer to
+        // us) or burns the whole token budget on hidden thinking. `enabled:
+        // false` stops the generation entirely — unlike `exclude: true`, which
+        // only hides reasoning from the response while still billing for it.
+        // Also insures against the unpinned preview alias silently shipping a
+        // reasoning-on provider revision.
+        reasoning: { enabled: false },
       }),
     });
 


### PR DESCRIPTION
Replaces #625, which was auto-closed when its base branch (`atlas/p01-paid-waterfall`, #622) merged and was deleted. Same change, now rebased onto main on top of #621/#622 — the anticipated trivial conflict with #621's `usage: { include: true }` line was resolved by keeping both additions.

## What

- `CHAT_MAX_TOKENS` default 800 → 1200. The eval measured ~3% of answers truncated mid-sentence or mid-table at 800 (answers average ~550 tokens with a long tail). Env override unchanged
- `reasoning: { enabled: false }` on the main chat request. Our SSE parser reads only `delta.content`; a reasoning-capable model either streams to `delta.reasoning` (empty answer to us) or silently burns the entire budget on hidden thinking — eval runs measured ~800 completion tokens billed for a 40-character answer. Also the `vercel-function-reviewer`'s requested insurance against the unpinned preview alias shipping a reasoning-on revision, and a hard prerequisite for the deferred DeepSeek swap (P1-1)
- Query-rewrite call untouched

## Doc note

OpenRouter docs: `exclude: true` still generates (and bills) reasoning, only hides it — wrong tool. `enabled: false` is the disable form. Live-verified accepted without error on the new waterfall.

## Verification

- Live streaming call with the paid models array + `reasoning: { enabled: false }`: HTTP 200, incremental `delta.content`, served by `google/gemini-3-flash-preview`
- Post-rebase diff vs main is exactly the two intended changes (verified); tests re-run after rebase: 163 pass + only the known pre-existing failures (plus one `ERR_MODULE_NOT_FOUND` artifact from the dep-less rebase worktree — passes with deps installed, and on #621's CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)