### PR TITLE
Name dead catalog repos in the stars alert and sweep for them daily

### DIFF
--- a/.github/workflows/audit-summaries.yml
+++ b/.github/workflows/audit-summaries.yml
@@ -9,7 +9,13 @@ concurrency:
 
 on:
   schedule:
-    - cron: '0 8 * * 1'  # Every Monday at 08:00 UTC
+    # Summary auditing stays weekly (Monday) — it burns OpenRouter credits.
+    # The dead-repo sweep runs daily because it is one free GraphQL query and
+    # a weekly cadence let ndesv21/socialclaw break the 6-hourly stars refresh
+    # for 6+ days: the 07-27 09:01Z audit passed, the repo died at 18:48Z, and
+    # the next check was not due until 08-03 (PR #662).
+    - cron: '0 8 * * 1'  # Every Monday at 08:00 UTC — full audit
+    - cron: '0 8 * * *'  # Daily at 08:00 UTC — dead-repo sweep only
   workflow_dispatch: {}
 
 jobs:
@@ -32,8 +38,12 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      # The daily cron exists only to sweep for dead repos. Skip the
+      # OpenRouter-billed summary audit on it; `github.event.schedule` is unset
+      # for workflow_dispatch, so manual runs still get the full audit.
       - name: Run summary audit
         id: audit
+        if: github.event.schedule != '0 8 * * *'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
@@ -50,6 +60,7 @@ jobs:
           fi
 
       - name: Commit if flagged
+        if: github.event.schedule != '0 8 * * *'
         run: |
           git add data/summaries.json
           if git diff --cached --quiet; then

--- a/.github/workflows/refresh-stars.yml
+++ b/.github/workflows/refresh-stars.yml
@@ -46,6 +46,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const fs = require('fs');
             const title = '[Workflow] GitHub stars refresh failed';
             const { data: open } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
@@ -54,16 +55,25 @@ jobs:
               labels: 'workflow-issue',
               per_page: 100
             });
-            const body = `The scheduled stars snapshot failed or GitHub reported an unavailable catalog repository.\n\nRun: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}\n\nThe API exposes stale and complete separately, so a partial or old snapshot cannot masquerade as healthy.`;
+
+            // push-stars-snapshot.js writes this when GitHub could not resolve
+            // catalog entries. Naming them here is the difference between a
+            // 2-minute fix and a manual investigation — the generic body alone
+            // left ndesv21/socialclaw breaking runs for ~26h (PR #662).
+            let detail = '';
+            try {
+              detail = fs.readFileSync('stars-unavailable.md', 'utf8');
+            } catch {
+              detail = 'No unavailable-repo report was produced, so the snapshot ' +
+                'failed before ingestion (network, auth, or a degraded API response). ' +
+                'Check the run log.\n';
+            }
+
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = `The scheduled stars snapshot failed.\n\nRun: ${runUrl}\n\n${detail}`;
             const existing = open.find((issue) => issue.title === title);
-            if (existing) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: existing.number,
-                body
-              });
-            } else {
+
+            if (!existing) {
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -71,4 +81,30 @@ jobs:
                 body,
                 labels: ['workflow-issue']
               });
+              return;
             }
+
+            // This workflow runs every 6h, so an unfixed dead repo would post 4
+            // identical comments a day and bury the one that matters. Comment
+            // only when the diagnosis actually changed; the run link alone is
+            // not a change worth notifying for.
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: existing.number,
+              per_page: 100
+            });
+            const lastBody = comments.length ? comments[comments.length - 1].body : existing.body;
+            const withoutRunUrl = (text) => String(text || '').replace(/Run: \S+/g, '').trim();
+
+            if (withoutRunUrl(lastBody) === withoutRunUrl(body)) {
+              core.info(`Issue #${existing.number} already reports this exact failure — not re-commenting.`);
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: existing.number,
+              body
+            });

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ CLAUDE.md
 .agents/
 skills-lock.json
 dead-repos.md
+stars-unavailable.md
 
 # In-progress tracking — stays in the private operations vault, never in this repo
 # Covers: roadmaps, launch playbooks, analytics setup plans, status/todo docs

--- a/scripts/push-stars-snapshot.js
+++ b/scripts/push-stars-snapshot.js
@@ -1,8 +1,48 @@
 #!/usr/bin/env node
-import { readFile } from "fs/promises";
+import { readFile, writeFile } from "fs/promises";
 import { fileURLToPath } from "url";
 import { resolve } from "path";
 import { fetchGitHubStars } from "../lib/github-stars.js";
