### PR TITLE
Skills Hub PR 1/2: curated data layer + fail-loud validator

### DIFF
--- a/.github/workflows/validate-skills-json.yml
+++ b/.github/workflows/validate-skills-json.yml
@@ -1,0 +1,46 @@
+name: Validate skills.json
+
+# Gates the curated Skills Hub join. The two failure modes worth blocking a
+# merge for: an entry recommending a repo that isn't in the Atlas catalog,
+# and a use-case group slug colliding with data/use-cases.json. Also runs
+# when data/repos.json or data/use-cases.json change, because dropping a
+# repo or renaming a use-case slug silently orphans skills.json entries.
+
+on:
+  pull_request:
+    paths:
+      - 'data/skills.json'
+      - 'data/repos.json'
+      - 'data/use-cases.json'
+      - 'scripts/validate-skills-json.js'
+      - 'tests/validate-skills-json.test.js'
+      - '.github/workflows/validate-skills-json.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'data/skills.json'
+      - 'data/repos.json'
+      - 'data/use-cases.json'
+      - 'scripts/validate-skills-json.js'
+      - 'tests/validate-skills-json.test.js'
+      - '.github/workflows/validate-skills-json.yml'
+  workflow_dispatch: {}
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Run skills.json tests
+        run: node --test tests/validate-skills-json.test.js
+
+      - name: Validate data/skills.json
+        run: node scripts/validate-skills-json.js

