### PR TITLE
Fail loud when the serverless live-refresh path cannot reach GitHub

### DIFF
--- a/.github/workflows/refresh-stars.yml
+++ b/.github/workflows/refresh-stars.yml
@@ -31,6 +31,18 @@ jobs:
           CRON_SECRET: ${{ secrets.CRON_SECRET }}
         run: node scripts/push-stars-snapshot.js
 
+      # Publication above uses the ACTIONS token, so it proves nothing about the
+      # GITHUB_TOKEN configured in Vercel. api/stars.js only reaches for that one
+      # when the cached snapshot is cold, and degrades silently when it fails —
+      # so an expired token stays invisible until the cache also expires. This
+      # forces the live path every run and fails loud instead.
+      #
+      # Runs after publication so a token problem can never block the snapshot.
+      - name: Probe the serverless live-refresh path
+        env:
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+        run: node scripts/probe-live-refresh.js
+
       - name: Close prior failure alerts after recovery
         if: success()
         env:
@@ -60,13 +72,19 @@ jobs:
             // catalog entries. Naming them here is the difference between a
             // 2-minute fix and a manual investigation — the generic body alone
             // left ndesv21/socialclaw breaking runs for ~26h (PR #662).
+            // probe-live-refresh.js writes this when the Vercel-side token
+            // cannot fetch. Checked first: it runs after publication, so if it
+            // produced a report the snapshot itself succeeded and the token is
+            // the actual finding.
             let detail = '';
