### PR TITLE
Move cognee to Memory & Context and add its homepage row

### DIFF
--- a/data/repos.json
+++ b/data/repos.json
@@ -2173,11 +2173,11 @@
     "owner": "topoteretes",
     "repo": "cognee",
     "name": "cognee",
-    "description": "Cognee is the open-source AI memory platform for agents. Give your AI agents persistent long-term memory across sessions with a self-hosted knowledge graph engine.",
+    "description": "Open-source AI memory platform — self-hosted knowledge graph plus vector search for persistent cross-session recall. The Hermes memory provider (cognee_recall / cognee_remember / cognee_forget) ships as a standalone plugin in topoteretes/cognee-integrations. Apache-2.0.",
     "stars": 29708,
     "url": "https://github.com/topoteretes/cognee",
     "official": false,
-    "category": "Skills & Skill Registries"
+    "category": "Memory & Context"
   },
   {
     "owner": "topoteretes",


### PR DESCRIPTION
Follow-up to #700, which added topoteretes/cognee automatically from #699.

Two things need fixing:

**Category.** It landed in Skills & Skill Registries because the suggestion form kept its default value. Cognee is a memory platform, so it belongs in Memory & Context. The wrong category also keeps it off /lists/best-memory-providers, since that page filters on `category === "Memory & Context"`.

**Description.** The bot copied the repo's GitHub blurb, which never mentions Hermes, so nothing on the entry explains why a general memory platform is on a Hermes map. Replaced with a description that names the provider, its tools and where the plugin lives, in the same shape as the mem0 and supermemory entries.

The Hermes plugin is in topoteretes/cognee-integrations under integrations/hermes-agent. It installs to `~/.hermes/plugins/cognee`, registers through the `hermes_agent.plugins` entry point, and is selected in `hermes memory setup`.

Also adds the `<a class="repo-row">` to index.html, which the bot PR skipped by design ("This PR only updates repos.json. The HTML map will need a manual update"), placed at star rank in Memory & Context, and bumps the three baked counters to 218 / 34.

Checks: `node scripts/validate-repos-json.js` passes at 218 repos; validate-repos-json, catalog-integrity, homepage-controls and seo-pages tests pass, except the sitemap assertion that needs build-pages to run.