+
+// The workflow reads this file to name the offending repos in its alert issue.
+// Without it the alert can only say "something failed", which cost ~26h and a
+// manual investigation when ndesv21/socialclaw was deleted (PR #662).
+export const UNAVAILABLE_REPORT_PATH = "stars-unavailable.md";
+
+/**
+ * Render the catalog entries GitHub could not resolve as an actionable issue
+ * body. The snapshot still publishes when this happens — these entries are a
+ * data problem in `data/repos.json`, not a fault in the refresh itself.
+ */
+export function formatUnavailableReport(unavailable) {
+  const rows = unavailable
+    .map((item) => {
+      const key = `${item.owner}/${item.repo}`;
+      const reason = item.reason ? ` — ${item.reason}` : "";
+      return `- \`${key}\` — https://github.com/${key}${reason}`;
+    })
+    .join("\n");
+
+  return (
+    `## Unavailable catalog repositories (${unavailable.length})\n\n` +
+    `${rows}\n\n` +
+    `These entries in \`data/repos.json\` no longer resolve on GitHub — deleted, ` +
+    `renamed, or made private. The snapshot still published; it is flagged ` +
+    `\`complete: false\` so a partial catalog cannot pass as healthy.\n\n` +
+    `**This blocks every 6-hourly stars refresh and the post-deploy smoke test ` +
+    `(which seeds stars through the same script) until the entry is removed.**\n\n` +
+    `### Fix\n\n` +
+    `1. Confirm with \`gh api repos/OWNER/REPO\` (check the owner account too — ` +
+    `it may be gone as well), and search for a rename target before removing.\n` +
+    `2. Remove the entry from \`data/repos.json\` **and** its \`data/summaries.json\` ` +
+    `record, then rebuild — \`build-pages.js\` prunes the orphan project page and ` +
+    `homepage row on its own.\n` +
+    `3. After merging, run \`gh workflow run "Refresh GitHub Stars" --ref main\` and ` +
+    `confirm \`/api/stars\` reports \`complete: true\`. The live snapshot stays ` +
+    `degraded until a refresh republishes it.\n\n` +
+    `See PR #662 (ndesv21/socialclaw) and PR #148 (Web3CZ) for prior removals.\n`
+  );
+}
 
 export async function pushStarsSnapshot({
   githubToken,
@@ -33,10 +73,13 @@ export async function pushStarsSnapshot({
     throw new Error("Snapshot ingestion returned a degraded response");
   }
   if (result.complete === false) {
-    const repos = (result.unavailableRepos || [])
-      .map((item) => `${item.owner}/${item.repo}`)
-      .join(", ");
-    throw new Error(`Snapshot published with unavailable catalog repositories: ${repos}`);
+    const unavailable = result.unavailableRepos || [];
+    const names = unavailable.map((item) => `${item.owner}/${item.repo}`).join(", ");
+    const error = new Error(`Snapshot published with unavailable catalog repositories: ${names}`);
+    // Carried so the CLI can write a named, actionable alert body. The throw
+    // itself is unchanged: a partial catalog must still fail the workflow.
+    error.unavailableRepos = unavailable;
+    throw error;
   }
   return result;
 }
@@ -52,8 +95,11 @@ if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.ur
         `Published ${result.totals.count} repos (${result.totals.stars} stars) at ${result.fetchedAt}`,
       );
     })