--- a/data/skills.json
+++ b/data/skills.json
@@ -1,0 +1,255 @@
+{
+  "updatedAt": "2026-08-20",
+  "testedAgainst": "v0.20.4",
+  "useCases": [
+    {
+      "slug": "coding",
+      "title": "Best Hermes Skills for Coding",
+      "intent": "Developers looking for skills or plugins that plan, review, harden, or simplify code changes inside Hermes Agent or Claude Code.",
+      "description": "Structured methodologies and subagent swarms that turn ad-hoc coding sessions into repeatable, checkpointed workflows — spec-first planning, adversarial code review, and multi-agent simplification passes."
+    },
+    {
+      "slug": "cybersecurity",
+      "title": "Best Hermes Skills for Cybersecurity",
+      "intent": "Security engineers and red-teamers looking for large, framework-mapped skill packs covering offense, defense, and compliance.",
+      "description": "Structured skill packs mapping MITRE ATT&CK, NIST, and CVE data into agent-usable procedures for pentesting, forensics, and threat modeling."
+    },
+    {
+      "slug": "skill-management",
+      "title": "Best Tools for Discovering & Managing Hermes Skills",
+      "intent": "Users who want to browse, retrieve, evolve, or bulk-install skills at scale rather than add a single-purpose skill.",
+      "description": "Meta-tools that sit above individual skills — registries, retrieval layers, evolution engines, and large curated skill collections spanning many professions."
+    },
+    {
+      "slug": "design-and-diagrams",
+      "title": "Best Hermes Skills for Design & Diagrams",
+      "intent": "Users generating diagrams, design prototypes, or image output through agent skills.",
+      "description": "Skills and tools that turn natural-language descriptions into draw.io diagrams, FLUX-generated images, or full local-first design prototypes."
+    },
+    {
+      "slug": "writing-and-content",
+      "title": "Best Hermes Skills for Writing & Content",
+      "intent": "Content creators and marketers who want to de-AI-ify prose, pull structured video/platform data, or automate content production.",
+      "description": "Skills for auditing AI-sounding prose, extracting structured YouTube data, and generating marketing or e-commerce material."
+    },
+    {
+      "slug": "crypto-and-payments",
+      "title": "Best Hermes Skills for Crypto & Agent Payments",
+      "intent": "Builders wiring agents into on-chain protocols or agent-to-agent payment and dispute-resolution rails.",
+      "description": "Skills for interacting with smart-contract oracle networks and for structuring agent-to-agent commerce, escrow, delegated permissions, and micropayments."
+    },
+    {
+      "slug": "personal-ops",
+      "title": "Best Hermes Skills for Personal Ops",
+      "intent": "Users who want Hermes to manage personal infrastructure — self-hosted services and cross-platform runtime friction.",
+      "description": "Skills that connect Hermes to personal infrastructure like self-hosted Nextcloud and that smooth over Windows/WSL/Git Bash path and runtime quirks."
+    }
+  ],
+  "skills": [
+    {
+      "owner": "obra",
+      "repo": "superpowers",
+      "type": "plugin",
+      "install": "hermes plugins install obra/superpowers --enable",
+      "compatibility": "Hermes Agent CLI (plugin); also ships as a Claude Code plugin via the official marketplace.",
+      "verdict": "The most-starred agentic skills framework in the catalog by two orders of magnitude. If you install exactly one dev-workflow plugin, this is the default.",
+      "useCases": ["coding"],
+      "topPick": true
+    },
+    {
+      "owner": "Cranot",
+      "repo": "super-hermes",
+      "type": "skill",
+      "install": "hermes skills tap add Cranot/super-hermes",
+      "compatibility": "Hermes Agent native (Skills Hub tap); manual git-clone install also documented for other harnesses.",
+      "verdict": "Built specifically for Hermes' own Skills Hub syntax rather than ported from Claude Code — teaches the agent to write its own analytical prompts via prism-scan plus seven proven analytical lenses.",
+      "useCases": ["coding"]
+    },
+    {
+      "owner": "Sahil-SS9",
+      "repo": "hermaguard",
+      "type": "skill",
+      "install": "Clone the repo and copy it into your harness's skill directory (pip install . provides its 9 console scripts); no Skills Hub listing yet.",
+      "compatibility": "Harness-agnostic Agent Skill, Python-backed; works with Hermes, Claude Code, and any agentskills.io-compatible client.",
+      "verdict": "Three parallel subagents attack code from different angles, then verify findings via sandboxed proof-of-concept execution before reporting VERIFIED or REFUTED — the most rigorous read-only code-review skill in this list.",
+      "useCases": ["coding"]
+    },
+    {
+      "owner": "Sahil-SS9",
+      "repo": "hermes-simplify-swarm",
+      "type": "skill",
+      "install": "git clone https://github.com/Sahil-SS9/hermes-simplify-swarm.git, then copy SKILL.md and references/ into your harness's skill directory as simplify-swarm/.",
+      "compatibility": "Harness-agnostic (copy-in SKILL.md); explicitly built for Hermes Agent, also works in Claude Code.",
+      "verdict": "Three read-only subagents (Hygiene, Clarity, Correctness) with a SAFE/CAREFUL/RISKY tiered approval gate before anything is applied — a safer default than a single autonomous simplification pass.",
+      "useCases": ["coding"]
+    },
+    {
+      "owner": "armelhbobdad",
+      "repo": "bmad-module-skill-forge",
+      "type": "skill",
+      "install": "npx bmad-module-skill-forge install",
+      "compatibility": "Node.js >= 22, Python >= 3.10, uv required; IDE-agnostic scaffolding tool, not Hermes-specific.",
+      "verdict": "Turns your own repo, docs, and developer discourse into agentskills.io-compliant skills with file/line provenance citations — for teams standardizing internal skills, not consuming someone else's.",
+      "useCases": ["coding", "skill-management"]
+    },
+    {
+      "owner": "mukul975",
+      "repo": "Anthropic-Cybersecurity-Skills",
+      "type": "collection",
+      "install": "npx skills add mukul975/Anthropic-Cybersecurity-Skills",
+      "compatibility": "agentskills.io-compatible clients (Claude Code, Copilot, Codex); installable on Hermes via hermes skills tap add or npx skills add.",
+      "verdict": "800+ skills across 29 security domains mapped to MITRE ATT&CK, ATLAS, D3FEND, and NIST — the largest and most-starred security pack in the catalog. Start here before any narrower pentest skill.",
+      "useCases": ["cybersecurity"],
+      "topPick": true
+    },
+    {
+      "owner": "handnewb",
+      "repo": "hermes-cybersec-lab",
+      "type": "collection",
+      "install": "git clone https://github.com/handnewb/hermes-cybersec-lab.git, run scripts/clone-all.sh, then copy into ~/.hermes/profiles/<profile>/skills/cybersecurity-lab/.",
+      "compatibility": "Hermes Agent native — the README targets ~/.hermes/profiles/<profile>/skills/ explicitly.",
+      "verdict": "2,000+ skills stitched from 7 external repos plus 130+ installable tools (Sigma, YARA, MISP). A deeper turnkey lab than the Anthropic-Cybersecurity-Skills pack, but a heavier multi-repo clone — pick it for a dedicated security profile, not a quick add.",
+      "useCases": ["cybersecurity"]
+    },
+    {
+      "owner": "AMAP-ML",
+      "repo": "SkillClaw",
+      "type": "registry",
+      "install": "git clone https://github.com/AMAP-ML/SkillClaw.git, run scripts/install_skillclaw.sh, activate the venv, then run skillclaw setup.",
+      "compatibility": "Standalone Python CLI/daemon; integrates with Hermes, Codex, Claude Code, and OpenAI-compatible APIs — not a drop-in SKILL.md.",
+      "verdict": "A genuinely different mechanism: runs in the background, deduplicates, and cross-pollinates your skill library across agents, devices, and users instead of just hosting a list.",
+      "useCases": ["skill-management"],
+      "topPick": true
+    },
+    {
+      "owner": "aidevelopers2",
+      "repo": "remoteopenclaw-mcp",
+      "type": "registry",
+      "install": "Add remoteopenclaw (npx -y remoteopenclaw) under mcp_servers in Hermes' config; for Claude Code: claude mcp add remoteopenclaw -- npx -y remoteopenclaw.",
+      "compatibility": "MCP server — any MCP client (Hermes, Cursor, Windsurf, Claude Code) via mcp_servers config.",
+      "verdict": "Searches 13,000+ MCP servers and 4,000+ agent skills from the terminal with no API key — the widest single search surface in this category, though it's discovery-only, not an installer.",
+      "useCases": ["skill-management"]
+    },
+    {
+      "owner": "willingning-coder",
+      "repo": "eagle-eye",
+      "type": "plugin",
+      "install": "git clone https://github.com/willingning-coder/eagle-eye.git, then run python scripts/generate_config.py.",
+      "compatibility": "Hermes Agent plugin; optional dense-embedding dependencies for the retrieval layers.",
+      "verdict": "Five-layer retrieval (hard triggers, FTS5, synonyms, dense embeddings, RRF fusion) built to solve Hermes' own skill-selection problem once your skills directory gets large — the most Hermes-native entry in this group.",
+      "useCases": ["skill-management"]
+    },
+    {
+      "owner": "mohitagw15856",
+      "repo": "pm-claude-skills",
+      "type": "collection",
+      "install": "npx pm-claude-skills add",
+      "compatibility": "Claude Code plugin directory + Hermes Agent (plain markdown skills run natively); also exposes an MCP server.",
+      "verdict": "1,000+ professional skills as plain markdown, the largest non-security collection here — organized into 120+ installable bundles instead of one all-or-nothing install.",
+      "useCases": ["skill-management"]
+    },
+    {
+      "owner": "wondelai",
+      "repo": "skills",
+      "type": "collection",
+      "install": "npx skills add wondelai/skills --all --global (or pick individual skills, e.g. npx skills add wondelai/skills/jobs-to-be-done --global).",
+      "compatibility": "skills.sh / agentskills.io-compatible clients including Claude Code and Hermes; also ships Claude Code plugin collections.",
+      "verdict": "62 skills built from 50 named business and design frameworks (Jobs-to-be-Done, the Mom Test, Refactoring UI) rather than generic prompts — a business-strategy layer to sit alongside a coding skill set.",
+      "useCases": ["skill-management"]
+    },
+    {
+      "owner": "Agents365-ai",
+      "repo": "drawio-skill",
+      "type": "skill",
+      "install": "npx skills add Agents365-ai/365-skills -g (or git clone into your skills directory).",
+      "compatibility": "Runs from a single SKILL.md, no MCP server or daemon (needs the draw.io desktop CLI for rendering); works anywhere agentskills.io skills load, including Hermes.",
+      "verdict": "Eleven diagram-type presets plus Mermaid-to-drawio conversion, and the most-starred diagram skill in the catalog — the clear default over hand-rolling diagram prompts.",
+      "useCases": ["design-and-diagrams"],
+      "topPick": true
+    },
+    {
+      "owner": "black-forest-labs",
+      "repo": "skills",
+      "type": "skill",
+      "install": "npx skills add black-forest-labs/skills (or target one: npx skills add black-forest-labs/skills --skill flux-image-best-practices).",
+      "compatibility": "agentskills.io spec; also a Claude Code plugin.",
+      "verdict": "The one official-vendor entry in this bucket — Black Forest Labs' own FLUX prompting guidelines and API integration patterns, not a third-party reverse-engineering of their docs.",
+      "useCases": ["design-and-diagrams"]
+    },
+    {
+      "owner": "nexu-io",
+      "repo": "open-design",
+      "type": "plugin",
+      "install": "curl -fsSL https://open-design.ai/install.sh | sh -s hermes (hosted); or self-host via docker compose from the repo's deploy/ directory.",
+      "compatibility": "Native desktop app (macOS/Windows) plus a CLI; the README explicitly lists Hermes Agent among supported coding-agent CLIs for prototype generation.",
+      "verdict": "By far the biggest project in the entire skills category — but it's a full local-first design platform, not a lightweight skill. Install it as prototyping infrastructure, not a five-minute skill add.",
+      "useCases": ["design-and-diagrams"]
+    },
+    {
+      "owner": "conorbronsdon",
+      "repo": "avoid-ai-writing",
+      "type": "skill",
+      "install": "git clone https://github.com/conorbronsdon/avoid-ai-writing into your skills directory (or install the plugin from its marketplace).",
+      "compatibility": "README states explicit compatibility with Claude Code, OpenClaw, Hermes, and Cursor.",
+      "verdict": "Three modes (Rewrite, Detect, Edit) and a 100+ entry tiered word-replacement table — the most mechanically detailed de-AI-ify skill in the category, not a vague 'sound more human' prompt.",
+      "useCases": ["writing-and-content"],
+      "topPick": true
+    },
+    {
+      "owner": "ZeroPointRepo",
+      "repo": "youtube-skills",
+      "type": "skill",
+      "install": "hermes skills install skills-sh/ZeroPointRepo/youtube-skills/skills/youtube-full",
+      "compatibility": "Hermes Agent (skills.sh source), OpenClaw, Claude Code, Cursor, and Codex via npx skills add.",
+      "verdict": "An explicit, working Hermes install line via the skills.sh hub source — covers YouTube transcript, search, channel, and playlist data in one skill.",
+      "useCases": ["writing-and-content"]
+    },
+    {
+      "owner": "jiawood2006",
+      "repo": "hermes-skills",
+      "type": "collection",
+      "install": "hermes skills install jiawood2006/hermes-skills/skills/video-to-text (repeat per skill: de-ai-writer, doc-ocr, ecommerce-material-studio).",
+      "compatibility": "Hermes Agent native install commands documented directly in the README; portable to other agentskills.io clients via manual copy.",
+      "verdict": "Four narrow, concrete skills — video transcription, AI-text de-humanizer, local OCR, e-commerce material generation — with correct Hermes-native install commands out of the box. Early-stage, but useful for e-commerce and Chinese-language workflows.",
+      "useCases": ["writing-and-content"]
+    },
+    {
+      "owner": "internet-court",
+      "repo": "internet-court-skill",
+      "type": "collection",
+      "install": "hermes skills tap add internet-court/internet-court-skill (the README prefers the tap over a direct URL install, which misses bundled reference files).",
+      "compatibility": "Hermes Agent (tap), Claude Code (plugin marketplace or manual clone), OpenClaw, and Codex.",
+      "verdict": "A genuinely new primitive — a master router plus vendored official protocol skills covering ERC-7710 delegated permissions, x402 payments, and escrow/dispute resolution as one catch-all agent-commerce skill.",
+      "useCases": ["crypto-and-payments"],
+      "topPick": true
+    },
+    {
+      "owner": "smartcontractkit",
+      "repo": "chainlink-agent-skills",
+      "type": "skill",
+      "install": "npx skills add smartcontractkit/chainlink-agent-skills",
+      "compatibility": "agentskills.io spec via the skills.sh CLI; project-level install is the default.",
+      "verdict": "The official Chainlink team's own oracle-network skills (CCIP, VRF, Data Feeds) — the vendor-authoritative pick for cross-chain or oracle work, versus a community reimplementation.",
+      "useCases": ["crypto-and-payments"]
+    },
+    {
+      "owner": "adnw-vinc",
+      "repo": "hermes-nextcloud",
+      "type": "skill",
+      "install": "git clone https://github.com/adnw-vinc/hermes-nextcloud.git into ~/.hermes/skills/productivity/nextcloud, then run its guided setup script.",
+      "compatibility": "Hermes Agent native — targets ~/.hermes/skills/ explicitly, with App Password validation for Nextcloud.",
+      "verdict": "The only skill in the catalog wiring Hermes directly into a self-hosted Nextcloud over WebDAV/CalDAV/CardDAV — no browser, no third-party sync service, credentials kept in a restricted local .env.",
+      "useCases": ["personal-ops"],
+      "topPick": true
+    },
+    {
+      "owner": "CorsenAI",
+      "repo": "hermes-windows-runtime-skills",
+      "type": "collection",
+      "install": "hermes skills tap add CorsenAI/hermes-windows-runtime-skills (or install each skill directly, e.g. hermes skills install CorsenAI/hermes-windows-runtime-skills/skills/windows-wsl-file-navigation).",
+      "compatibility": "Hermes Agent native, specifically for native Windows, Git Bash/MSYS, and WSL environments.",
+      "verdict": "Solves a real, narrow Hermes pain point — deterministic path routing and non-destructive Python runtime selection across Windows, Git Bash, and WSL — with exact hermes skills install commands in the README.",
+      "useCases": ["personal-ops"]
+    }
+  ]
+}

