### PR TITLE
Add direct MiniMax chat provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ OPENROUTER_API_KEY=sk-or-... node scripts/test-rag.js
 | `REDIS_URL` | Redis Cloud connection string | Yes (for cache + history) |
 | `OPENROUTER_MODEL` | Override primary LLM model | No (default: `deepseek/deepseek-v4-flash`) |
 | `OPENROUTER_FALLBACK_MODELS` | Comma-separated fallback chain | No (default: `google/gemini-3-flash-preview,google/gemini-3.1-flash-lite-preview`) |
+| `CHAT_PROVIDER` | Chat LLM transport (`openrouter` or `minimax`) | No (default: `openrouter`) |
+| `MINIMAX_API_KEY` | MiniMax API key (required when `CHAT_PROVIDER=minimax`) | No |
+| `MINIMAX_REGION` | MiniMax regional endpoint (`global_en` or `cn_zh`) | No (default: `global_en`) |
+| `MINIMAX_MODELS` | Comma-separated MiniMax model list | No (default: `MiniMax-M3,MiniMax-M2.7`) |
 
 ## Contributing
 

--- a/api/chat.js
+++ b/api/chat.js
@@ -3,6 +3,13 @@ import { combinedRetrievalScore, enrichChunkMetadata } from "../lib/rag-scoring.
 import { buildLatestReleaseBlock, detectLatestReleaseQuery } from "../lib/latest-release.js";
 import { parseChunkStore } from "../lib/chunk-store.js";
 import { matchUseCases, buildUseCaseBlock, inferCategory } from "../lib/use-case-match.js";
+import {
+  chatProviderConfig,
+  streamChatRequest,
+  chatStreamDelta,
+  chatStreamModel,
+  chatStreamUsage,
+} from "../lib/chat-provider.js";
 import { readFileSync } from "fs";
 import { join } from "path";
 
