### PR TITLE
Add handnewb/hermes-cybersec-lab to registry

### DIFF
--- a/data/repos.json
+++ b/data/repos.json
@@ -2208,5 +2208,15 @@
     "url": "https://github.com/freehul/progressive-skill",
     "official": false,
     "category": "Guides & Docs"
+  },
+  {
+    "owner": "handnewb",
+    "repo": "hermes-cybersec-lab",
+    "name": "Hermes Cybersecurity Lab",
+    "description": "Turnkey cybersecurity lab for Hermes Agent — 15+ preconfigured tools (nmap, nuclei, binwalk, volatility3, sqlmap, ffuf, masscan, radare2, gdb, scapy, impacket, pwntools), wordlists (SecLists, rockyou), forensics, structured methodology, and automated daily intelligence updates.",
+    "stars": 0,
+    "url": "https://github.com/handnewb/hermes-cybersec-lab",
+    "official": false,
+    "category": "Skills & Skill Registries"
   }
 ]


### PR DESCRIPTION
## Hermes Cybersecurity Lab

🛡️ Turnkey cybersecurity lab for Hermes Agent — 152+ preconfigured tools, 247 categorized skills, 23 frameworks, and automated installer.

### What's included
- **152 tools** across 18 security categories (network, exploitation, malware RE, forensics, cloud, CTI, OT/ICS, OSINT, SOC/SIEM, WAF, NDR/IDS, supply chain, etc.)
- **247 procedural skills** cataloged from real Hermes deployments across 15 domains
- **23 frameworks**: MITRE ATT&CK, D3FEND, ATLAS, F3, MISP, CVSS v4, EPSS, STIX/TAXII, OWASP Top 10, OWASP LLM Top 10, OWASP AST10, OWASP Agentic Applications Top 10, NIST CSF 2.0, NIST SP 800-53, NIST AI RMF, ISO 27001, CIS Controls v8, Sigma, YARA, FEND, and more
- **8 external repositories** referenced (1,900+ discoverable skills)
- One-shot installer script (7 phases)
- Living methodology & findings log

### Category
Skills & Skill Registries

### Links
- Repo: https://github.com/handnewb/hermes-cybersec-lab
- License: MIT