--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -19,6 +19,7 @@ import { JSDOM } from "jsdom";
 import createDOMPurify from "dompurify";
 import { githubHeaders, fetchReadme, fetchAllMetadata } from "../lib/github.js";
 import { REFRESHED_CONTENT_PATHS } from "../lib/build-artifacts.js";
+import { validateSkills } from "./validate-skills-json.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..");
@@ -2101,6 +2102,21 @@ async function main() {
     }
     console.log(`  Loaded ${Object.keys(handbookMentions).length} handbook mentions`);
   } catch { console.log("  No handbook-mentions.json found"); }
+
+  // Skills Hub data (new, hand-curated — data/skills.json). Optional until
+  // it's added; gate it here the same way validate-skills-json.js gates CI
+  // so a bad hand-edit fails the build instead of shipping silently broken.
+  const skillsPath = path.join(ROOT, "data", "skills.json");
+  if (fs.existsSync(skillsPath)) {
+    const skillsData = JSON.parse(fs.readFileSync(skillsPath, "utf-8"));
+    const skillsErrors = validateSkills(skillsData, repos, useCases);
+    if (skillsErrors.length > 0) {
+      throw new Error(`data/skills.json validation failed:\n- ${skillsErrors.join("\n- ")}`);
+    }
+    console.log(`  Loaded data/skills.json (${skillsData.skills.length} skills)`);
+  } else {
+    console.log("  data/skills.json not present; skills hub skipped");
+  }
   console.log();
 
   // Ensure output directories exist

