### PR TITLE
Promote deepseek-v4-flash to chat primary; gemini becomes fallback (P1-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ OPENROUTER_API_KEY=sk-or-... node scripts/test-rag.js
 | `GITHUB_TOKEN` | Fine-grained PAT, public repos read-only | For 5000/hr rate limit (60/hr without) |
 | `OPENROUTER_API_KEY` | LLM API key for chat | Yes |
 | `REDIS_URL` | Redis Cloud connection string | Yes (for cache + history) |
-| `OPENROUTER_MODEL` | Override primary LLM model | No (default: `google/gemini-3-flash-preview`) |
-| `OPENROUTER_FALLBACK_MODELS` | Comma-separated fallback chain | No (default: `google/gemini-3.1-flash-lite-preview,mistralai/mistral-small-2603`) |
+| `OPENROUTER_MODEL` | Override primary LLM model | No (default: `deepseek/deepseek-v4-flash`) |
+| `OPENROUTER_FALLBACK_MODELS` | Comma-separated fallback chain | No (default: `google/gemini-3-flash-preview,google/gemini-3.1-flash-lite-preview`) |
 
 ## Contributing
 

--- a/api/chat.js
+++ b/api/chat.js
@@ -224,10 +224,16 @@ const OPENROUTER_KEY = process.env.OPENROUTER_API_KEY;
 // Model config — supports primary + fallback via OpenRouter's native routing.
 // OpenRouter caps the models array at 3 total.
 //
-// IMPORTANT: Only use NON-REASONING models here. Reasoning models (GLM-4.7-Flash,
-// Nemotron 3 Super) either stream to `delta.reasoning` instead of `delta.content`
-// (returning empty content to our parser) or leak reasoning text into their
-// content output.
+// IMPORTANT: Our SSE parser reads ONLY `delta.content`. Reasoning models
+// (GLM-4.7-Flash, Nemotron 3 Super) either stream to `delta.reasoning` instead
+// of `delta.content` (returning empty content to our parser) or leak reasoning
+// text into their content output. deepseek-v4-flash (current primary) is
+// itself REASONING-CAPABLE and is only safe in this waterfall because the chat
+// request body explicitly sends `reasoning: { enabled: false }` (added in
+// PR #626). That param MUST NEVER be removed while a reasoning-capable model is
+// in the waterfall — doing so would either blank the answer or burn the whole
+// token budget on hidden thinking. Any purely NON-reasoning model can be added
+// without that constraint, but the param is now load-bearing regardless.
 //
 // PAID DEFAULTS (2026-07-23): the chat waterfall deliberately excludes free-tier
 // models. The free gemma-4-31b:free either failed ~91% of calls (mid-July) or,
@@ -237,15 +243,22 @@ const OPENROUTER_KEY = process.env.OPENROUTER_API_KEY;
 // batch summaries (a cost tradeoff, hallucination-audited) — keep the two in sync
 // in awareness of each other.
 //
+// EVAL EVIDENCE (decision 2026-07-23): deepseek-v4-flash promoted to primary
+// over gemini-3-flash-preview. Through the identical production RAG pipeline,
+// deepseek scored 8.96 vs gemini's 9.14 (a statistical tie within judge noise)
+// at ~6x lower cost ($0.71 vs $4.21 per 1k questions). gemini stays as the
+// reliable fallback; the max-3 waterfall is preserved.
+//
 // PIN NOTE (2026-07-23): OpenRouter exposes no separately-routable dated variant
-// of gemini-3-flash-preview (the dated form appears only as canonical_slug
-// metadata), so we use the unpinned alias. Unpinned preview aliases inherit
-// provider updates silently — mid-July an identical config scored 8.16 → 9.14
+// of deepseek-v4-flash or gemini-3-flash-preview (the dated forms —
+// deepseek-v4-flash-20260423, etc. — appear only as canonical_slug metadata),
+// so we use the unpinned aliases. Unpinned preview aliases inherit provider
+// updates silently — mid-July an identical gemini config scored 8.16 → 9.14
 // after an unannounced provider revision. Re-pin here if a dated slug is listed.
-const PRIMARY_MODEL = process.env.OPENROUTER_MODEL || "google/gemini-3-flash-preview";
+const PRIMARY_MODEL = process.env.OPENROUTER_MODEL || "deepseek/deepseek-v4-flash";
 const FALLBACK_MODELS = (process.env.OPENROUTER_FALLBACK_MODELS ||
-  "google/gemini-3.1-flash-lite-preview," +
-  "mistralai/mistral-small-2603"
+  "google/gemini-3-flash-preview," +
+  "google/gemini-3.1-flash-lite-preview"
 ).split(",").map(s => s.trim()).filter(Boolean).slice(0, 2);
 
 const MAX_TOKENS = parseInt(process.env.CHAT_MAX_TOKENS || "1200");


### PR DESCRIPTION
## What

Approved model swap per the eval program's decision-grade data: through the **identical production RAG pipeline** on the 100-question graded suite, deepseek-v4-flash scored 8.96 vs gemini-3-flash-preview's 9.14 — a statistical tie inside the ±0.4 judge-noise band — at **~1/6th the measured cost** ($0.71 vs $4.21 per 1k questions, API-billed).

- `PRIMARY_MODEL` default → `deepseek/deepseek-v4-flash`; fallbacks → `google/gemini-3-flash-preview, google/gemini-3.1-flash-lite-preview` (mistral-small drops; max-3 waterfall preserved; env overrides unchanged)
- Comment block updated: deepseek is reasoning-capable and is only safe here because the request sends `reasoning: { enabled: false }` (#626) — documented as **load-bearing, never remove** while a reasoning-capable model is in the waterfall
- Pin check: no separately-routable dated deepseek slug on OpenRouter (dated form is canonical_slug metadata only) — unpinned alias with documented risk, same policy as gemini
- README defaults updated

## Prerequisites (all deployed)

- 1200-token cap + `reasoning:{enabled:false}` (#626) — the eval measured deepseek burning the entire 800 budget on hidden reasoning without this
- Serving-mix + usage counters (#621) — live, so this swap's effect on the mix is observable from day one
- The stale `OPENROUTER_MODEL=gemma:free` Vercel env override (104 days old, silently defeating code defaults) was removed today; this PR's deploy is what puts the new defaults in effect

## Live verification (pre-merge, exact production request shape)

Three streaming calls with the new models array (stream, max_tokens 1200, temp 0.3, usage.include, reasoning disabled), including a structured-markdown prompt and a "think step by step" bait prompt:

| Probe | Served by | Visible chars | completion_tokens | Reasoning leakage |
|---|---|---|---|---|
| one-liner | deepseek-v4-flash | 302 | 51 | none |
| structured + bullets | deepseek-v4-flash | 1,494 | 292 | none |
| CoT-bait | deepseek-v4-flash | 1,421 | 321 | none |

No hidden-reasoning token burn (completion_tokens ≤ visible-text estimate in all cases), `delta.reasoning` empty throughout, usage in final chunk, incremental `delta.content` streaming.

## Post-merge verification plan

Three live probes on hermesatlas.com: `__META__` reports deepseek, clean streaming, no CoT leakage; Redis `chat:model:{date}` mix shows deepseek serving. Roll back = revert this PR (gemini fallback remains functional either way).

- `node --test tests/*.test.js`: 187 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)