### PR TITLE
Authenticate the smoke test's upstream release call and warn on rate limits

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -144,6 +144,9 @@ jobs:
         env:
           SMOKE_BASE: ${{ inputs.base || 'https://hermesatlas.com' }}
           SMOKE_SAMPLE: ${{ inputs.sample || '25' }}
+          # Raises the upstream release-freshness call from 60 req/hour per
+          # shared runner IP to 5000, which is what was intermittently 403ing.
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -o pipefail
           node scripts/smoke-test-prod.js \

--- a/scripts/smoke-test-prod.js
+++ b/scripts/smoke-test-prod.js
@@ -146,6 +146,15 @@ function fail(check, message, detail) {
   console.log(`  ${c.red("FAIL")}  ${check} ${c.dim(`- ${message}`)}`);
   if (VERBOSE && detail) console.log(c.dim(`        ${detail}`));
 }
+// A condition that is real but not a production defect — a shared-runner rate
+// limit, say. Recorded and printed like any other result so it can never pass
+// unnoticed, but kept out of `failures` so it does not fail the run.
+function warn(check, message, detail) {
+  results.push({ check, status: "warn", message, detail });
+  warnings.push({ check, message, detail });
+  console.log(`  ${c.yellow("WARN")}  ${check} ${c.dim(`- ${message}`)}`);
+  if (VERBOSE && detail) console.log(c.dim(`        ${detail}`));
+}
 function info(msg) {
   if (VERBOSE) console.log(c.dim(`  ${msg}`));
 }
@@ -376,10 +385,29 @@ await section("2. Public API contracts are semantically healthy", async () => {
           );
         }
       } else {
+        // Authenticate when a token is available: unauthenticated GitHub allows
+        // 60 requests/hour per IP, and Actions runners share IPs, so this call
+        // was intermittently 403ing and reporting production as stale when the
+        // only thing wrong was the rate limit.
+        const ghToken = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
         const upstreamResponse = await fetchWithTimeout(HERMES_RELEASES_URL, {
-          headers: { Accept: "application/vnd.github+json" },
+          headers: {
+            Accept: "application/vnd.github+json",
+            ...(ghToken ? { Authorization: `Bearer ${ghToken}` } : {}),
+          },
         });
-        if (!upstreamResponse.ok) {
+        const rateLimited =
+          (upstreamResponse.status === 403 || upstreamResponse.status === 429) &&
+          upstreamResponse.headers.get("x-ratelimit-remaining") === "0";
+        if (rateLimited) {
+          // Not a production defect — the site artifact was never inspected.
+          // Warn rather than fail, but stay loud about which check was skipped.
+          warn(
+            "latest release freshness",
+            `upstream rate limit (HTTP ${upstreamResponse.status}${ghToken ? "" : ", unauthenticated"}) — freshness not verified`,
+            HERMES_RELEASES_URL,
+          );
+        } else if (!upstreamResponse.ok) {
           fail("latest release freshness", `upstream HTTP ${upstreamResponse.status}`, HERMES_RELEASES_URL);
         } else {
           const upstreamReleases = await readJson(upstreamResponse, "latest release freshness");
@@ -698,12 +726,14 @@ const passed = results.filter((r) => r.status === "pass").length;
 const warned = results.filter((r) => r.status === "warn").length;
 const failed = results.filter((r) => r.status === "fail").length;
 const parts = [c.green(`${passed} passed`)];
-if (warned > 0) parts.push(c.yellow(`${warned} warned (acknowledged)`));
+if (warned > 0) parts.push(c.yellow(`${warned} warned`));
 parts.push(failed > 0 ? c.red(`${failed} failed`) : c.dim("0 failed"));
 console.log(`  ${parts.join(", ")}`);
 
 if (warnings.length > 0) {
-  console.log(c.bold("\nAcknowledged failures (not blocking)"));
+  // Covers both allow-listed acknowledgements and checks that could not be
+  // run (e.g. an upstream rate limit). Neither blocks, both stay visible.
+  console.log(c.bold("\nWarnings (not blocking)"));
   for (const w of warnings) {
     console.log(`  ${c.yellow("!")} ${w.check}: ${w.message}`);
     if (w.detail) console.log(c.dim(`     ${w.detail}`));

--- a/tests/post-deploy-smoke-workflow.test.js
+++ b/tests/post-deploy-smoke-workflow.test.js
@@ -19,6 +19,20 @@ test("post-deploy smoke seeds stars before enforcing semantic freshness", () => 
   assert.match(workflow, /if: github\.event_name == 'push'[\s\S]*?GITHUB_TOKEN: \$\{\{ github\.token \}\}[\s\S]*?CRON_SECRET: \$\{\{ secrets\.CRON_SECRET \}\}[\s\S]*?node scripts\/push-stars-snapshot\.js/);
 });
 
+// The release-freshness check calls the GitHub API. Unauthenticated that is 60
+// requests/hour per IP, and Actions runners share IPs, so the call 403'd and
+// reported production as stale when only the rate limit was at fault.
+test("post-deploy smoke authenticates the upstream release-freshness call", () => {
+  const smoke = workflow.indexOf("- name: Run smoke test");
+  assert.ok(smoke >= 0, "workflow must run the smoke test");
+  const step = workflow.slice(smoke);
+  assert.match(
+    step,
+    /SMOKE_BASE:[\s\S]*?GITHUB_TOKEN: \$\{\{ github\.token \}\}[\s\S]*?node scripts\/smoke-test-prod\.js/,
+    "smoke step must pass github.token so the upstream release call is authenticated",
+  );
+});
+
 test("post-deploy smoke closes the one active alert after recovery", () => {
   const smoke = workflow.indexOf("- name: Run smoke test");
   const recovery = workflow.indexOf("Close smoke alert after recovery");


### PR DESCRIPTION
Fixes the `latest release freshness: upstream HTTP 403` failure that has been red in the daily smoke test since yesterday.

## Root cause

`scripts/smoke-test-prod.js` called `api.github.com/repos/NousResearch/hermes-agent/releases` with no `Authorization` header, so it ran under the **unauthenticated limit of 60 requests/hour per IP** — and Actions runners share IPs. Confirmed against the live API:

```
unauthenticated  ->  x-ratelimit-limit: 60
authenticated    ->  x-ratelimit-limit: 5000
```

## Two changes

**1. Send `github.token`** when available — the actual fix.

**2. Treat a real rate limit as a warning, not a failure.** On `403`/`429` with `x-ratelimit-remaining: 0`, the site artifact was never inspected, so failing the check reports *production* as stale when the check simply didn't run. Any other non-OK status still fails.

The warning is recorded, printed inline, and listed in the summary — a skipped check stays visible rather than passing silently. Summary wording moves from "acknowledged failures" to "warnings", since it now covers both allow-listed acknowledgements and checks that couldn't run.

`smoke-test-pr.yml` is deliberately **untouched**: preview mode compares against the checkout and never calls upstream, so it needs no token.

## Verification

| Scenario | Result |
|---|---|
| Authenticated run against production | **PASS** — `latest release freshness - v0.19.0 (v2026.7.20)`, 34 checks, 0 failed |
| Mock upstream `403` + `x-ratelimit-remaining: 0` | **WARN**, exit 0, listed under Warnings |
| Mock upstream `500` | **FAIL**, exit 1 — the gate still fails loud |

`npm test` **267/267**, including a new assertion that the workflow keeps passing `github.token` to the smoke step so the wiring can't be silently dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)