### PR TITLE
Add handnewb/hermes-cybersec-lab to Skills & Skill Registries

### DIFF
--- a/data/repos.json
+++ b/data/repos.json
@@ -2238,5 +2238,15 @@
     "url": "https://github.com/jiawood2006/hermes-skills",
     "official": false,
     "category": "Skills & Skill Registries"
+  },
+  {
+    "owner": "handnewb",
+    "repo": "hermes-cybersec-lab",
+    "name": "hermes-cybersec-lab",
+    "description": "Turnkey cybersecurity lab for Hermes Agent — 1,927 skills, 131+ tools, 23 frameworks (MITRE ATT&CK, MISP, CVSS, EPSS, OWASP, NIST, ISO, Sigma, YARA). One-command ecosystem clone across 8 repos.",
+    "stars": 2,
+    "url": "https://github.com/handnewb/hermes-cybersec-lab",
+    "official": false,
+    "category": "Skills & Skill Registries"
   }
 ]


### PR DESCRIPTION
Resubmission after the previous PR (#739) was closed — counts updated after recent audit.

Adds [handnewb/hermes-cybersec-lab](https://github.com/handnewb/hermes-cybersec-lab) to the ecosystem map.

**Stars:** 2
**Category:** Skills & Skill Registries
**Description:** Turnkey cybersecurity lab for Hermes Agent — 1,927 skills, 131+ tools, 23 frameworks (MITRE ATT&CK, MISP, CVSS, EPSS, OWASP, NIST, ISO, Sigma, YARA). One-command ecosystem clone across 8 repos.

### What changed since PR #739

| Item | Before | After |
|---|---|---|
| Skills | 247 | **1,927** (247 embedded + 1,680 across 7 external repos) |
| Tools | 152 | **131+** (verified, categorized) |
| Clone method | Manual, piecemeal | **1 command**: `bash scripts/clone-all.sh` |
| README | Misleading counts (15 tools) | Accurate breakdown with ecosystem diagram |

> Note: This PR only updates repos.json. The HTML map will need a manual update to include the new chip, or will be picked up in the next full refresh.