### PR TITLE
Chunk the stars GraphQL query so fine-grained PATs can fetch the catalog

### DIFF
--- a/lib/github-stars.js
+++ b/lib/github-stars.js
@@ -1,43 +1,63 @@
-export async function fetchGitHubStars({ repoList, token, fetchImpl = fetch }) {
-  if (!token) throw new Error("GitHub token unavailable");
-  if (!Array.isArray(repoList) || repoList.length === 0) {
-    throw new Error("Repo list unavailable");
-  }
+// Fine-grained PATs get a lower per-query resource ceiling than classic
+// tokens: a single query over the whole catalog (227 repos, 2026-08-17)
+// fails with "Resource limits for this query exceeded" while the same
+// query from the Actions token succeeds. Chunk the aliases and merge the
+// responses; alias indices stay global so error attribution is unchanged.
+export const GRAPHQL_CHUNK_SIZE = 100;
 
+function buildChunkQuery(repoList, start, end, includeAtlas) {
   const varDecls = [];
   const variables = {};
-  const repoQueries = repoList.map((repo, index) => {
+  const repoQueries = [];
+  for (let index = start; index < end; index++) {
+    const repo = repoList[index];
     varDecls.push(`$owner${index}: String!`, `$name${index}: String!`);
     variables[`owner${index}`] = repo.owner;
     variables[`name${index}`] = repo.repo;
     const releaseField = repo.owner === "NousResearch" && repo.repo === "hermes-agent"
       ? "latestRelease { tagName name publishedAt }"
       : "";
-    return `repo${index}: repository(owner: $owner${index}, name: $name${index}) {
+    repoQueries.push(`repo${index}: repository(owner: $owner${index}, name: $name${index}) {
       stargazerCount
       updatedAt
       pushedAt
       ${releaseField}
-    }`;
-  }).join("\n");
-
-  const query = `query (${varDecls.join(", ")}) { ${repoQueries}
-    atlas: repository(owner: "ksimback", name: "hermes-ecosystem") {
-      stargazerCount
-    }
+    }`);
+  }
+  const atlasField = includeAtlas
+    ? `atlas: repository(owner: "ksimback", name: "hermes-ecosystem") { stargazerCount }`
+    : "";
+  const query = `query (${varDecls.join(", ")}) { ${repoQueries.join("\n")}
+    ${atlasField}
   }`;
-  const response = await fetchImpl("https://api.github.com/graphql", {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json",
-      "User-Agent": "hermes-atlas-stars",
-    },
-    body: JSON.stringify({ query, variables }),
-  });
+  return { query, variables };
+}
 
-  if (!response.ok) throw new Error(`GitHub GraphQL HTTP ${response.status}`);
-  const payload = await response.json();
+export async function fetchGitHubStars({ repoList, token, fetchImpl = fetch, chunkSize = GRAPHQL_CHUNK_SIZE }) {
+  if (!token) throw new Error("GitHub token unavailable");
+  if (!Array.isArray(repoList) || repoList.length === 0) {
+    throw new Error("Repo list unavailable");
+  }
+
+  const payload = { data: {}, errors: [] };
+  for (let start = 0; start < repoList.length; start += chunkSize) {
+    const end = Math.min(start + chunkSize, repoList.length);
+    const { query, variables } = buildChunkQuery(repoList, start, end, start === 0);
+    const response = await fetchImpl("https://api.github.com/graphql", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "User-Agent": "hermes-atlas-stars",
+      },
+      body: JSON.stringify({ query, variables }),
+    });
+    if (!response.ok) throw new Error(`GitHub GraphQL HTTP ${response.status}`);
+    const chunk = await response.json();
+    Object.assign(payload.data, chunk.data || {});
+    if (Array.isArray(chunk.errors)) payload.errors.push(...chunk.errors);
+  }
+
   let hermesRelease = null;
   const errors = payload.errors || [];
   const unavailableRepos = [];

--- a/tests/github-stars.test.js
+++ b/tests/github-stars.test.js
@@ -124,3 +124,29 @@ test("validateStarData rejects duplicates and invalid counts", () => {
     /Duplicate repo|Invalid star count/,
   );
 });
+
+test("fetchGitHubStars chunks large catalogs and merges responses", async () => {
+  const many = Array.from({ length: 5 }, (_, i) => ({ owner: "o", repo: `r${i}`, stars: 1 }));
+  const bodies = [];
+  const result = await fetchGitHubStars({
+    repoList: many,
+    token: "token",
+    chunkSize: 2,
+    fetchImpl: async (url, options) => {
+      const body = JSON.parse(options.body);
+      bodies.push(body);
+      const data = {};
+      for (const key of Object.keys(body.variables)) {
+        const m = key.match(/^owner(\d+)$/);
+        if (m) data[`repo${m[1]}`] = { stargazerCount: Number(m[1]) + 10, updatedAt: "2026-01-01T00:00:00Z", pushedAt: null };
+      }
+      if (body.query.includes("atlas:")) data.atlas = { stargazerCount: 42 };
+      return githubResponse({ data });
+    },
+  });
+  assert.equal(bodies.length, 3);
+  assert.equal(bodies.filter((b) => b.query.includes("atlas:")).length, 1);
+  assert.equal(result.atlasStars, 42);
+  assert.deepEqual(result.starData.map((r) => r.stars), [10, 11, 12, 13, 14]);
+  assert.equal(result.complete, true);
+});


### PR DESCRIPTION
Follow-up to #812. After rotating the Vercel `GITHUB_TOKEN` to a fine-grained PAT, the **Probe the serverless live-refresh path** step went from `401` to:

```
GitHub GraphQL errors: Resource limits for this query exceeded.
```

Reproduced locally: `fetchGitHubStars` sends all 227 repos as aliases in one query. With the fine-grained PAT, 120 repos succeed and 227 fail; the Actions token has a higher ceiling so `push-stars-snapshot.js` was unaffected.

Fix: split into ≤100-repo requests (`GRAPHQL_CHUNK_SIZE`), merge `data`/`errors`, keep global `repoN` alias indices so unavailable-repo attribution and all downstream logic are untouched. `atlas` is queried once (first chunk).

Verified: full 227-repo catalog fetches with the fine-grained PAT (`complete: true`); `npm test` 281/281 (+1 chunking test).

After merge: `gh workflow run "Refresh GitHub Stars" --ref main` should finally go green end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)