### PR TITLE
Fix nightly build-pages failures: batch list-summary generation (truncated JSON)

### DIFF
--- a/lib/list-summary-batching.js
+++ b/lib/list-summary-batching.js
@@ -1,0 +1,98 @@
+/**
+ * list-summary-batching.js
+ *
+ * Pure helpers for generating a list's per-repo descriptions in bounded
+ * batches. The list-summary LLM call asks for a JSON object mapping
+ * "owner/repo" -> a 2-3 sentence description for every repo in the list. With a
+ * fixed maxTokens cap (3200), a large enough list (e.g. top-skills at 34 repos)
+ * requires more output than the cap allows, so the JSON is truncated mid-string
+ * and every parse-retry truncates identically -> hard failure. Chunking the
+ * repos into small groups keeps every call comfortably under the cap; the
+ * per-chunk objects are merged back into the single map shape the cache stores.
+ */
+
+// Max repos per LLM call. 12 * (~2-3 sentence description) stays well under the
+// 3200-token output cap that a 34-repo single call blows past.
+export const LIST_CHUNK_SIZE = 12;
+
+/**
+ * Split an array into consecutive chunks of at most `size` items.
+ * Pure; does not mutate the input.
+ */
+export function chunkList(items, size = LIST_CHUNK_SIZE) {
+  if (!Array.isArray(items)) {
+    throw new TypeError("chunkList expects an array");
+  }
+  if (!Number.isInteger(size) || size < 1) {
+    throw new RangeError("chunkList size must be a positive integer");
+  }
+  const chunks = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+
+/**
+ * Merge per-chunk entry objects into a single "owner/repo" -> description map.
+ * Each chunk response must be a plain JSON object (fail loud otherwise, since a
+ * non-object means a chunk call returned something unusable). Later chunks win
+ * on key collision, though chunk membership is disjoint in normal operation.
+ */
+export function mergeEntryMaps(maps) {
+  if (!Array.isArray(maps)) {
+    throw new TypeError("mergeEntryMaps expects an array of objects");
+  }
+  const merged = {};
+  for (const map of maps) {
+    if (!map || typeof map !== "object" || Array.isArray(map)) {
+      throw new Error("Each chunk response must be a JSON object");
+    }
+    Object.assign(merged, map);
+  }
+  return merged;
+}
+
+/**
+ * Return the member keys that lack a usable (non-empty string) description in
+ * the merged entries. Empty result => every repo has a description.
+ */
+export function findMissingEntries(entries, memberKeys) {
+  const keys = memberKeys instanceof Set ? memberKeys : new Set(memberKeys);
+  const missing = [];
+  for (const key of keys) {
+    const value = entries ? entries[key] : undefined;
+    if (typeof value !== "string" || value.trim().length === 0) {
+      missing.push(key);
+    }
+  }
+  return missing;
+}
+
+/**
+ * Build the list-summary user prompt for a set of member repos. Kept identical
+ * in shape to the single-call prompt — chunking only reduces how many repos are
+ * passed per call. Pure over (list, memberRepos, summariesData).
+ */
+export function buildListPrompt(list, memberRepos, summariesData) {
+  const projectLines = memberRepos
+    .slice()
+    .sort((a, b) => (b.stars || 0) - (a.stars || 0))
+    .map((r) => {
+      const key = `${r.owner}/${r.repo}`;
+      const s = summariesData[key];
+      const highlights = s?.highlights?.join("; ") || "No highlights available";
+      return `- ${key} (${r.stars} stars): ${r.description}\n  Key highlights: ${highlights}`;
+    })
+    .join("\n");
+
+  return `You are writing a listicle section for "${list.title}" on Hermes Atlas.
+
+For each project below, write a 2-3 sentence description that explains what it does and why it belongs in this list. Differentiate each project from the others — avoid repetitive phrasing. Ground your descriptions in the highlights provided.
+
+Projects (ranked by stars):
+${projectLines}
+
+Output a JSON object mapping "owner/repo" to a string (the 2-3 sentence description).
+Respond with ONLY the JSON object, no markdown fences.`;
+}

--- a/scripts/generate-summaries.js
+++ b/scripts/generate-summaries.js
@@ -26,6 +26,13 @@ import {
 } from "../lib/summary-pruning.js";
 import { writeJsonCheckpoint } from "../lib/json-checkpoint.js";
 import { mapWithConcurrency } from "../lib/bounded-concurrency.js";
+import {
+  LIST_CHUNK_SIZE,
+  chunkList,
+  mergeEntryMaps,
+  findMissingEntries,
+  buildListPrompt,
+} from "../lib/list-summary-batching.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..");
@@ -148,28 +155,8 @@ Output a JSON object with exactly these fields:
 Respond with ONLY the JSON object, no markdown fences, no explanation.`;
 }
 
-// ── List summary generation ──
-function buildListPrompt(list, memberRepos, summariesData) {
-  const projectLines = memberRepos
-    .sort((a, b) => (b.stars || 0) - (a.stars || 0))
-    .map((r) => {
-      const key = `${r.owner}/${r.repo}`;
-      const s = summariesData[key];
-      const highlights = s?.highlights?.join("; ") || "No highlights available";
-      return `- ${key} (${r.stars} stars): ${r.description}\n  Key highlights: ${highlights}`;
-    })
-    .join("\n");
-
-  return `You are writing a listicle section for "${list.title}" on Hermes Atlas.
-
-For each project below, write a 2-3 sentence description that explains what it does and why it belongs in this list. Differentiate each project from the others — avoid repetitive phrasing. Ground your descriptions in the highlights provided.
-
-Projects (ranked by stars):
-${projectLines}
-
-Output a JSON object mapping "owner/repo" to a string (the 2-3 sentence description).
-Respond with ONLY the JSON object, no markdown fences.`;
-}
+// buildListPrompt + batch chunk/merge helpers now live in
+// lib/list-summary-batching.js so they can be unit-tested in isolation.
 
 // ── Main ──
 async function main() {
@@ -320,12 +307,38 @@ async function main() {
 
     console.log(`  ${list.slug}: generating (${memberRepos.length} projects)...`);
     try {
-      const entries = await callOpenRouterJSON({
-        system: SYSTEM_PROMPT,
-        user: buildListPrompt(list, memberRepos, summaries),
-        apiKey: OPENROUTER_KEY,
-        maxTokens: 3200,
-      });
+      // Rank by stars across the whole list, THEN chunk, so chunk membership
+      // follows the global star order the single-call prompt used to present.
+      // A single call for a large list (e.g. top-skills at 34 repos) asks for
+      // more JSON than maxTokens 3200 can emit, truncating the response
+      // mid-string; batching keeps every call well under the cap.
+      const rankedMembers = memberRepos
+        .slice()
+        .sort((a, b) => (b.stars || 0) - (a.stars || 0));
+      const chunks = chunkList(rankedMembers, LIST_CHUNK_SIZE);
+      const chunkMaps = [];
+      for (const chunk of chunks) {
+        const chunkEntries = await callOpenRouterJSON({
+          system: SYSTEM_PROMPT,
+          user: buildListPrompt(list, chunk, summaries),
+          apiKey: OPENROUTER_KEY,
+          maxTokens: 3200,
+        });
+        chunkMaps.push(chunkEntries);
+        if (chunks.length > 1) await sleep(DELAY_MS);
+      }
+      const entries = mergeEntryMaps(chunkMaps);
+
+      // Fail loud if any member lost its description in a chunk (e.g. a chunk
+      // still truncated, or a model dropped a key). Same failure path as a
+      // single-call failure: throw -> caught below -> listsFailed++ -> the run
+      // throws at the end. The cache is not half-written.
+      const missing = findMissingEntries(entries, memberKeys);
+      if (missing.length > 0) {
+        throw new Error(
+          `Missing list descriptions after batching: ${missing.join(", ")}`,
+        );
+      }
 
       validateListEntries(entries, memberKeys);
 

--- a/tests/list-summary-batching.test.js
+++ b/tests/list-summary-batching.test.js
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  LIST_CHUNK_SIZE,
+  chunkList,
+  mergeEntryMaps,
+  findMissingEntries,
+} from "../lib/list-summary-batching.js";
+
+test("chunkList splits into chunks of at most the given size", () => {
+  const items = Array.from({ length: 34 }, (_, i) => i);
+  const chunks = chunkList(items, 12);
+  assert.equal(chunks.length, 3);
+  assert.deepEqual(chunks.map((c) => c.length), [12, 12, 10]);
+  // Order preserved and no items dropped or duplicated.
+  assert.deepEqual(chunks.flat(), items);
+});
+
+test("chunkList handles exact multiples, remainder, empty, and small inputs", () => {
+  assert.deepEqual(chunkList([1, 2, 3, 4], 2).map((c) => c.length), [2, 2]);
+  assert.deepEqual(chunkList([1, 2, 3], 12).map((c) => c.length), [3]);
+  assert.deepEqual(chunkList([], 12), []);
+  assert.equal(LIST_CHUNK_SIZE, 12);
+});
+
+test("chunkList does not mutate its input and rejects bad args", () => {
+  const input = [1, 2, 3];
+  chunkList(input, 2);
+  assert.deepEqual(input, [1, 2, 3]);
+  assert.throws(() => chunkList("nope", 12), TypeError);
+  assert.throws(() => chunkList([1, 2], 0), RangeError);
+  assert.throws(() => chunkList([1, 2], 1.5), RangeError);
+});
+
+test("mergeEntryMaps merges disjoint chunk objects into one map", () => {
+  const merged = mergeEntryMaps([
+    { "a/one": "desc one", "a/two": "desc two" },
+    { "b/three": "desc three" },
+    {},
+  ]);
+  assert.deepEqual(merged, {
+    "a/one": "desc one",
+    "a/two": "desc two",
+    "b/three": "desc three",
+  });
+});
+
+test("mergeEntryMaps fails loud on a non-object chunk response", () => {
+  assert.throws(() => mergeEntryMaps([{ "a/one": "x" }, null]), /JSON object/);
+  assert.throws(() => mergeEntryMaps([["a/one", "x"]]), /JSON object/);
+  assert.throws(() => mergeEntryMaps("nope"), TypeError);
+});
+
+test("findMissingEntries flags members lacking a usable description", () => {
+  const members = new Set(["a/one", "a/two", "a/three"]);
+  const entries = {
+    "a/one": "A complete description.",
+    "a/two": "   ", // whitespace only -> missing
+    // a/three absent entirely -> missing
+  };
+  assert.deepEqual(findMissingEntries(entries, members), ["a/two", "a/three"]);
+  // All present -> empty.
+  assert.deepEqual(
+    findMissingEntries(
+      { "a/one": "x", "a/two": "y", "a/three": "z" },
+      members,
+    ),
+    [],
+  );
+  // Accepts an array of keys too.
+  assert.deepEqual(findMissingEntries({}, ["a/one"]), ["a/one"]);
+});


### PR DESCRIPTION
## What / why you were getting emails

The daily 07:21 UTC scheduled `build-pages` run has been failing (07-22, 07-23 → nightly alert emails + an auto-filed `workflow-issue`). Root cause: list-summary generation made **one** LLM call per list asking for a JSON map of every repo → 2–3 sentence description, capped at `maxTokens: 3200`. The `top-skills` list grew to 34 repos; the required output exceeds the cap, so the JSON truncates mid-string ("Unterminated string at position 4427"), all 3 parse-retries truncate identically, and the script fails loud. Manual daytime runs passed only because the SHA cache skipped regeneration — the scheduled morning run is the first to see overnight list-membership changes and regenerate.

## Fix

- New `lib/list-summary-batching.js`: pure, unit-tested helpers — `chunkList` (≤12 repos/call), `mergeEntryMaps`, `findMissingEntries`, plus `buildListPrompt` moved there (non-mutating) for testability
- `scripts/generate-summaries.js`: rank the full list by stars (preserving the old prompt's global ordering), chunk, one call per chunk with the existing 1.5s inter-call delay, merge, then **fail loud** if any repo lacks a description (same `listsFailed` path; cache only written after all gates pass)
- Bounded per call regardless of future list growth (34 repos → 3 calls of 12/12/10)
- Untouched by design: `lib/openrouter.js` (owned by the in-flight `codex/automation-reliability` branch), the regeneration-trigger logic, cache shape, and the per-project summary path

## Verification

- `node --test tests/*.test.js`: **193 pass, 0 fail** (+6 new tests: chunk sizes/remainders/empty, non-mutation, merge correctness, non-object fail-loud, missing/whitespace-entry detection)
- Live run of the real chunked path against the API for the top-skills list (no `data/` writes): 3 chunks, 0 parse failures, every member described, `validateListEntries` PASS

## After merge

The next scheduled run (07:21 UTC) should go green — then the auto-filed `[Workflow] build-pages failed` issue can be closed. If you want it confirmed sooner, a manual `workflow_dispatch` of Build Project & List Pages will exercise the same path once list content next changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)