### PR TITLE
Detect renamed catalog repos in the daily health sweep

### DIFF
--- a/.github/workflows/audit-summaries.yml
+++ b/.github/workflows/audit-summaries.yml
@@ -101,18 +101,21 @@ jobs:
           gh workflow run build-pages.yml
           echo "Dispatched build-pages.yml to regenerate flagged summaries"
 
-      - name: Detect dead repos
+      - name: Sweep catalog health (dead, renamed, drifted)
         if: always()  # run even if earlier steps failed
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node scripts/check-dead-repos.js
 
-      - name: Open or update dead-repo tracking issue
+      - name: Open or update catalog-health tracking issue
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          title="Dead repos detected in data/repos.json"
+          # Covers dead, renamed, and ECOSYSTEM.md-drifted entries. Renamed
+          # repos resolve fine on GitHub, so they never surfaced under the
+          # previous dead-only title.
+          title="Catalog health: dead, renamed, or drifted repos"
           # `in:title` scopes the search to the title field so we don't
           # match stray issues that happen to mention the phrase in their body.
           existing=$(gh issue list \
@@ -123,11 +126,11 @@ jobs:
             --jq '.[0].number // empty')
 
           if [ ! -s dead-repos.md ]; then
-            echo "No dead repos detected"
+            echo "Catalog healthy: no dead, renamed, or drifted entries"
             if [ -n "$existing" ]; then
               gh issue close "$existing" \
                 --repo "$GITHUB_REPOSITORY" \
-                --comment "Auto-closed: no dead repos detected in latest audit run."
+                --comment "Auto-closed: no dead, renamed, or drifted catalog entries in latest audit run."
               echo "Closed stale issue #$existing"
             fi
             exit 0

