### PR TITLE
Update Hermes-OTG listing: new tagline + overview copy

### DIFF
--- a/projects/MilkyWay008/Hermes-OTG.html
+++ b/projects/MilkyWay008/Hermes-OTG.html
@@ -4,20 +4,20 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>MilkyWay008/Hermes-OTG — Hermes Agent Deployment &amp; Infra | Hermes Atlas</title>
-<meta name="description" content="Hermes OTG is a portable, zero-install distribution of the Hermes Agent designed for Windows 10 and 11. It functions as a TUI, a full desktop application, or a…">
+<meta name="description" content="Hermes OTG is a portable, zero-install, instant-run distribution of the Hermes Agent on a USB stick for Win10/11 — your agentic system rescue companion for when updates break your host. No host pollution, runs side-by-side with your installed Hermes.">
 <link rel="canonical" href="https://hermesatlas.com/projects/MilkyWay008/Hermes-OTG">
 <meta property="og:title" content="MilkyWay008/Hermes-OTG — Hermes Atlas">
-<meta property="og:description" content="Hermes OTG is a portable, zero-install distribution of the Hermes Agent designed for Windows 10 and 11. It functions as a TUI, a full desktop application, or a…">
+<meta property="og:description" content="Hermes OTG is a portable, zero-install, instant-run distribution of the Hermes Agent on a USB stick for Win10/11 — your agentic system rescue companion for when updates break your host. No host pollution, runs side-by-side with your installed Hermes.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/MilkyWay008/Hermes-OTG">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=Hermes-OTG&amp;subtitle=Hermes+OTG+%E2%80%94+The+Portable+Hermes+Agent+That+Does+*Everything*.+Full+production+package+distributed+via+GitHub+Releases+%28see+PACKAGE-STRUCTURE.md%29.&amp;kind=project+%C2%B7+deployment">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=Hermes-OTG&amp;subtitle=Your+agentic+system+rescue+companion%2C+especially+for+broken+host+Hermes.+Hermes+Agent+on+a+USB+stick+%E2%80%94+zero+install+%26+portable%2C+hot-swappable+%26+instant+full+agent+power+on+any+PC.&amp;kind=project+%C2%B7+deployment">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="MilkyWay008/Hermes-OTG — Hermes Atlas">
-<meta name="twitter:description" content="Hermes OTG is a portable, zero-install distribution of the Hermes Agent designed for Windows 10 and 11. It functions as a TUI, a full desktop application, or a…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Hermes-OTG&amp;subtitle=Hermes+OTG+%E2%80%94+The+Portable+Hermes+Agent+That+Does+*Everything*.+Full+production+package+distributed+via+GitHub+Releases+%28see+PACKAGE-STRUCTURE.md%29.&amp;kind=project+%C2%B7+deployment">
+<meta name="twitter:description" content="Hermes OTG is a portable, zero-install, instant-run distribution of the Hermes Agent on a USB stick for Win10/11 — your agentic system rescue companion for when updates break your host. No host pollution, runs side-by-side with your installed Hermes.">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Hermes-OTG&amp;subtitle=Your+agentic+system+rescue+companion%2C+especially+for+broken+host+Hermes.+Hermes+Agent+on+a+USB+stick+%E2%80%94+zero+install+%26+portable%2C+hot-swappable+%26+instant+full+agent+power+on+any+PC.&amp;kind=project+%C2%B7+deployment">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -35,7 +35,7 @@
   "@type": "SoftwareApplication",
   "@id": "https://hermesatlas.com/projects/MilkyWay008/Hermes-OTG#software",
   "name": "Hermes-OTG",