-            try {
-              detail = fs.readFileSync('stars-unavailable.md', 'utf8');
-            } catch {
-              detail = 'No unavailable-repo report was produced, so the snapshot ' +
-                'failed before ingestion (network, auth, or a degraded API response). ' +
-                'Check the run log.\n';
+            const read = (file) => {
+              try { return fs.readFileSync(file, 'utf8'); } catch { return ''; }
+            };
+            detail = read('stars-probe.md') || read('stars-unavailable.md');
+            if (!detail) {
+              detail = 'Neither a probe report nor an unavailable-repo report was ' +
+                'produced, so the snapshot failed before ingestion (network, auth, ' +
+                'or a degraded API response). Check the run log.\n';
             }
 
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ CLAUDE.md
 skills-lock.json
 dead-repos.md
 stars-unavailable.md
+stars-probe.md
 
 # In-progress tracking — stays in the private operations vault, never in this repo
 # Covers: roadmaps, launch playbooks, analytics setup plans, status/todo docs

--- a/api/stars.js
+++ b/api/stars.js
@@ -203,6 +203,12 @@ export function createStarsHandler({
         return res.status(200).json(cached);
       }
 
+      // Why the fallback below is degraded. A live-refresh failure used to
+      // collapse into the generic "Live refresh unavailable", so an expired
+      // GITHUB_TOKEN was indistinguishable from a transient GitHub outage —
+      // the response looked identical either way and nothing named the cause.
+      let refreshError = null;
+
       if (env.GITHUB_TOKEN) {
         try {
           const snapshot = await fetchGitHubStars({
@@ -213,21 +219,33 @@ export function createStarsHandler({
           const response = await persistSnapshot(repoList, snapshot, "github-api");
           return res.status(200).json(response);
         } catch (error) {
-          console.error("Live star refresh failed:", error.message);
+          refreshError = error.message;
+          console.error("Live star refresh failed:", refreshError);
           if (refresh) {
             res.setHeader("Cache-Control", "no-store");
-            return res.status(503).json({ error: "Star refresh failed", stale: true });
+            return res
+              .status(503)
+              .json({ error: "Star refresh failed", reason: refreshError, stale: true });
           }
         }
       } else if (refresh) {
         res.setHeader("Cache-Control", "no-store");
         return res.status(503).json({ error: "GitHub token unavailable", stale: true });
+      } else {
+        refreshError = "GITHUB_TOKEN is not configured";
       }
 
       const lastGood = await kvGetImpl(STAR_KEYS.lastGood);
       if (storedResponseIsValid(lastGood, repoList)) {
         res.setHeader("Cache-Control", "no-store");
-        return res.status(200).json(markFallback(lastGood, "Live refresh unavailable"));
+        return res
+          .status(200)
+          .json(
+            markFallback(
+              lastGood,
+              refreshError ? `Live refresh failed: ${refreshError}` : "Live refresh unavailable",
+            ),
+          );
       }
 
       res.setHeader("Cache-Control", "no-store");

--- a/scripts/probe-live-refresh.js
+++ b/scripts/probe-live-refresh.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * Probe the serverless live-refresh path so a dead Vercel GITHUB_TOKEN fails
+ * loudly instead of silently.
+ *
+ * Why this exists: nothing exercised that token. push-stars-snapshot.js fetches
+ * GitHub with the *Actions* token and POSTs the result, so the 6-hourly refresh
+ * passes regardless of what Vercel holds. api/stars.js only reaches for its own
+ * GITHUB_TOKEN when the cached snapshot is missing or invalid, and on failure it
+ * logs and serves the last-good snapshot with a 200. So an expired token stayed
+ * invisible until the cache also went cold — a latent double failure. That is
+ * how the previous token sat dead undetected.
+ *
+ * An authenticated GET with the cron flag bypasses the cache and forces the live
+ * path, which returns 503 when the token cannot fetch. Running it right after
+ * publication converts that latent failure into a workflow failure, and the
+ * existing alert step in refresh-stars.yml opens the issue.
+ *
+ * Writes stars-probe.md on failure so the alert body names the cause.
+ */
+import { writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export function buildProbeReport({ reason, endpoint }) {
+  return (
+    `## Live star refresh probe failed\n\n` +
+    `An authenticated \`GET ${endpoint}\` did not return a fresh snapshot.\n\n` +
+    `**Reason**: ${reason}\n\n` +
+    `**What this means**: the serverless function could not fetch star counts ` +
+    `using the \`GITHUB_TOKEN\` configured in Vercel. This is a *different* token ` +
+    `from the one this workflow uses — \`push-stars-snapshot.js\` fetches GitHub ` +
+    `with the Actions token, so publication can keep succeeding while the ` +
+    `Vercel token is dead.\n\n` +
+    `**Blast radius**: none while the published snapshot stays warm. ` +
+    `\`api/stars.js\` serves the cached snapshot and only falls back to a live ` +
+    `fetch when that cache is missing or invalid. If the token is still dead ` +
+    `then, \`/api/stars\` starts serving \`stale: true\` from last-good, and the ` +
+    `smoke test's stars-freshness assertion fails.\n\n` +
+    `## Fix\n\n` +
+    `1. Check the token: \`vercel env ls\` and confirm \`GITHUB_TOKEN\` exists for production.\n` +
+    `2. A classic PAT with **no scopes** is sufficient — the query only reads public ` +
+    `\`stargazerCount\`/\`pushedAt\`. Do not grant \`public_repo\`; that adds *write* access.\n` +
+    `3. Verify the new token against the real query before saving it, then ` +
+    `\`vercel env rm GITHUB_TOKEN production\` / \`vercel env add\` and redeploy.\n` +
+    `4. Re-run \`gh workflow run "Refresh GitHub Stars" --ref main\` to confirm recovery.\n\n` +
+    `_Auto-detected by \`scripts/probe-live-refresh.js\`._\n`
+  );
+}
+
+export async function probeLiveRefresh({
+  cronSecret,
+  endpoint = "https://hermesatlas.com/api/stars?cron=1",
+  fetchImpl = fetch,
+} = {}) {
+  if (!cronSecret) throw new Error("CRON_SECRET is required");
+
+  const response = await fetchImpl(endpoint, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${cronSecret}`,
+      "User-Agent": "hermes-atlas-stars-probe",
+    },
+  });
+
+  if (!response.ok) {
+    const detail = (await response.text().catch(() => "")).slice(0, 500);
+    throw new Error(`HTTP ${response.status} ${detail}`.trim());
+  }
+
+  const result = await response.json();
+
+  // The cron flag bypasses the cache, so a healthy probe must come back from a
+  // live fetch. "last-good" here means the live path failed and the handler
+  // quietly degraded — precisely the condition this probe exists to catch.
+  if (result.source !== "github-api") {
+    throw new Error(
+      `expected a live snapshot (source "github-api"), got "${result.source}"` +
+      (result.degradedReason ? ` — ${result.degradedReason}` : "")
+    );
+  }
+  if (result.stale) throw new Error("live snapshot reported stale");
+  if (result.complete === false) {
+    // Dead catalog entries are push-stars-snapshot.js's alert to raise; this
+    // probe is about token health, so don't duplicate that diagnosis.
+    const names = (result.unavailableRepos || [])
+      .map((item) => `${item.owner}/${item.repo}`)
+      .join(", ");
+    throw new Error(`live snapshot incomplete — unavailable: ${names || "unknown"}`);
+  }
+
+  return result;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const endpoint =
+    process.env.STARS_ENDPOINT || "https://hermesatlas.com/api/stars?cron=1";
+  try {
+    const result = await probeLiveRefresh({
+      cronSecret: process.env.CRON_SECRET,
+      endpoint,
+    });
+    console.log(
+      `Live refresh probe OK: ${result.totals?.count ?? "?"} repos from ${result.source} at ${result.fetchedAt}`
+    );
+  } catch (error) {
+    console.error(`Live refresh probe failed: ${error.message}`);
+    await writeFile("stars-probe.md", buildProbeReport({ reason: error.message, endpoint }));
+    process.exit(1);
+  }
+}

--- a/tests/probe-live-refresh.test.js
+++ b/tests/probe-live-refresh.test.js
@@ -1,0 +1,127 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { probeLiveRefresh, buildProbeReport } from "../scripts/probe-live-refresh.js";
+
+const ENDPOINT = "https://example.test/api/stars?cron=1";
+
+function jsonResponse(body, { ok = true, status = 200 } = {}) {
+  return {
+    ok,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+const HEALTHY = {
+  source: "github-api",
+  stale: false,
+  complete: true,
+  totals: { count: 216 },
+  fetchedAt: "2026-07-29T12:00:00Z",
+};
+
+test("probeLiveRefresh requires the cron secret", async () => {
+  await assert.rejects(() => probeLiveRefresh({ endpoint: ENDPOINT }), /CRON_SECRET is required/);
+});
+
+test("probeLiveRefresh sends the cron secret as a bearer token", async () => {
+  let seen = null;
+  await probeLiveRefresh({
+    cronSecret: "s3cret",
+    endpoint: ENDPOINT,
+    fetchImpl: async (url, init) => {
+      seen = { url, init };
+      return jsonResponse(HEALTHY);
+    },
+  });
+  assert.equal(seen.url, ENDPOINT);
+  assert.equal(seen.init.method, "GET");
+  assert.equal(seen.init.headers.Authorization, "Bearer s3cret");
+});
+
+test("probeLiveRefresh accepts a live, complete snapshot", async () => {
+  const result = await probeLiveRefresh({
+    cronSecret: "s",
+    endpoint: ENDPOINT,
+    fetchImpl: async () => jsonResponse(HEALTHY),
+  });
+  assert.equal(result.totals.count, 216);
+});
+
+// The whole point of the probe: the cron flag bypasses the cache, so a
+// last-good response means the live path failed and the handler degraded
+// quietly. That must be an error, not a pass.
+test("probeLiveRefresh fails when the handler silently served last-good", async () => {
+  await assert.rejects(
+    () =>
+      probeLiveRefresh({
+        cronSecret: "s",
+        endpoint: ENDPOINT,
+        fetchImpl: async () =>
+          jsonResponse({
+            source: "last-good",
+            stale: true,
+            degradedReason: "Live refresh failed: Bad credentials",
+          }),
+      }),
+    /expected a live snapshot.*got "last-good".*Bad credentials/s
+  );
+});
+
+test("probeLiveRefresh fails on a 503 from the refresh path", async () => {
+  await assert.rejects(
+    () =>
+      probeLiveRefresh({
+        cronSecret: "s",
+        endpoint: ENDPOINT,
+        fetchImpl: async () => ({
+          ok: false,
+          status: 503,
+          text: async () => '{"error":"Star refresh failed","reason":"Bad credentials"}',
+        }),
+      }),
+    /HTTP 503.*Bad credentials/s
+  );
+});
+
+test("probeLiveRefresh fails a live snapshot flagged stale", async () => {
+  await assert.rejects(
+    () =>
+      probeLiveRefresh({
+        cronSecret: "s",
+        endpoint: ENDPOINT,
+        fetchImpl: async () => jsonResponse({ ...HEALTHY, stale: true }),
+      }),
+    /reported stale/
+  );
+});
+
+test("probeLiveRefresh names unavailable repos when the snapshot is incomplete", async () => {
+  await assert.rejects(
+    () =>
+      probeLiveRefresh({
+        cronSecret: "s",
+        endpoint: ENDPOINT,
+        fetchImpl: async () =>
+          jsonResponse({
+            ...HEALTHY,
+            complete: false,
+            unavailableRepos: [{ owner: "gone", repo: "x" }],
+          }),
+      }),
+    /incomplete — unavailable: gone\/x/
+  );
+});
+
+test("buildProbeReport explains the two-token distinction and the no-scope fix", () => {
+  const body = buildProbeReport({ reason: "HTTP 503", endpoint: ENDPOINT });
+  assert.match(body, /HTTP 503/);
+  assert.match(body, /different.*token/i);
+  assert.match(body, /Actions token/);
+  assert.match(body, /no scopes/);
+  // Guard the security guidance: public_repo grants write access and must stay
+  // called out as the wrong choice.
+  assert.match(body, /Do not grant `public_repo`/);
+  assert.match(body, /vercel env/);
+});

--- a/tests/stars-api.test.js
+++ b/tests/stars-api.test.js
@@ -167,6 +167,65 @@ test("authenticated GET refresh reports GitHub failure as HTTP 503", async () =>
   assert.equal(res.body.stale, true);
 });
 
+// A live-refresh failure used to collapse into the generic "Live refresh
+// unavailable", making an expired GITHUB_TOKEN indistinguishable from a
+// transient GitHub outage. The degraded response must name the cause.
+test("last-good fallback names the live-refresh failure that caused it", async () => {
+  const lastGood = buildStarsResponse({
+    starData,
+    hermesRelease: release,
+    atlasStars: 42,
+    fetchedAt: "2026-07-14T00:00:00Z",
+    source: "github-actions",
+    stale: false,
+  });
+  const res = responseRecorder();
+  await handler({
+    env: { GITHUB_TOKEN: "expired" },
+    kvGetImpl: async (key) => (key === STAR_KEYS.lastGood ? lastGood : null),
+    fetchImpl: async () => {
+      throw new Error("Bad credentials");
+    },
+  })(request(), res);
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.source, "last-good");
+  assert.equal(res.body.stale, true);
+  assert.match(res.body.degradedReason, /Live refresh failed: Bad credentials/);
+});
+
+test("last-good fallback distinguishes an absent token from a failing one", async () => {
+  const lastGood = buildStarsResponse({
+    starData,
+    hermesRelease: release,
+    atlasStars: 42,
+    fetchedAt: "2026-07-14T00:00:00Z",
+    source: "github-actions",
+    stale: false,
+  });
+  const res = responseRecorder();
+  await handler({
+    env: {},
+    kvGetImpl: async (key) => (key === STAR_KEYS.lastGood ? lastGood : null),
+  })(request(), res);
+  assert.match(res.body.degradedReason, /GITHUB_TOKEN is not configured/);
+});
+
+test("authenticated GET refresh surfaces the failure reason in the 503 body", async () => {
+  const res = responseRecorder();
+  await handler({
+    env: { CRON_SECRET: "secret", GITHUB_TOKEN: "expired" },
+    fetchImpl: async () => {
+      throw new Error("Bad credentials");
+    },
+  })(request({
+    query: { cron: "1" },
+    headers: { authorization: "Bearer secret" },
+  }), res);
+  assert.equal(res.statusCode, 503);
+  assert.equal(res.body.stale, true);
+  assert.equal(res.body.reason, "Bad credentials");
+});
+
 test("refresh and POST routes reject missing authorization", async () => {
   const run = handler({ env: { CRON_SECRET: "secret" } });
   for (const req of [


### PR DESCRIPTION
Item 1 from the session pick-up list. Closes the silent-expiry loop left by #675.

## Why the original plan wouldn't have worked

The list said "add a `workflow-issue` alert on the `api/stars.js` catch block." Tracing the code shows that alone would not have caught the failure it was meant to catch:

- `push-stars-snapshot.js:57` fetches GitHub with the **Actions** token, then POSTs the snapshot. **Vercel's `GITHUB_TOKEN` is never exercised by the cron path** — the 6-hourly refresh passes no matter what Vercel holds.
- `api/stars.js` only reaches for its own token when the cached snapshot is missing or invalid, and on failure logged + served last-good with a **200**.

So the catch block rarely runs, and detection required a cron failure *and* a cold cache simultaneously. That is precisely how the previous token sat dead undetected.

## The fix: exercise the path, don't wait for it

`scripts/probe-live-refresh.js` issues an authenticated `GET /api/stars?cron=1`. The cron flag bypasses the cache and forces the live fetch, then the probe asserts the response is live (`source: "github-api"`), fresh, and complete. **A last-good response here means the handler degraded quietly** — the exact condition being hunted.

Wired into `refresh-stars.yml` **after** the publish step, so:
- a token problem can never block the snapshot, and
- the probe only runs once publication has succeeded, making a probe failure unambiguously about the Vercel-side path.

The failure step now prefers `stars-probe.md` over `stars-unavailable.md` for the same reason — no duplicate diagnosis, and dead-repo alerts still win when publication is what failed.

## Secondary: the response now names its cause

`"Live refresh unavailable"` was returned for an expired token and a transient GitHub outage alike. The actual reason is now carried into `degradedReason` and the 503 body. The two changes compose — the handler names the cause, the probe lifts it into the alert.

## Verification

- **11 new tests**; `npm test` **266/266** (was 255).
- **End-to-end against a mock endpoint**, all four cases correct:

| Case | Result |
|---|---|
| Healthy live snapshot | exit 0, no report |
| **HTTP 200 + last-good** (the silent case) | exit 1, report quotes `Live refresh failed: Bad credentials` |
| HTTP 401 (wrong cron secret) | exit 1, reason recorded |
| Missing `CRON_SECRET` | throws rather than passing silently |

- `stars-probe.md` added to `.gitignore`, mirroring `stars-unavailable.md`.
- Workflow YAML re-parsed after editing.

## Tradeoff worth flagging

The probe adds one GraphQL query per 6-hour run and re-persists the snapshot with `source: "github-api"`. Negligible cost, but it does mean **the stars workflow now depends on the Vercel deployment being reachable** — a site outage would newly fail this workflow rather than passing quietly. That is the intended direction (loud over silent), but it is a real behavior change; easy to downgrade to a warning if you'd rather.

🤖 Generated with [Claude Code](https://claude.com/claude-code)