--- a/lib/catalog-health.js
+++ b/lib/catalog-health.js
@@ -1,0 +1,223 @@
+/**
+ * Catalog health classification for data/repos.json and ECOSYSTEM.md.
+ *
+ * Pure functions over an already-fetched GitHub GraphQL response, so the
+ * classification rules are testable without network access. The I/O and
+ * orchestration live in scripts/check-dead-repos.js.
+ *
+ * The distinction that matters here is dead vs renamed. GitHub resolves a
+ * renamed repository when queried by its OLD owner/name and returns the
+ * CURRENT nameWithOwner, so a stale catalog entry answers 200, returns star
+ * counts, and passes every availability check. Nothing fails; the catalog
+ * just carries a name that no longer exists. Only NOT_FOUND means dead.
+ */
+
+// owner/repo are validated to this charset by validate-repos-json.js. Re-check
+// here so a malformed entry can never inject into the GraphQL document.
+const SAFE_NAME_RE = /^[A-Za-z0-9_.-]+$/;
+
+export function isSafeName(name) {
+  return SAFE_NAME_RE.test(name ?? "");
+}
+
+/**
+ * Build an aliased GraphQL selection set for the given entries.
+ *
+ * Aliases keep the ORIGINAL array index (`${prefix}${i}`) even when entries are
+ * skipped, so callers can map a response alias or error path back to the entry
+ * that produced it.
+ */
+export function buildRepoQuery(entries, prefix = "repo") {
+  const skipped = [];
+  const fields = entries
+    .map((entry, i) => {
+      if (!isSafeName(entry.owner) || !isSafeName(entry.repo)) {
+        skipped.push({ index: i, entry });
+        return null;
+      }
+      return `${prefix}${i}: repository(owner: "${entry.owner}", name: "${entry.repo}") { nameWithOwner }`;
+    })
+    .filter(Boolean);
+  return { query: fields.join("\n"), skipped };
+}
+
+function indexFromAlias(alias, prefix) {
+  if (typeof alias !== "string" || !alias.startsWith(prefix)) return null;
+  const idx = Number.parseInt(alias.slice(prefix.length), 10);
+  return Number.isInteger(idx) ? idx : null;
+}
+
+/**
+ * Entries GitHub reported as NOT_FOUND — deleted, made private, or the owner
+ * account is gone. These are the entries that break the stars snapshot.
+ */
+export function findDeadRepos(entries, errors = [], prefix = "repo") {
+  const dead = [];
+  for (const err of errors) {
+    if (err?.type !== "NOT_FOUND") continue;
+    const idx = indexFromAlias(err.path?.[0], prefix);
+    if (idx === null) continue;
+    const entry = entries[idx];
+    if (!entry) continue;
+    dead.push({
+      owner: entry.owner,
+      repo: entry.repo,
+      url: entry.url || `https://github.com/${entry.owner}/${entry.repo}`,
+    });
+  }
+  return dead;
+}
+
+/**
+ * Entries that resolve to a different nameWithOwner than the catalog records.
+ * Compared case-insensitively: GitHub preserves owner/repo casing, and a
+ * case-only difference is not a rename.
+ */
+export function findRenamedRepos(entries, data = {}, prefix = "repo") {
+  const renamed = [];
+  for (const [i, entry] of entries.entries()) {
+    const current = data?.[`${prefix}${i}`]?.nameWithOwner;
+    if (!current) continue;
+    const recorded = `${entry.owner}/${entry.repo}`;
+    if (current.toLowerCase() !== recorded.toLowerCase()) {
+      renamed.push({ from: recorded, to: current });
+    }
+  }
+  return renamed;
+}
+
+/**
+ * Repo links present in ECOSYSTEM.md but absent from the catalog.
+ *
+ * ECOSYSTEM.md is bundled into llms-full.txt and the RAG chunks, so a row left
+ * behind after a catalog change quietly pollutes LLM retrieval. Upstream
+ * hermes-agent links are expected and never drift.
+ */
+export function findEcosystemDrift(ecoText, repos) {
+  const inCatalog = new Set(repos.map((r) => `${r.owner}/${r.repo}`.toLowerCase()));
+  const linked = [
+    ...new Set(
+      [...ecoText.matchAll(/github\.com\/([\w.-]+\/[\w.-]+)/g)].map((m) =>
+        m[1].replace(/\.git$/, "").toLowerCase()
+      )
+    ),
+  ];
+  return linked.filter(
+    (k) => !inCatalog.has(k) && !k.startsWith("nousresearch/hermes-agent")
+  );
+}
+
+/**
+ * Split drifted ECOSYSTEM.md rows into the three cases that need different
+ * fixes. Treating them all as "stale rows to delete" removes live projects
+ * from the LLM corpus, which is what a renamed row looks like.
+ *
+ *   renamed — resolves to a name that IS catalogued: rewrite the row
+ *   dead    — NOT_FOUND on GitHub: delete the row
+ *   missing — resolves, but nothing in the catalog matches: re-add or delete
+ */
+export function classifyDrift(driftNames, { data = {}, errors = [] } = {}, repos = []) {
+  const inCatalog = new Set(repos.map((r) => `${r.owner}/${r.repo}`.toLowerCase()));
+  const deadIndexes = new Set(
+    errors
+      .filter((e) => e?.type === "NOT_FOUND")
+      .map((e) => indexFromAlias(e.path?.[0], "eco"))
+      .filter((i) => i !== null)
+  );
+
+  const renamed = [];
+  const dead = [];
+  const missing = [];
+
+  for (const [i, name] of driftNames.entries()) {
+    if (deadIndexes.has(i)) {
+      dead.push(name);
+      continue;
+    }
+    const current = data?.[`eco${i}`]?.nameWithOwner;
+    if (!current) {
+      // No node and no NOT_FOUND: the query never resolved this row (unsafe
+      // name, or a non-NOT_FOUND error). Report it rather than dropping it.
+      missing.push({ name, current: null });
+      continue;
+    }
+    if (inCatalog.has(current.toLowerCase())) renamed.push({ name, current });
+    else missing.push({ name, current });
+  }
+
+  return { renamed, dead, missing };
+}
+
+export function renderIssueBody({ dead = [], renamed = [], drift = null } = {}) {
+  const d = drift || { renamed: [], dead: [], missing: [] };
+  let body = "";
+
+  if (dead.length > 0) {
+    body +=
+      `The following ${dead.length} repo${dead.length === 1 ? "" : "s"} in \`data/repos.json\` no longer resolve on GitHub. ` +
+      `They were deleted, made private, or the owner account is gone.\n\n` +
+      `**Why this matters**: a dead entry makes \`push-stars-snapshot.js\` publish an incomplete ` +
+      `snapshot and exit 1, which fails both Refresh GitHub Stars (6-hourly) and the Post-Deploy ` +
+      `Smoke Test. It also leaves stale external links and generated project pages.\n\n` +
+      `## Dead entries\n\n`;
+    for (const x of dead) body += `- \`${x.owner}/${x.repo}\` — ${x.url}\n`;
+    body +=
+      `\n**Fix**: remove each entry from \`data/repos.json\`, re-run the regen pipeline, and merge. ` +
+      `See PR #675 (Rainhoole removal) and #662 (ndesv21/socialclaw) for prior examples.\n\n`;
+  }
+
+  if (renamed.length > 0) {
+    body +=
+      `## Renamed entries (${renamed.length})\n\n` +
+      `These entries still resolve, so nothing fails — GitHub redirects a renamed repo and returns ` +
+      `its current name. The catalog is simply carrying a name that no longer exists, which means ` +
+      `stale slugs, duplicate risk on the next discovery run, and a project page that disagrees ` +
+      `with the project's real identity.\n\n`;
+    for (const x of renamed) body += `- \`${x.from}\` → \`${x.to}\`\n`;
+    body +=
+      `\n**Fix**: update \`owner\`/\`repo\`/\`url\` in \`data/repos.json\`, move the matching ` +
+      `\`data/summaries.json\` key with the entry (\`readmeHash\` caching depends on it), update the ` +
+      `\`ECOSYSTEM.md\` row, and add a \`{source, destination, permanent: true}\` entry to ` +
+      `\`vercel.json\` redirects for the old \`/projects/{owner}/{repo}\` path. See PR #665.\n\n`;
+  }
+
+  const driftTotal = d.renamed.length + d.dead.length + d.missing.length;
+  if (driftTotal > 0) {
+    body +=
+      `## ECOSYSTEM.md drift (${driftTotal})\n\n` +
+      `These rows are linked in \`ECOSYSTEM.md\` but not in \`data/repos.json\`. ` +
+      `\`ECOSYSTEM.md\` is bundled into \`llms-full.txt\` and the RAG chunks, so stale rows ` +
+      `pollute LLM retrieval.\n\n` +
+      `**Each row is resolved against GitHub below — do not blanket-delete them.** ` +
+      `A renamed repo looks identical to a stale row, and deleting it removes a live project ` +
+      `from the LLM corpus.\n\n`;
+
+    if (d.renamed.length > 0) {
+      body += `### Renamed — rewrite the row (do NOT delete)\n\n`;
+      for (const x of d.renamed) body += `- \`${x.name}\` → \`${x.current}\` (already in the catalog)\n`;
+      body += `\n`;
+    }
+    if (d.dead.length > 0) {
+      body += `### Dead — delete the row\n\n`;
+      for (const name of d.dead) body += `- \`${name}\`\n`;
+      body += `\n`;
+    }
+    if (d.missing.length > 0) {
+      body += `### Not in the catalog — re-add the repo, or delete the row\n\n`;
+      for (const x of d.missing) {
+        body += x.current
+          ? `- \`${x.name}\` — resolves to \`${x.current}\`, which is not catalogued\n`
+          : `- \`${x.name}\` — could not be resolved; check manually\n`;
+      }
+      body += `\n`;
+    }
+  }
+
+  if (body) {
+    body +=
+      `_Auto-detected by \`scripts/check-dead-repos.js\` via \`audit-summaries.yml\`. ` +
+      `This issue updates in place; it auto-closes when the lists go empty._\n`;
+  }
+
+  return body;
+}