@@ -239,6 +246,19 @@ function mmrSelect(candidates, queryEmbedding, k, lambda = 0.6) {
 
 const OPENROUTER_KEY = process.env.OPENROUTER_API_KEY;
 
+// Active chat LLM provider, resolved once via lib/chat-provider.js so the
+// transport config (regional MiniMax endpoints, model list) has a single
+// source of truth that is also unit-tested. Defaults to "openrouter" (the
+// historical waterfall). Set CHAT_PROVIDER=minimax to route the streaming
+// chat completion directly to a MiniMax Anthropic Messages-compatible endpoint
+// instead of OpenRouter. Everything downstream (SSE parsing, usage recording,
+// rate-limit) is transport-agnostic.
+const CHAT_CFG = chatProviderConfig(process.env);
+const CHAT_PROVIDER = CHAT_CFG.provider;
+const MINIMAX_API_KEY = process.env.MINIMAX_API_KEY;
+const MINIMAX_BASE_URL = CHAT_CFG.baseUrl;
+const MINIMAX_PRIMARY_MODEL = CHAT_CFG.model;
+
 // Model config — supports primary + fallback via OpenRouter's native routing.
 // OpenRouter caps the models array at 3 total.
 //
@@ -294,7 +314,10 @@ export default async function handler(req, res) {
     return res.status(405).json({ error: "Method not allowed" });
   }
 
-  if (!OPENROUTER_KEY) {
+  if (CHAT_PROVIDER === "minimax" && !MINIMAX_API_KEY) {
+    return res.status(500).json({ error: "Chat not configured — missing API key" });
+  }
+  if (CHAT_PROVIDER !== "minimax" && !OPENROUTER_KEY) {
     return res.status(500).json({ error: "Chat not configured — missing API key" });
   }
 
@@ -546,39 +569,19 @@ ${retrievedContext}${useCaseBlock}${repoMetadataBlock}`;
       { role: "user", content: message },
     ];
 
-    // 6. Stream from LLM
-    const llmRes = await fetch("https://openrouter.ai/api/v1/chat/completions", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${OPENROUTER_KEY}`,
-        "Content-Type": "application/json",
-        "HTTP-Referer": "https://hermesatlas.com",
-        "X-Title": "Hermes Atlas",
-      },
+    // 6. Stream from LLM. The transport is built via lib/chat-provider.js so
+    // the request shape for each provider lives in one tested place. The
+    // OpenRouter waterfall and the MiniMax direct path stay fully isolated —
+    // neither branch sees the other's request shape.
+    const llmRes = await streamChatRequest({
+      provider: CHAT_PROVIDER,
+      baseUrl: CHAT_PROVIDER === "minimax" ? MINIMAX_BASE_URL : "https://openrouter.ai/api/v1",
+      apiKey: CHAT_PROVIDER === "minimax" ? MINIMAX_API_KEY : OPENROUTER_KEY,
+      model: CHAT_PROVIDER === "minimax" ? MINIMAX_PRIMARY_MODEL : PRIMARY_MODEL,
+      fallbackModels: CHAT_PROVIDER === "minimax" ? [] : FALLBACK_MODELS,
+      messages,
+      maxTokens: MAX_TOKENS,
       signal: ac.signal,
-      body: JSON.stringify({
-        // OpenRouter native fallback — pass ONLY `models` array (no `model` field)
-        // It will try each in order until one succeeds
-        ...(FALLBACK_MODELS.length > 0
-          ? { models: [PRIMARY_MODEL, ...FALLBACK_MODELS] }
-          : { model: PRIMARY_MODEL }),
-        messages,
-        stream: true,
-        max_tokens: MAX_TOKENS,
-        temperature: 0.3,
-        // Ask OpenRouter to include token usage (and cost) in the final SSE
-        // chunk. That chunk may carry an empty choices array — the parser below
-        // tolerates it (it only reads choices[0] optionally).
-        usage: { include: true },
-        // Force reasoning OFF. Our SSE parser reads only delta.content; a
-        // reasoning-capable model streams to delta.reasoning (empty answer to
-        // us) or burns the whole token budget on hidden thinking. `enabled:
-        // false` stops the generation entirely — unlike `exclude: true`, which
-        // only hides reasoning from the response while still billing for it.
-        // Also insures against the unpinned preview alias silently shipping a
-        // reasoning-on provider revision.
-        reasoning: { enabled: false },
-      }),
     });
 
     if (!llmRes.ok) {
@@ -601,8 +604,8 @@ ${retrievedContext}${useCaseBlock}${repoMetadataBlock}`;
     const decoder = new TextDecoder();
     let buffer = "";
     let totalContent = "";
-    let actualModel = null; // Captured from OpenRouter SSE chunks
-    let usage = null; // Token usage from the final SSE chunk (usage.include)
+    let actualModel = null; // Captured from provider SSE chunks
+    let usage = null; // Token usage from the final SSE chunk
 
     while (true) {
       const { done, value } = await reader.read();
@@ -629,19 +632,29 @@ ${retrievedContext}${useCaseBlock}${repoMetadataBlock}`;
             return res.end();
           }
 
-          // Capture which model OpenRouter actually selected (after fallback routing)
-          if (parsed.model && !actualModel) {
-            actualModel = parsed.model;
+          // Capture which model the provider actually selected/served.
+          // OpenRouter reports it on every chunk; MiniMax reports it on the
+          // `message_start` event as `message.model`. Either way we keep the
+          // first non-empty value so the usage trailer attributes the request.
+          const streamModel = chatStreamModel(parsed);
+          if (streamModel && !actualModel) {
+            actualModel = streamModel;
           }
 
           // Capture token usage — OpenRouter emits it on the final chunk (the
-          // one that may have an empty choices array). Overwrite so we keep the
+          // one that may have an empty choices array). MiniMax emits it on the
+          // `message_delta` event as `usage`. Overwrite so we keep the
           // last/most-complete usage object seen.
-          if (parsed.usage) {
-            usage = parsed.usage;
+          const streamUsage = chatStreamUsage(parsed);
+          if (streamUsage) {
+            usage = streamUsage;
           }
 
-          const content = parsed.choices?.[0]?.delta?.content;
+          // OpenRouter content arrives as choices[].delta.content. MiniMax
+          // content arrives as delta.text on `content_block_delta` events.
+          // Both shapes are read here so the existing content-forwarding path
+          // is transport-agnostic.
+          const content = chatStreamDelta(parsed);
           if (content) {
             totalContent += content;
             res.write(content);

--- a/lib/chat-provider.js
+++ b/lib/chat-provider.js
@@ -1,0 +1,179 @@
+/**
+ * chat-provider.js — Chat LLM transport selection.
+ *
+ * The Atlas chatbot historically talked only to OpenRouter. This module adds a
+ * direct MiniMax provider so the streaming chat completion can be served from
+ * MiniMax's Anthropic Messages-compatible endpoint instead, without going
+ * through OpenRouter. MiniMax exposes both an OpenAI-compatible endpoint and an
+ * Anthropic Messages-compatible endpoint (`/anthropic`); we use the
+ * Anthropic-compatible transport, which keeps the existing delta.content SSE
+ * parser working.
+ *
+ * Two regional hosts are supported — the global host (api.minimax.io) and the
+ * China host (api.minimaxi.com) — selectable via MINIMAX_REGION. The current
+ * MiniMax text models (MiniMax-M3 and MiniMax-M2.7) are served from both
+ * regions; the model list is configurable via MINIMAX_MODELS so new models can
+ * be added without editing this file.
+ */
+
+// Regional endpoint pairs for the MiniMax Anthropic-compatible transport.
+const MINIMAX_REGIONS = {
+  global_en: {
+    anthropic_base_url: "https://api.minimax.io/anthropic",
+    openai_base_url: "https://api.minimax.io/v1",
+    docs_root: "https://platform.minimax.io/docs",
+  },
+  cn_zh: {
+    anthropic_base_url: "https://api.minimaxi.com/anthropic",
+    openai_base_url: "https://api.minimaxi.com/v1",
+    docs_root: "https://platform.minimaxi.com/docs",
+  },
+};
+
+export const MINIMAX_DEFAULT_MODELS = ["MiniMax-M3", "MiniMax-M2.7"];
+
+/**
+ * Resolve the chat provider configuration from environment variables.
+ *
+ * @param {Object} env - Environment variables (defaults to process.env).
+ * @returns {{provider:string,baseUrl:string,model:string,modelIds:string[]}}
+ *   The resolved provider configuration. `baseUrl` is the API root for the
+ *   selected transport; `model`/`modelIds` describe the MiniMax model list
+ *   (empty for OpenRouter, which selects models elsewhere).
+ */
+export function chatProviderConfig(env = process.env) {
+  const provider = (env.CHAT_PROVIDER || "openrouter").trim().toLowerCase();
+
+  if (provider === "minimax") {
+    const region = (env.MINIMAX_REGION || "global_en").trim().toLowerCase();
+    const regionCfg = MINIMAX_REGIONS[region] || MINIMAX_REGIONS.global_en;
+    const modelIds = (env.MINIMAX_MODELS || MINIMAX_DEFAULT_MODELS.join(","))
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    return {
+      provider: "minimax",
+      baseUrl: regionCfg.anthropic_base_url,
+      model: modelIds[0] || MINIMAX_DEFAULT_MODELS[0],
+      modelIds,
+    };
+  }
+
+  return {
+    provider: "openrouter",
+    baseUrl: "https://openrouter.ai/api/v1",
+    model: "",
+    modelIds: [],
+  };
+}
+
+/**
+ * Build and send the streaming chat request for the selected provider.
+ *
+ * The two transports are kept fully isolated — neither branch sees the other's
+ * request shape — so a provider bug stays confined to its own branch.
+ *
+ * @param {Object} options
+ * @param {string} options.provider - "openrouter" or "minimax"
+ * @param {string} options.baseUrl - API root for the transport
+ * @param {string} options.apiKey - Provider API key
+ * @param {string} options.model - Primary model id
+ * @param {string[]} [options.fallbackModels] - OpenRouter fallback chain (max 2 extra)
+ * @param {Array} options.messages - Chat messages
+ * @param {number} options.maxTokens - Max output tokens
+ * @param {AbortSignal} [options.signal] - Abort signal for client disconnects
+ * @returns {Promise<Response>} The upstream fetch response (streaming)
+ */
+export async function streamChatRequest({
+  provider,
+  baseUrl,
+  apiKey,
+  model,
+  fallbackModels = [],
+  messages,
+  maxTokens,
+  signal,
+}) {
+  if (provider === "minimax") {
+    // MiniMax exposes an Anthropic Messages-compatible endpoint. The Anthropic
+    // Messages API takes a single `model` (not a model array), so fallback is
+    // handled client-side by the caller if desired. `max_tokens` is required by
+    // the Anthropic Messages spec.
+    return fetch(`${baseUrl}/v1/messages`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      signal,
+      body: JSON.stringify({
+        model,
+        messages,
+        max_tokens: maxTokens,
+        stream: true,
+      }),
+    });
+  }
+
+  // OpenRouter native fallback — pass ONLY `models` array (no `model` field);
+  // it tries each in order until one succeeds. Cap at 3 total (provider limit).
+  const models = [model, ...fallbackModels].slice(0, 3);
+  return fetch(`${baseUrl}/chat/completions`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+      "HTTP-Referer": "https://hermesatlas.com",
+      "X-Title": "Hermes Atlas",
+    },
+    signal,
+    body: JSON.stringify({
+      ...(fallbackModels.length > 0 ? { models } : { model }),
+      messages,
+      stream: true,
+      max_tokens: maxTokens,
+      temperature: 0.3,
+      usage: { include: true },
+      // Force reasoning OFF. Our SSE parser reads only delta.content; a
+      // reasoning-capable model streams to delta.reasoning (empty answer to us)
+      // or burns the whole token budget on hidden thinking.
+      reasoning: { enabled: false },
+    }),
+  });
+}
+
+/**
+ * Extract a streamed text delta from a single SSE data payload, regardless of
+ * provider. OpenRouter emits content as `choices[0].delta.content`; MiniMax
+ * (Anthropic-compatible) emits it as `delta.text` on content_block_delta events.
+ *
+ * @param {Object} parsed - Parsed SSE payload
+ * @returns {string|null} The text delta, or null if the payload carries none
+ */
+export function chatStreamDelta(parsed) {
+  return parsed.choices?.[0]?.delta?.content ?? parsed.delta?.text ?? null;
+}
+
+/**
+ * Extract the model id from a streamed SSE payload, regardless of provider.
+ * OpenRouter reports `model` on every chunk; MiniMax reports `message.model`
+ * on the `message_start` event.
+ *
+ * @param {Object} parsed - Parsed SSE payload
+ * @returns {string|null} The model id, or null if the payload carries none
+ */
+export function chatStreamModel(parsed) {
+  return parsed.model ?? parsed.message?.model ?? null;
+}
+
+/**
+ * Extract token usage from a streamed SSE payload, regardless of provider.
+ * OpenRouter emits `usage` on the final chunk; MiniMax emits it on the
+ * `message_delta` event.
+ *
+ * @param {Object} parsed - Parsed SSE payload
+ * @returns {Object|null} The usage object, or null if the payload carries none
+ */
+export function chatStreamUsage(parsed) {
+  return parsed.usage ?? null;
+}

--- a/tests/chat-provider.test.js
+++ b/tests/chat-provider.test.js
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  chatProviderConfig,
+  streamChatRequest,
+  chatStreamDelta,
+  chatStreamModel,
+  chatStreamUsage,
+} from "../lib/chat-provider.js";
+
+test("chatProviderConfig resolves the MiniMax global region", () => {
+  const cfg = chatProviderConfig({ CHAT_PROVIDER: "minimax", MINIMAX_REGION: "global_en" });
+  assert.equal(cfg.provider, "minimax");
+  assert.equal(cfg.baseUrl, "https://api.minimax.io/anthropic");
+  assert.equal(cfg.model, "MiniMax-M3");
+  assert.deepEqual(cfg.modelIds, ["MiniMax-M3", "MiniMax-M2.7"]);
+});
+
+test("chatProviderConfig resolves the MiniMax China region", () => {
+  const cfg = chatProviderConfig({ CHAT_PROVIDER: "minimax", MINIMAX_REGION: "cn_zh" });
+  assert.equal(cfg.baseUrl, "https://api.minimaxi.com/anthropic");
+});
+
+test("chatProviderConfig falls back to the global region on an unknown region", () => {
+  const cfg = chatProviderConfig({ CHAT_PROVIDER: "minimax", MINIMAX_REGION: "mars" });
+  assert.equal(cfg.baseUrl, "https://api.minimax.io/anthropic");
+});
+
+test("chatProviderConfig defaults to OpenRouter", () => {
+  const cfg = chatProviderConfig({});
+  assert.equal(cfg.provider, "openrouter");
+  assert.equal(cfg.baseUrl, "https://openrouter.ai/api/v1");
+  assert.deepEqual(cfg.modelIds, []);
+});
+
+test("chatProviderConfig lets MINIMAX_MODELS override the model list", () => {
+  const cfg = chatProviderConfig({
+    CHAT_PROVIDER: "minimax",
+    MINIMAX_MODELS: "MiniMax-M2.7,MiniMax-M3",
+  });
+  assert.equal(cfg.model, "MiniMax-M2.7");
+  assert.deepEqual(cfg.modelIds, ["MiniMax-M2.7", "MiniMax-M3"]);
+});
+
+function fakeStreamResponse() {
+  return {
+    ok: true,
+    body: { getReader: () => ({ read: async () => ({ done: true }) }) },
+  };
+}
+
+test("streamChatRequest sends a MiniMax Anthropic Messages request", async () => {
+  const captured = {};
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    captured.url = url;
+    captured.init = init;
+    return fakeStreamResponse();
+  };
+  try {
+    await streamChatRequest({
+      provider: "minimax",
+      baseUrl: "https://api.minimax.io/anthropic",
+      apiKey: "test-key",
+      model: "MiniMax-M3",
+      messages: [{ role: "user", content: "hi" }],
+      maxTokens: 100,
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+  assert.equal(captured.url, "https://api.minimax.io/anthropic/v1/messages");
+  assert.equal(captured.init.headers.Authorization, "Bearer test-key");
+  const body = JSON.parse(captured.init.body);
+  assert.equal(body.model, "MiniMax-M3");
+  assert.equal(body.stream, true);
+  assert.equal(body.max_tokens, 100);
+});
+
+test("streamChatRequest sends an OpenRouter chat completions request", async () => {
+  const captured = {};
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    captured.url = url;
+    captured.init = init;
+    return fakeStreamResponse();
+  };
+  try {
+    await streamChatRequest({
+      provider: "openrouter",
+      baseUrl: "https://openrouter.ai/api/v1",
+      apiKey: "or-key",
+      model: "deepseek/deepseek-v4-flash",
+      fallbackModels: ["google/gemini-3-flash-preview"],
+      messages: [{ role: "user", content: "hi" }],
+      maxTokens: 100,
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+  assert.equal(captured.url, "https://openrouter.ai/api/v1/chat/completions");
+  const body = JSON.parse(captured.init.body);
+  assert.deepEqual(body.models, ["deepseek/deepseek-v4-flash", "google/gemini-3-flash-preview"]);
+  assert.equal(body.stream, true);
+  assert.equal(body.reasoning.enabled, false);
+});
+
+test("chatStreamDelta reads OpenRouter and MiniMax delta shapes", () => {
+  assert.equal(
+    chatStreamDelta({ choices: [{ delta: { content: "or" } }] }),
+    "or",
+  );
+  assert.equal(
+    chatStreamDelta({ delta: { text: "minimax" } }),
+    "minimax",
+  );
+  assert.equal(chatStreamDelta({ other: true }), null);
+});
+
+test("chatStreamModel reads OpenRouter and MiniMax model shapes", () => {
+  assert.equal(chatStreamModel({ model: "deepseek/deepseek-v4-flash" }), "deepseek/deepseek-v4-flash");
+  assert.equal(chatStreamModel({ message: { model: "MiniMax-M3" } }), "MiniMax-M3");
+  assert.equal(chatStreamModel({ other: true }), null);
+});
+
+test("chatStreamUsage reads the usage payload", () => {
+  assert.deepEqual(chatStreamUsage({ usage: { prompt_tokens: 10 } }), { prompt_tokens: 10 });
+  assert.equal(chatStreamUsage({ other: true }), null);
+});


### PR DESCRIPTION
Reason: Add a direct MiniMax chat provider so the Ask the Atlas RAG path can stream from MiniMax's Anthropic Messages-compatible endpoint instead of being OpenRouter-only.

## Changes
- Add `lib/chat-provider.js`: a single transport-selection module that resolves the active chat provider (`openrouter`, default, or `minimax`) and builds the streaming chat request for each. For MiniMax it targets the Anthropic Messages-compatible endpoint, supports the global (`api.minimax.io`) and China (`api.minimaxi.com`) regional hosts via `MINIMAX_REGION`, and serves the current MiniMax text models (`MiniMax-M3`, `MiniMax-M2.7`) via the `MINIMAX_MODELS` list. The module also exposes transport-agnostic SSE accessors (`chatStreamDelta`, `chatStreamModel`, `chatStreamUsage`) covering both OpenRouter (`choices[].delta.content` / `model` / `usage`) and MiniMax Anthropic (`delta.text` / `message.model` / `usage`) chunk shapes.
- Wire `api/chat.js` to use the new module: provider config is resolved once at module load, the API-key gate and the streaming fetch are dispatched per provider, and the SSE loop reads deltas/model/usage through the shared accessors. The OpenRouter waterfall is unchanged in behavior; the MiniMax path is opt-in via `CHAT_PROVIDER=minimax`.
- Add `tests/chat-provider.test.js` covering region resolution, model-list override, and the request shape for both transports.
- Document the new `CHAT_PROVIDER`, `MINIMAX_API_KEY`, `MINIMAX_REGION`, and `MINIMAX_MODELS` environment variables in the README env table.

## Checks
- `node --check api/chat.js`
- `node --check lib/chat-provider.js`
- `node --test tests/chat-provider.test.js` (10/10 passing)
- `node --test tests/openrouter.test.js` (existing OpenRouter tests still green)

MiniMax is reached through its OpenAI-compatible and Anthropic-compatible endpoints; the chatbot uses the Anthropic-compatible transport so the existing streaming parser keeps working without per-provider branching.
