### PR TITLE
Make the chat widget a first-class feature: a11y, empty state, citations

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -3,6 +3,7 @@ import { combinedRetrievalScore, enrichChunkMetadata } from "../lib/rag-scoring.
 import { buildLatestReleaseBlock, detectLatestReleaseQuery } from "../lib/latest-release.js";
 import { parseChunkStore } from "../lib/chunk-store.js";
 import { matchUseCases, buildUseCaseBlock, inferCategory } from "../lib/use-case-match.js";
+import { collectSourceLinks } from "../lib/source-links.js";
 import { readFileSync } from "fs";
 import { join } from "path";
 
@@ -665,11 +666,17 @@ ${retrievedContext}${useCaseBlock}${repoMetadataBlock}`;
     // data/use-cases.json, leaving loadUseCases() permanently empty) stays
     // observable from outside, instead of silently degrading to the old
     // full-catalog behavior while every check stays green.
-    if (actualModel || useCaseMatches.length > 0) {
+    //
+    // `sources` carries the citations the client renders as links. Only
+    // published pages resolve (see lib/source-links.js); Atlas-internal
+    // research is deliberately uncited rather than linked somewhere invented.
+    const sourceLinks = collectSourceLinks(scored);
+    if (actualModel || useCaseMatches.length > 0 || sourceLinks.length > 0) {
       const meta = { model: actualModel };
       if (useCaseMatches.length > 0) {
         meta.useCases = useCaseMatches.map((m) => m.useCase.slug);
       }
+      if (sourceLinks.length > 0) meta.sources = sourceLinks;
       const trailer = `\u200E__META__${JSON.stringify(meta)}__META__\u200E`;
       res.write(trailer);
     }

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -741,6 +741,94 @@
   padding-top: 6px;
   border-top: 1px solid var(--chat-rule-soft);
 }
+
+/* Cited sources — only published pages are ever linked (lib/source-links.js). */
+.chat-sources {
+  margin-top: 10px;
+  padding-top: 8px;
+  border-top: 1px solid var(--chat-rule-soft);
+}
+.chat-sources-label {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: var(--chat-ink-mute);
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+}
+.chat-sources ul {
+  list-style: none;
+  margin: 5px 0 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 10px;
+}
+.chat-sources li { margin: 0; }
+.chat-sources a {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--chat-accent);
+  border-bottom: 1px solid var(--chat-rule-soft);
+}
+.chat-sources a:hover,
+.chat-sources a:focus-visible { border-bottom-color: var(--chat-accent); }
+
+/* Streaming indicator. Replaces the old italic "searching…" text, which a
+   screen reader announced as though it were the answer. */
+.chat-loading-dots {
+  display: inline-flex;
+  gap: 4px;
+  align-items: center;
+}
+.chat-loading-dots i {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--chat-ink-mute);
+  animation: chat-dot 1.2s ease-in-out infinite;
+}
+.chat-loading-dots i:nth-child(2) { animation-delay: 0.15s; }
+.chat-loading-dots i:nth-child(3) { animation-delay: 0.3s; }
+@keyframes chat-dot {
+  0%, 100% { opacity: 0.25; }
+  50%      { opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .chat-loading-dots i { animation: none; opacity: 0.6; }
+}
+
+/* Empty state: starter questions, shown only before the first exchange. */
+.chat-starters {
+  padding: 0 20px 12px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.chat-starters[hidden] { display: none; }
+.chat-starters-label {
+  flex-basis: 100%;
+  margin: 0 0 2px;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: var(--chat-ink-mute);
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+}
+.chat-starter {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--chat-ink-dim);
+  background: transparent;
+  border: 1px solid var(--chat-rule);
+  padding: 5px 9px;
+  cursor: pointer;
+  text-align: left;
+}
+.chat-starter:hover,
+.chat-starter:focus-visible {
+  color: var(--chat-accent);
+  border-color: var(--chat-accent);
+}
 .chat-input-wrap {
   display: flex;
   gap: 0;

--- a/assets/js/homepage.js
+++ b/assets/js/homepage.js
@@ -348,21 +348,79 @@
     try { localStorage.removeItem(CHAT_STORAGE_KEY); } catch {}
     chatMessages.innerHTML = '';
     appendStaticMessage('assistant', WELCOME_MSG);
+    syncStarters();
   }
 
-  function appendStaticMessage(role, text, modelUsed) {
+  // Citations come from the API's meta trailer, already filtered to published
+  // pages with resolved URLs (lib/source-links.js). Built with createElement
+  // rather than innerHTML so a source label can never inject markup.
+  function appendSources(el, sources) {
+    if (!Array.isArray(sources) || sources.length === 0) return;
+    const wrap = document.createElement('div');
+    wrap.className = 'chat-sources';
+
+    const label = document.createElement('span');
+    label.className = 'chat-sources-label';
+    label.textContent = 'sources';
+    wrap.appendChild(label);
+
+    const list = document.createElement('ul');
+    for (const src of sources) {
+      if (!src || typeof src.url !== 'string') continue;
+      // Defense in depth: only ever render http(s) destinations.
+      if (!/^https:\/\//i.test(src.url)) continue;
+      const li = document.createElement('li');
+      const a = document.createElement('a');
+      a.href = src.url;
+      a.target = '_blank';
+      a.rel = 'noopener noreferrer';
+      a.textContent = src.label || src.url;
+      if (src.kind) a.title = src.kind + ' — ' + src.url;
+      li.appendChild(a);
+      list.appendChild(li);
+    }
+    if (!list.children.length) return;
+    wrap.appendChild(list);
+    el.appendChild(wrap);
+  }
+
+  function appendModelBadge(el, modelUsed) {
+    if (!modelUsed) return;
+    const badge = document.createElement('div');
+    badge.className = 'chat-model-badge';
+    badge.textContent = formatModelName(modelUsed);
+    badge.title = 'Answered by ' + modelUsed;
+    el.appendChild(badge);
+  }
+
+  function appendStaticMessage(role, text, modelUsed, sources) {
     const el = document.createElement('div');
     el.className = 'chat-msg chat-' + role;
     el.innerHTML = role === 'user' ? escapeHtml(text) : renderMarkdown(text);
-    if (role === 'assistant' && modelUsed) {
-      const badge = document.createElement('div');
-      badge.className = 'chat-model-badge';
-      badge.textContent = formatModelName(modelUsed);
-      badge.title = 'Answered by ' + modelUsed;
-      el.appendChild(badge);
+    if (role === 'assistant') {
+      appendSources(el, sources);
+      appendModelBadge(el, modelUsed);
     }
     chatMessages.appendChild(el);
     return el;
+  }
+
+  // Starter questions are the empty state: they show only before the first
+  // exchange, and disappear once there is a conversation to read.
+  const chatStarters = document.getElementById('chat-starters');
+
+  function syncStarters() {
+    if (!chatStarters) return;
+    chatStarters.hidden = chatHistory.length > 0;
+  }
+
+  if (chatStarters) {
+    for (const btn of chatStarters.querySelectorAll('.chat-starter')) {
+      btn.addEventListener('click', () => {
+        chatInput.value = btn.textContent.trim();
+        sendMessage();
+      });
+    }
   }
 
   function initChat() {
@@ -371,24 +429,88 @@
       chatHistory = saved;
       appendStaticMessage('assistant', WELCOME_MSG);
       for (const msg of saved) {
-        appendStaticMessage(msg.role, msg.content, msg.model);
+        appendStaticMessage(msg.role, msg.content, msg.model, msg.sources);
       }
     } else {
       appendStaticMessage('assistant', WELCOME_MSG);
     }
+    syncStarters();
   }
   initChat();
 
+  // ── Panel open/close, focus management ──
+  // The panel is a modal dialog: while it is open, Tab must not escape into the
+  // page behind it, Escape must close it, and focus must return to the trigger
+  // so a keyboard user is not dumped at the top of the document.
+  const FOCUSABLE = 'a[href], button:not([disabled]), input:not([disabled]), select, textarea, [tabindex]:not([tabindex="-1"])';
+
+  function chatIsOpen() {
+    return chatPanel.classList.contains('open');
+  }
+
+  function focusableInPanel() {
+    // Deliberately not an offsetParent check: the panel is position:fixed, so
+    // offsetParent is null for it and every descendant, which would leave the
+    // trap with nothing to cycle through. The only conditional visibility in
+    // here is the `hidden` attribute on the starters block, so test for that.
+    return Array.from(chatPanel.querySelectorAll(FOCUSABLE)).filter(
+      (el) => !el.disabled && !el.closest('[hidden]'),
+    );
+  }
+
+  function openChat() {
+    chatPanel.classList.add('open');
+    if (chatBtn) chatBtn.setAttribute('aria-expanded', 'true');
+    syncStarters();
+    chatInput.focus();
+    chatMessages.scrollTop = chatMessages.scrollHeight;
+  }
+
+  function closeChat({ restoreFocus = true } = {}) {
+    if (!chatIsOpen()) return;
+    chatPanel.classList.remove('open');
+    if (chatBtn) {
+      chatBtn.setAttribute('aria-expanded', 'false');
+      if (restoreFocus) chatBtn.focus();
+    }
+  }
+
   if (chatBtn) {
     chatBtn.addEventListener('click', () => {
-      chatPanel.classList.toggle('open');
-      if (chatPanel.classList.contains('open')) {
-        chatInput.focus();
-        chatMessages.scrollTop = chatMessages.scrollHeight;
-      }
+      if (chatIsOpen()) closeChat();
+      else openChat();
     });
-    chatClose.addEventListener('click', () => chatPanel.classList.remove('open'));
+    chatClose.addEventListener('click', () => closeChat());
   }
+
+  document.addEventListener('keydown', (e) => {
+    if (!chatIsOpen()) return;
+
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      closeChat();
+      return;
+    }
+
+    if (e.key !== 'Tab') return;
+    const items = focusableInPanel();
+    if (items.length === 0) return;
+    const first = items[0];
+    const last = items[items.length - 1];
+
+    // Wrap at both ends. Also catches the case where focus has drifted outside
+    // the panel entirely (e.g. a click on the page behind it).
+    if (!chatPanel.contains(document.activeElement)) {
+      e.preventDefault();
+      first.focus();
+    } else if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  });
   if (chatClear) {
     chatClear.addEventListener('click', () => {
       if (chatHistory.length === 0 || confirm('clear conversation history?')) {
@@ -396,6 +518,19 @@
         chatInput.focus();
       }
     });
+  }
+
+  // Visible "working" state. Replaces the old 'searching the research...'
+  // text, which a screen reader read as if it were the answer.
+  function buildLoadingSkeleton() {
+    const wrap = document.createElement('span');
+    wrap.className = 'chat-loading-dots';
+    for (let i = 0; i < 3; i++) wrap.appendChild(document.createElement('i'));
+    const sr = document.createElement('span');
+    sr.className = 'sr-only';
+    sr.textContent = 'searching the research…';
+    wrap.appendChild(sr);
+    return wrap;
   }
 
   async function sendMessage() {
@@ -407,10 +542,15 @@
     chatHistory.push({ role: 'user', content: msg });
     saveChatHistory();
 
+    syncStarters();
+
     chatSend.disabled = true;
     chatInput.disabled = true;
-    const loadingEl = appendMessage('assistant', 'searching the research...');
+    const loadingEl = appendMessage('assistant', '');
     loadingEl.classList.add('loading');
+    // Announce that work is in flight without narrating every streamed token.
+    loadingEl.setAttribute('aria-busy', 'true');
+    loadingEl.appendChild(buildLoadingSkeleton());
 
     try {
       const controller = new AbortController();
@@ -464,24 +604,25 @@
       clearTimeout(timeoutId);
 
       let modelUsed = null;
+      let sources = null;
       const trailerMatch = fullResponse.match(/\u200E__META__(.*?)__META__\u200E/);
       if (trailerMatch) {
-        try { modelUsed = JSON.parse(trailerMatch[1]).model; } catch {}
+        try {
+          const meta = JSON.parse(trailerMatch[1]);
+          modelUsed = meta.model;
+          if (Array.isArray(meta.sources)) sources = meta.sources;
+        } catch {}
         fullResponse = fullResponse.replace(trailerMatch[0], '');
       }
 
       if (!fullResponse.trim()) throw new Error('no response received. please try again.');
 
       loadingEl.innerHTML = renderMarkdown(fullResponse);
-      if (modelUsed) {
-        const badge = document.createElement('div');
-        badge.className = 'chat-model-badge';
-        badge.textContent = formatModelName(modelUsed);
-        badge.title = 'Answered by ' + modelUsed;
-        loadingEl.appendChild(badge);
-      }
+      loadingEl.removeAttribute('aria-busy');
+      appendSources(loadingEl, sources);
+      appendModelBadge(loadingEl, modelUsed);
 
-      chatHistory.push({ role: 'assistant', content: fullResponse, model: modelUsed });
+      chatHistory.push({ role: 'assistant', content: fullResponse, model: modelUsed, sources });
       saveChatHistory();
     } catch (e) {
       let msg = e.message || 'something went wrong. please try again.';
@@ -490,6 +631,7 @@
       }
       loadingEl.textContent = msg;
       loadingEl.classList.remove('loading');
+      loadingEl.removeAttribute('aria-busy');
       loadingEl.classList.add('error');
     } finally {
       chatSend.disabled = false;

--- a/index.html
+++ b/index.html
@@ -916,7 +916,7 @@
         <div class="repo-desc">Accelerating Long Context LLM Inference with Accuracy-Preserving Context Optimization in SGLang, vLLM, llama.cpp, OpenClaw, RAG, and Agentic AI.</div>
       </div>
       <div class="repo-delta">— / wk</div>
-    </a>
+    </a>
     <a class="repo-row" href="/projects/yepyhun/Brainstack" data-github="https://github.com/yepyhun/Brainstack" data-desc="Memory kernel stack for Hermes agent">
       <div class="repo-stars">★ 43</div>
       <div class="repo-body">
@@ -1434,7 +1434,7 @@
         <div class="repo-desc">17 specialized agents — research, planning, implementation, quality, infrastructure.</div>
       </div>
       <div class="repo-delta">— / wk</div>
-    </a>
+    </a>
     <a class="repo-row" href="/projects/agent-of-empires/agent-of-empires" data-github="https://github.com/agent-of-empires/agent-of-empires" data-desc="TUI and web control surface for managing multiple coding agents including Hermes Agent, Claude Code, OpenCode, Codex, Gemini, and others">
       <div class="repo-stars">★ 2,912</div>
       <div class="repo-body">
@@ -2157,11 +2157,11 @@
 </footer>
 
 <!-- Chat widget -->
-<button id="chat-btn" title="Ask the Atlas">ask the atlas</button>
-<aside id="chat-panel" aria-label="Atlas chat">
+<button id="chat-btn" title="Ask the Atlas" aria-expanded="false" aria-controls="chat-panel">ask the atlas</button>
+<aside id="chat-panel" role="dialog" aria-modal="true" aria-labelledby="chat-title">
   <div class="chat-header">
     <div>
-      <h3>ask the atlas</h3>
+      <h3 id="chat-title">ask the atlas</h3>
       <span>openrouter · grounded in research</span>
     </div>
     <div class="chat-header-actions">
@@ -2169,7 +2169,16 @@
       <button id="chat-close" title="Close" aria-label="Close chat">close</button>
     </div>
   </div>
-  <div id="chat-messages"></div>
+  <!-- Answers stream in here. aria-live announces them; aria-atomic="false" so
+       only the new message is read, not the whole transcript on every token. -->
+  <div id="chat-messages" aria-live="polite" aria-atomic="false"></div>
+  <div id="chat-starters" class="chat-starters" hidden>
+    <p class="chat-starters-label">try asking</p>
+    <button type="button" class="chat-starter">Which memory provider should I use?</button>
+    <button type="button" class="chat-starter">Hermes vs Claude Code?</button>
+    <button type="button" class="chat-starter">How do I install Hermes Agent?</button>
+    <button type="button" class="chat-starter">What can I build with it?</button>
+  </div>
   <div class="chat-input-wrap">
     <input type="text" id="chat-input" placeholder="ask anything about hermes agent..." aria-label="Ask a question">
     <button id="chat-send" title="Send">send</button>

--- a/lib/source-links.js
+++ b/lib/source-links.js
@@ -1,0 +1,94 @@
+/**
+ * Map a RAG chunk `source` to a public URL, so Ask the Atlas can cite its
+ * sources as links.
+ *
+ * Only *published* documentation resolves. The corpus also holds Atlas-internal
+ * research (`research/NN-*.md`, `repos/*.md`, `ECOSYSTEM.md`) that has no reader-
+ * facing page; those return null and the caller drops them rather than inventing
+ * a destination. That is ~9% of chunks — the docs mirror is the overwhelming
+ * majority and maps cleanly.
+ *
+ * Every mapping below was verified to return HTTP 200 before being added. If a
+ * new source prefix enters the corpus it stays uncited until it is mapped here,
+ * which is the safe direction: a missing citation is recoverable, a broken one
+ * is not.
+ */
+
+const UPSTREAM_DOCS = "https://hermes-agent.nousresearch.com/docs";
+const ATLAS = "https://hermesatlas.com";
+
+function titleize(segment) {
+  return segment
+    .replace(/\.md$/i, "")
+    .replace(/[-_]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/\b\w/g, (ch) => ch.toUpperCase());
+}
+
+/**
+ * @returns {{url: string, label: string, kind: string} | null}
+ */
+export function resolveSourceUrl(source) {
+  if (typeof source !== "string" || !source) return null;
+  const clean = source.trim();
+  if (!clean || clean.includes("..")) return null;
+
+  // Upstream Hermes docs mirror — the canonical home for these pages is Nous's
+  // docs site, not Atlas, so cite there.
+  if (clean.startsWith("research/docs/")) {
+    const path = clean.slice("research/docs/".length).replace(/\.md$/i, "");
+    if (!path) return null;
+    const segments = path.split("/").filter(Boolean);
+    if (segments.length === 0) return null;
+    return {
+      url: `${UPSTREAM_DOCS}/${segments.join("/")}`,
+      label: titleize(segments[segments.length - 1]),
+      kind: "Hermes docs",
+    };
+  }
+
+  // Atlas-published pages. These sources are already URL paths (they are
+  // recorded with a trailing slash by build-chunks), not file paths.
+  if (clean === "guide/" || clean.startsWith("guide/")) {
+    const path = clean.replace(/\/+$/, "");
+    const segments = path.split("/").filter(Boolean);
+    return {
+      url: `${ATLAS}/${segments.join("/")}/`,
+      label: segments.length > 1 ? titleize(segments[segments.length - 1]) : "Hermes Agent guide",
+      kind: "Atlas guide",
+    };
+  }
+
+  if (clean.startsWith("use-cases/")) {
+    const path = clean.replace(/\/+$/, "");
+    const segments = path.split("/").filter(Boolean);
+    if (segments.length < 2) return null;
+    return {
+      url: `${ATLAS}/${segments.join("/")}/`,
+      label: titleize(segments[segments.length - 1]),
+      kind: "Atlas use case",
+    };
+  }
+
+  // research/NN-*.md, repos/*.md, ECOSYSTEM.md — real sources, but no public
+  // page to point a reader at. Deliberately uncited.
+  return null;
+}
+
+/**
+ * Reduce retrieved chunks to a short, de-duplicated citation list.
+ * Order is preserved (chunks arrive ranked), so the strongest match leads.
+ */
+export function collectSourceLinks(chunks, limit = 4) {
+  const seen = new Set();
+  const out = [];
+  for (const chunk of chunks || []) {
+    const resolved = resolveSourceUrl(chunk?.source);
+    if (!resolved || seen.has(resolved.url)) continue;
+    seen.add(resolved.url);
+    out.push(resolved);
+    if (out.length >= limit) break;
+  }
+  return out;
+}

