### PR TITLE
Add OrcaRouter gateway switch for chat, summaries, and embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,26 @@ OPENROUTER_API_KEY=sk-or-... node scripts/test-rag.js
 | Variable | Purpose | Required |
 |----------|---------|----------|
 | `GITHUB_TOKEN` | Fine-grained PAT, public repos read-only | For 5000/hr rate limit (60/hr without) |
-| `OPENROUTER_API_KEY` | LLM API key for chat | Yes |
+| `OPENROUTER_API_KEY` | LLM API key for chat (OpenRouter gateway) | Yes, unless `CHAT_GATEWAY=orcarouter` |
 | `REDIS_URL` | Redis Cloud connection string | Yes (for cache + history) |
 | `OPENROUTER_MODEL` | Override primary LLM model | No (default: `deepseek/deepseek-v4-flash`) |
 | `OPENROUTER_FALLBACK_MODELS` | Comma-separated fallback chain | No (default: `google/gemini-3-flash-preview,google/gemini-3.1-flash-lite-preview`) |
+| `CHAT_GATEWAY` | Chat LLM gateway: `openrouter` (default) or `orcarouter` | No |
+| `ORCAROUTER_API_KEY` | LLM API key for chat when `CHAT_GATEWAY=orcarouter` | Yes when using the OrcaRouter gateway |
+| `ORCAROUTER_MODEL` | Override the OrcaRouter chat/rewrite model | No (default: `deepseek/deepseek-v4-flash`) |
+| `LLM_GATEWAY` | Gateway for batch summary scripts (`generate-summaries.js`, `audit-summaries.js`): `openrouter` (default) or `orcarouter` | No |
+
+### OrcaRouter gateway
+
+The site's LLM calls default to [OpenRouter](https://openrouter.ai). You can switch the
+chat endpoint (answer streaming, query rewrite, and embeddings) to
+[OrcaRouter](https://www.orcarouter.ai) by setting `CHAT_GATEWAY=orcarouter` and
+`ORCAROUTER_API_KEY`, and the batch summary scripts by setting `LLM_GATEWAY=orcarouter`.
+OrcaRouter is an OpenAI-compatible model routing gateway that requires namespaced model
+IDs (for example `deepseek/deepseek-v4-flash`, `openai/gpt-5.5`). It also runs
+gateway-level, zero-trust security for AI agents on the same endpoint — screening every
+prompt/response and governing every tool call on a default-deny basis, with no application
+code changes.
 
 ## Contributing
 

--- a/api/chat.js
+++ b/api/chat.js
@@ -238,7 +238,15 @@ function mmrSelect(candidates, queryEmbedding, k, lambda = 0.6) {
   return selected;
 }
 
+// LLM gateway: "openrouter" (default) or "orcarouter".
+// OrcaRouter is an OpenAI-compatible model routing gateway; when selected, the
+// answer, query rewrite, and embeddings paths all target
+// https://api.orcarouter.ai/v1 using ORCAROUTER_API_KEY.
+const CHAT_GATEWAY = process.env.CHAT_GATEWAY || "openrouter";
+const isOrcaRouter = CHAT_GATEWAY === "orcarouter";
+
 const OPENROUTER_KEY = process.env.OPENROUTER_API_KEY;
+const ORCAROUTER_KEY = process.env.ORCAROUTER_API_KEY;
 
 // Model config — supports primary + fallback via OpenRouter's native routing.
 // OpenRouter caps the models array at 3 total.
@@ -280,6 +288,12 @@ const FALLBACK_MODELS = (process.env.OPENROUTER_FALLBACK_MODELS ||
   "google/gemini-3.1-flash-lite-preview"
 ).split(",").map(s => s.trim()).filter(Boolean).slice(0, 2);
 
+// OrcaRouter gateway config (CHAT_GATEWAY=orcarouter). OrcaRouter takes a
+// single `model` field (no `models` fallback array), so the waterfall is
+// collapsed to one namespaced model ID. Reasoning is disabled per-request via
+// `thinking: { type: "disabled" }` (OrcaRouter honours `thinking.type`).
+const ORCAROUTER_MODEL = process.env.ORCAROUTER_MODEL || "deepseek/deepseek-v4-flash";
+
 const MAX_TOKENS = parseInt(process.env.CHAT_MAX_TOKENS || "1200");
 
 // Per-IP rate limits
@@ -295,7 +309,7 @@ export default async function handler(req, res) {
     return res.status(405).json({ error: "Method not allowed" });
   }
 
-  if (!OPENROUTER_KEY) {
+  if (isOrcaRouter ? !ORCAROUTER_KEY : !OPENROUTER_KEY) {
     return res.status(500).json({ error: "Chat not configured — missing API key" });
   }
 
@@ -548,39 +562,63 @@ ${retrievedContext}${useCaseBlock}${repoMetadataBlock}`;
     ];
 
     // 6. Stream from LLM
-    const llmRes = await fetch("https://openrouter.ai/api/v1/chat/completions", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${OPENROUTER_KEY}`,
-        "Content-Type": "application/json",
-        "HTTP-Referer": "https://hermesatlas.com",
-        "X-Title": "Hermes Atlas",
-      },
-      signal: ac.signal,
-      body: JSON.stringify({
-        // OpenRouter native fallback — pass ONLY `models` array (no `model` field)
-        // It will try each in order until one succeeds
-        ...(FALLBACK_MODELS.length > 0
-          ? { models: [PRIMARY_MODEL, ...FALLBACK_MODELS] }
-          : { model: PRIMARY_MODEL }),
-        messages,
-        stream: true,
-        max_tokens: MAX_TOKENS,
-        temperature: 0.3,
-        // Ask OpenRouter to include token usage (and cost) in the final SSE
-        // chunk. That chunk may carry an empty choices array — the parser below
-        // tolerates it (it only reads choices[0] optionally).
-        usage: { include: true },
-        // Force reasoning OFF. Our SSE parser reads only delta.content; a
-        // reasoning-capable model streams to delta.reasoning (empty answer to
-        // us) or burns the whole token budget on hidden thinking. `enabled:
-        // false` stops the generation entirely — unlike `exclude: true`, which
-        // only hides reasoning from the response while still billing for it.
-        // Also insures against the unpinned preview alias silently shipping a
-        // reasoning-on provider revision.
-        reasoning: { enabled: false },
-      }),
-    });
+    const llmRes = await fetch(
+      isOrcaRouter
+        ? "https://api.orcarouter.ai/v1/chat/completions"
+        : "https://openrouter.ai/api/v1/chat/completions",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${isOrcaRouter ? ORCAROUTER_KEY : OPENROUTER_KEY}`,
+          "Content-Type": "application/json",
+          // OpenRouter requires attribution headers; OrcaRouter does not.
+          ...(isOrcaRouter
+            ? {}
+            : { "HTTP-Referer": "https://hermesatlas.com", "X-Title": "Hermes Atlas" }),
+        },
+        signal: ac.signal,
+        body: JSON.stringify(
+          isOrcaRouter
+            ? {
+                // OrcaRouter is OpenAI-compatible: a single namespaced `model`
+                // (no `models` fallback array). Reasoning is disabled via
+                // `thinking: { type: "disabled" }` — the same discipline as the
+                // OpenRouter `reasoning: { enabled: false }` below: a reasoning
+                // model would otherwise stream to `delta.reasoning` and return
+                // empty content to our parser.
+                model: ORCAROUTER_MODEL,
+                messages,
+                stream: true,
+                max_tokens: MAX_TOKENS,
+                temperature: 0.3,
+                thinking: { type: "disabled" },
+              }
+            : {
+                // OpenRouter native fallback — pass ONLY `models` array (no `model` field)
+                // It will try each in order until one succeeds
+                ...(FALLBACK_MODELS.length > 0
+                  ? { models: [PRIMARY_MODEL, ...FALLBACK_MODELS] }
+                  : { model: PRIMARY_MODEL }),
+                messages,
+                stream: true,
+                max_tokens: MAX_TOKENS,
+                temperature: 0.3,
+                // Ask OpenRouter to include token usage (and cost) in the final SSE
+                // chunk. That chunk may carry an empty choices array — the parser below
+                // tolerates it (it only reads choices[0] optionally).
+                usage: { include: true },
+                // Force reasoning OFF. Our SSE parser reads only delta.content; a
+                // reasoning-capable model streams to delta.reasoning (empty answer to
+                // us) or burns the whole token budget on hidden thinking. `enabled:
+                // false` stops the generation entirely — unlike `exclude: true`, which
+                // only hides reasoning from the response while still billing for it.
+                // Also insures against the unpinned preview alias silently shipping a
+                // reasoning-on provider revision.
+                reasoning: { enabled: false },
+              }
+        ),
+      }
+    );
 
     if (!llmRes.ok) {
       const err = await llmRes.text();
@@ -817,31 +855,49 @@ ${historyText}
 Latest: ${message}
 Rewritten:`;
 
-    const res = await fetch("https://openrouter.ai/api/v1/chat/completions", {
-      method: "POST",
-      signal,
-      headers: {
-        Authorization: `Bearer ${OPENROUTER_KEY}`,
-        "Content-Type": "application/json",
-        "HTTP-Referer": "https://hermesatlas.com",
-        "X-Title": "Hermes Atlas — Query Rewriter",
-      },
-      body: JSON.stringify({
-        // Query rewriting needs fast, reliable, non-reasoning models with good
-        // instruction following. Avoid reasoning models (GLM-4.7-Flash) which
-        // put output in a 'reasoning' field and return null content.
-        // All three options below are paid but cost fractions of a cent per call.
-        models: [
-          "google/gemini-3.1-flash-lite-preview",
-          "qwen/qwen3.5-flash-02-23",
-          "mistralai/mistral-small-2603",
-        ],
-        messages: [{ role: "user", content: rewritePrompt }],
-        max_tokens: 100,
-        temperature: 0,
-        stop: ["\n\n", "History:", "Latest:"],
-      }),
-    });
+    const res = await fetch(
+      isOrcaRouter
+        ? "https://api.orcarouter.ai/v1/chat/completions"
+        : "https://openrouter.ai/api/v1/chat/completions",
+      {
+        method: "POST",
+        signal,
+        headers: {
+          Authorization: `Bearer ${isOrcaRouter ? ORCAROUTER_KEY : OPENROUTER_KEY}`,
+          "Content-Type": "application/json",
+          ...(isOrcaRouter
+            ? {}
+            : { "HTTP-Referer": "https://hermesatlas.com", "X-Title": "Hermes Atlas — Query Rewriter" }),
+        },
+        body: JSON.stringify(
+          isOrcaRouter
+            ? {
+                // Single namespaced model + reasoning disabled (see main request).
+                model: ORCAROUTER_MODEL,
+                messages: [{ role: "user", content: rewritePrompt }],
+                max_tokens: 100,
+                temperature: 0,
+                stop: ["\n\n", "History:", "Latest:"],
+                thinking: { type: "disabled" },
+              }
+            : {
+                // Query rewriting needs fast, reliable, non-reasoning models with good
+                // instruction following. Avoid reasoning models (GLM-4.7-Flash) which
+                // put output in a 'reasoning' field and return null content.
+                // All three options below are paid but cost fractions of a cent per call.
+                models: [
+                  "google/gemini-3.1-flash-lite-preview",
+                  "qwen/qwen3.5-flash-02-23",
+                  "mistralai/mistral-small-2603",
+                ],
+                messages: [{ role: "user", content: rewritePrompt }],
+                max_tokens: 100,
+                temperature: 0,
+                stop: ["\n\n", "History:", "Latest:"],
+              }
+        ),
+      }
+    );
 
     if (!res.ok) {
       console.warn("Query rewrite failed, using original");
@@ -884,15 +940,20 @@ async function getEmbedding(text, signal) {
   };
   if (corpusDim && corpusDim !== 1536) body.dimensions = corpusDim;
 
-  const res = await fetch("https://openrouter.ai/api/v1/embeddings", {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${OPENROUTER_KEY}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(body),
-    signal,
-  });
+  const res = await fetch(
+    isOrcaRouter
+      ? "https://api.orcarouter.ai/v1/embeddings"
+      : "https://openrouter.ai/api/v1/embeddings",
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${isOrcaRouter ? ORCAROUTER_KEY : OPENROUTER_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+      signal,
+    }
+  );
 
   if (!res.ok) throw new Error(`Embedding error: ${res.status}`);
   const data = await res.json();

--- a/lib/orcarouter.js
+++ b/lib/orcarouter.js
@@ -1,0 +1,144 @@
+/**
+ * Shared OrcaRouter LLM call helper with retry.
+ *
+ * [OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible model routing
+ * gateway. It requires namespaced model IDs (`deepseek/deepseek-v4-flash`,
+ * `openai/gpt-5.5`, ...) and takes a single `model` field — unlike the
+ * OpenRouter helper, which sends a `models` fallback array with `route:
+ * "fallback"`. Reasoning is disabled via `thinking: { type: "disabled" }` so
+ * batch outputs land in `content`, not `reasoning_content` (a reasoning-capable
+ * model such as deepseek-v4-flash otherwise burns its whole token budget on
+ * hidden thinking and returns an empty `content`).
+ *
+ * Mirror of `lib/openrouter.js` used by the batch summary scripts when
+ * `LLM_GATEWAY=orcarouter`.
+ */
+const DEFAULT_MODEL = "deepseek/deepseek-v4-flash";
+
+// Exponential backoff for transient failures: 1s, 2s, 4s between retries.
+// Total max wait is ~7s — small enough not to balloon CI runtime, large
+// enough to ride out a typical 429 burst or brief upstream blip.
+const RETRY_DELAYS_MS = [1000, 2000, 4000];
+const JSON_RETRY_DELAYS_MS = [250, 750];
+
+async function callOrcaRouterOnce({ system, user, apiKey, model, maxTokens }) {
+  const res = await fetch("https://api.orcarouter.ai/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model,
+      messages: [
+        { role: "system", content: system },
+        { role: "user", content: user },
+      ],
+      max_tokens: maxTokens,
+      temperature: 0.3,
+      thinking: { type: "disabled" },
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    const err = new Error(`OrcaRouter ${res.status}: ${body.slice(0, 200)}`);
+    err.status = res.status;
+    throw err;
+  }
+
+  const data = await res.json();
+  const content = data.choices?.[0]?.message?.content;
+  if (!content) throw new Error("Empty response from OrcaRouter");
+
+  return content;
+}
+
+/**
+ * Call OrcaRouter with retry on transient errors.
+ *
+ * Retries on 429 (rate limit), 5xx (server error), and network failures.
+ * Does NOT retry on 4xx (bad request, missing key, etc.) — those are caller bugs.
+ *
+ * @param {Object} options
+ * @param {string} options.system - System prompt
+ * @param {string} options.user - User prompt
+ * @param {string} options.apiKey - OrcaRouter API key
+ * @param {string} [options.model] - Namespaced model ID (default: `deepseek/deepseek-v4-flash`)
+ * @param {number} [options.maxTokens=800] - Max output tokens
+ * @returns {Promise<string>} Raw response text
+ */
+export async function callOrcaRouter({
+  system,
+  user,
+  apiKey,
+  model = DEFAULT_MODEL,
+  maxTokens = 800,
+}) {
+  if (!apiKey) throw new Error("OrcaRouter API key required");
+
+  const args = { system, user, apiKey, model, maxTokens };
+
+  let lastError;
+  for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt++) {
+    try {
+      return await callOrcaRouterOnce(args);
+    } catch (err) {
+      lastError = err;
+
+      // Retryable: HTTP 429, any 5xx, or no status (network/DNS/timeout).
+      // Non-retryable: 4xx other than 429 (auth, malformed prompt, etc.).
+      const isRetryable = !err.status || err.status === 429 || err.status >= 500;
+      const isLastAttempt = attempt === RETRY_DELAYS_MS.length;
+
+      if (!isRetryable || isLastAttempt) throw err;
+
+      const delay = RETRY_DELAYS_MS[attempt];
+      console.warn(
+        `OrcaRouter ${err.status || "network error"} — retrying in ${delay}ms (attempt ${attempt + 1}/${RETRY_DELAYS_MS.length})`
+      );
+      await new Promise((r) => setTimeout(r, delay));
+    }
+  }
+  throw lastError; // unreachable, but keeps TS/lints happy
+}
+
+/**
+ * Call OrcaRouter and parse the response as JSON.
+ * Strips markdown code fences if present.
+ *
+ * @param {Object} options - Same as callOrcaRouter
+ * @returns {Promise<Object>} Parsed JSON object
+ */
+export async function callOrcaRouterJSON({
+  jsonRetryDelaysMs = JSON_RETRY_DELAYS_MS,
+  ...options
+}) {
+  let lastError;
+  for (let attempt = 0; attempt <= jsonRetryDelaysMs.length; attempt++) {
+    const raw = await callOrcaRouter(options);
+
+    // Strip markdown fences if the model wraps output in ```json ... ```
+    const cleaned = raw
+      .replace(/^```(?:json)?\s*/i, "")
+      .replace(/\s*```\s*$/, "")
+      .trim();
+
+    try {
+      return JSON.parse(cleaned);
+    } catch (error) {
+      lastError = new Error(
+        `Failed to parse JSON from OrcaRouter response: ${error.message}\nRaw: ${raw.slice(0, 300)}`
+      );
+      if (attempt === jsonRetryDelaysMs.length) throw lastError;
+
+      const delay = jsonRetryDelaysMs[attempt];
+      console.warn(
+        `OrcaRouter returned invalid JSON — regenerating in ${delay}ms ` +
+        `(attempt ${attempt + 2}/${jsonRetryDelaysMs.length + 1})`,
+      );
+      if (delay > 0) await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+  throw lastError;
+}

--- a/scripts/audit-summaries.js
+++ b/scripts/audit-summaries.js
@@ -18,6 +18,7 @@ import crypto from "crypto";
 import { fileURLToPath } from "url";
 import { githubHeaders, fetchReadme } from "../lib/github.js";
 import { callOpenRouter } from "../lib/openrouter.js";
+import { callOrcaRouter } from "../lib/orcarouter.js";
 import { writeJsonCheckpoint } from "../lib/json-checkpoint.js";
 import { mapWithConcurrency } from "../lib/bounded-concurrency.js";
 import { auditVerdictIsPass } from "../lib/summary-pruning.js";
@@ -26,10 +27,19 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..");
 
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
-const OPENROUTER_KEY = process.env.OPENROUTER_API_KEY;
 
-if (!GITHUB_TOKEN || !OPENROUTER_KEY) {
-  console.error("Error: GITHUB_TOKEN and OPENROUTER_API_KEY required");
+// LLM gateway: "openrouter" (default) or "orcarouter" (see lib/orcarouter.js).
+const LLM_GATEWAY = process.env.LLM_GATEWAY || "openrouter";
+const isOrcaRouter = LLM_GATEWAY === "orcarouter";
+const audit = isOrcaRouter ? callOrcaRouter : callOpenRouter;
+const LLM_KEY = isOrcaRouter
+  ? process.env.ORCAROUTER_API_KEY
+  : process.env.OPENROUTER_API_KEY;
+
+if (!GITHUB_TOKEN || !LLM_KEY) {
+  console.error(
+    `Error: GITHUB_TOKEN and ${isOrcaRouter ? "ORCAROUTER_API_KEY" : "OPENROUTER_API_KEY"} required`
+  );
   process.exit(1);
 }
 
@@ -83,7 +93,7 @@ async function main() {
     console.log(`  ${key}: auditing...`);
 
     try {
-      const response = await callOpenRouter({
+      const response = await audit({
         system:
           "You are a fact-checker. Compare a summary against its source README. Identify any specific claims in the summary that are NOT supported by the README content. Be strict — if a number, feature name, or capability is mentioned in the summary but not in the README, flag it.",
         user: `README (source of truth):
@@ -98,7 +108,7 @@ Highlights to verify:
 ${entry.highlights?.map((h) => `- "${h}"`).join("\n") || "None"}
 
 List each unsupported claim, or respond with exactly "NONE" if all claims are supported.`,
-        apiKey: OPENROUTER_KEY,
+        apiKey: LLM_KEY,
         maxTokens: 300,
       });
 

--- a/scripts/generate-summaries.js
+++ b/scripts/generate-summaries.js
@@ -19,6 +19,7 @@ import crypto from "crypto";
 import { fileURLToPath } from "url";
 import { githubHeaders, fetchReadme } from "../lib/github.js";
 import { callOpenRouterJSON } from "../lib/openrouter.js";
+import { callOrcaRouterJSON } from "../lib/orcarouter.js";
 import {
   listSummaryNeedsRegeneration,
   pruneObjectKeys,
@@ -38,14 +39,24 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..");
 
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
-const OPENROUTER_KEY = process.env.OPENROUTER_API_KEY;
+
+// LLM gateway: "openrouter" (default) or "orcarouter". The orcarouter helper
+// sends a single namespaced model with reasoning disabled (see lib/orcarouter.js).
+const LLM_GATEWAY = process.env.LLM_GATEWAY || "openrouter";
+const isOrcaRouter = LLM_GATEWAY === "orcarouter";
+const summarize = isOrcaRouter ? callOrcaRouterJSON : callOpenRouterJSON;
+const LLM_KEY = isOrcaRouter
+  ? process.env.ORCAROUTER_API_KEY
+  : process.env.OPENROUTER_API_KEY;
 
 if (!GITHUB_TOKEN) {
   console.error("Error: GITHUB_TOKEN environment variable required");
   process.exit(1);
 }
-if (!OPENROUTER_KEY) {
-  console.error("Error: OPENROUTER_API_KEY environment variable required");
+if (!LLM_KEY) {
+  console.error(
+    `Error: ${isOrcaRouter ? "ORCAROUTER_API_KEY" : "OPENROUTER_API_KEY"} environment variable required`
+  );
   process.exit(1);
 }
 
@@ -205,13 +216,13 @@ async function main() {
     // Generate summary
     console.log(`  ${key}: generating summary...`);
     try {
-      const result = await callOpenRouterJSON({
+      const result = await summarize({
         system: SYSTEM_PROMPT,
         user: buildProjectPrompt(
           { ...repo, audit: existing?.audit, auditNotes: existing?.auditNotes },
           readmeRaw,
         ),
-        apiKey: OPENROUTER_KEY,
+        apiKey: LLM_KEY,
         maxTokens: 600,
       });
 
@@ -318,10 +329,10 @@ async function main() {
       const chunks = chunkList(rankedMembers, LIST_CHUNK_SIZE);
       const chunkMaps = [];
       for (const chunk of chunks) {
-        const chunkEntries = await callOpenRouterJSON({
+        const chunkEntries = await summarize({
           system: SYSTEM_PROMPT,
           user: buildListPrompt(list, chunk, summaries),
-          apiKey: OPENROUTER_KEY,
+          apiKey: LLM_KEY,
           maxTokens: 3200,
         });
         chunkMaps.push(chunkEntries);

--- a/tests/orcarouter.test.js
+++ b/tests/orcarouter.test.js
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { callOrcaRouterJSON, callOrcaRouter } from "../lib/orcarouter.js";
+
+function orcaRouterResponse(content) {
+  return {
+    ok: true,
+    async json() {
+      return { choices: [{ message: { content } }] };
+    },
+  };
+}
+
+test("callOrcaRouterJSON regenerates truncated JSON", async () => {
+  const originalFetch = globalThis.fetch;
+  const responses = [
+    orcaRouterResponse('{"summary":"truncated'),
+    orcaRouterResponse('{"summary":"complete"}'),
+  ];
+  let calls = 0;
+  globalThis.fetch = async () => responses[calls++];
+
+  try {
+    const result = await callOrcaRouterJSON({
+      system: "system",
+      user: "user",
+      apiKey: "test",
+      jsonRetryDelaysMs: [0, 0],
+    });
+    assert.deepEqual(result, { summary: "complete" });
+    assert.equal(calls, 2);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("callOrcaRouterJSON fails after bounded regeneration attempts", async () => {
+  const originalFetch = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls++;
+    return orcaRouterResponse('{"still":"truncated');
+  };
+
+  try {
+    await assert.rejects(
+      callOrcaRouterJSON({
+        system: "system",
+        user: "user",
+        apiKey: "test",
+        jsonRetryDelaysMs: [0, 0],
+      }),
+      /Failed to parse JSON from OrcaRouter response/,
+    );
+    assert.equal(calls, 3);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("callOrcaRouter posts a single namespaced model with reasoning disabled", async () => {
+  const originalFetch = globalThis.fetch;
+  let capturedUrl;
+  let capturedHeaders;
+  let capturedBody;
+  globalThis.fetch = async (url, init) => {
+    capturedUrl = String(url);
+    capturedHeaders = init.headers;
+    capturedBody = JSON.parse(init.body);
+    return orcaRouterResponse("ok");
+  };
+
+  try {
+    const result = await callOrcaRouter({
+      system: "system",
+      user: "user",
+      apiKey: "sk-orca-test",
+      model: "deepseek/deepseek-v4-flash",
+      maxTokens: 300,
+    });
+    assert.equal(result, "ok");
+    assert.equal(capturedUrl, "https://api.orcarouter.ai/v1/chat/completions");
+    assert.equal(capturedHeaders.Authorization, "Bearer sk-orca-test");
+    // No OpenRouter attribution headers on the OrcaRouter path.
+    assert.equal(capturedHeaders["HTTP-Referer"], undefined);
+    assert.equal(capturedHeaders["X-Title"], undefined);
+    // Single `model` field (not OpenRouter's `models` fallback array), namespaced,
+    // and reasoning disabled so content is not diverted to reasoning_content.
+    assert.equal(capturedBody.model, "deepseek/deepseek-v4-flash");
+    assert.equal(capturedBody.models, undefined);
+    assert.deepEqual(capturedBody.thinking, { type: "disabled" });
+    assert.equal(capturedBody.max_tokens, 300);
+    assert.equal(capturedBody.temperature, 0.3);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("callOrcaRouter defaults to a namespaced model", async () => {
+  const originalFetch = globalThis.fetch;
+  let capturedBody;
+  globalThis.fetch = async (_url, init) => {
+    capturedBody = JSON.parse(init.body);
+    return orcaRouterResponse("ok");
+  };
+
+  try {
+    await callOrcaRouter({ system: "system", user: "user", apiKey: "sk-orca-test" });
+    // Default must be a namespaced ID — OrcaRouter rejects bare model names.
+    assert.match(capturedBody.model, /\//);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Why this change

Hermes Atlas' chat endpoint, query rewrite, and embeddings calls are hard-wired to OpenRouter. This adds an opt-in switch so the same pipeline can target [OrcaRouter](https://www.orcarouter.ai) instead — an OpenAI-compatible model gateway. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

The switch is off by default (`CHAT_GATEWAY=openrouter`), so existing behavior is unchanged.

## What's inside

- **`api/chat.js`** — reads `CHAT_GATEWAY` (default `openrouter`); when set to `orcarouter`, the streaming answer request, the conversation-aware query rewrite, and the embeddings call all branch to OrcaRouter's OpenAI-compatible endpoint with a single namespaced model id. The OpenRouter path keeps its existing `models` fallback array, `usage.include`, attribution headers, and `reasoning.enabled: false` untouched.
- **`lib/orcarouter.js`** — new helper mirroring `lib/openrouter.js`: `callOrcaRouter` (retry + plain-text completion) and `callOrcaRouterJSON` (retry + JSON regeneration on invalid/truncated output), used by the summary scripts.
- **`scripts/generate-summaries.js`** / **`scripts/audit-summaries.js`** — read `LLM_GATEWAY` (default `openrouter`) and use the matching helper/key for their batch LLM calls.
- **`README.md`** — documents `CHAT_GATEWAY`, `LLM_GATEWAY`, `ORCAROUTER_API_KEY`, and `ORCAROUTER_MODEL`.

## Request shape differences

OrcaRouter accepts one `model` string (e.g. `deepseek/deepseek-v4-flash`) and rejects OpenRouter-only fields, so the OrcaRouter branch sends:

- `model` (single namespaced id) instead of a `models` fallback array
- `thinking: { type: "disabled" }` — OrcaRouter rejects `thinking.enabled: false` (HTTP 400), and the default reasoning mode spends the whole token budget on `reasoning_content`, returning empty `content`
- no `usage.include`, `HTTP-Referer`, or `X-Title`

## Enabling it

```bash
CHAT_GATEWAY=orcarouter LLM_GATEWAY=orcarouter \
ORCAROUTER_API_KEY=sk-orca-... \
node api/chat.js            # or deploy with those env vars
```

`ORCAROUTER_MODEL` overrides the default `deepseek/deepseek-v4-flash`.

## Validation

- `node --check` on all changed files
- `node --test tests/orcarouter.test.js tests/openrouter.test.js` → 6/6 pass (new tests cover the JSON helper, retry exhaustion, and the exact request body/headers for the OrcaRouter path)
- Live L3 test against the real gateway confirmed the streaming response, the `thinking: { type: "disabled" }` requirement, and the embeddings endpoint
- Full suite: the 9 remaining failures (production smoke, chat-widget, homepage-controls, masterclass-page, redis, stars-api, stars-history) fail identically on unmodified main — they require live production, GitHub API, and Redis, and are unrelated to this change

I'm an engineer on the OrcaRouter team.
