### PR TITLE
Serve use-case bundles from chat and cut the full-catalog dump

### DIFF
--- a/.github/workflows/rebuild-chunks.yml
+++ b/.github/workflows/rebuild-chunks.yml
@@ -19,6 +19,11 @@ on:
       - 'repos/*.md'
       - 'ECOSYSTEM.md'
       - 'data/repos.json'
+      # Use-case bundles are synthesized into retrievable pages by
+      # build-chunks.js, so editing a bundle (or the corpus it cites) must
+      # re-embed them or the KB serves the previous stack.
+      - 'data/use-cases.json'
+      - 'data/user-stories.json'
       - 'drafts/handbook-hub.md'
       - 'drafts/handbook-vs-claude-code.md'
       - 'scripts/build-chunks.js'

--- a/api/chat.js
+++ b/api/chat.js
@@ -2,6 +2,7 @@ import { kvIncr, kvIncrBy, kvExpireNx } from "../lib/redis.js";
 import { combinedRetrievalScore, enrichChunkMetadata } from "../lib/rag-scoring.js";
 import { buildLatestReleaseBlock, detectLatestReleaseQuery } from "../lib/latest-release.js";
 import { parseChunkStore } from "../lib/chunk-store.js";
+import { matchUseCases, buildUseCaseBlock, inferCategory } from "../lib/use-case-match.js";
 import { readFileSync } from "fs";
 import { join } from "path";
 
@@ -11,6 +12,7 @@ let corpusDimensions = null;
 let bm25Index = null;
 let reposData = null;
 let latestReleaseData = null;
+let useCasesData = null;
 
 function loadChunks() {
   if (chunks) return chunks;
@@ -41,6 +43,22 @@ function loadRepos() {
   } catch (e) {
     console.error("Failed to load repos.json:", e.message);
     return [];
+  }
+}
+
+function loadUseCases() {
+  if (useCasesData) return useCasesData;
+  try {
+    // Literal join(process.cwd(), ...) so Vercel's file tracer bundles it —
+    // same constraint as loadChunks above.
+    const raw = readFileSync(join(process.cwd(), "data", "use-cases.json"), "utf-8");
+    useCasesData = JSON.parse(raw);
+    return useCasesData;
+  } catch (e) {
+    // Missing bundles degrade to the pre-existing catalog-dump behavior.
+    console.error("Failed to load use-cases.json:", e.message);
+    useCasesData = [];
+    return useCasesData;
   }
 }
 
