### PR TITLE
Keep acronyms upper-case in chat source citations

### DIFF
--- a/lib/source-links.js
+++ b/lib/source-links.js
@@ -17,13 +17,29 @@
 const UPSTREAM_DOCS = "https://hermes-agent.nousresearch.com/docs";
 const ATLAS = "https://hermesatlas.com";
 
+// Terms that must not be sentence-cased. Without this, real doc paths render
+// as "Cli Commands" and "Faq" in the citation list.
+const ACRONYMS = new Map(
+  [
+    "ACP", "AI", "API", "CLI", "CI", "CPU", "CN", "CSS", "DNS", "FAQ", "GPU",
+    "GPT", "HTTP", "HTTPS", "IDE", "JSON", "LLM", "MCP", "OAuth", "RAG", "REST",
+    "RL", "SDK", "SQL", "SSH", "SSE", "TTS", "UI", "URL", "UX", "VS", "YAML",
+  ].map((a) => [a.toLowerCase(), a]),
+);
+
 function titleize(segment) {
   return segment
     .replace(/\.md$/i, "")
     .replace(/[-_]+/g, " ")
     .replace(/\s+/g, " ")
     .trim()
-    .replace(/\b\w/g, (ch) => ch.toUpperCase());
+    .split(" ")
+    .map((word) => {
+      const known = ACRONYMS.get(word.toLowerCase());
+      if (known) return known;
+      return word.charAt(0).toUpperCase() + word.slice(1);
+    })
+    .join(" ");
 }
 
 /**

--- a/tests/source-links.test.js
+++ b/tests/source-links.test.js
@@ -51,6 +51,21 @@ test("rejects malformed, empty, and traversal-shaped sources", () => {
   assert.equal(resolveSourceUrl("research/docs/"), null);
 });
 
+// Caught in real production output, where the live API cited "Cli Commands"
+// and "Faq" for an install question.
+test("labels keep acronyms upper-case instead of sentence-casing them", () => {
+  assert.equal(resolveSourceUrl("research/docs/reference/cli-commands.md").label, "CLI Commands");
+  assert.equal(resolveSourceUrl("research/docs/reference/faq.md").label, "FAQ");
+  assert.equal(resolveSourceUrl("research/docs/developer-guide/acp-internals.md").label, "ACP Internals");
+  assert.equal(resolveSourceUrl("research/docs/integrations/mcp-gateway.md").label, "MCP Gateway");
+  // Ordinary words are still capitalized normally.
+  assert.equal(resolveSourceUrl("research/docs/getting-started/quickstart.md").label, "Quickstart");
+  assert.equal(
+    resolveSourceUrl("research/docs/user-guide/features/credential-pools.md").label,
+    "Credential Pools",
+  );
+});
+
 test("collectSourceLinks de-duplicates by URL and preserves rank order", () => {
   const links = collectSourceLinks([
     { source: "research/docs/getting-started/quickstart.md" },


### PR DESCRIPTION
Follow-up to #691, caught in **live production output**.

Asking hermesatlas.com "How do I install Hermes Agent?" returned these citations:

```
Quickstart         ✓
Cli Commands       ✗  should be "CLI Commands"
Platform Support   ✓
Faq                ✗  should be "FAQ"
```

`titleize()` upper-cased the first letter of every word, which is wrong for the acronyms that run through the docs paths. Adds a lookup for the terms the corpus actually uses (CLI, FAQ, ACP, MCP, API, SDK, RAG, …) and leaves ordinary words untouched.

Verified against the exact four labels the live API returned, plus regression coverage that normal words still capitalize normally. `npm test` **289/289**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)