--- a/scripts/validate-skills-json.js
+++ b/scripts/validate-skills-json.js
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+// Gate for data/skills.json — the curated Skills Hub join between hand-picked
+// use-case groups ("coding", "writing", ...) and the Atlas catalog
+// (data/repos.json). Mirrors scripts/validate-use-cases.js.
+//
+// Invariants that matter and aren't obvious from reading the file:
+//
+//  1. Every skill must reference a repo already accepted into the Atlas
+//     catalog — same "no generic recommendations" rule as use-cases.json.
+//  2. A skill's repo must actually be categorized under "Skills & Skill
+//     Registries" unless the curator explicitly flags it crossCategory —
+//     otherwise the hub silently pulls in unrelated tooling.
+//  3. Use-case group slugs must not collide with data/use-cases.json slugs —
+//     the two "I want to build X" surfaces share a URL namespace.
+//  4. Each group needs >=2 skills (a group of one is a single card, not a
+//     grouping) and at most one topPick (the hub renders one hero per group).
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "..");
+
+export const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+export const SKILLS_CATEGORY = "Skills & Skill Registries";
+export const VALID_TYPES = ["skill", "plugin", "registry", "collection"];
+export const MIN_GROUP_SKILLS = 2;
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isPlainObject(value) {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * @param {unknown} skillsData     parsed data/skills.json
+ * @param {Array} reposData        parsed data/repos.json
+ * @param {Array} useCasesData     parsed data/use-cases.json
+ * @returns {string[]} human-readable errors; empty means valid
+ */
+export function validateSkills(skillsData, reposData, useCasesData) {
+  const errors = [];
+
+  if (!isPlainObject(skillsData)) {
+    return ["data/skills.json must contain a top-level object"];
+  }
+
+  // ── top-level fields ──
+  if (!isNonEmptyString(skillsData.updatedAt) || !ISO_DATE_RE.test(skillsData.updatedAt)) {
+    errors.push("updatedAt must be a YYYY-MM-DD date string");
+  } else {
+    const today = new Date().toISOString().slice(0, 10);
+    if (skillsData.updatedAt > today) {
+      errors.push(`updatedAt "${skillsData.updatedAt}" is in the future`);
+    }
+  }
+
+  if (!isNonEmptyString(skillsData.testedAgainst) || !skillsData.testedAgainst.trim().startsWith("v")) {
+    errors.push('testedAgainst must be a non-empty string starting with "v" (e.g. "v0.20.4")');
+  }
+
+  const useCases = Array.isArray(skillsData.useCases) ? skillsData.useCases : null;
+  if (!useCases || useCases.length === 0) {
+    errors.push("useCases must be a non-empty array");
+  }
+
+  const skills = Array.isArray(skillsData.skills) ? skillsData.skills : null;
+  if (!skills || skills.length === 0) {
+    errors.push("skills must be a non-empty array");
+  }
+
+  if (!useCases || !skills) {
+    return errors;
+  }
+
+  // ── use-case groups ──
+  const existingUseCaseSlugs = new Set(
+    (Array.isArray(useCasesData) ? useCasesData : [])
+      .map((uc) => uc?.slug)
+      .filter(isNonEmptyString)
+  );
+
+  const groupSlugs = new Set();
+  const groupCounts = new Map();
+  const groupTopPicks = new Map();
+
+  useCases.forEach((group, index) => {
+    const label = isNonEmptyString(group?.slug) ? `useCases[${group.slug}]` : `useCases[${index}]`;
+
+    if (!isPlainObject(group)) {
+      errors.push(`${label} entry must be an object`);
+      return;
+    }
+
+    if (!isNonEmptyString(group.slug)) {
+      errors.push(`${label} slug must be a non-empty string`);
+    } else {
+      if (!SLUG_RE.test(group.slug)) {
+        errors.push(`${label} slug must be lowercase kebab-case`);
+      }
+      if (groupSlugs.has(group.slug)) {
+        errors.push(`${label} duplicate slug`);
+      } else {
+        groupSlugs.add(group.slug);
+      }
+      if (existingUseCaseSlugs.has(group.slug)) {
+        errors.push(
+          `${label} slug "${group.slug}" collides with a slug already defined in data/use-cases.json`
+        );
+      }
+    }
+
+    for (const field of ["title", "intent", "description"]) {
+      if (!isNonEmptyString(group[field])) {
+        errors.push(`${label} ${field} must be a non-empty string`);
+      }
+    }
+  });
+
+  // ── skills ──
+  const repoCategory = new Map(
+    (Array.isArray(reposData) ? reposData : []).map((r) => [`${r.owner}/${r.repo}`, r.category])
+  );
+
+  const seenRepoEntries = new Set();
+
+  skills.forEach((skill, index) => {
+    const key = isNonEmptyString(skill?.owner) && isNonEmptyString(skill?.repo)
+      ? `${skill.owner}/${skill.repo}`
+      : null;
+    const label = key ? `skills[${key}]` : `skills[${index}]`;
+
+    if (!isPlainObject(skill)) {
+      errors.push(`${label} entry must be an object`);
+      return;
+    }
+
+    if (!isNonEmptyString(skill.owner) || !isNonEmptyString(skill.repo)) {
+      errors.push(`${label} owner and repo must both be non-empty strings`);
+      return;
+    }
+
+    if (seenRepoEntries.has(key)) {
+      errors.push(`${label} duplicate skill entry for ${key}`);
+    } else {
+      seenRepoEntries.add(key);
+    }
+
+    if (!repoCategory.has(key)) {
+      errors.push(
+        `${label} ${key} is not in data/repos.json — skills hub entries may only reference repos already accepted into Atlas`
+      );
+    } else {
+      const category = repoCategory.get(key);
+      if (category !== SKILLS_CATEGORY && skill.crossCategory !== true) {
+        errors.push(
+          `${label} ${key} is categorized "${category}", not "${SKILLS_CATEGORY}" — set crossCategory: true if this is intentional`
+        );
+      }
+    }
+
+    if (!VALID_TYPES.includes(skill.type)) {
+      errors.push(`${label} type must be one of: ${VALID_TYPES.join(", ")}`);
+    }
+
+    if ((skill.type === "skill" || skill.type === "plugin") && !isNonEmptyString(skill.install)) {
+      errors.push(`${label} install is required and must be non-empty when type is "${skill.type}"`);
+    }
+
+    if (!isNonEmptyString(skill.verdict)) {
+      errors.push(`${label} verdict must be a non-empty string`);
+    }
+
+    if (!Array.isArray(skill.useCases) || skill.useCases.length === 0) {
+      errors.push(`${label} useCases must be a non-empty array of group slugs`);
+    } else {
+      for (const slug of skill.useCases) {
+        if (!isNonEmptyString(slug) || !groupSlugs.has(slug)) {
+          errors.push(`${label} useCases references undefined group slug "${slug}"`);
+          continue;
+        }
+        groupCounts.set(slug, (groupCounts.get(slug) || 0) + 1);
+        if (skill.topPick === true) {
+          const existing = groupTopPicks.get(slug);
+          if (existing) {
+            errors.push(
+              `${label} sets topPick alongside ${existing} — only one topPick allowed per group [${slug}]`
+            );
+          } else {
+            groupTopPicks.set(slug, key);
+          }
+        }
+      }
+    }
+  });
+
+  for (const slug of groupSlugs) {
+    const count = groupCounts.get(slug) || 0;
+    if (count < MIN_GROUP_SKILLS) {
+      errors.push(`useCases[${slug}] has only ${count} skill(s) referencing it — needs at least ${MIN_GROUP_SKILLS}`);
+    }
+  }
+
+  return errors;
+}
+
+function readJson(filePath, description) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch (error) {
+    console.error(`${description} could not be read: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+function main() {
+  const skillsPath = path.join(ROOT, "data", "skills.json");
+  if (!fs.existsSync(skillsPath)) {
+    console.error("data/skills.json not found — nothing to validate");
+    process.exit(1);
+  }
+
+  const skillsData = readJson(skillsPath, "data/skills.json");
+  const reposData = readJson(path.join(ROOT, "data", "repos.json"), "data/repos.json");
+  const useCasesData = readJson(path.join(ROOT, "data", "use-cases.json"), "data/use-cases.json");
+
+  const errors = validateSkills(skillsData, reposData, useCasesData);
+  if (errors.length > 0) {
+    console.error("data/skills.json validation failed:");
+    for (const error of errors) console.error(`- ${error}`);
+    process.exit(1);
+  }
+
+  console.log(
+    `data/skills.json validation passed ` +
+    `(${skillsData.useCases.length} use-case groups, ${skillsData.skills.length} skills)`
+  );
+}
+
+// Windows-safe entry check — see scripts/validate-repos-json.js:176
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/tests/validate-skills-json.test.js
+++ b/tests/validate-skills-json.test.js
@@ -1,0 +1,167 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { validateSkills, MIN_GROUP_SKILLS, SKILLS_CATEGORY } from "../scripts/validate-skills-json.js";
+
+// ── fixtures ──────────────────────────────────────────────────────────────
+
+const repos = [
+  { owner: "acme", repo: "coder-skill", category: SKILLS_CATEGORY },
+  { owner: "acme", repo: "coder-plugin", category: SKILLS_CATEGORY },
+  { owner: "acme", repo: "writer-registry", category: SKILLS_CATEGORY },
+  { owner: "acme", repo: "writer-collection", category: SKILLS_CATEGORY },
+  { owner: "acme", repo: "unrelated-tool", category: "Memory & Context" },
+];
+
+const existingUseCases = [{ slug: "already-taken" }];
+
+function makeSkillsData() {
+  return {
+    updatedAt: "2026-08-20",
+    testedAgainst: "v0.20.4",
+    useCases: [
+      {
+        slug: "coding",
+        title: "Coding",
+        intent: "I want skills that help me write code",
+        description: "Skills useful for software development tasks.",
+      },
+      {
+        slug: "writing",
+        title: "Writing",
+        intent: "I want skills that help me write prose",
+        description: "Skills useful for writing tasks.",
+      },
+    ],
+    skills: [
+      {
+        owner: "acme",
+        repo: "coder-skill",
+        type: "skill",
+        install: "hermes skill install acme/coder-skill",
+        compatibility: "v0.20+",
+        verdict: "Solid.",
+        useCases: ["coding"],
+        topPick: true,
+      },
+      {
+        owner: "acme",
+        repo: "coder-plugin",
+        type: "plugin",
+        install: "hermes plugin install acme/coder-plugin",
+        compatibility: "v0.20+",
+        verdict: "Also solid.",
+        useCases: ["coding"],
+      },
+      {
+        owner: "acme",
+        repo: "writer-registry",
+        type: "registry",
+        install: "",
+        compatibility: "v0.20+",
+        verdict: "Good registry.",
+        useCases: ["writing"],
+        topPick: true,
+      },
+      {
+        owner: "acme",
+        repo: "writer-collection",
+        type: "collection",
+        compatibility: "v0.20+",
+        verdict: "Good collection.",
+        useCases: ["writing"],
+      },
+    ],
+  };
+}
+
+// ── validate-skills-json ─────────────────────────────────────────────────
+
+test("accepts a well-formed skills.json fixture", () => {
+  assert.deepEqual(validateSkills(makeSkillsData(), repos, existingUseCases), []);
+});
+
+test("rejects a skill whose repo is not in data/repos.json", () => {
+  const data = makeSkillsData();
+  data.skills.push({
+    owner: "ghost",
+    repo: "not-in-atlas",
+    type: "skill",
+    install: "x",
+    verdict: "v",
+    useCases: ["coding"],
+  });
+  const errors = validateSkills(data, repos, existingUseCases);
+  assert.ok(errors.some((e) => /ghost\/not-in-atlas is not in data\/repos\.json/.test(e)));
+});
+
+test("rejects a repo outside the Skills category without crossCategory", () => {
+  const data = makeSkillsData();
+  data.skills.push({
+    owner: "acme",
+    repo: "unrelated-tool",
+    type: "skill",
+    install: "x",
+    verdict: "v",
+    useCases: ["coding"],
+  });
+  const errors = validateSkills(data, repos, existingUseCases);
+  assert.ok(errors.some((e) => /not "Skills & Skill Registries"/.test(e)));
+
+  // crossCategory: true lets it through.
+  data.skills[data.skills.length - 1].crossCategory = true;
+  const errors2 = validateSkills(data, repos, existingUseCases);
+  assert.ok(!errors2.some((e) => /not "Skills & Skill Registries"/.test(e)));
+});
+
+test("rejects a skill referencing an undefined use-case group slug", () => {
+  const data = makeSkillsData();
+  data.skills[0].useCases = ["not-a-real-group"];
+  const errors = validateSkills(data, repos, existingUseCases);
+  assert.ok(errors.some((e) => /references undefined group slug "not-a-real-group"/.test(e)));
+});
+
+test("rejects two topPicks within the same group", () => {
+  const data = makeSkillsData();
+  data.skills[1].topPick = true; // coder-plugin also in "coding" group
+  const errors = validateSkills(data, repos, existingUseCases);
+  assert.ok(errors.some((e) => /only one topPick allowed per group \[coding\]/.test(e)));
+});
+
+test("rejects a group with fewer than the minimum number of skills", () => {
+  const data = makeSkillsData();
+  data.useCases.push({
+    slug: "lonely-group",
+    title: "Lonely",
+    intent: "I want a group with one skill",
+    description: "Only one skill references this.",
+  });
+  data.skills[0].useCases.push("lonely-group");
+  const errors = validateSkills(data, repos, existingUseCases);
+  assert.ok(
+    errors.some((e) => new RegExp(`\\[lonely-group\\] has only 1 skill.*at least ${MIN_GROUP_SKILLS}`).test(e))
+  );
+});
+
+test("rejects a use-case group slug that collides with data/use-cases.json", () => {
+  const data = makeSkillsData();
+  data.useCases[0].slug = "already-taken";
+  data.skills[0].useCases = ["already-taken"];
+  data.skills[1].useCases = ["already-taken"];
+  const errors = validateSkills(data, repos, existingUseCases);
+  assert.ok(errors.some((e) => /collides with a slug already defined in data\/use-cases\.json/.test(e)));
+});
+
+test("rejects a future updatedAt", () => {
+  const data = makeSkillsData();
+  data.updatedAt = "2099-01-01";
+  const errors = validateSkills(data, repos, existingUseCases);
+  assert.ok(errors.some((e) => /is in the future/.test(e)));
+});
+
+test("rejects a skill of type 'skill' missing install", () => {
+  const data = makeSkillsData();
+  delete data.skills[0].install;
+  const errors = validateSkills(data, repos, existingUseCases);
+  assert.ok(errors.some((e) => /install is required and must be non-empty when type is "skill"/.test(e)));
+});


### PR DESCRIPTION
## What

First half of the **/skills/ hub** (strategy move 1 from the 2026-08-20 GSC traffic analysis: skills queries = 54% of all Atlas search clicks; the hub defends that franchise against Nous's own Skills Hub with curation + judgment).

- **`data/skills.json`** — hand-curated: 7 use-case groups, 22 enriched entries out of the 44 skills-category repos. Each entry: `type` (skill/plugin/registry/collection), `install` (verified against the repo's README mirror + official `hermes skills` / `hermes plugins` syntax from the docs mirror), `compatibility`, one-line editorial `verdict`, ≤1 `topPick` per group. Verdicts deliberately avoid exact star counts so they don't bake stale — pages will render live stars from `repos.json`.
- **`scripts/validate-skills-json.js`** — pure validator + CLI, modeled on `validate-use-cases.js`. Fail-loud: entries must reference repos already in the catalog; category must be "Skills & Skill Registries" unless `crossCategory: true`; group slugs can't collide with `use-cases.json`; ≥2 skills per group; install required for skill/plugin types.
- **`tests/validate-skills-json.test.js`** — 9 tests covering each rule.
- **`.github/workflows/validate-skills-json.yml`** — CI gate on the data file.
- **`scripts/build-pages.js`** — validates `skills.json` at build time when present (skips gracefully while absent), so a bad hand-edit fails the build instead of shipping.

PR 2 will add the pages: `/skills/` hub index, `/skills/for-{slug}` pages, install box on project pages, sitemap/llms/nav wiring. `/lists/top-skills` is untouched.

## Review focus

The **editorial content** in `data/skills.json` — groups, picks, verdicts, install commands. Spot-checked top-pick install commands against local README mirrors (one fix caught: drawio-skill installs via its `365-skills` marketplace repo).

## Verification

- `node scripts/validate-skills-json.js` → passes (7 groups, 22 skills)
- `npm test` → **290/290 pass** (incl. 9 new)
- Deliberate-failure paths covered by tests (missing repo, wrong category, dup topPick, etc.)
- Build behavior unchanged when the data file is absent (graceful skip, verified)

## Flagged for follow-up (not in this PR)

- `topoteretes/cognee` appears miscategorized as "Skills & Skill Registries" — it's a memory platform; recategorizing would let it join the memory list instead.
- ~19 thin/niche skills-category repos intentionally left unenriched (long-tail pass later).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rNWuEGEjuDprjNEseLpsf