--- a/tests/chat-widget.test.js
+++ b/tests/chat-widget.test.js
@@ -1,0 +1,251 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { JSDOM } from "jsdom";
+
+// Behavioral tests for the chat widget's dialog semantics, empty state, and
+// source citations. Same harness as homepage-controls.test.js: jsdom does not
+// fetch external <script src>, so the app bundle is eval'd manually after parse,
+// which matches the `defer` semantics the real page relies on.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const html = fs.readFileSync(path.join(__dirname, "..", "index.html"), "utf8");
+const appJs = fs.readFileSync(
+  path.join(__dirname, "..", "assets", "js", "homepage.js"),
+  "utf8",
+);
+
+function loadHomepage({ runScripts = true, storage = null } = {}) {
+  const window = new JSDOM(html, {
+    url: "https://hermesatlas.com/",
+    runScripts: "dangerously",
+    beforeParse(win) {
+      win.fetch = () => Promise.reject(new Error("network disabled in test"));
+      if (storage !== null) {
+        try {
+          win.localStorage.setItem("hermes-chat-history-v1", JSON.stringify(storage));
+        } catch {}
+      }
+    },
+  }).window;
+  if (runScripts) window.eval(appJs);
+  return window;
+}
+
+function press(window, key, opts = {}) {
+  window.document.dispatchEvent(
+    new window.KeyboardEvent("keydown", { key, bubbles: true, ...opts }),
+  );
+}
+
+// ── Dialog semantics ──
+
+test("chat panel declares dialog semantics and a labelled title", () => {
+  const { document } = loadHomepage({ runScripts: false });
+  const panel = document.getElementById("chat-panel");
+
+  assert.equal(panel.getAttribute("role"), "dialog");
+  assert.equal(panel.getAttribute("aria-modal"), "true");
+  const labelledBy = panel.getAttribute("aria-labelledby");
+  assert.ok(labelledBy, "panel must be labelled by its heading");
+  assert.ok(document.getElementById(labelledBy), "aria-labelledby must resolve");
+});
+
+test("trigger advertises and tracks expanded state", () => {
+  const window = loadHomepage();
+  const { document } = window;
+  const btn = document.getElementById("chat-btn");
+
+  assert.equal(btn.getAttribute("aria-controls"), "chat-panel");
+  assert.equal(btn.getAttribute("aria-expanded"), "false");
+
+  btn.click();
+  assert.equal(btn.getAttribute("aria-expanded"), "true");
+
+  btn.click();
+  assert.equal(btn.getAttribute("aria-expanded"), "false");
+});
+
+test("streamed answers are announced without re-reading the transcript", () => {
+  const { document } = loadHomepage({ runScripts: false });
+  const messages = document.getElementById("chat-messages");
+
+  assert.equal(messages.getAttribute("aria-live"), "polite");
+  assert.equal(messages.getAttribute("aria-atomic"), "false");
+});
+
+// ── Keyboard behavior ──
+
+test("Escape closes the panel and returns focus to the trigger", () => {
+  const window = loadHomepage();
+  const { document } = window;
+  const btn = document.getElementById("chat-btn");
+  const panel = document.getElementById("chat-panel");
+
+  btn.click();
+  assert.ok(panel.classList.contains("open"));
+
+  press(window, "Escape");
+  assert.ok(!panel.classList.contains("open"), "Escape must close the panel");
+  assert.equal(btn.getAttribute("aria-expanded"), "false");
+  assert.equal(document.activeElement, btn, "focus must return to the trigger");
+});
+
+test("Escape is inert while the panel is closed", () => {
+  const window = loadHomepage();
+  const { document } = window;
+  const panel = document.getElementById("chat-panel");
+
+  assert.ok(!panel.classList.contains("open"));
+  press(window, "Escape"); // must not throw or toggle anything
+  assert.ok(!panel.classList.contains("open"));
+});
+
+test("Tab is trapped inside the open panel", () => {
+  const window = loadHomepage();
+  const { document } = window;
+  document.getElementById("chat-btn").click();
+
+  const panel = document.getElementById("chat-panel");
+  const items = Array.from(
+    panel.querySelectorAll('a[href], button:not([disabled]), input:not([disabled]), select, textarea, [tabindex]:not([tabindex="-1"])'),
+  );
+  assert.ok(items.length >= 2, "panel needs multiple focusables to trap");
+  const first = items[0];
+  const last = items[items.length - 1];
+
+  // Forward from the last element wraps to the first.
+  last.focus();
+  press(window, "Tab");
+  assert.equal(document.activeElement, first);
+
+  // Backward from the first wraps to the last.
+  first.focus();
+  press(window, "Tab", { shiftKey: true });
+  assert.equal(document.activeElement, last);
+});
+
+test("focus that drifted outside the panel is pulled back on Tab", () => {
+  const window = loadHomepage();
+  const { document } = window;
+  document.getElementById("chat-btn").click();
+
+  document.body.focus();
+  press(window, "Tab");
+  assert.ok(
+    document.getElementById("chat-panel").contains(document.activeElement),
+    "focus must be recaptured into the dialog",
+  );
+});
+
+// ── Empty state ──
+
+test("starter questions show on a fresh session and are real, sendable prompts", () => {
+  const { document } = loadHomepage();
+  const starters = document.getElementById("chat-starters");
+
+  assert.ok(starters, "starter container must exist");
+  assert.equal(starters.hidden, false, "starters show when there is no history");
+
+  const buttons = starters.querySelectorAll(".chat-starter");
+  assert.ok(buttons.length >= 3, "offer at least three starting points");
+  for (const b of buttons) {
+    assert.ok(b.textContent.trim().length > 0, "starter must have visible text");
+  }
+});
+
+test("starter click populates the input with its question", () => {
+  const { document } = loadHomepage();
+  document.getElementById("chat-btn").click();
+
+  const starter = document.querySelector(".chat-starter");
+  const expected = starter.textContent.trim();
+  starter.click();
+
+  // sendMessage() reads and clears the input, and the fetch stub rejects, so
+  // assert the question was routed rather than inspecting the cleared field.
+  const userMsgs = document.querySelectorAll(".chat-msg.chat-user");
+  assert.equal(userMsgs.length, 1, "clicking a starter must send it");
+  assert.equal(userMsgs[0].textContent.trim(), expected);
+});
+
+test("starters hide once a conversation exists", () => {
+  const { document } = loadHomepage({
+    storage: [
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "hello" },
+    ],
+  });
+  assert.equal(
+    document.getElementById("chat-starters").hidden,
+    true,
+    "starters must not compete with a restored transcript",
+  );
+});
+
+// ── Citations ──
+
+test("restored history renders cited sources as links", () => {
+  const { document } = loadHomepage({
+    storage: [
+      { role: "user", content: "how do I install it?" },
+      {
+        role: "assistant",
+        content: "Run the install script.",
+        sources: [
+          {
+            url: "https://hermes-agent.nousresearch.com/docs/getting-started/quickstart",
+            label: "Quickstart",
+            kind: "Hermes docs",
+          },
+        ],
+      },
+    ],
+  });
+
+  const link = document.querySelector(".chat-sources a");
+  assert.ok(link, "a cited source must render as a link");
+  assert.equal(link.getAttribute("href"), "https://hermes-agent.nousresearch.com/docs/getting-started/quickstart");
+  assert.equal(link.textContent, "Quickstart");
+  assert.equal(link.getAttribute("rel"), "noopener noreferrer");
+  assert.equal(link.getAttribute("target"), "_blank");
+});
+
+test("a message with no sources renders no citation block", () => {
+  const { document } = loadHomepage({
+    storage: [
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "hello", sources: [] },
+    ],
+  });
+  assert.equal(document.querySelector(".chat-sources"), null);
+});
+
+// Source labels originate from chunk paths. Rendering them via createElement
+// (not innerHTML) means a hostile label is inert text, and the scheme guard
+// keeps javascript: URLs out of href entirely.
+test("citation rendering neutralizes hostile labels and non-https URLs", () => {
+  const { document } = loadHomepage({
+    storage: [
+      { role: "user", content: "hi" },
+      {
+        role: "assistant",
+        content: "answer",
+        sources: [
+          { url: "javascript:alert(1)", label: "bad" },
+          { url: "http://insecure.example/doc", label: "insecure" },
+          { url: "https://hermesatlas.com/guide/", label: "<img src=x onerror=alert(1)>" },
+        ],
+      },
+    ],
+  });
+
+  const links = document.querySelectorAll(".chat-sources a");
+  assert.equal(links.length, 1, "only the https source may render");
+  assert.equal(links[0].getAttribute("href"), "https://hermesatlas.com/guide/");
+  assert.equal(links[0].querySelector("img"), null, "label must not become markup");
+  assert.equal(links[0].textContent, "<img src=x onerror=alert(1)>");
+});