--- a/scripts/check-dead-repos.js
+++ b/scripts/check-dead-repos.js
@@ -1,17 +1,34 @@
 #!/usr/bin/env node
 /**
- * Dead-repo detector for data/repos.json.
+ * Catalog health sweep for data/repos.json and ECOSYSTEM.md.
  *
- * Issues a single GraphQL query for every entry, captures NOT_FOUND
- * errors (deleted / renamed / private repos), and writes a markdown
- * tracking-issue body to dead-repos.md. Empty file = no dead repos.
+ * Issues one GraphQL query for every catalog entry and a second for any
+ * ECOSYSTEM.md row that is not in the catalog, then writes a markdown
+ * tracking-issue body to dead-repos.md. Empty file = healthy.
  *
- * Background: deleted / renamed / private repos should be removed from
- * Atlas even when build-pages can skip missing metadata, because they
- * otherwise leave stale GitHub links and project pages in the catalog.
+ * Reports three distinct conditions, because they need different fixes:
+ *
+ *   dead    — NOT_FOUND. Breaks the stars snapshot; remove the entry.
+ *   renamed — resolves to a different nameWithOwner. Nothing fails, which is
+ *             why this went undetected for months: GitHub redirects renamed
+ *             repos, so a stale entry returns stars and passes availability
+ *             checks while the catalog carries a name that no longer exists.
+ *   drift   — an ECOSYSTEM.md row with no catalog entry, sub-classified by
+ *             resolving it, since a rename is indistinguishable from a stale
+ *             row by string comparison alone.
+ *
+ * Classification rules live in lib/catalog-health.js and are unit-tested.
  */
 import fs from "node:fs/promises";
 import { githubHeaders } from "../lib/github.js";