-    .catch((error) => {
+    .catch(async (error) => {
       console.error(error.message);
+      if (error.unavailableRepos?.length) {
+        await writeFile(UNAVAILABLE_REPORT_PATH, formatUnavailableReport(error.unavailableRepos));
+      }
       process.exitCode = 1;
     });
 }

--- a/tests/push-stars-snapshot.test.js
+++ b/tests/push-stars-snapshot.test.js
@@ -1,7 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { readFile } from "fs/promises";
-import { pushStarsSnapshot } from "../scripts/push-stars-snapshot.js";
+import {
+  formatUnavailableReport,
+  pushStarsSnapshot,
+} from "../scripts/push-stars-snapshot.js";
 
 const repos = [{ owner: "example", repo: "tool", stars: 6 }];
 
@@ -152,4 +155,95 @@ test("refresh workflow owns scheduling, authentication, and alert recovery", asy
   assert.match(workflow, /push-stars-snapshot\.js/);
   assert.match(workflow, /GitHub stars refresh failed/);
   assert.equal(vercel.crons, undefined);
+});
+
+test("partial-snapshot error carries the unavailable repos for the alert body", async () => {
+  let call = 0;
+  await assert.rejects(
+    pushStarsSnapshot({
+      githubToken: "github-token",
+      cronSecret: "cron-secret",
+      repoList: repos,
+      fetchImpl: async () => {
+        call += 1;
+        if (call === 1) {
+          return {
+            ok: true,
+            status: 200,
+            async json() {
+              return {
+                data: { repo0: null, atlas: { stargazerCount: 42 } },
+                errors: [{ message: "repository deleted", path: ["repo0"] }],
+              };
+            },
+          };
+        }
+        return {
+          ok: true,
+          status: 200,
+          async json() {
+            return {
+              source: "github-actions",
+              stale: false,
+              complete: false,
+              unavailableRepos: [{
+                owner: "ndesv21",
+                repo: "socialclaw",
+                reason: "Could not resolve to a Repository",
+              }],
+            };
+          },
+        };
+      },
+    }),
+    // Without this the workflow can only say "something failed" and a human has
+    // to open the run log to learn which entry broke the catalog.
+    (error) => {
+      assert.deepEqual(error.unavailableRepos, [{
+        owner: "ndesv21",
+        repo: "socialclaw",
+        reason: "Could not resolve to a Repository",
+      }]);
+      return true;
+    },
+  );
+});
+
+test("unavailable report names each repo, its reason, and the recovery steps", () => {
+  const report = formatUnavailableReport([
+    { owner: "ndesv21", repo: "socialclaw", reason: "Could not resolve to a Repository" },
+    { owner: "example", repo: "gone" },
+  ]);
+
+  assert.match(report, /Unavailable catalog repositories \(2\)/);
+  assert.match(report, /`ndesv21\/socialclaw` — https:\/\/github\.com\/ndesv21\/socialclaw — Could not resolve/);
+  // A missing reason must not render as "undefined" next to the repo name.
+  assert.match(report, /`example\/gone` — https:\/\/github\.com\/example\/gone\n/);
+  assert.doesNotMatch(report, /undefined/);
+  // The alert has to state the blast radius and the republish step, because
+  // merging the removal alone leaves the live snapshot degraded.
+  assert.match(report, /post-deploy smoke test/);
+  assert.match(report, /data\/summaries\.json/);
+  assert.match(report, /Refresh GitHub Stars/);
+});
+
+test("stars alert names the dead repos and does not repeat an unchanged diagnosis", async () => {
+  const workflow = await readFile(new URL("../.github/workflows/refresh-stars.yml", import.meta.url), "utf8");
+  // The alert must consume the report the script writes, or it degrades back
+  // to the generic "workflow failed" body that started this incident.
+  assert.match(workflow, /stars-unavailable\.md/);
+  assert.match(workflow, /listComments/);
+  assert.match(workflow, /not re-commenting/);
+  // Run URLs differ every run; comparing them would defeat the dedupe.
+  assert.match(workflow, /withoutRunUrl/);
+});
+
+test("dead-repo sweep runs daily while the billed summary audit stays weekly", async () => {
+  const workflow = await readFile(new URL("../.github/workflows/audit-summaries.yml", import.meta.url), "utf8");
+  assert.match(workflow, /cron: '0 8 \* \* 1'/);
+  assert.match(workflow, /cron: '0 8 \* \* \*'/);
+  // A weekly-only sweep left a dead repo breaking the 6-hourly refresh for 6+
+  // days. The daily cron must still skip the OpenRouter-billed audit steps.
+  assert.match(workflow, /if: github\.event\.schedule != '0 8 \* \* \*'/);
+  assert.match(workflow, /check-dead-repos\.js/);
 });


### PR DESCRIPTION
Follow-up to #662. That PR removed the dead repo; this one makes the next one cheap to find.

## Why

The `ndesv21/socialclaw` deletion broke the 6-hourly stars refresh and the post-deploy smoke test for ~26h and needed a manual investigation. Both safety nets missed, for different reasons:

**The alert knew and didn't say.** `/api/stars` returns `unavailableRepos` with GitHub's own reason string. The workflow discarded it and opened an issue reading *"failed or GitHub reported an unavailable catalog repository"* plus a run link — so diagnosing it meant opening the run log.

**The sweep was aimed at the wrong cadence.** `check-dead-repos.js` already existed and would have caught this — but it runs weekly, guarding a pipeline that runs every 6h:

| when | what |
|---|---|
| Mon 07-27 09:01Z | audit ran clean, socialclaw still alive |
| Mon 07-27 18:48Z | socialclaw deleted, stars begins failing |
| Mon 08-03 08:00Z | next scheduled check — **6d 13h later** |

## Changes

- **`push-stars-snapshot.js`** — attaches `unavailableRepos` to the thrown error and writes `stars-unavailable.md`. The throw is unchanged; a partial catalog still fails the workflow.
- **`refresh-stars.yml`** — renders that report into the alert: repo names, GitHub's reason, blast radius, and recovery steps *including the post-merge republish* (merging the removal alone leaves the live snapshot `complete:false`, which cost an extra step last time).
- **`audit-summaries.yml`** — dead-repo sweep now also runs daily. The OpenRouter-billed summary audit stays weekly behind a `github.event.schedule` guard, so the extra runs cost one free GraphQL query.
- **Noise** — no longer re-comments an unchanged diagnosis. At 4 runs/day an unfixed repo posted 4 identical comments daily. Run URLs are normalized out before comparing, since they differ every run and would defeat the check.

## Verification

- **End-to-end**: ran the CLI against a mock ingestion endpoint returning a partial snapshot — writes the report, still exits 1, fail-loud intact
- **Alert logic**: extracted the embedded script from the YAML and executed it against mocked GitHub APIs — all four paths pass (create when none open, comment when diagnosis changed, stay silent when only the run URL differs, useful fallback when no report exists)
- **Syntax**: embedded script syntax-checked as the async wrapper `github-script` evaluates it
- `npm test` — 206/206 (4 new)

The rendered alert body is in the commit; it names the repo, the reason, and the three fix steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)