--- a/tests/source-links.test.js
+++ b/tests/source-links.test.js
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { resolveSourceUrl, collectSourceLinks } from "../lib/source-links.js";
+
+// Every mapping here was verified against the live sites (HTTP 200) before the
+// rule was added. These tests lock the shape so a refactor cannot silently
+// start emitting 404s into user-facing citations.
+test("maps the upstream docs mirror to the canonical Nous docs URL", () => {
+  const r = resolveSourceUrl("research/docs/getting-started/quickstart.md");
+  assert.equal(r.url, "https://hermes-agent.nousresearch.com/docs/getting-started/quickstart");
+  assert.equal(r.kind, "Hermes docs");
+  assert.equal(r.label, "Quickstart");
+});
+
+test("preserves nested docs paths", () => {
+  const r = resolveSourceUrl("research/docs/user-guide/features/credential-pools.md");
+  assert.equal(
+    r.url,
+    "https://hermes-agent.nousresearch.com/docs/user-guide/features/credential-pools",
+  );
+  assert.equal(r.label, "Credential Pools");
+});
+
+test("maps Atlas guide and use-case sources to their published pages", () => {
+  assert.equal(resolveSourceUrl("guide/").url, "https://hermesatlas.com/guide/");
+  assert.equal(
+    resolveSourceUrl("guide/vs-claude-code/").url,
+    "https://hermesatlas.com/guide/vs-claude-code/",
+  );
+  const uc = resolveSourceUrl("use-cases/hermes-in-your-pocket/");
+  assert.equal(uc.url, "https://hermesatlas.com/use-cases/hermes-in-your-pocket/");
+  assert.equal(uc.kind, "Atlas use case");
+  assert.equal(uc.label, "Hermes In Your Pocket");
+});
+
+// The decision: sources with no reader-facing page are dropped, not linked
+// somewhere invented and not rendered as dead text.
+test("returns null for Atlas-internal research with no public page", () => {
+  assert.equal(resolveSourceUrl("research/00-landing-page.md"), null);
+  assert.equal(resolveSourceUrl("research/31-orange-book-complete-guide.md"), null);
+  assert.equal(resolveSourceUrl("repos/all-star-counts.md"), null);
+  assert.equal(resolveSourceUrl("ECOSYSTEM.md"), null);
+});
+
+test("rejects malformed, empty, and traversal-shaped sources", () => {
+  assert.equal(resolveSourceUrl(""), null);
+  assert.equal(resolveSourceUrl(null), null);
+  assert.equal(resolveSourceUrl(undefined), null);
+  assert.equal(resolveSourceUrl(42), null);
+  assert.equal(resolveSourceUrl("research/docs/../../etc/passwd"), null);
+  assert.equal(resolveSourceUrl("research/docs/"), null);
+});
+
+test("collectSourceLinks de-duplicates by URL and preserves rank order", () => {
+  const links = collectSourceLinks([
+    { source: "research/docs/getting-started/quickstart.md" },
+    { source: "research/00-landing-page.md" },
+    { source: "research/docs/getting-started/quickstart.md" },
+    { source: "guide/" },
+  ]);
+  assert.equal(links.length, 2);
+  assert.match(links[0].url, /quickstart$/);
+  assert.equal(links[1].url, "https://hermesatlas.com/guide/");
+});
+
+test("collectSourceLinks caps the list and tolerates junk input", () => {
+  const many = Array.from({ length: 12 }, (_, i) => ({
+    source: `research/docs/reference/cmd-${i}.md`,
+  }));
+  assert.equal(collectSourceLinks(many).length, 4);
+  assert.equal(collectSourceLinks(many, 2).length, 2);
+  assert.deepEqual(collectSourceLinks(null), []);
+  assert.deepEqual(collectSourceLinks([null, {}, { source: "" }]), []);
+});
+
+test("every emitted URL is https, so the client's scheme guard never trips", () => {
+  const links = collectSourceLinks([
+    { source: "research/docs/reference/cli-commands.md" },
+    { source: "use-cases/cut-your-token-bill/" },
+    { source: "guide/vs-claude-code/" },
+  ]);
+  assert.equal(links.length, 3);
+  for (const l of links) assert.match(l.url, /^https:\/\//);
+});


### PR DESCRIPTION
Roadmap item 13. The widget worked, but it wasn't usable without a mouse and gave no provenance for its answers.

## Accessibility

The panel was an `<aside>` with only an `aria-label` — no dialog role, no keyboard close, and Tab escaped into the page behind it.

- `role="dialog"` + `aria-modal="true"` + `aria-labelledby`; trigger gets `aria-expanded`/`aria-controls` and tracks state
- **Escape** closes and returns focus to the trigger
- **Tab** cycles within the panel, wrapping both directions and recapturing focus that has drifted outside
- `#chat-messages` gets `aria-live="polite"` + `aria-atomic="false"` — a streamed answer is announced once, not re-read per token

**A bug the tests caught:** my first focus-trap filtered on `offsetParent !== null`. The panel is `position: fixed`, so `offsetParent` is null for it *and every descendant* — the trap would have had nothing to cycle through. That would have shipped broken in real browsers, not just under jsdom. It now filters on `disabled` + `[hidden]` ancestry, the only conditional visibility actually present.

## Empty state

Four starter questions, shown before the first exchange and hidden once a transcript exists. One routes into the use-case bundles from #667.

The loading state was the literal string `'searching the research...'` — which a screen reader announced as if it were the answer. Now an animated indicator (stilled under `prefers-reduced-motion`) with `aria-busy` and an sr-only label.

## Cited sources

`api/chat.js` already emitted a `__META__` trailer with `model` and `useCases`; it now also carries resolved source links, rendered under each answer.

`lib/source-links.js` maps chunk sources to public URLs and returns `null` for anything unpublished:

| Source | Share | Cited as |
|---|---|---|
| `research/docs/**` | ~90% | `hermes-agent.nousresearch.com/docs/...` |
| `guide/**`, `use-cases/**` | ~1% | hermesatlas.com pages |
| `research/NN-*.md`, `repos/*.md`, `ECOSYSTEM.md` | ~9% | **not cited** — no reader-facing page |

Per your call, unlinkable sources are dropped rather than shown as dead text. Every mapping rule was verified against the live sites before being added, and a new source prefix stays uncited until mapped — a missing citation is recoverable, a broken one isn't.

Links are built with `createElement` and an https-only scheme guard, so a source label can never become markup.

## Verification

- **21 new tests**; `npm test` **288/288** (was 267).
- Behavioral jsdom coverage: Escape + focus return, Tab wrap both directions, focus recapture, `aria-expanded` tracking, starter click sends, citations render as links, no-sources renders no block, and hostile-label / `javascript:` / `http:` sources are all rejected.
- Against **real corpus data**: a simulated retrieval cites 2 of 6 chunks (4 correctly dropped), and both emitted URLs return **HTTP 200**.

## Scope

Homepage only — that's where the widget exists today. Extending it to project pages means touching the generated-page template and 217+ pages; that's the follow-up we discussed, kept separate to keep this reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)