+import {
+  buildRepoQuery,
+  findDeadRepos,
+  findRenamedRepos,
+  findEcosystemDrift,
+  classifyDrift,
+  renderIssueBody,
+} from "../lib/catalog-health.js";
 
 const TOKEN = process.env.GITHUB_TOKEN;
 if (!TOKEN) {
@@ -25,117 +42,73 @@ if (!TOKEN) {
   process.exit(process.env.CI ? 1 : 0);
 }
 
+async function graphql(query) {
+  const res = await fetch("https://api.github.com/graphql", {
+    method: "POST",
+    headers: { ...githubHeaders(TOKEN), "Content-Type": "application/json" },
+    body: JSON.stringify({ query: `query { ${query} }` }),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    console.error(`GraphQL HTTP ${res.status}: ${body.slice(0, 200)}`);
+    process.exit(1);
+  }
+  const json = await res.json();
+  for (const err of json.errors || []) {
+    if (err?.type !== "NOT_FOUND") {
+      console.warn(`Non-NOT_FOUND GraphQL error: ${JSON.stringify(err).slice(0, 200)}`);
+    }
+  }
+  return { data: json.data || {}, errors: json.errors || [] };
+}
+
 const repos = JSON.parse(await fs.readFile("data/repos.json", "utf8"));
 
-// Guard the string interpolation below: owner/repo are validated to this
-// charset by validate-repos-json.js, but skip-and-warn here too so a bad
-// entry can never inject into the GraphQL document. Aliases keep the
-// ORIGINAL array index so the repos[idx] lookup in error handling stays
-// correct even when entries are skipped.
-const SAFE_NAME_RE = /^[A-Za-z0-9_.-]+$/;
-const repoQueries = repos
-  .map((r, i) => {
-    if (!SAFE_NAME_RE.test(r.owner ?? "") || !SAFE_NAME_RE.test(r.repo ?? "")) {
-      console.warn(
-        `Skipping entry ${i} with unsafe owner/repo: ${JSON.stringify(r.owner)}/${JSON.stringify(r.repo)}`
-      );
-      return null;
-    }
-    return `repo${i}: repository(owner: "${r.owner}", name: "${r.repo}") { nameWithOwner }`;
-  })
-  .filter(Boolean)
-  .join("\n");
-
-if (!repoQueries) {
+const { query: repoQuery, skipped } = buildRepoQuery(repos, "repo");
+for (const s of skipped) {
+  console.warn(
+    `Skipping entry ${s.index} with unsafe owner/repo: ` +
+    `${JSON.stringify(s.entry.owner)}/${JSON.stringify(s.entry.repo)}`
+  );
+}
+if (!repoQuery) {
   console.error("No valid repo entries to check; aborting.");
   process.exit(1);
 }
 
-const res = await fetch("https://api.github.com/graphql", {
-  method: "POST",
-  headers: { ...githubHeaders(TOKEN), "Content-Type": "application/json" },
-  body: JSON.stringify({ query: `query { ${repoQueries} }` }),
-});
+const catalogResult = await graphql(repoQuery);
+const dead = findDeadRepos(repos, catalogResult.errors, "repo");
+const renamed = findRenamedRepos(repos, catalogResult.data, "repo");
 
-if (!res.ok) {
-  const body = await res.text().catch(() => "");
-  console.error(`GraphQL HTTP ${res.status}: ${body.slice(0, 200)}`);
-  process.exit(1);
-}
+console.log(`Checked ${repos.length} repos: ${dead.length} dead, ${renamed.length} renamed`);
+for (const r of renamed) console.log(`  renamed: ${r.from} -> ${r.to}`);
 
-const data = await res.json();
-const dead = [];
-
-for (const err of data.errors || []) {
-  if (err.type !== "NOT_FOUND") {
-    console.warn(`Non-NOT_FOUND GraphQL error: ${JSON.stringify(err).slice(0, 200)}`);
-    continue;
-  }
-  const alias = err.path?.[0];
-  if (!alias || !alias.startsWith("repo")) continue;
-  const idx = parseInt(alias.slice(4), 10);
-  const r = repos[idx];
-  if (!r) continue;
-  dead.push({
-    owner: r.owner,
-    repo: r.repo,
-    url: r.url || `https://github.com/${r.owner}/${r.repo}`,
-  });
-}
-
-console.log(`Checked ${repos.length} repos: ${dead.length} dead`);
-
-// ECOSYSTEM.md drift: it mirrors the catalog and is bundled into llms-full.txt
-// + the RAG chunks, so repo rows left behind after a catalog removal quietly
-// pollute LLM retrieval. Flag any ECOSYSTEM.md repo link not in data/repos.json.
-let ecoDrift = [];
+// ECOSYSTEM.md drift, resolved rather than assumed. Advising a blanket delete
+// here would strip live projects out of llms-full.txt and the RAG corpus
+// whenever a repo is renamed.
+let drift = null;
 try {
   const eco = await fs.readFile("ECOSYSTEM.md", "utf8");
-  const inCatalog = new Set(repos.map((r) => `${r.owner}/${r.repo}`.toLowerCase()));
-  const linked = [
-    ...new Set(
-      [...eco.matchAll(/github\.com\/([\w.-]+\/[\w.-]+)/g)].map((m) =>
-        m[1].replace(/\.git$/, "").toLowerCase()
-      )
-    ),
-  ];
-  ecoDrift = linked.filter(
-    (k) => !inCatalog.has(k) && !k.startsWith("nousresearch/hermes-agent")
-  );
-  console.log(`ECOSYSTEM.md: ${ecoDrift.length} repo rows not in catalog`);
+  const driftNames = findEcosystemDrift(eco, repos);
+  console.log(`ECOSYSTEM.md: ${driftNames.length} repo rows not in catalog`);
+
+  if (driftNames.length > 0) {
+    const entries = driftNames.map((name) => {
+      const [owner, repo] = name.split("/");
+      return { owner, repo };
+    });
+    const { query: ecoQuery } = buildRepoQuery(entries, "eco");
+    const ecoResult = ecoQuery ? await graphql(ecoQuery) : { data: {}, errors: [] };
+    drift = classifyDrift(driftNames, ecoResult, repos);
+    console.log(
+      `  drift breakdown: ${drift.renamed.length} renamed, ` +
+      `${drift.dead.length} dead, ${drift.missing.length} not catalogued`
+    );
+  } else {
+    drift = { renamed: [], dead: [], missing: [] };
+  }
 } catch (e) {
   console.warn(`Could not read ECOSYSTEM.md for drift check: ${e.message}`);
 }
 
-let body = "";
-if (dead.length > 0) {
-  body =
-    `The following ${dead.length} repo${dead.length === 1 ? "" : "s"} in \`data/repos.json\` no longer resolve on GitHub. ` +
-    `They may have been deleted, renamed, or made private.\n\n` +
-    `**Why this matters**: dead GitHub entries leave stale external links, stale generated project pages, ` +
-    `and incomplete metadata in Atlas.\n\n` +
-    `## Dead entries\n\n`;
-  for (const d of dead) {
-    body += `- \`${d.owner}/${d.repo}\` — ${d.url}\n`;
-  }
-  body +=
-    `\n## Fix\n\nRemove each entry from \`data/repos.json\` and merge. ` +
-    `See PR #148 (Web3CZ removal) and a4e906e (iamagenius00/hermes-a2a removal) for prior examples.\n\n`;
-}
-
-if (ecoDrift.length > 0) {
-  body +=
-    `## ECOSYSTEM.md drift (${ecoDrift.length})\n\n` +
-    `These repos are linked in \`ECOSYSTEM.md\` but are no longer in \`data/repos.json\`. ` +
-    `\`ECOSYSTEM.md\` is bundled into \`llms-full.txt\` and the RAG chunks, so these stale rows ` +
-    `pollute LLM retrieval.\n\n`;
-  for (const k of ecoDrift) body += `- \`${k}\`\n`;
-  body += `\n**Fix**: remove each stale row from \`ECOSYSTEM.md\` (or re-add the repo to the catalog).\n\n`;
-}
-
-if (body) {
-  body +=
-    `_Auto-detected by \`scripts/check-dead-repos.js\` via \`audit-summaries.yml\`. This issue updates in place; it auto-closes when the lists go empty._\n`;
-}
-
-await fs.writeFile("dead-repos.md", body);
+await fs.writeFile("dead-repos.md", renderIssueBody({ dead, renamed, drift }));

--- a/tests/catalog-health.test.js
+++ b/tests/catalog-health.test.js
@@ -1,0 +1,169 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildRepoQuery,
+  findDeadRepos,
+  findRenamedRepos,
+  findEcosystemDrift,
+  classifyDrift,
+  renderIssueBody,
+} from "../lib/catalog-health.js";
+
+const REPOS = [
+  { owner: "alive", repo: "one", url: "https://github.com/alive/one" },
+  { owner: "oldowner", repo: "two", url: "https://github.com/oldowner/two" },
+  { owner: "gone", repo: "three", url: "https://github.com/gone/three" },
+];
+
+test("buildRepoQuery aliases by original index so skipped entries do not shift lookups", () => {
+  const entries = [
+    { owner: "ok", repo: "one" },
+    { owner: 'bad"inject', repo: "two" },
+    { owner: "ok", repo: "three" },
+  ];
+  const { query, skipped } = buildRepoQuery(entries);
+  assert.equal(skipped.length, 1);
+  assert.equal(skipped[0].index, 1);
+  assert.match(query, /repo0: repository\(owner: "ok", name: "one"\)/);
+  assert.match(query, /repo2: repository\(owner: "ok", name: "three"\)/);
+  // The unsafe entry must not appear at all — no injection into the document.
+  assert.doesNotMatch(query, /repo1:/);
+  assert.doesNotMatch(query, /inject/);
+});
+
+test("buildRepoQuery honors the alias prefix so catalog and drift queries stay distinct", () => {
+  const { query } = buildRepoQuery([{ owner: "a", repo: "b" }], "eco");
+  assert.match(query, /^eco0: repository/);
+});
+
+test("findDeadRepos maps NOT_FOUND error paths back to catalog entries", () => {
+  const errors = [{ type: "NOT_FOUND", path: ["repo2"] }];
+  const dead = findDeadRepos(REPOS, errors);
+  assert.deepEqual(dead, [
+    { owner: "gone", repo: "three", url: "https://github.com/gone/three" },
+  ]);
+});
+
+test("findDeadRepos ignores non-NOT_FOUND errors and unknown aliases", () => {
+  const errors = [
+    { type: "RATE_LIMITED", path: ["repo0"] },
+    { type: "NOT_FOUND", path: ["totals"] },
+    { type: "NOT_FOUND", path: ["repo99"] },
+  ];
+  assert.deepEqual(findDeadRepos(REPOS, errors), []);
+});
+
+test("findDeadRepos synthesizes a URL when the entry has none", () => {
+  const repos = [{ owner: "gone", repo: "x" }];
+  const dead = findDeadRepos(repos, [{ type: "NOT_FOUND", path: ["repo0"] }]);
+  assert.equal(dead[0].url, "https://github.com/gone/x");
+});
+
+// The core blind spot: GitHub resolves a renamed repo queried by its old name
+// and returns the CURRENT nameWithOwner, so the entry looks perfectly healthy.
+test("findRenamedRepos detects an entry that resolves to a different name", () => {
+  const data = {
+    repo0: { nameWithOwner: "alive/one" },
+    repo1: { nameWithOwner: "newowner/two" },
+  };
+  assert.deepEqual(findRenamedRepos(REPOS, data), [
+    { from: "oldowner/two", to: "newowner/two" },
+  ]);
+});
+
+test("findRenamedRepos treats a case-only difference as unchanged", () => {
+  const data = { repo0: { nameWithOwner: "Alive/One" } };
+  assert.deepEqual(findRenamedRepos([REPOS[0]], data), []);
+});
+
+test("findRenamedRepos skips entries with no resolved node", () => {
+  assert.deepEqual(findRenamedRepos(REPOS, { repo2: null }), []);
+});
+
+test("findEcosystemDrift finds linked rows absent from the catalog, excluding upstream", () => {
+  const eco = `
+| [alive/one](https://github.com/alive/one) | x | — | Beta |
+| [oldowner/two](https://github.com/oldowner/two) | x | — | Beta |
+| [stale/row](https://github.com/stale/row) | x | — | Beta |
+| [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent) | x | — | Production |
+`;
+  const drift = findEcosystemDrift(eco, REPOS);
+  assert.deepEqual(drift, ["stale/row"]);
+});
+
+test("findEcosystemDrift normalizes case and strips .git suffixes", () => {
+  const eco = "https://github.com/ALIVE/ONE.git and https://github.com/other/thing";
+  assert.deepEqual(findEcosystemDrift(eco, REPOS), ["other/thing"]);
+});
+
+// Regression guard for the 2026-07-29 incident: the sweep reported two renamed
+// repos as "stale rows" and advised deleting them. Both were live and already
+// catalogued under new owners; deleting would have dropped them from
+// llms-full.txt and the RAG corpus.
+test("classifyDrift separates a renamed row from a genuinely dead one", () => {
+  const driftNames = ["oldowner/lint", "deleted/repo", "unknown/thing"];
+  const repos = [{ owner: "newowner", repo: "lint" }];
+  const result = classifyDrift(
+    driftNames,
+    {
+      data: {
+        eco0: { nameWithOwner: "newowner/lint" },
+        eco2: { nameWithOwner: "unknown/thing" },
+      },
+      errors: [{ type: "NOT_FOUND", path: ["eco1"] }],
+    },
+    repos
+  );
+  assert.deepEqual(result.renamed, [{ name: "oldowner/lint", current: "newowner/lint" }]);
+  assert.deepEqual(result.dead, ["deleted/repo"]);
+  assert.deepEqual(result.missing, [{ name: "unknown/thing", current: "unknown/thing" }]);
+});
+
+test("classifyDrift reports an unresolved row instead of silently dropping it", () => {
+  const result = classifyDrift(["weird/row"], { data: {}, errors: [] }, []);
+  assert.deepEqual(result.missing, [{ name: "weird/row", current: null }]);
+  assert.equal(result.dead.length, 0);
+  assert.equal(result.renamed.length, 0);
+});
+
+test("renderIssueBody returns empty string when the catalog is healthy", () => {
+  assert.equal(renderIssueBody({ dead: [], renamed: [], drift: null }), "");
+  assert.equal(renderIssueBody(), "");
+});
+
+test("renderIssueBody tells the reader to rewrite renamed rows, never delete them", () => {
+  const body = renderIssueBody({
+    dead: [],
+    renamed: [],
+    drift: {
+      renamed: [{ name: "old/x", current: "new/x" }],
+      dead: [],
+      missing: [],
+    },
+  });
+  assert.match(body, /do not blanket-delete/i);
+  assert.match(body, /Renamed — rewrite the row \(do NOT delete\)/);
+  assert.match(body, /`old\/x` → `new\/x`/);
+});
+
+test("renderIssueBody documents the stars-snapshot blast radius for dead entries", () => {
+  const body = renderIssueBody({
+    dead: [{ owner: "gone", repo: "x", url: "https://github.com/gone/x" }],
+  });
+  assert.match(body, /push-stars-snapshot\.js/);
+  assert.match(body, /Smoke Test/);
+  assert.match(body, /`gone\/x`/);
+});
+
+test("renderIssueBody lists renamed catalog entries with the full rename checklist", () => {
+  const body = renderIssueBody({ renamed: [{ from: "a/b", to: "c/b" }] });
+  assert.match(body, /`a\/b` → `c\/b`/);
+  assert.match(body, /summaries\.json/);
+  assert.match(body, /vercel\.json/);
+  assert.match(body, /ECOSYSTEM\.md/);
+});
+
+test("renderIssueBody always closes with the auto-close footer when non-empty", () => {
+  const body = renderIssueBody({ renamed: [{ from: "a/b", to: "c/b" }] });
+  assert.match(body, /auto-closes when the lists go empty/);
+});


### PR DESCRIPTION
Closes the systemic gap behind #665 and #673. Item 2 from the session pick-up list.

## The blind spot

Querying a **renamed** repo by its old `owner/name` returns HTTP 200 with the repo's **current** `nameWithOwner`. So a stale catalog entry serves star counts, passes every availability check, and renders a project page — nothing ever fails. The catalog just carries a name that no longer exists.

Verified against the live API:

```
roli-lpci/lintlang                 -> hermes-labs-ai/lintlang        (renamed, resolves)
rookiemann/portable-hermes-agent   -> aivrar/portable-hermes-agent   (renamed, resolves)
Rainhoole/hermes-agent-acp-skill   -> NOT_FOUND                      (genuinely dead)
```

Eight stale-named entries plus a duplicate pair accumulated undetected before #665 fixed them by hand.

**The fix costs no extra API budget** — `check-dead-repos.js` already requested `nameWithOwner` and threw it away. It's now compared against the catalog key, case-insensitively so canonical-case differences aren't misreported.

## The ECOSYSTEM.md advice was actively harmful

Drift was computed by literal string comparison and reported with *"remove each stale row"*. A renamed repo produces exactly that signature. Following that advice this morning on #673 would have deleted **two live projects** from `ECOSYSTEM.md` — which `build-pages.js:708` bundles into `llms-full.txt` and the RAG corpus.

Drifted rows are now resolved against GitHub and split into three sections with distinct fixes:

| Case | Fix |
|---|---|
| Renamed (resolves to a catalogued name) | **rewrite the row — do not delete** |
| Dead (`NOT_FOUND`) | delete the row |
| Not catalogued | re-add the repo, or delete the row |

## Structure

Classification moves to `lib/catalog-health.js` as pure functions over an already-fetched GraphQL response, matching the existing `lib/*.js` ↔ `tests/*.test.js` pairing. `scripts/check-dead-repos.js` keeps I/O and orchestration.

## Verification

- **17 new unit tests**; `npm test` **255/255** (was 238).
- Live run against the real 216-repo catalog: `0 dead, 0 renamed, 0 drift` — confirms #675 left the catalog clean.
- **Detection proven to fire**: temporarily injected the known `roli-lpci/lintlang` rename; the sweep reported `renamed: roli-lpci/lintlang -> hermes-labs-ai/lintlang` and emitted the rewrite-don't-delete guidance. Catalog restored (`git checkout`) and re-verified clean.
- Workflow YAML re-parsed after editing.

## Note on the issue title

Renamed to `Catalog health: dead, renamed, or drifted repos`, since it no longer reports only dead repos. The workflow finds its issue by exact title search — no open issue carries the old title (#673 closed when #675 merged), so nothing is orphaned. This is the safe moment to make the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)