@@ -421,16 +439,37 @@ export default async function handler(req, res) {
 
     console.log(`[RAG] Top result: ${scored[0]?.source} (${scored[0]?._authority}/${scored[0]?._contentKind}, cos=${scored[0]?._cosine.toFixed(3)}, bm25=${scored[0]?._bm25.toFixed(3)}); ${new Set(scored.map(s => s.source)).size} unique sources`);
 
-    // 6. Detect ranking/comparison queries and inject repo metadata
-    // This gives the LLM live star counts to actually rank/compare repos
+    // 6. Curated use-case bundles for "I want to build X" questions.
+    // A matched bundle is ~300 tokens of curated stack + rationale, versus the
+    // ~7,900-token full-catalog dump below that the model would otherwise have
+    // to re-rank itself. Matching is deterministic (lib/use-case-match.js) and
+    // shared with the /use-cases/ page matcher so the two can't disagree.
+    const repos = loadRepos();
+    const repoIndex = new Map(repos.map((r) => [`${r.owner}/${r.repo}`, r]));
+    const useCaseMatches = matchUseCases(`${message}\n${searchQuery}`, loadUseCases());
+    const useCaseBlock = buildUseCaseBlock(useCaseMatches, repoIndex);
+    if (useCaseBlock) {
+      console.log(`[RAG] Injected ${useCaseMatches.length} use-case bundle(s): ${useCaseMatches.map(m => `${m.useCase.slug}(${m.score})`).join(", ")}`);
+    }
+
+    // 7. Detect ranking/comparison queries and inject repo metadata.
+    // This gives the LLM live star counts to actually rank/compare repos.
+    //
+    // Narrow to a single category when the query unambiguously names one —
+    // that is a ~83% token cut on this path (7.9k → ~1.4k). inferCategory
+    // returns null on ambiguous or absent signals, which keeps the full dump;
+    // narrowing wrongly would starve a legitimate cross-category ranking
+    // question, and that is worse than paying the tokens.
     const needsRepoData = isRepoMetadataQuery(searchQuery);
     let repoMetadataBlock = "";
-    if (needsRepoData) {
-      const repos = loadRepos();
-      if (repos.length > 0) {
-        repoMetadataBlock = `\n\n## REPO METADATA (sorted by stars within each category)\n${buildRepoSummary(repos)}\n`;
-        console.log(`[RAG] Injected repo metadata (${repos.length} repos) for ranking query`);
-      }
+    if (needsRepoData && repos.length > 0) {
+      const category = inferCategory(`${message}\n${searchQuery}`);
+      const scopedRepos = category ? repos.filter((r) => r.category === category) : repos;
+      // Never let a narrow-but-empty slice silently replace the catalog.
+      const effective = scopedRepos.length > 0 ? scopedRepos : repos;
+      const scopeLabel = category && scopedRepos.length > 0 ? ` — scoped to ${category}` : "";
+      repoMetadataBlock = `\n\n## REPO METADATA (sorted by stars within each category${scopeLabel})\n${buildRepoSummary(effective)}\n`;
+      console.log(`[RAG] Injected repo metadata (${effective.length}/${repos.length} repos${category ? `, category=${category}` : ", full catalog"})`);
     }
 
     const needsLatestRelease = detectLatestReleaseQuery(`${message}\n${searchQuery}`);
@@ -474,7 +513,7 @@ Then run \`hermes\` to start. Only Git is required as a prerequisite — the ins
 
 ANSWER RULES:
 - Synthesize confidently from what the context DOES contain; state plainly when it doesn't contain the answer. Skip filler hedges like "based on the available records" — but never manufacture confidence the context can't support.
-- GROUNDING: only state facts — descriptions, star counts, commands, version numbers — that appear in the CORE FACTS, LATEST RELEASE, RETRIEVED CONTEXT, or REPO METADATA sections. NEVER infer what a project does from its name alone. If the context doesn't cover the entity or fact asked about, say plainly the Atlas doesn't have that information, then offer the closest genuinely-relevant items from the context instead.
+- GROUNDING: only state facts — descriptions, star counts, commands, version numbers — that appear in the CORE FACTS, LATEST RELEASE, RETRIEVED CONTEXT, USE-CASE BUNDLES, or REPO METADATA sections. NEVER infer what a project does from its name alone. If the context doesn't cover the entity or fact asked about, say plainly the Atlas doesn't have that information, then offer the closest genuinely-relevant items from the context instead.
 - PREMISES: if the question asserts something the context doesn't support (e.g. "why was X removed?"), verify it against the context and correct the premise rather than answering as if it were true.
 - AMBIGUITY: if two or more projects in the context share (or nearly share) a name, present them all and disambiguate — never silently pick one.
 - SCOPE: for questions unrelated to the Hermes ecosystem, or requests to produce code or tasks against this site (e.g. scraping it), politely redirect to what Ask the Atlas is for rather than complying.
@@ -484,6 +523,7 @@ ANSWER RULES:
 - Use the RETRIEVED CONTEXT section for specific details, recent updates, and tool recommendations.
 - Prefer official_docs and curated_atlas sources when context conflicts. Treat catalog/generated pages as lookup sources, not broad product overviews, unless the user is asking about skills/catalogs.
 - For ranking/comparison/recommendation questions, use the REPO METADATA section for accurate star counts, and ALWAYS cite exact star counts when comparing or recommending repos.
+- If a USE-CASE BUNDLES section is present, the user is asking what to build. Lead with that curated stack — give the repos in the order listed with their roles, summarize the "Why", and surface any Caveats or Known gaps honestly rather than dropping them. Link the Atlas page. Treat the bundle as a starting point, not an exhaustive list: if REPO METADATA contains a clearly better fit for what they described, say so.
 - Cite sources from RETRIEVED CONTEXT using [Source: filename.md] format in brackets.
 - For "what is" questions, give a proper 2-3 sentence overview first, THEN details.
 - For "how do I" questions, give concrete steps with commands.
@@ -495,7 +535,7 @@ ${baselineContext}${latestReleaseBlock}
 
 ## RETRIEVED CONTEXT (relevant to this specific question)
 
-${retrievedContext}${repoMetadataBlock}`;
+${retrievedContext}${useCaseBlock}${repoMetadataBlock}`;
 
     const messages = [
       { role: "system", content: systemPrompt },
@@ -619,8 +659,18 @@ ${retrievedContext}${repoMetadataBlock}`;
 
     // Append model trailer at end of stream — client splits it off
     // Format: \u200E (LRM, invisible) + JSON + \u200E
-    if (actualModel) {
-      const trailer = `\u200E__META__${JSON.stringify({ model: actualModel })}__META__\u200E`;
+    //
+    // `useCases` reports which bundles were injected. It exists so the failure
+    // mode this feature is most exposed to (Vercel's file tracer not bundling
+    // data/use-cases.json, leaving loadUseCases() permanently empty) stays
+    // observable from outside, instead of silently degrading to the old
+    // full-catalog behavior while every check stays green.
+    if (actualModel || useCaseMatches.length > 0) {
+      const meta = { model: actualModel };
+      if (useCaseMatches.length > 0) {
+        meta.useCases = useCaseMatches.map((m) => m.useCase.slug);
+      }
+      const trailer = `\u200E__META__${JSON.stringify(meta)}__META__\u200E`;
       res.write(trailer);
     }
 

--- a/lib/rag-scoring.js
+++ b/lib/rag-scoring.js
@@ -1,6 +1,9 @@
 const OFFICIAL_DOC_PREFIX = "research/docs/";
 const CURATED_PREFIX = "research/";
 const REPO_PREFIX = "repos/";
+// Use-case bundles are hand-curated Atlas editorial, gated by
+// scripts/validate-use-cases.js — same authority tier as research/.
+const USE_CASE_PREFIX = "use-cases/";
 
 const SKILLS_TERMS = [
   "skill", "skills", "skills hub", "catalog", "registry", "source", "sources",
@@ -53,7 +56,7 @@ export function classifyChunkSource(chunk) {
 
   if (source.startsWith(OFFICIAL_DOC_PREFIX)) {
     authority = "official_docs";
-  } else if (source.startsWith(CURATED_PREFIX)) {
+  } else if (source.startsWith(CURATED_PREFIX) || source.startsWith(USE_CASE_PREFIX)) {
     authority = "curated_atlas";
   } else if (source.startsWith(REPO_PREFIX) || source === "ECOSYSTEM.md") {
     authority = "atlas_data";

--- a/lib/use-case-match.js
+++ b/lib/use-case-match.js
@@ -1,0 +1,177 @@
+// Deterministic use-case matching for the chat path.
+//
+// Mirrors the client-side matcher in assets/js/use-cases.js on purpose: the
+// /use-cases/ page and Ask the Atlas should not disagree about which bundle a
+// phrase means. Kept dependency-free and side-effect-free so it can be unit
+// tested without booting the chat handler.
+//
+// Why this exists: api/chat.js used to answer every ranking/recommendation
+// query by injecting the ENTIRE catalog (217 repos ≈ 7,900 tokens) and asking
+// the model to re-rank it. That is expensive on a query class where a curated
+// bundle is both cheaper and a better answer.
+
+export const STOP_WORDS = new Set([
+  "i", "a", "an", "the", "to", "my", "me", "want", "wants", "wanted", "need",
+  "needs", "build", "building", "make", "making", "get", "have", "for", "with",
+  "and", "or", "of", "on", "in", "it", "that", "this", "how", "do", "can",
+  "hermes", "agent", "something", "some", "like", "should", "use", "using",
+  "best", "good", "any", "there", "are", "is", "what", "which", "recommend",
+]);
+
+// Prefix matching only kicks in for terms long enough to be specific —
+// otherwise "minecraft mod" scores against "models".
+export const MIN_PREFIX_LEN = 5;
+
+export function terms(query) {
+  return String(query || "")
+    .toLowerCase()
+    .split(/[^a-z0-9+]+/)
+    .filter((t) => t.length > 1 && !STOP_WORDS.has(t));
+}
+
+export function wordsOf(text) {
+  return new Set(
+    String(text || "")
+      .toLowerCase()
+      .split(/[^a-z0-9+]+/)
+      .filter(Boolean)
+  );
+}
+
+export function matchesTerm(words, term) {
+  if (words.has(term)) return true;
+  if (term.length < MIN_PREFIX_LEN) return false;
+  for (const word of words) {
+    if (word.startsWith(term)) return true;
+    if (word.length >= MIN_PREFIX_LEN && term.startsWith(word)) return true;
+  }
+  return false;
+}
+
+/**
+ * Score a query against use-case bundles.
+ *
+ * Threshold is `minScore` matching terms, OR one term that is *itself a curated
+ * alias* of exactly one bundle. Requiring two matches unconditionally rejected
+ * the most canonical query there is ("I want to build a telegram bot" → only
+ * "telegram" survives stop-word removal).
+ *
+ * Rarity alone is NOT enough to carry a single-term match: "server" appears in
+ * exactly one bundle (inside the alias "home server agent") but is generic, and
+ * accepting it made "minecraft mod for my server" recommend a personal-ops
+ * stack. An alias is a phrase a curator deliberately wrote down as a way people
+ * ask for this bundle, so a query term that *equals* one is a real signal in a
+ * way that a word merely buried inside one is not.
+ *
+ * @returns {Array<{useCase: object, score: number}>} best first, ties keep curation order
+ */
+export function matchUseCases(query, useCases, { minScore = 2, limit = 2 } = {}) {
+  const queryTerms = terms(query);
+  if (queryTerms.length === 0 || !Array.isArray(useCases) || useCases.length === 0) return [];
+
+  const wordSets = useCases.map((useCase) =>
+    wordsOf([useCase.title, useCase.intent, ...(useCase.aliases || [])].join(" "))
+  );
+
+  // Document frequency per query term, across bundles.
+  const df = new Map();
+  for (const term of queryTerms) {
+    df.set(term, wordSets.reduce((n, words) => n + (matchesTerm(words, term) ? 1 : 0), 0));
+  }
+
+  return useCases
+    .map((useCase, index) => {
+      const words = wordSets[index];
+      const matched = queryTerms.filter((t) => matchesTerm(words, t));
+      const aliases = new Set((useCase.aliases || []).map((a) => String(a).trim().toLowerCase()));
+      // Both conditions: the term is a curated alias of THIS bundle, and it
+      // doesn't also match any other bundle.
+      const distinctive = matched.some((t) => aliases.has(t) && df.get(t) === 1);
+      return { useCase, score: matched.length, distinctive, index };
+    })
+    .filter((m) => m.score >= minScore || (m.score >= 1 && m.distinctive))
+    .sort((a, b) => b.score - a.score || a.index - b.index)
+    .slice(0, limit)
+    .map(({ useCase, score }) => ({ useCase, score }));
+}
+
+// Category synonyms used to narrow the catalog dump. Deliberately omits
+// "Developer Tools", "Domain Applications" and "Core & Official" — their
+// natural-language signals ("tool", "app", "official") are too generic and
+// would narrow queries that legitimately span the whole catalog.
+export const CATEGORY_SIGNALS = {
+  "Memory & Context": [
+    "memory", "memories", "remember", "remembers", "recall", "context",
+    "forget", "forgets", "forgetting", "compaction", "persistence",
+  ],
+  "Workspaces & GUIs": [
+    "gui", "guis", "ui", "workspace", "workspaces", "desktop", "dashboard",
+    "interface", "webui", "tui", "frontend",
+  ],
+  "Skills & Skill Registries": ["skill", "skills", "skillset", "registry", "registries"],
+  "Deployment & Infra": [
+    "deploy", "deployment", "docker", "kubernetes", "k8s", "helm", "vps",
+    "hosting", "selfhost", "nix", "systemd", "server",
+  ],
+  "Multi-Agent & Orchestration": [
+    "orchestration", "orchestrator", "swarm", "fleet", "kanban", "multiagent", "subagents",
+  ],
+  "Integrations & Bridges": [
+    "integration", "integrations", "bridge", "bridges", "connector", "telegram",
+    "discord", "whatsapp", "signal", "slack", "imessage", "wechat", "feishu",
+  ],
+  "Plugins & Extensions": ["plugin", "plugins", "extension", "extensions"],
+  "Guides & Docs": ["guide", "guides", "tutorial", "tutorials", "documentation", "docs"],
+  "Forks & Derivatives": ["fork", "forks", "derivative", "derivatives"],
+};
+
+/**
+ * Infer a single catalog category from a query, but ONLY when the signal is
+ * unambiguous. Zero or multiple matching categories returns null, which keeps
+ * the caller on the full-catalog fallback — a wrong narrowing starves a
+ * legitimate cross-category ranking question, which is worse than paying the
+ * tokens.
+ * @returns {string|null}
+ */
+export function inferCategory(query, signals = CATEGORY_SIGNALS) {
+  const queryTerms = terms(query);
+  if (queryTerms.length === 0) return null;
+
+  const hits = [];
+  for (const [category, words] of Object.entries(signals)) {
+    const set = new Set(words);
+    if (queryTerms.some((t) => set.has(t))) hits.push(category);
+  }
+  return hits.length === 1 ? hits[0] : null;
+}
+
+/**
+ * Compact prompt block for matched bundles. Includes star counts so the
+ * assistant's "always cite exact star counts when recommending" rule still
+ * holds without the full catalog present.
+ */
+export function buildUseCaseBlock(matches, repoIndex) {
+  if (!matches || matches.length === 0) return "";
+
+  const body = matches
+    .map(({ useCase }) => {
+      const stack = useCase.stack
+        .map((item) => {
+          const repo = repoIndex.get(`${item.owner}/${item.repo}`);
+          const stars = repo ? ` (★ ${repo.stars})` : "";
+          const category = repo ? ` [${repo.category}]` : "";
+          return `  - ${item.role}: **${item.owner}/${item.repo}**${stars}${category} — ${item.why}`;
+        })
+        .join("\n");
+      const caveats = (useCase.caveats || []).length
+        ? `\n  Caveats: ${useCase.caveats.join(" ")}`
+        : "";
+      const gaps = (useCase.gaps || []).length
+        ? `\n  Known gaps: ${useCase.gaps.join(" ")}`
+        : "";
+      return `### ${useCase.title}\nIntent: ${useCase.intent}\nAtlas page: https://hermesatlas.com/use-cases/${useCase.slug}\nStack:\n${stack}\n  Why: ${useCase.rationale}${caveats}${gaps}`;
+    })
+    .join("\n\n");
+
+  return `\n\n## USE-CASE BUNDLES (curated stacks matching this question)\n${body}\n`;
+}

--- a/scripts/build-chunks.js
+++ b/scripts/build-chunks.js
@@ -82,6 +82,17 @@ async function main() {
     source: file.source,
     content: fs.readFileSync(file.path, "utf-8"),
   }));
+
+  // Use-case bundles live in JSON, not markdown, so synthesize a page per
+  // bundle here rather than committing a duplicate markdown copy that could
+  // drift from data/use-cases.json. Sources are labeled as URL paths
+  // ("use-cases/<slug>/") so RAG citations point at the real page and
+  // classifyChunkSource tiers them as curated_atlas.
+  const useCaseFiles = buildUseCaseMarkdown();
+  markdownFiles.push(...useCaseFiles);
+  if (useCaseFiles.length > 0) {
+    console.log(`Added ${useCaseFiles.length} synthesized use-case pages`);
+  }
   writeLatestReleaseMetadata(markdownFiles);
 
   // Chunk all files
@@ -175,6 +186,67 @@ function writeLatestReleaseMetadata(markdownFiles) {
   fs.mkdirSync(path.dirname(outputPath), { recursive: true });
   fs.writeFileSync(outputPath, `${JSON.stringify(latestRelease, null, 2)}\n`);
   console.log(`Latest release metadata: ${latestRelease.version} (${latestRelease.tag || "no tag"})`);
+}
+
+// Render each use-case bundle as a retrievable markdown page. Includes the
+// stack with live star counts, the rationale, caveats/gaps, and the cited
+// community stories, so a RAG hit carries the same substance the page does.
+function buildUseCaseMarkdown() {
+  const useCasesPath = path.join(ROOT, "data", "use-cases.json");
+  if (!fs.existsSync(useCasesPath)) return [];
+
+  const useCases = JSON.parse(fs.readFileSync(useCasesPath, "utf-8"));
+  const repos = JSON.parse(fs.readFileSync(path.join(ROOT, "data", "repos.json"), "utf-8"));
+  const repoIndex = new Map(repos.map((r) => [`${r.owner}/${r.repo}`, r]));
+
+  let stories = [];
+  const storiesPath = path.join(ROOT, "data", "user-stories.json");
+  if (fs.existsSync(storiesPath)) {
+    const corpus = JSON.parse(fs.readFileSync(storiesPath, "utf-8"));
+    stories = Array.isArray(corpus?.stories) ? corpus.stories : [];
+  }
+  const storyIndex = new Map(stories.map((s) => [s.id, s]));
+
+  return useCases.map((useCase) => {
+    const stack = useCase.stack
+      .map((item) => {
+        const repo = repoIndex.get(`${item.owner}/${item.repo}`);
+        const stars = repo ? ` — ${repo.stars} stars` : "";
+        const category = repo ? ` [${repo.category}]` : "";
+        return `- **${item.role}: ${item.owner}/${item.repo}**${category}${stars}\n  ${item.why}\n  https://hermesatlas.com/projects/${item.owner}/${item.repo}`;
+      })
+      .join("\n");
+
+    const section = (heading, items) =>
+      Array.isArray(items) && items.length
+        ? `\n\n## ${heading}\n\n${items.map((v) => `- ${v}`).join("\n")}`
+        : "";
+
+    const evidence = (useCase.evidence || [])
+      .map((id) => storyIndex.get(id))
+      .filter(Boolean)
+      .map((s) => `- "${s.headline}" — ${s.author || s.source} (${s.source}) ${s.url}`)
+      .join("\n");
+
+    const content = `# ${useCase.title}
+
+Use case: "${useCase.intent}"
+
+Atlas page: https://hermesatlas.com/use-cases/${useCase.slug}
+
+## Recommended stack
+
+${stack}
+
+## Why this stack
+
+${useCase.rationale}${section("Caveats", useCase.caveats)}${section("Gaps in the catalog", useCase.gaps)}${
+      evidence ? `\n\n## Community stories that prove this use case\n\n${evidence}` : ""
+    }
+`;
+
+    return { source: `use-cases/${useCase.slug}/`, content };
+  });
 }
 
 function* walkMarkdown(dir) {

--- a/scripts/smoke-test-prod.js
+++ b/scripts/smoke-test-prod.js
@@ -328,6 +328,37 @@ await section("2. Public API contracts are semantically healthy", async () => {
     fail("Ask the Atlas", `HTTP ${chat.status}${chat.ok ? ", empty response" : ""}`, `${BASE}/api/chat`);
   }
 
+  // Use-case bundles reach the chat path by reading data/use-cases.json from
+  // inside the serverless function. If Vercel's file tracer ever stops
+  // bundling it, loadUseCases() returns [] forever and every recommendation
+  // silently reverts to the full-catalog dump — no error, no failing check.
+  // The __META__ trailer reports matched slugs, so assert on that rather than
+  // on the model's prose, which is non-deterministic.
+  const bundleChat = await fetchWithTimeout(`${BASE}/api/chat`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ message: "I want to build a telegram bot to chat with my agent from my phone" }),
+  });
+  if (!bundleChat.ok) {
+    fail("use-case bundle injection", `HTTP ${bundleChat.status}`, `${BASE}/api/chat`);
+  } else {
+    const body = await bundleChat.text();
+    const trailer = body.match(/‎__META__(.*?)__META__‎/);
+    let matched = [];
+    try {
+      matched = trailer ? JSON.parse(trailer[1]).useCases || [] : [];
+    } catch {}
+    if (matched.length > 0) {
+      pass("use-case bundle injection", `matched ${matched.join(", ")}`);
+    } else {
+      fail(
+        "use-case bundle injection",
+        "no bundle matched a canonical build query — data/use-cases.json may not be bundled into the function",
+        `${BASE}/api/chat`
+      );
+    }
+  }
+
   const releaseArtifactResponse = await fetchWithTimeout(`${BASE}/data/latest-release.json`);
   if (!releaseArtifactResponse.ok) {
     fail("latest release freshness", `artifact HTTP ${releaseArtifactResponse.status}`, `${BASE}/data/latest-release.json`);

--- a/tests/automation-workflows.test.js
+++ b/tests/automation-workflows.test.js
@@ -28,6 +28,24 @@ test("knowledge rebuild has a scheduled reconciliation path", () => {
   assert.match(workflow, /workflow_dispatch:/);
 });
 
+test("knowledge rebuild triggers on every data file build-chunks reads", () => {
+  const workflow = fs.readFileSync(".github/workflows/rebuild-chunks.yml", "utf-8");
+  const script = fs.readFileSync("scripts/build-chunks.js", "utf-8");
+
+  // build-chunks.js synthesizes retrievable pages from JSON that isn't picked
+  // up by the research/**-style globs. If it reads a data file the workflow
+  // doesn't watch, edits land on the site but the KB keeps serving the old
+  // content — silently, until someone notices the chatbot is wrong.
+  for (const dataFile of ["use-cases.json", "user-stories.json", "repos.json"]) {
+    if (script.includes(`"${dataFile}"`)) {
+      assert.ok(
+        workflow.includes(`data/${dataFile}`),
+        `scripts/build-chunks.js reads data/${dataFile} — add it to rebuild-chunks.yml push paths`
+      );
+    }
+  }
+});
+
 test("page build regenerates from latest main after a rejected push", () => {
   const workflow = fs.readFileSync(".github/workflows/build-pages.yml", "utf-8");
   assert.match(workflow, /Push rejected \(attempt \$attempt\).*regenerating from latest main/);

--- a/tests/rag-scoring.test.js
+++ b/tests/rag-scoring.test.js
@@ -12,6 +12,9 @@ test("classifies official docs, generated catalog docs, and curated Atlas source
   assert.equal(classifyChunkSource({ source: "research/docs/skills/index.md" }).contentKind, "catalog");
   assert.equal(classifyChunkSource({ source: "research/atlas-official-docs-updates.md" }).authority, "curated_atlas");
   assert.equal(classifyChunkSource({ source: "repos/all-star-counts.md" }).contentKind, "repo_metadata");
+  // Use-case bundles are gated, hand-curated editorial — same tier as research/,
+  // not the "community" default they'd otherwise fall through to.
+  assert.equal(classifyChunkSource({ source: "use-cases/obsidian-second-brain/" }).authority, "curated_atlas");
 });
 
 test("official feature docs outrank equally relevant community chunks", () => {

--- a/tests/smoke-test-prod.test.js
+++ b/tests/smoke-test-prod.test.js
@@ -70,7 +70,16 @@ async function withAtlasFixture({ stars = {}, releaseTag = "v2026.7.7.2" } = {})
         prerelease: false,
       }]));
     }
-    if (url.pathname === "/api/chat") return send(200, "text/event-stream", "data: Hermes Agent is ready.\n\n");
+    if (url.pathname === "/api/chat") {
+      // The smoke test sends a second, build-flavored query and asserts the
+      // __META__ trailer names a matched bundle — that's the only external
+      // signal that data/use-cases.json reached the serverless function.
+      const meta = `‎__META__${JSON.stringify({
+        model: "test/model",
+        useCases: ["hermes-in-your-pocket"],
+      })}__META__‎`;
+      return send(200, "text/event-stream", `data: Hermes Agent is ready.\n\n${meta}`);
+    }
     if (url.pathname === "/api/stars") {
       const response = {
         stale: false,

--- a/tests/use-case-match.test.js
+++ b/tests/use-case-match.test.js
@@ -1,0 +1,139 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  matchUseCases,
+  inferCategory,
+  buildUseCaseBlock,
+  matchesTerm,
+  wordsOf,
+  terms,
+} from "../lib/use-case-match.js";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const readJson = (rel) => JSON.parse(fs.readFileSync(path.join(ROOT, rel), "utf8"));
+const useCases = readJson("data/use-cases.json");
+const repos = readJson("data/repos.json");
+const repoIndex = new Map(repos.map((r) => [`${r.owner}/${r.repo}`, r]));
+
+// ── tokenization ──
+
+test("stop words are dropped so filler doesn't inflate scores", () => {
+  assert.deepEqual(terms("I want to build a telegram bot"), ["telegram", "bot"]);
+  // Every word being filler must produce no terms rather than matching everything.
+  assert.deepEqual(terms("what should I use"), []);
+});
+
+test("short terms match only whole words; long terms may prefix-match", () => {
+  const words = wordsOf("local models and deployment options");
+  assert.equal(matchesTerm(words, "mod"), false, '"mod" must not match "models"');
+  assert.equal(matchesTerm(words, "models"), true);
+  assert.equal(matchesTerm(words, "deploy"), true, '"deploy" prefix-matches "deployment"');
+  assert.equal(matchesTerm(words, "deployments"), true, "stem match works in reverse too");
+});
+
+// ── bundle matching against the real committed data ──
+
+const EXPECTED = [
+  ["I want to build a telegram bot I can use from my phone", "hermes-in-your-pocket"],
+  ["my agent keeps forgetting things between sessions", "obsidian-second-brain"],
+  ["how do I see what my agents are doing", "see-what-your-agent-is-doing"],
+  ["I want to run local models with no cloud", "fully-self-hosted-private-stack"],
+  ["cut my token spend", "cut-your-token-bill"],
+];
+
+for (const [query, slug] of EXPECTED) {
+  test(`"${query}" matches ${slug}`, () => {
+    const matches = matchUseCases(query, useCases);
+    assert.ok(matches.length > 0, "expected at least one match");
+    assert.equal(matches[0].useCase.slug, slug);
+  });
+}
+
+test("an off-topic query matches nothing rather than guessing", () => {
+  assert.deepEqual(matchUseCases("minecraft mod for my server", useCases), []);
+  assert.deepEqual(matchUseCases("what is hermes agent", useCases), []);
+});
+
+test("a single term carries a match only when it is a curated alias", () => {
+  const bundles = [
+    {
+      slug: "alpha",
+      title: "Alpha",
+      intent: "do alpha things",
+      // "server" is rare across the set but buried inside a longer alias;
+      // "telegram" is an alias in its own right.
+      aliases: ["home server agent", "telegram"],
+      stack: [],
+    },
+    { slug: "beta", title: "Beta", intent: "do beta things", aliases: ["kubernetes"], stack: [] },
+  ];
+
+  assert.equal(matchUseCases("minecraft mod for my server", bundles).length, 0);
+  assert.equal(matchUseCases("telegram", bundles)[0]?.useCase.slug, "alpha");
+
+  // An alias shared by two bundles is no longer distinctive, so one hit
+  // isn't enough for either.
+  const shared = bundles.map((b) => ({ ...b, aliases: [...b.aliases, "telegram"] }));
+  assert.equal(matchUseCases("telegram", shared).length, 0);
+});
+
+test("matches are capped and ordered by score", () => {
+  const matches = matchUseCases("I want a self-hosted local memory stack for my team", useCases, {
+    limit: 2,
+  });
+  assert.ok(matches.length <= 2);
+  for (let i = 1; i < matches.length; i++) {
+    assert.ok(matches[i - 1].score >= matches[i].score, "scores must be descending");
+  }
+});
+
+// ── category inference ──
+
+test("infers a category only when exactly one signal group matches", () => {
+  assert.equal(inferCategory("which memory provider should I use"), "Memory & Context");
+  assert.equal(inferCategory("best telegram bridge"), "Integrations & Bridges");
+  assert.equal(inferCategory("compare deployment options"), "Deployment & Infra");
+});
+
+test("ambiguous or absent signals fall back to null (full catalog)", () => {
+  // Two categories in play — narrowing either way would starve the answer.
+  assert.equal(inferCategory("compare memory plugins"), null);
+  assert.equal(inferCategory("what are the most starred repos"), null);
+  assert.equal(inferCategory(""), null);
+});
+
+test("inferred categories are real catalog categories", () => {
+  const known = new Set(repos.map((r) => r.category));
+  for (const q of ["memory", "telegram", "kubernetes", "skills", "plugins", "guides"]) {
+    const inferred = inferCategory(q);
+    if (inferred) assert.ok(known.has(inferred), `${inferred} must exist in repos.json`);
+  }
+});
+
+// ── prompt block ──
+
+test("bundle block carries stars, categories and the Atlas URL", () => {
+  const matches = matchUseCases("telegram on my phone", useCases);
+  const block = buildUseCaseBlock(matches, repoIndex);
+  assert.match(block, /## USE-CASE BUNDLES/);
+  assert.match(block, /https:\/\/hermesatlas\.com\/use-cases\/hermes-in-your-pocket/);
+  assert.match(block, /★ \d+/, "star counts must survive into the prompt");
+  assert.match(block, /\[Workspaces & GUIs\]/);
+});
+
+test("no matches produces an empty block, not a header", () => {
+  assert.equal(buildUseCaseBlock([], repoIndex), "");
+  assert.equal(buildUseCaseBlock(null, repoIndex), "");
+});
+
+test("a bundle block is dramatically cheaper than the full catalog dump", () => {
+  const matches = matchUseCases("I want to build a telegram bot on my phone", useCases);
+  const block = buildUseCaseBlock(matches, repoIndex);
+  // The full catalog dump is ~31.8k chars; a matched bundle must stay far under
+  // it or the whole point of this path is lost.
+  assert.ok(block.length < 4000, `bundle block was ${block.length} chars`);
+});


### PR DESCRIPTION
Follow-up to #667. Roadmap #14, surface 2 of 3 (chat intent). MCP tool still deferred.

## The problem, measured

`api/chat.js` answered every ranking/recommendation query by injecting the **entire catalog** and asking the model to re-rank it:

```
full catalog dump: 31,764 chars ≈ 7,941 tokens
```

It fires from `isRepoMetadataQuery()`, whose keyword list includes `which`, `best`, `top`, `recommend`, `compare`, `options`, `alternatives`. On realistic phrasings:

```
DUMPS  which memory provider should i use
DUMPS  recommend a telegram bridge
DUMPS  compare mem0 and supermemory
DUMPS  which deployment options are there
  ok   how do i install hermes
```

So a large share of natural recommendation phrasing paid ~7.9k input tokens — and being handed a wall of 217 repos to re-rank is also *why* those answers were mediocre.

## Two changes, both deterministic, both falling back to current behavior

**1. Matched bundles get injected** (~300–550 tokens of curated stack + rationale + caveats). `lib/use-case-match.js` is shared with the `/use-cases/` page matcher, so the page and the chatbot can't disagree about what a phrase means.

**2. The catalog dump narrows to one category** when the query unambiguously names one — 7.9k → ~1.4k tokens. `inferCategory()` returns `null` on ambiguous *or* absent signals, keeping the full dump. Narrowing wrongly starves a legitimate cross-category ranking question, which is worse than paying the tokens. `Developer Tools`, `Domain Applications` and `Core & Official` are deliberately excluded — signals like "tool", "app", "official" are too generic to narrow on.

### Result across a 10-query sample

| before | after | bundle | query |
|---:|---:|---|---|
| 7,919 | 1,375 | — | which memory provider should i use |
| 0 | 541 | hermes-in-your-pocket | i want to build a telegram bot |
| 7,919 | 958 | hermes-in-your-pocket | recommend a telegram bridge |
| 7,919 | 7,919 | — | what are the most starred repos |
| 7,919 | 7,919 | — | compare mem0 and supermemory |
| 0 | 537 | cut-your-token-bill | how do i cut my token bill |
| 7,919 | 356 | — | which deployment options are there |
| 0 | 0 | — | minecraft mod for my server |
| 0 | 0 | — | what is hermes agent |
| 0 | 489 | obsidian-second-brain | i want obsidian as my memory |

**47,514 → 28,013 tokens (~41% cut)**, concentrated on exactly the queries that were worst served. Genuine ranking questions still get the full catalog.

## The matching threshold took two attempts

Two matching terms, **or** one term that is *itself a curated alias* of exactly one bundle.

- Requiring two unconditionally rejected the most canonical query there is: `"I want to build a telegram bot"` → only `telegram` survives stop-word removal.
- Rarity alone was tried and **rejected**: `server` occurs in exactly one bundle (inside the alias `"home server agent"`) but is generic, and accepting it made **"minecraft mod for my server" recommend a personal-ops stack**. An alias is a phrase a curator deliberately wrote down; a word buried inside one is not.

Both cases are regression-tested.

## Bundles are now retrievable too

`build-chunks.js` synthesizes a markdown page per bundle rather than committing a copy that could drift from the JSON, and `rag-scoring.js` tiers `use-cases/` as `curated_atlas` instead of the `community` default it would otherwise fall through to.

`rebuild-chunks.yml` triggers on the data files `build-chunks.js` reads, with a test asserting that coupling — otherwise editing a bundle updates the site while the KB keeps serving the previous stack, silently.

## The silent failure this is most exposed to

Vercel's file tracer not bundling `data/use-cases.json` would leave `loadUseCases()` empty forever, reverting everything above with **no error and no failing check**. So the `__META__` trailer now reports matched slugs, and the prod smoke test asserts on it rather than on the model's (non-deterministic) prose.

Verified by simulation: with the trailer's `useCases` removed, the check fails with
`no bundle matched a canonical build query — data/use-cases.json may not be bundled into the function`.

## Verification

```
npm test  → 238 pass / 0 fail   (16 new in tests/use-case-match.test.js)
```

Deliberate-break tests, all confirmed to fail loudly then restored:
- removed `data/use-cases.json` from `rebuild-chunks.yml` → coupling test fails with the actionable message
- removed `useCases` from the smoke trailer → bundle-injection check fails

Degradation paths are all safe by construction: missing `use-cases.json` → `[]` → current behavior; no bundle match → empty string, no header; empty category slice → full catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)