-  "description": "Hermes OTG is a portable, zero-install distribution of the Hermes Agent designed for Windows 10 and 11. It functions as a TUI, a full desktop application, or a gateway and is designed to run from any drive or folder without host pollution.",
+  "description": "Hermes OTG is a portable, zero-install distribution of the Hermes Agent on a USB stick, designed for Win10/11. It runs from any drive or folder — as full Desktop app, TUI, or Gateway — with zero host pollution, and can run side-by-side with an installed Hermes. It's the agentic system rescue companion; it comes in handy when an update breaks your installed host Hermes.",
   "url": "https://hermesatlas.com/projects/MilkyWay008/Hermes-OTG",
   "codeRepository": "https://github.com/MilkyWay008/Hermes-OTG",
   "applicationCategory": "DeveloperApplication",
@@ -116,7 +116,7 @@
   <h1 class="project-name">
     <span class="org">MilkyWay008</span><span class="slash">/</span>Hermes-OTG
   </h1>
-  <p class="project-desc">Hermes OTG — The Portable Hermes Agent That Does *Everything*. Full production package distributed via GitHub Releases (see PACKAGE-STRUCTURE.md).</p>
+  <p class="project-desc">Your agentic system rescue companion, especially for broken host Hermes. Hermes Agent on a USB stick — zero install &amp; portable, hot-swappable &amp; instant full agent power on any PC.</p>
 
   <div class="meta-row">
     <span class="stars">★ 4</span>
@@ -138,11 +138,12 @@
 <section class="project-summary">
   <div class="section-label">overview</div>
   <div>
-    <p class="summary-text">Hermes OTG is a portable, zero-install distribution of the Hermes Agent designed for Windows 10 and 11. It functions as a TUI, a full desktop application, or a gateway and is designed to run from any drive or folder without host pollution.</p>
+    <p class="summary-text">Hermes OTG is a portable, zero-install distribution of the Hermes Agent on a USB stick, designed for Win10/11. It runs from any drive or folder — as full Desktop app, TUI, or Gateway — with zero host pollution, and can run side-by-side with an installed Hermes. It's the agentic system rescue companion; it comes in handy when an update breaks your installed host Hermes.</p>
     <ul class="summary-highlights">
-      <li>Runs as TUI, Desktop app, or Gateway</li>
-      <li>Includes bundled CPython 3.12 and PortableGit</li>
-      <li>Supports side-by-side execution with installed Hermes</li>
+      <li>Runs as Desktop app, TUI, or Gateway — side-by-side with installed host Hermes</li>
+      <li>Zero install &amp; portable: instant run from any USB drive or folder, no host pollution</li>
+      <li>Bundled CPython 3.12 + PortableGit, fully offline-capable</li>
+      <li>The rescue companion for broken host Hermes deployments</li>
     </ul>
   </div>
 </section>
@@ -154,7 +155,7 @@
   <img src="https://raw.githubusercontent.com/NousResearch/hermes-agent/main/assets/banner.png" alt="Hermes Agent banner" width="100%">
 </p>
 
-<h2><p align="center">🚀 Hermes OTG — The Portable Hermes Agent That Does <em>Everything</em></p></h2>
+<h2><p align="center">🚀 Hermes OTG — Your Pocket Agent System Rescue Companion</p></h2>
 <p align="center">
   <strong>Full-featured Hermes Agent on a USB stick. Zero install. Zero host pollution.</strong><br>
   Run it from any drive, any folder, any Windows 10/11 machine — as TUI, full Desktop app, or Gateway.<br>


### PR DESCRIPTION
Refresh the Hermes-OTG project listing to match the project's new positioning (repo description + README updated on the source repo).

**Changes:**
- `project-desc`: new tagline — "Your agentic system rescue companion, especially for broken host Hermes..."
- `summary-text` + `summary-highlights`: refreshed overview copy (USB stick, zero install, side-by-side, rescue angle)
- meta/og/twitter descriptions: instant-run version with the rescue hook up front
- og:image subtitle: new tagline (was the old "Does *Everything*" tag)
- embedded README H1 snapshot: "Your Pocket Agent System Rescue Companion"

Minor copy refresh only — no structural changes.