### PR TITLE
Skills Hub PR 2/2: /skills/ pages + SEO wiring (rebased on merged #860)

### DIFF
--- a/.github/workflows/build-pages.yml
+++ b/.github/workflows/build-pages.yml
@@ -15,6 +15,7 @@ on:
     paths:
       - 'data/repos.json'
       - 'data/lists.json'
+      - 'data/skills.json'
       - 'data/latest-release.json'
       - 'scripts/build-pages.js'
   workflow_dispatch: {}

--- a/404.html
+++ b/404.html
@@ -34,6 +34,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/assets/css/page.css
+++ b/assets/css/page.css
@@ -240,6 +240,70 @@
   .handbook-mention { margin: 0 20px 20px; padding: 14px 16px; }
 }
 
+/* ─── Install box (skills-hub enriched projects) ────────────
+   Rendered on a project page only when data/skills.json carries a curated
+   entry for that repo. Same panel geometry as .handbook-mention so the two
+   stack cleanly when a project has both. */
+.install-box {
+  margin: 0 40px 24px;
+  padding: 16px 20px;
+  border-left: 3px solid var(--accent);
+  background: var(--surface, rgba(212, 154, 79, 0.06));
+}
+.install-box .ib-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--accent);
+  margin-bottom: 8px;
+}
+.install-box .ib-type {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--ink-soft);
+  border: 1px solid var(--rule-strong);
+  padding: 1px 8px;
+  margin-left: 8px;
+}
+.install-box .ib-cmd {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  line-height: 1.6;
+  color: var(--ink);
+  background: var(--bg-offset);
+  border: 1px solid var(--rule-strong);
+  padding: 10px 14px;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+.install-box .ib-compat,
+.install-box .ib-verdict {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.6;
+  color: var(--ink-dim);
+  margin: 8px 0 0;
+}
+.install-box .ib-compat { color: var(--ink-mute); }
+.install-box .ib-more {
+  display: inline-block;
+  margin-top: 10px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--accent);
+  border-bottom: 1px solid var(--accent-dim);
+}
+.install-box .ib-more:hover { border-bottom-color: var(--accent); }
+@media (max-width: 768px) {
+  .install-box { margin: 0 20px 20px; padding: 14px 16px; }
+}
+
 /* ─── Summary block ────────────────────────────────────────── */
 .project-summary {
   padding: 40px 40px;

--- a/assets/css/skills.css
+++ b/assets/css/skills.css
@@ -1,0 +1,215 @@
+/* ─── Skills Hub (/skills/, /skills/for-*) ──────────────────
+   Loaded after page.css (which supplies .list-page/.list-table/.list-row,
+   .section-label and .back-link) and use-cases.css (which supplies the
+   .uc-section shell these pages reuse). Only the pieces unique to the hub —
+   the freshness stamp, top-pick cards, install blocks, and the FAQ — live
+   here. The install box itself is styled in page.css: project pages render it
+   too and they do not load this file. */
+
+/* The honest stamp. Never bumped by a rebuild — it mirrors data/skills.json's
+   updatedAt/testedAgainst, plus a "Hermes vX is out" warning when the catalog
+   has moved past the last hand re-verification. */
+.sk-freshness {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--ink-mute);
+  letter-spacing: 0.04em;
+  margin-top: var(--s-4);
+}
+.sk-freshness .sk-stale {
+  color: var(--negative);
+}
+
+.sk-lede {
+  margin-top: var(--s-5);
+}
+.sk-lede a {
+  color: var(--accent);
+  border-bottom: 1px solid var(--accent-dim);
+}
+
+/* ── Top-pick cards ── */
+.sk-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: var(--s-4);
+}
+.sk-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-3);
+  padding: var(--s-5);
+  background: var(--bg-elev);
+  border: 1px solid var(--rule);
+}
+.sk-card-group {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--accent);
+}
+.sk-card-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--s-3);
+}
+.sk-card-name {
+  font-family: var(--font-display);
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  color: var(--ink);
+}
+.sk-card-name .org {
+  color: var(--ink-mute);
+  font-weight: 400;
+}
+.sk-card-stars {
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  color: var(--accent);
+  white-space: nowrap;
+}
+.sk-verdict {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  line-height: 1.6;
+  color: var(--ink-dim);
+  margin: 0;
+}
+.sk-card-link {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--accent);
+  border-bottom: 1px solid var(--accent-dim);
+  align-self: flex-start;
+}
+.sk-card-link:hover { border-bottom-color: var(--accent); }
+
+/* ── Type badge ── */
+.sk-type {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--ink-soft);
+  border: 1px solid var(--rule-strong);
+  padding: 1px var(--s-2);
+  margin-left: var(--s-2);
+  white-space: nowrap;
+}
+
+/* ── Install command ──
+   Plain selectable code, deliberately not a JS "copy" button: the site ships
+   no inline script and the hub is not worth a new bundle. */
+.sk-install-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--ink-mute);
+  margin-bottom: var(--s-2);
+}
+.sk-install {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  line-height: 1.6;
+  color: var(--ink);
+  background: var(--bg-offset);
+  border: 1px solid var(--rule-strong);
+  border-left: 2px solid var(--accent);
+  padding: var(--s-3) var(--s-4);
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+.sk-compat {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.6;
+  color: var(--ink-mute);
+  margin-top: var(--s-2);
+}
+.sk-compat .sk-compat-label {
+  color: var(--ink-soft);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 9.5px;
+  margin-right: var(--s-2);
+}
+
+/* ── Ranked entries on a /skills/for-* page ── */
+.sk-entry {
+  padding: var(--s-6) 0;
+  border-bottom: 1px solid var(--rule);
+}
+.sk-entry:last-child { border-bottom: 0; }
+.sk-entry-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--s-3);
+}
+.sk-entry-name {
+  font-family: var(--font-display);
+  font-size: 18px;
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  margin: 0;
+}
+.sk-entry-name a { color: var(--ink); }
+.sk-entry-name a:hover { color: var(--accent); }
+.sk-entry-name .org { color: var(--ink-mute); font-weight: 400; }
+.sk-entry-body { margin-top: var(--s-4); }
+.sk-pick-flag {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--bg);
+  background: var(--accent);
+  padding: 2px var(--s-2);
+  margin-left: var(--s-2);
+}
+
+/* ── "How we picked" + FAQ ── */
+.sk-method {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  line-height: 1.7;
+  color: var(--ink-dim);
+  max-width: 74ch;
+}
+.sk-faq {
+  max-width: 74ch;
+}
+.sk-faq-item {
+  padding-bottom: var(--s-5);
+  margin-bottom: var(--s-5);
+  border-bottom: 1px solid var(--rule);
+}
+.sk-faq-item:last-child { border-bottom: 0; margin-bottom: 0; }
+.sk-faq-q {
+  font-family: var(--font-display);
+  font-size: 16px;
+  font-weight: 500;
+  letter-spacing: -0.015em;
+  color: var(--ink);
+  margin-bottom: var(--s-3);
+}
+.sk-faq-a {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  line-height: 1.7;
+  color: var(--ink-dim);
+  margin: 0;
+}
+
+@media (max-width: 720px) {
+  .sk-card-grid { grid-template-columns: 1fr; }
+  .sk-entry-head { flex-direction: column; gap: var(--s-1); }
+}

--- a/dev/agent-loop.html
+++ b/dev/agent-loop.html
@@ -65,6 +65,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/dev/building-on-hermes.html
+++ b/dev/building-on-hermes.html
@@ -65,6 +65,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/dev/codebase-map.html
+++ b/dev/codebase-map.html
@@ -65,6 +65,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/dev/glossary.html
+++ b/dev/glossary.html
@@ -65,6 +65,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/dev/index.html
+++ b/dev/index.html
@@ -59,6 +59,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/dev/mcp-gateway-cron.html
+++ b/dev/mcp-gateway-cron.html
@@ -65,6 +65,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/dev/memory.html
+++ b/dev/memory.html
@@ -65,6 +65,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/dev/skill-template.html
+++ b/dev/skill-template.html
@@ -65,6 +65,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/dev/skills.html
+++ b/dev/skills.html
@@ -65,6 +65,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/dev/tools-and-toolsets.html
+++ b/dev/tools-and-toolsets.html
@@ -65,6 +65,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/dev/what-is-hermes-agent.html
+++ b/dev/what-is-hermes-agent.html
@@ -65,6 +65,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/guide/index.html
+++ b/guide/index.html
@@ -212,6 +212,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/" class="active">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/guide/install/index.html
+++ b/guide/install/index.html
@@ -195,6 +195,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/" class="active">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/guide/memory/index.html
+++ b/guide/memory/index.html
@@ -99,6 +99,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/" class="active">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/guide/vs-claude-code/index.html
+++ b/guide/vs-claude-code/index.html
@@ -127,6 +127,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/" class="active">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/index.html
+++ b/index.html
@@ -100,6 +100,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -217,6 +218,10 @@
   <div class="tt-desc" id="tt-desc"></div>
   <div class="tt-link">view project page →</div>
 </div>
+
+<!-- Skills entry point. Skills queries are the single largest slice of search
+     demand; /skills/ is the decision layer above /lists/top-skills. -->
+<p class="catalog-usecase-cta">Looking for skills? <a href="/skills/">The Hermes Skills Hub — best picks by use case →</a></p>
 
 <!-- Curated lists -->
 <section class="curated-lists" id="curated-lists">

--- a/lib/build-artifacts.js
+++ b/lib/build-artifacts.js
@@ -22,6 +22,7 @@ export const GENERATED_ARTIFACT_PATHS = [
   "projects/",
   "lists/",
   "use-cases/",
+  "skills/",
   "reports/",
   "sitemap.xml",
   "robots.txt",

--- a/lists/best-memory-providers.html
+++ b/lists/best-memory-providers.html
@@ -274,6 +274,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/" class="active">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -302,6 +303,7 @@
   <h1 class="list-title">Best Memory Providers for Hermes Agent</h1>
   <p class="list-intro">The top community-built memory and context management tools for Hermes Agent, ranked by GitHub stars. Memory is what makes Hermes self-improving — these tools extend its built-in recall with long-term semantic memory, graph-based retrieval, and cross-session persistence.</p>
   <p class="list-intro">For the architecture behind these tools, read <a href="/guide/memory/">The Hermes Agent Memory Guidebook</a>.</p>
+  
 </section>
 
 <div class="list-table" aria-label="Ranked list">
@@ -314,7 +316,7 @@
     <div class="list-rank">01</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">mem0ai /</span> mem0</div>
-      <div class="list-cell-desc">Universal memory layer for AI Agents</div>
+      <div class="list-cell-desc">Universal memory layer for AI Agents — official Hermes Agent memory provider, available as managed cloud or Apache-2.0 self-hosted OSS</div>
     </div>
     <div class="list-cell-stars">★ 63.7K</div>
   </a>
@@ -322,7 +324,7 @@
     <div class="list-rank">02</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">volcengine /</span> OpenViking</div>
-      <div class="list-cell-desc">Self-evolving Context Database for AI Agents. Unify Agent Memory, Knowledge RAG and Skills.</div>
+      <div class="list-cell-desc">Open-source context database for AI agents — official Hermes Agent memory provider using viking:// URIs and tiered L0/L1/L2 loading; 91% tok</div>
     </div>
     <div class="list-cell-stars">★ 31.4K</div>
   </a>
@@ -330,7 +332,7 @@
     <div class="list-rank">03</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">supermemoryai /</span> supermemory</div>
-      <div class="list-cell-desc">Memory and context engine + app that is extremely fast, scalable, and can be run fully locally. The Memory API for the AI era.</div>
+      <div class="list-cell-desc">Memory engine and API — official Hermes Agent memory provider with sub-300ms recall sustained at 100B+ tokens/month, custom vector graph eng</div>
     </div>
     <div class="list-cell-stars">★ 29.0K</div>
   </a>
@@ -346,7 +348,7 @@
     <div class="list-rank">05</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">vectorize-io /</span> hindsight <span class="repo-flag">official</span></div>
-      <div class="list-cell-desc">Hindsight: Agent Memory That  Learns</div>
+      <div class="list-cell-desc">Agent memory that learns — long-term retain/recall/reflect workflows</div>
     </div>
     <div class="list-cell-stars">★ 20.8K</div>
   </a>
@@ -354,7 +356,7 @@
     <div class="list-rank">06</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">plastic-labs /</span> honcho <span class="repo-flag">official</span></div>
-      <div class="list-cell-desc"> Memory library for building stateful agents</div>
+      <div class="list-cell-desc">Memory library for building stateful agents — the upstream library that the elkimek/honcho-self-hosted Hermes wrapper builds on.</div>
     </div>
     <div class="list-cell-stars">★ 6.8K</div>
   </a>
@@ -362,7 +364,7 @@
     <div class="list-rank">07</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">campfirein /</span> byterover-cli</div>
-      <div class="list-cell-desc">ByteRover CLI (brv) - The portable memory layer for  autonomous coding agents (formerly Cipher)</div>
+      <div class="list-cell-desc">Memory as a git repo (formerly Cipher) — official Hermes Agent memory provider with 5-tier retrieval (4 tiers non-LLM, sub-100ms), brv vc co</div>
     </div>
     <div class="list-cell-stars">★ 4.9K</div>
   </a>
@@ -370,7 +372,7 @@
     <div class="list-rank">08</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">mnemosyne-oss /</span> mnemosyne</div>
-      <div class="list-cell-desc">Zero-cloud AI memory that works everywhere. SQLite-backed. One pure-Python dependency.</div>
+      <div class="list-cell-desc">The Zero-Dependency, Sub-Millisecond AI Memory System for Hermes Agents</div>
     </div>
     <div class="list-cell-stars">★ 2.7K</div>
   </a>
@@ -378,7 +380,7 @@
     <div class="list-rank">09</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">ClaudioDrews /</span> memory-os</div>
-      <div class="list-cell-desc">A 7-layer memory operating system for Hermes Agent — persistent memory with Qdrant, structured facts, fabric recall, auto-curated wiki, and </div>
+      <div class="list-cell-desc">Seven-layer memory system for Hermes Agent: persistent memory on Qdrant, structured facts, fabric recall, and an auto-curated wiki.</div>
     </div>
     <div class="list-cell-stars">★ 1.3K</div>
   </a>
@@ -386,7 +388,7 @@
     <div class="list-rank">10</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">greyhaven-ai /</span> autocontext</div>
-      <div class="list-cell-desc">a recursive self-improving harness designed to help your agents (and future iterations of those agents) succeed on any task</div>
+      <div class="list-cell-desc">Recursive self-improving context harness — helps agents succeed on complex tasks</div>
     </div>
     <div class="list-cell-stars">★ 1.3K</div>
   </a>
@@ -402,7 +404,7 @@
     <div class="list-rank">12</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">elkimek /</span> honcho-self-hosted</div>
-      <div class="list-cell-desc">Self-host Honcho memory layer for Hermes Agent — OpenRouter + Venice, no code changes</div>
+      <div class="list-cell-desc">Self-hosted Honcho memory backend for cross-session persistence</div>
     </div>
     <div class="list-cell-stars">★ 362</div>
   </a>
@@ -410,7 +412,7 @@
     <div class="list-rank">13</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">Signet-AI /</span> signetai</div>
-      <div class="list-cell-desc">Sync and store memories, shared identity files (AGENTS.md, CLAUDE.md), session transcripts, institutional knowledge, and secrets between all</div>
+      <div class="list-cell-desc">Local-first identity, memory, and secrets layer for AI agents — portable state across Hermes Agent, Claude Code, Codex, OpenCode, OpenClaw, </div>
     </div>
     <div class="list-cell-stars">★ 253</div>
   </a>
@@ -418,7 +420,7 @@
     <div class="list-rank">14</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">plur-ai /</span> plur</div>
-      <div class="list-cell-desc">Shared memory for AI agents</div>
+      <div class="list-cell-desc">Shared memory layer with open engram YAML format for multi-agent systems</div>
     </div>
     <div class="list-cell-stars">★ 241</div>
   </a>
@@ -426,7 +428,7 @@
     <div class="list-rank">15</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">yoloshii /</span> ClawMem</div>
-      <div class="list-cell-desc">On-device memory layer for AI agents. Claude Code, Hermes and OpenClaw. Hooks + MCP server + hybrid RAG search.</div>
+      <div class="list-cell-desc">On-device memory and context engine for agents — local-first, no cloud dependencies</div>
     </div>
     <div class="list-cell-stars">★ 199</div>
   </a>
@@ -450,7 +452,7 @@
     <div class="list-rank">18</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">yantrikos /</span> yantrikdb-hermes-plugin</div>
-      <div class="list-cell-desc">YantrikDB memory provider for NousResearch/hermes-agent — self-maintaining memory with benchmarked recall, self-tuning ranking, contradictio</div>
+      <div class="list-cell-desc">Self-maintaining Hermes memory plugin with explainable retrieval — every recall comes back with a why_retrieved tag, plus canonicalization, </div>
     </div>
     <div class="list-cell-stars">★ 81</div>
   </a>
@@ -466,7 +468,7 @@
     <div class="list-rank">20</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">amanning3390 /</span> flowstate-qmd</div>
-      <div class="list-cell-desc">FlowState QMD — Anticipatory Memory for AI Agents. Hermes 2026 Hackathon Entry.</div>
+      <div class="list-cell-desc">Anticipatory memory with RAG and vector search — Hermes 2026 Hackathon entry</div>
     </div>
     <div class="list-cell-stars">★ 45</div>
   </a>
@@ -482,7 +484,7 @@
     <div class="list-rank">22</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">generalbusiness-ai /</span> keep</div>
-      <div class="list-cell-desc">Reflective memory for agents</div>
+      <div class="list-cell-desc">Reflective memory for AI agents</div>
     </div>
     <div class="list-cell-stars">★ 39</div>
   </a>
@@ -490,7 +492,7 @@
     <div class="list-rank">23</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">Perseus-Computing-LLC /</span> perseus</div>
-      <div class="list-cell-desc">Live context engine for AI agents: resolve verified workspace state before the context window opens. Pairs with Perseus Vault for persistent</div>
+      <div class="list-cell-desc">The memory &amp; context layer for AI agents: load only the context they actually need. Resolves live workspace state into verified facts before</div>
     </div>
     <div class="list-cell-stars">★ 37</div>
   </a>
@@ -506,7 +508,7 @@
     <div class="list-rank">25</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">Ladybug-Memory /</span> hermes-memory-plugin</div>
-      <div class="list-cell-desc">Ladybug memory plugin for Hermes Agent</div>
+      <div class="list-cell-desc">Local-only Hermes memory plugin with built-in 1-10 importance ranking so the things that matter most surface first. Columnar .lbdb embedded </div>
     </div>
     <div class="list-cell-stars">★ 20</div>
   </a>
@@ -514,7 +516,7 @@
     <div class="list-rank">26</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">MukundaKatta /</span> hermes-agentmemory</div>
-      <div class="list-cell-desc">Pull-model episodic memory plugin for Hermes Agent. Real deletes, audit trace, BYO Claude. MIT.</div>
+      <div class="list-cell-desc">Pull-model episodic memory plugin for Hermes Agent with real deletion (no persistent summaries that haunt future recall) and a trace.jsonl a</div>
     </div>
     <div class="list-cell-stars">★ 9</div>
   </a>
@@ -538,7 +540,7 @@
     <div class="list-rank">29</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">stepanov1975 /</span> hermes-local-knowledge</div>
-      <div class="list-cell-desc">Hermes Agent plugin for local knowledge search and artifact routing—find the right skill, script, runbook, cron job, MCP server, or document</div>
+      <div class="list-cell-desc">Reusable Hermes Agent plugin for local capability indexing and routing</div>
     </div>
     <div class="list-cell-stars">★ 6</div>
   </a>
@@ -570,7 +572,7 @@
     <div class="list-rank">33</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">penfieldlabs /</span> hermes-penfield</div>
-      <div class="list-cell-desc">🧠 Penfield memory provider for Hermes agent</div>
+      <div class="list-cell-desc">🧠 Penfield memory providers for Hermes agent</div>
     </div>
     <div class="list-cell-stars">★ 3</div>
   </a>

--- a/lists/deployment-options.html
+++ b/lists/deployment-options.html
@@ -148,6 +148,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/" class="active">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -176,6 +177,7 @@
   <h1 class="list-title">Deployment Options for Hermes Agent</h1>
   <p class="list-intro">How to deploy Hermes Agent in production — Docker images, Nix packages, systemd services, and managed cloud templates. From a $5 VPS to enterprise Kubernetes.</p>
   
+  
 </section>
 
 <div class="list-table" aria-label="Ranked list">
@@ -188,7 +190,7 @@
     <div class="list-rank">01</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">numtide /</span> llm-agents.nix</div>
-      <div class="list-cell-desc">Nix packages for AI coding agents and development tools. Automatically updated daily.</div>
+      <div class="list-cell-desc">Nix packages for AI coding agents including Hermes</div>
     </div>
     <div class="list-cell-stars">★ 1.8K</div>
   </a>
@@ -196,7 +198,7 @@
     <div class="list-rank">02</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">marshallrichards /</span> ClawPhone</div>
-      <div class="list-cell-desc">Scripts and Tweaks for running agents like OpenClaw, Claude Code, Codex, Hermes Agent, and more on an Android smartphone</div>
+      <div class="list-cell-desc">Scripts and notes for running agent CLIs including Hermes Agent on Android smartphones through Termux</div>
     </div>
     <div class="list-cell-stars">★ 546</div>
   </a>
@@ -204,7 +206,7 @@
     <div class="list-rank">03</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">AbuZar-Ansarii /</span> Hermes-Agent-On-Android</div>
-      <div class="list-cell-desc">Run Hermes Agent - a self-evolving AI assistant - on any Android device using Termux. One-line installation.</div>
+      <div class="list-cell-desc">Termux-based installer and guide for running Hermes Agent on Android devices</div>
     </div>
     <div class="list-cell-stars">★ 198</div>
   </a>
@@ -212,7 +214,7 @@
     <div class="list-rank">04</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">ultraworkers /</span> hermes-agent-helm-chart</div>
-      <div class="list-cell-desc">The community-driven unofficial chart packages Hermes Agent for Kubernetes with cloud-native defaults, explicit state-safety guardrails, and</div>
+      <div class="list-cell-desc">Unofficial community Helm chart for deploying Hermes Agent on Kubernetes with cloud-native state-safety guardrails</div>
     </div>
     <div class="list-cell-stars">★ 134</div>
   </a>
@@ -220,7 +222,7 @@
     <div class="list-rank">05</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">amirghm /</span> hermes-agent-mobile</div>
-      <div class="list-cell-desc">Hermes AI assistant for mobile. Install on Android or iOS with one command.</div>
+      <div class="list-cell-desc">One-command installer that brings the Hermes AI assistant to Android and iOS.</div>
     </div>
     <div class="list-cell-stars">★ 85</div>
   </a>
@@ -228,7 +230,7 @@
     <div class="list-rank">06</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">TheAiSingularity /</span> hermesclaw</div>
-      <div class="list-cell-desc">Hermes Agent (NousResearch) sandboxed by NVIDIA OpenShell — hardware-enforced network/filesystem/syscall policy, full memory + gateway stack</div>
+      <div class="list-cell-desc">Hermes Agent sandboxed with hardware-level enforcement</div>
     </div>
     <div class="list-cell-stars">★ 61</div>
   </a>
@@ -236,7 +238,7 @@
     <div class="list-rank">07</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">xmbshwll /</span> hermes-agent-docker</div>
-      <div class="list-cell-desc">Simple docker sandbox image for Hermes Agent</div>
+      <div class="list-cell-desc">Simple Docker sandbox image for Hermes Agent</div>
     </div>
     <div class="list-cell-stars">★ 48</div>
   </a>
@@ -244,7 +246,7 @@
     <div class="list-rank">08</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">0xrsydn /</span> nix-hermes-agent</div>
-      <div class="list-cell-desc">Nix package and NixOS module for Hermes Agent by Nous Research</div>
+      <div class="list-cell-desc">Nix package and NixOS module for reproducible Hermes deployment</div>
     </div>
     <div class="list-cell-stars">★ 40</div>
   </a>
@@ -252,7 +254,7 @@
     <div class="list-rank">09</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">solomon2773 /</span> nora</div>
-      <div class="list-cell-desc">Open-source, self-hosted control plane for OpenClaw and Hermes AI-agent fleets on Docker/Kubernetes — REST, CLI, and MCP.</div>
+      <div class="list-cell-desc">Self-hosted control plane to deploy, monitor, and operate OpenClaw and Hermes AI agents on Docker/Kubernetes — with REST, CLI, and MCP.</div>
     </div>
     <div class="list-cell-stars">★ 32</div>
   </a>
@@ -268,7 +270,7 @@
     <div class="list-rank">11</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">JackTheGit /</span> hermes-autonomous-server</div>
-      <div class="list-cell-desc">Run Hermes Agent autonomously on your Linux server using systemd and native cron scheduler. Production-ready, headless setup with Nous Porta</div>
+      <div class="list-cell-desc">Headless systemd deployment with Nous Portal integration — production-ready</div>
     </div>
     <div class="list-cell-stars">★ 15</div>
   </a>
@@ -276,7 +278,7 @@
     <div class="list-rank">12</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">MilkyWay008 /</span> Hermes-OTG</div>
-      <div class="list-cell-desc">Your agentic system rescue companion, especially for broken host Hermes. Hermes Agent on a USB stick — zero install &amp; portable, hot-swappabl</div>
+      <div class="list-cell-desc">Hermes OTG — The Portable Hermes Agent That Does *Everything*. Full production package distributed via GitHub Releases (see PACKAGE-STRUCTUR</div>
     </div>
     <div class="list-cell-stars">★ 8</div>
   </a>

--- a/lists/developer-tools.html
+++ b/lists/developer-tools.html
@@ -184,6 +184,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/" class="active">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -212,6 +213,7 @@
   <h1 class="list-title">Developer Tools for Hermes Agent</h1>
   <p class="list-intro">CLI tools, linters, migration helpers, token trackers, and other utilities that make developing with Hermes easier.</p>
   
+  
 </section>
 
 <div class="list-table" aria-label="Ranked list">
@@ -224,7 +226,7 @@
     <div class="list-rank">01</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">colbymchenry /</span> codegraph</div>
-      <div class="list-cell-desc">Pre-indexed code knowledge graph, auto syncs on code changes, for Claude Code, Codex, Gemini, Cursor, OpenCode, AntiGravity, Kiro, and Herme</div>
+      <div class="list-cell-desc">Local pre-indexed code knowledge graph for Hermes Agent and other coding agents to reduce token usage and tool calls</div>
     </div>
     <div class="list-cell-stars">★ 67.5K</div>
   </a>
@@ -232,7 +234,7 @@
     <div class="list-rank">02</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">junhoyeo /</span> tokscale</div>
-      <div class="list-cell-desc">🛰️ Track token usage across AI coding agents from your terminal. 🏅 Global leaderboard with trillions of tokens tracked.</div>
+      <div class="list-cell-desc">CLI tool for tracking token usage from Claude Code, OpenClaw, Hermes, Codex, Gemini, and more</div>
     </div>
     <div class="list-cell-stars">★ 5.1K</div>
   </a>
@@ -240,7 +242,7 @@
     <div class="list-rank">03</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">liaohch3 /</span> claude-tap</div>
-      <div class="list-cell-desc">Intercept and inspect Coding Agent API traffic from Claude Code, Codex CLI, Gemini CLI, Cursor CLI, OpenCode, Kimi/Kimi Code, Pi, and Hermes</div>
+      <div class="list-cell-desc">Local trace viewer for inspecting coding-agent API traffic from Hermes Agent, Claude Code, Codex, Gemini, Cursor, OpenCode, and others</div>
     </div>
     <div class="list-cell-stars">★ 3.1K</div>
   </a>
@@ -256,7 +258,7 @@
     <div class="list-rank">05</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">Javis603 /</span> token-monitor</div>
-      <div class="list-cell-desc">Local-first desktop widget for tracking token usage, costs, and limits across 31+ AI coding tools—including Claude Code, Codex, Cursor, Open</div>
+      <div class="list-cell-desc">Real-time token, cost, and rate-limit widget with multi-device sync, reading Hermes Agent state directly alongside Claude Code, Codex, and o</div>
     </div>
     <div class="list-cell-stars">★ 1.6K</div>
   </a>
@@ -264,7 +266,7 @@
     <div class="list-rank">06</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">Salomondiei08 /</span> oh-my-hermes</div>
-      <div class="list-cell-desc">An opinionated workflow layer for building, shipping, and operating apps with Hermes Agent</div>
+      <div class="list-cell-desc">Opinionated workflow layer for building, shipping, and operating apps with Hermes Agent</div>
     </div>
     <div class="list-cell-stars">★ 850</div>
   </a>
@@ -272,7 +274,7 @@
     <div class="list-rank">07</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">joeynyc /</span> hermes-skins</div>
-      <div class="list-cell-desc">Custom skins (visual themes) for the Hermes CLI agent</div>
+      <div class="list-cell-desc">Community CLI skins and themes for Hermes terminal UI</div>
     </div>
     <div class="list-cell-stars">★ 556</div>
   </a>
@@ -288,7 +290,7 @@
     <div class="list-rank">09</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">unmodeled-tyler /</span> vessel-browser</div>
-      <div class="list-cell-desc">Built from the ground-up for agents, Vessel Browser is an open source AI browser for Linux/Mac/Windows that provides a durable state, MCP co</div>
+      <div class="list-cell-desc">AI-native browser built for autonomous agent control via MCP</div>
     </div>
     <div class="list-cell-stars">★ 127</div>
   </a>
@@ -312,7 +314,7 @@
     <div class="list-rank">12</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">adityahimaone /</span> hermes-agent-rtk-caveman</div>
-      <div class="list-cell-desc">Hermes Agent RTK + Caveman setup - 90-99% token savings on CLI operations with 35+ pre-configured skills</div>
+      <div class="list-cell-desc">Hermes Agent RTK and Caveman setup with preconfigured skills and token-saving CLI workflows</div>
     </div>
     <div class="list-cell-stars">★ 76</div>
   </a>
@@ -320,7 +322,7 @@
     <div class="list-rank">13</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">Abruptive /</span> Ankh.md</div>
-      <div class="list-cell-desc">A mysterious multi-agent swarm framework summoned by TAW Agent from 1971 to help you craft a better future towards 2133 &amp; beyond. Ankh.md is</div>
+      <div class="list-cell-desc">TAW Agent framework for creating scoped Hermes Agents</div>
     </div>
     <div class="list-cell-stars">★ 74</div>
   </a>
@@ -328,7 +330,7 @@
     <div class="list-rank">14</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">42-evey /</span> evey-setup</div>
-      <div class="list-cell-desc">Get a hermes-agent stack running in minutes. Free models, 29 plugins, zero cost.</div>
+      <div class="list-cell-desc">Get a hermes-agent stack running in minutes — free models, 29 plugins, zero cost</div>
     </div>
     <div class="list-cell-stars">★ 62</div>
   </a>
@@ -336,7 +338,7 @@
     <div class="list-rank">15</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">hermes-labs-ai /</span> lintlang</div>
-      <div class="list-cell-desc">Static analysis for AI agent configs, tool descriptions, and system prompts — catches vague tool descriptions, missing stop conditions, and </div>
+      <div class="list-cell-desc">Static linter for AI agent configs, tool descriptions, and system prompts. HERM v1.1 scoring.</div>
     </div>
     <div class="list-cell-stars">★ 61</div>
   </a>
@@ -344,7 +346,7 @@
     <div class="list-rank">16</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">0xNyk /</span> openclaw-to-hermes</div>
-      <div class="list-cell-desc">Migrate from OpenClaw to Hermes Agent — complete, battle-tested migration tool</div>
+      <div class="list-cell-desc">Migration tool from OpenClaw to Hermes Agent</div>
     </div>
     <div class="list-cell-stars">★ 37</div>
   </a>

--- a/lists/index.html
+++ b/lists/index.html
@@ -119,6 +119,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/" class="active">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/lists/multi-agent-frameworks.html
+++ b/lists/multi-agent-frameworks.html
@@ -148,6 +148,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/" class="active">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -176,6 +177,7 @@
   <h1 class="list-title">Multi-Agent Frameworks for Hermes</h1>
   <p class="list-intro">Orchestration tools for running multiple Hermes agents together. Fleet management dashboards, swarm coordinators, and multi-agent delegation systems.</p>
   
+  
 </section>
 
 <div class="list-table" aria-label="Ranked list">
@@ -196,7 +198,7 @@
     <div class="list-rank">02</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">builderz-labs /</span> mission-control</div>
-      <div class="list-cell-desc">Self-hosted control plane for AI agents: dispatch tasks, review runs, track spend, and operate OpenClaw, Claude Code, Codex, and other runti</div>
+      <div class="list-cell-desc">Self-hosted AI agent orchestration — dispatch tasks, run multi-agent workflows, monitor spend</div>
     </div>
     <div class="list-cell-stars">★ 6.0K</div>
   </a>
@@ -204,7 +206,7 @@
     <div class="list-rank">03</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">agent-of-empires /</span> agent-of-empires</div>
-      <div class="list-cell-desc">Manage multiple Claude Code, OpenCode agents from either TUI or Web for easy access on mobile. Also supports Mistral Vibe, Codex CLI, Gemini</div>
+      <div class="list-cell-desc">TUI and web control surface for managing multiple coding agents including Hermes Agent, Claude Code, OpenCode, Codex, Gemini, and others</div>
     </div>
     <div class="list-cell-stars">★ 3.1K</div>
   </a>
@@ -212,7 +214,7 @@
     <div class="list-rank">04</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">CryptoDmitry /</span> hermes-agent-control-room</div>
-      <div class="list-cell-desc">Control Room-first template for managing Hermes agents from one VPS agent to specialist teams and orchestrated workflows </div>
+      <div class="list-cell-desc">Control Room-first template for managing Hermes agents from one VPS agent to specialist teams and orchestrated workflows</div>
     </div>
     <div class="list-cell-stars">★ 751</div>
   </a>
@@ -220,7 +222,7 @@
     <div class="list-rank">05</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">shannhk /</span> hermes-agent-control-room</div>
-      <div class="list-cell-desc">Control Room-first template for managing Hermes agents from one VPS agent to specialist teams and orchestrated workflows</div>
+      <div class="list-cell-desc">Control Room-first template for scaling Hermes Agent from one VPS agent to specialist teams and automated workflows</div>
     </div>
     <div class="list-cell-stars">★ 696</div>
   </a>
@@ -228,7 +230,7 @@
     <div class="list-rank">06</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">swarmclawai /</span> swarmclaw</div>
-      <div class="list-cell-desc">Open-source self-hosted AI agent runtime and multi-agent framework for autonomous agent swarms. Agent memory, MCP tools, schedules, delegati</div>
+      <div class="list-cell-desc">Build autonomous AI agent swarms with orchestration, skills, and multiple model providers</div>
     </div>
     <div class="list-cell-stars">★ 649</div>
   </a>
@@ -236,7 +238,7 @@
     <div class="list-rank">07</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">agent37-platform /</span> minions</div>
-      <div class="list-cell-desc">Mission Control for your Hermes agents</div>
+      <div class="list-cell-desc">Mission Control for Hermes agents: create, supervise, and review autonomous Hermes Agent work from one screen</div>
     </div>
     <div class="list-cell-stars">★ 619</div>
   </a>
@@ -244,7 +246,7 @@
     <div class="list-rank">08</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">1ilkhamov /</span> opencode-hermes-multiagent</div>
-      <div class="list-cell-desc">Hermes — a multi-agent system for OpenCode AI. 17 specialized agents for research, planning, implementation, quality, and infrastructure.</div>
+      <div class="list-cell-desc">17 specialized agents for research, planning, implementation, quality, and infrastructure</div>
     </div>
     <div class="list-cell-stars">★ 181</div>
   </a>
@@ -252,7 +254,7 @@
     <div class="list-rank">09</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">linke-ai /</span> hermes-agent-team</div>
-      <div class="list-cell-desc">基于 Hermes Agent 构建的本地多 Agent 团队协作 Web 系统</div>
+      <div class="list-cell-desc">Local multi-agent team collaboration web system built on Hermes Agent profiles, MCP, ACP, and Hermes Kanban</div>
     </div>
     <div class="list-cell-stars">★ 179</div>
   </a>
@@ -260,7 +262,7 @@
     <div class="list-rank">10</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">howdymary /</span> hermes-agent-metaharness</div>
-      <div class="list-cell-desc">An implementation of a Meta Harness for Hermes.</div>
+      <div class="list-cell-desc">Meta-harness for Hermes Agent — meta-optimization with arxiv paper reference</div>
     </div>
     <div class="list-cell-stars">★ 107</div>
   </a>
@@ -268,7 +270,7 @@
     <div class="list-rank">11</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">runtimenoteslabs /</span> gladiator</div>
-      <div class="list-cell-desc">Two zero-human AI companies battle for GitHub stars using Hermes Agent + Paperclip. Nous Research Hackathon 2026.</div>
+      <div class="list-cell-desc">Autonomous AI companies competing for GitHub stars — agent-vs-agent arena</div>
     </div>
     <div class="list-cell-stars">★ 74</div>
   </a>
@@ -276,7 +278,7 @@
     <div class="list-rank">12</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">InfiniteWhispers /</span> HermesAgent-MultiModel</div>
-      <div class="list-cell-desc">A fully-local, multi-model AI agent framework with Mixture-of-Agents (MoA) orchestration. Run a high-performance agentic stack on consumer G</div>
+      <div class="list-cell-desc">Fully-local multi-model agent framework running a Mixture-of-Agents stack on consumer GPUs with Hermes and Ollama, no cloud dependencies.</div>
     </div>
     <div class="list-cell-stars">★ 54</div>
   </a>

--- a/lists/top-skills.html
+++ b/lists/top-skills.html
@@ -340,6 +340,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/" class="active">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -368,6 +369,7 @@
   <h1 class="list-title">Top Skills for Hermes Agent</h1>
   <p class="list-intro">The most popular skills and skill registries in the Hermes ecosystem, ranked by GitHub stars. Skills are reusable capabilities that follow the agentskills.io open standard — from cybersecurity to diagram generation to creative ideation.</p>
   
+  <p class="list-intro">This page ranks the whole category by stars. For picks by what you're trying to do — with install commands, compatibility notes, and a verdict per skill — see the <a href="/skills/">Hermes Skills Hub</a>.</p>
 </section>
 
 <div class="list-table" aria-label="Ranked list">
@@ -388,7 +390,7 @@
     <div class="list-rank">02</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">nexu-io /</span> open-design</div>
-      <div class="list-cell-desc">🎨 Best DeepSeek Harness Design Plugin. The open-source Claude Design alternative. 🖥️ Local-first desktop app. 🖼️ Your coding agent become</div>
+      <div class="list-cell-desc">Local-first open-source design/prototyping system with coding-agent CLI support including Hermes Agent</div>
     </div>
     <div class="list-cell-stars">★ 90.0K</div>
   </a>
@@ -396,7 +398,7 @@
     <div class="list-rank">03</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</div>
-      <div class="list-cell-desc">817 structured cybersecurity skills for AI agents · Mapped to 6 frameworks: MITRE ATT&amp;CK, NIST CSF 2.0, MITRE ATLAS, D3FEND, NIST AI RMF &amp; M</div>
+      <div class="list-cell-desc">754 structured cybersecurity skills mapped to MITRE ATT&amp;CK, NIST CSF 2.0, ATLAS, D3FEND &amp; NIST AI RMF</div>
     </div>
     <div class="list-cell-stars">★ 30.5K</div>
   </a>
@@ -412,7 +414,7 @@
     <div class="list-rank">05</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">Agents365-ai /</span> drawio-skill</div>
-      <div class="list-cell-desc">Generate draw.io diagrams from natural language — 11 presets (UML, SysML/MBSE, BPMN, network, C4…), 36 tools: codebase/CI/infra-to-diagram, </div>
+      <div class="list-cell-desc">Generate draw.io diagrams from natural language descriptions</div>
     </div>
     <div class="list-cell-stars">★ 7.9K</div>
   </a>
@@ -428,7 +430,7 @@
     <div class="list-rank">07</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">conorbronsdon /</span> avoid-ai-writing</div>
-      <div class="list-cell-desc">Skill that audits and rewrites content to remove AI writing patterns. Use it with your favorite agents including Claude Code, OpenClaw, Code</div>
+      <div class="list-cell-desc">Audits and rewrites content to eliminate detectable AI writing patterns</div>
     </div>
     <div class="list-cell-stars">★ 3.2K</div>
   </a>
@@ -436,7 +438,7 @@
     <div class="list-rank">08</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">AMAP-ML /</span> SkillClaw</div>
-      <div class="list-cell-desc">Let Skills Evolve Collectively with Agentic Evolver </div>
+      <div class="list-cell-desc">Let Skills Evolve Collectively with Agentic Evolver</div>
     </div>
     <div class="list-cell-stars">★ 2.5K</div>
   </a>
@@ -444,7 +446,7 @@
     <div class="list-rank">09</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">wondelai /</span> skills</div>
-      <div class="list-cell-desc">Wondel.ai Agent Skills — Business, Marketing, UX &amp; Coding Frameworks from Bestselling Books. 50 skills + 12 guided journeys for Claude Code,</div>
+      <div class="list-cell-desc">Cross-platform skills library for Claude Code and agentskills.io-compatible agents</div>
     </div>
     <div class="list-cell-stars">★ 2.0K</div>
   </a>
@@ -452,7 +454,7 @@
     <div class="list-rank">10</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">mohitagw15856 /</span> pm-claude-skills</div>
-      <div class="list-cell-desc">1098 professional Agent Skills for Claude, ChatGPT, Gemini, Cursor &amp; Codex — from PRDs and postmortems to appealing a disability benefit, bu</div>
+      <div class="list-cell-desc">822 professional agent skills that run natively in Hermes Agent and Claude Code, with ready-to-paste exports for other assistants.</div>
     </div>
     <div class="list-cell-stars">★ 1.3K</div>
   </a>
@@ -460,7 +462,7 @@
     <div class="list-rank">11</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">ZeroPointRepo /</span> youtube-skills</div>
-      <div class="list-cell-desc">YouTube Transcript API skills for AI agents. Get transcripts, search videos, browse channels. Works with OpenClaw, Hermes Agent, and other a</div>
+      <div class="list-cell-desc">YouTube transcript, search, channel, and playlist skills for Hermes Agent, OpenClaw, Claude Code, Cursor, and Windsurf</div>
     </div>
     <div class="list-cell-stars">★ 544</div>
   </a>
@@ -468,7 +470,7 @@
     <div class="list-rank">12</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">Romanescu11 /</span> hermes-skill-factory</div>
-      <div class="list-cell-desc"> A meta-skill plugin for Nous Research's Hermes AI agent that watches your workflows and automatically turns them into reusable skills.  Eve</div>
+      <div class="list-cell-desc">Meta-skill plugin that watches workflows and auto-generates reusable skills</div>
     </div>
     <div class="list-cell-stars">★ 527</div>
   </a>
@@ -484,7 +486,7 @@
     <div class="list-rank">14</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">DougTrajano /</span> pydantic-ai-skills</div>
-      <div class="list-cell-desc">This package implements Agent Skills (https://agentskills.io) support with progressive disclosure for Pydantic AI. Supports filesystem and p</div>
+      <div class="list-cell-desc">Type-safe agentskills.io support with progressive disclosure for Pydantic AI</div>
     </div>
     <div class="list-cell-stars">★ 360</div>
   </a>
@@ -492,7 +494,7 @@
     <div class="list-rank">15</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">AkoliteZA /</span> hermes-agent-idea-workflow</div>
-      <div class="list-cell-desc">Pre-build idea-to-spec workflow skills for Hermes Agent: turn rough ideas into design docs, implementation specs, and Superpowers-ready buil</div>
+      <div class="list-cell-desc">Pre-build idea-to-spec workflow skills for Hermes Agent that turn rough ideas into design docs and implementation handoffs</div>
     </div>
     <div class="list-cell-stars">★ 261</div>
   </a>
@@ -500,7 +502,7 @@
     <div class="list-rank">16</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">tlehman /</span> litprog-skill</div>
-      <div class="list-cell-desc">Literate programming skill for agent harnesses like Claude Code, OpenCode and Hermes Agent</div>
+      <div class="list-cell-desc">Literate programming skill — weave code and documentation across agents</div>
     </div>
     <div class="list-cell-stars">★ 251</div>
   </a>
@@ -508,7 +510,7 @@
     <div class="list-rank">17</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">ReinaMacCredy /</span> maestro</div>
-      <div class="list-cell-desc"> Gives Claude Code, Codex, and CI a shared task system, verdict ledger, and state store so agent work is traceable and auditable.</div>
+      <div class="list-cell-desc">Harness for long-running AI agents — structured memory, cross-feature learning, plan-approve-execute</div>
     </div>
     <div class="list-cell-stars">★ 227</div>
   </a>
@@ -516,7 +518,7 @@
     <div class="list-rank">18</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">esaradev /</span> icarus-plugin</div>
-      <div class="list-cell-desc">Self-memory and replacement models for Hermes agents. Remember your work. Train your replacement.</div>
+      <div class="list-cell-desc">Self-memory and replacement models — remember your work, train your replacement</div>
     </div>
     <div class="list-cell-stars">★ 142</div>
   </a>
@@ -524,7 +526,7 @@
     <div class="list-rank">19</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
-      <div class="list-cell-desc">[PUBLIC] Repository for Chainlink Skills that implement https://agentskills.io/specification</div>
+      <div class="list-cell-desc">Oracle network and smart contract interaction skills (agentskills.io spec)</div>
     </div>
     <div class="list-cell-stars">★ 125</div>
   </a>
@@ -540,7 +542,7 @@
     <div class="list-rank">21</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">black-forest-labs /</span> skills</div>
-      <div class="list-cell-desc">Official skills from Black Forest Labs for FLUX image generation models. These skills provide prompting guidelines and API integration patte</div>
+      <div class="list-cell-desc">Official FLUX image generation skills — prompting guidelines and API integration</div>
     </div>
     <div class="list-cell-stars">★ 103</div>
   </a>
@@ -548,7 +550,7 @@
     <div class="list-rank">22</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">armelhbobdad /</span> bmad-module-skill-forge</div>
-      <div class="list-cell-desc">A standalone BMAD module that transforms code repositories, documentation websites, and developer discourse into agentskills.io-compliant, v</div>
+      <div class="list-cell-desc">Converts repos, docs, and developer discourse into agentskills.io-compliant skills</div>
     </div>
     <div class="list-cell-stars">★ 93</div>
   </a>
@@ -556,7 +558,7 @@
     <div class="list-rank">23</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">chigwell /</span> skilldock.io</div>
-      <div class="list-cell-desc">SkillDock.io is a registry of reusable AI Skills based on the AgentSkills specification. Discover, install, and publish versioned Skills tha</div>
+      <div class="list-cell-desc">Registry of reusable AI skills based on AgentSkills specification</div>
     </div>
     <div class="list-cell-stars">★ 86</div>
   </a>
@@ -564,7 +566,7 @@
     <div class="list-rank">24</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">tiann /</span> execplan-skill</div>
-      <div class="list-cell-desc">An [Agent Skill](https://agentskills.io) that enables AI coding agents to tackle complex, long-running implementation tasks autonomously.</div>
+      <div class="list-cell-desc">Complex multi-step task execution with checkpoints and recovery</div>
     </div>
     <div class="list-cell-stars">★ 67</div>
   </a>
@@ -580,7 +582,7 @@
     <div class="list-rank">26</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">adnw-vinc /</span> hermes-nextcloud</div>
-      <div class="list-cell-desc">Hermes Agent skill for Nextcloud - manage files, notes, calendar, tasks, and contacts via WebDAV and CalDAV</div>
+      <div class="list-cell-desc">Hermes Agent skill for Nextcloud — manage files, notes, calendar, tasks, and contacts via WebDAV and CalDAV.</div>
     </div>
     <div class="list-cell-stars">★ 44</div>
   </a>
@@ -588,7 +590,7 @@
     <div class="list-rank">27</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">cablate /</span> Agentic-MCP-Skill</div>
-      <div class="list-cell-desc">Agentic-MCP, Progressive MCP client with three-layer lazy loading. Validates AgentSkills.io pattern for efficient token usage. Use MCP witho</div>
+      <div class="list-cell-desc">Progressive MCP client with three-layer lazy loading — validates agentskills.io pattern</div>
     </div>
     <div class="list-cell-stars">★ 39</div>
   </a>
@@ -596,7 +598,7 @@
     <div class="list-rank">28</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">willingning-coder /</span> eagle-eye</div>
-      <div class="list-cell-desc">🦅 5-Layer Intelligent Skill Retrieval for Hermes Agent — hard triggers, FTS5, synonym dictionary, dense embedding, RRF fusion. Zero core mo</div>
+      <div class="list-cell-desc">5-layer intelligent skill retrieval for Hermes Agent with hard triggers, FTS5, synonyms, dense embeddings, and RRF fusion.</div>
     </div>
     <div class="list-cell-stars">★ 33</div>
   </a>
@@ -612,7 +614,7 @@
     <div class="list-rank">30</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">amanning3390 /</span> hermeshub</div>
-      <div class="list-cell-desc">HermesHub - The Skills Hub for Hermes Agent by Nous Research. Browse, share, and install community skills.</div>
+      <div class="list-cell-desc">Community skill browsing, search, and one-click installation hub</div>
     </div>
     <div class="list-cell-stars">★ 23</div>
   </a>
@@ -628,7 +630,7 @@
     <div class="list-rank">32</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">Sahil-SS9 /</span> hermes-multichannel-prompt-optimizer</div>
-      <div class="list-cell-desc">Hermes Agent plugin: rewrites your prompts before they hit the LLM — across CLI, TUI, Discord, Telegram. Quality scoring + analytics + arrow</div>
+      <div class="list-cell-desc">Hermes Agent plugin that rewrites and scores prompts across CLI, TUI, Discord, Telegram, and other surfaces.</div>
     </div>
     <div class="list-cell-stars">★ 20</div>
   </a>
@@ -636,7 +638,7 @@
     <div class="list-rank">33</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">teixeirazeus /</span> fablize-for-hermes</div>
-      <div class="list-cell-desc"> This project adapts fablize's verified procedures — verification grounding, multi-story evidence gating, investigation protocol, and early-</div>
+      <div class="list-cell-desc">This project adapts fablize's verified procedures — verification grounding, multi-story evidence gating, investigation protocol, and early-s</div>
     </div>
     <div class="list-cell-stars">★ 15</div>
   </a>
@@ -652,7 +654,7 @@
     <div class="list-rank">35</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">PederHP /</span> skillsdotnet</div>
-      <div class="list-cell-desc">C# implementation of agent skills (agentskills.io) with MCP integration and convenience.</div>
+      <div class="list-cell-desc">C# / .NET implementation of agentskills.io with MCP integration</div>
     </div>
     <div class="list-cell-stars">★ 12</div>
   </a>

--- a/lists/workspaces-and-guis.html
+++ b/lists/workspaces-and-guis.html
@@ -214,6 +214,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/" class="active">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -242,6 +243,7 @@
   <h1 class="list-title">Workspaces &amp; GUIs for Hermes Agent</h1>
   <p class="list-intro">Web-based and desktop interfaces that wrap Hermes Agent with visual UIs — chat interfaces, terminal emulators, memory browsers, and configuration dashboards.</p>
   
+  
 </section>
 
 <div class="list-table" aria-label="Ranked list">
@@ -254,7 +256,7 @@
     <div class="list-rank">01</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">farion1231 /</span> cc-switch</div>
-      <div class="list-cell-desc">A cross-platform desktop All-in-One assistant for Claude Code, Codex, OpenCode, OpenClaw, Grok Build &amp; Hermes Agent. Only official website: </div>
+      <div class="list-cell-desc">Cross-platform all-in-one manager for Claude Code, Codex, OpenCode, OpenClaw, Gemini CLI, and Hermes Agent</div>
     </div>
     <div class="list-cell-stars">★ 128.6K</div>
   </a>
@@ -262,7 +264,7 @@
     <div class="list-rank">02</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">iOfficeAI /</span> AionUi</div>
-      <div class="list-cell-desc">Open-source 24/7 Cowork app for OpenClaw, Hermes, Claude Code, Codex, OpenCode and 20+ more CLI Agent | Customize your assistants | Team the</div>
+      <div class="list-cell-desc">Local open-source cowork app for OpenClaw, Hermes Agent, Claude Code, Codex, OpenCode, Gemini CLI, and other agent CLIs</div>
     </div>
     <div class="list-cell-stars">★ 32.2K</div>
   </a>
@@ -278,7 +280,7 @@
     <div class="list-rank">04</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">fathah /</span> hermes-desktop</div>
-      <div class="list-cell-desc">Desktop Companion for Hermes Agent</div>
+      <div class="list-cell-desc">Desktop companion app for installing, configuring, and chatting with Hermes Agent</div>
     </div>
     <div class="list-cell-stars">★ 14.0K</div>
   </a>
@@ -286,7 +288,7 @@
     <div class="list-rank">05</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">EKKOLearnAI /</span> hermes-studio</div>
-      <div class="list-cell-desc">Web dashboard for Hermes Agent — multi-platform AI chat, session management, scheduled jobs, usage analytics </div>
+      <div class="list-cell-desc">Web dashboard for Hermes Agent — multi-platform AI chat, session management, scheduled jobs, usage analytics &amp; channel configuration (Telegr</div>
     </div>
     <div class="list-cell-stars">★ 10.5K</div>
   </a>
@@ -294,7 +296,7 @@
     <div class="list-rank">06</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">outsourc-e /</span> hermes-workspace</div>
-      <div class="list-cell-desc">Native web workspace for Hermes Agent — chat, terminal, memory, skills, inspector.</div>
+      <div class="list-cell-desc">Native web workspace — chat, terminal, memory browser, skills manager, and inspector panel</div>
     </div>
     <div class="list-cell-stars">★ 6.5K</div>
   </a>
@@ -302,7 +304,7 @@
     <div class="list-rank">07</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">xintaofei /</span> codeg</div>
-      <div class="list-cell-desc">Collaborative multi-agent AI coding workspace: aggregate sessions from Claude Code, Codex, OpenCode, Pi, Grok Build, etc. Desktop app, self-</div>
+      <div class="list-cell-desc">Collaborative multi-agent coding workspace that aggregates sessions from Hermes, Claude Code, Codex, OpenCode, and others as a desktop or se</div>
     </div>
     <div class="list-cell-stars">★ 2.9K</div>
   </a>
@@ -310,7 +312,7 @@
     <div class="list-rank">08</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">dodo-reach /</span> hermes-desktop</div>
-      <div class="list-cell-desc">The safest, simplest way to manage Hermes from your Mac. Pure SSH. No gateways, no exposed ports, no browser layer.</div>
+      <div class="list-cell-desc">A native Mac workspace for Hermes: real SSH, real terminal, real session data.</div>
     </div>
     <div class="list-cell-stars">★ 2.0K</div>
   </a>
@@ -318,7 +320,7 @@
     <div class="list-rank">09</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">Eynzof /</span> Hermes-CN-Desktop</div>
-      <div class="list-cell-desc">Hermes Agent CN desktop app, Windows-First, built with Tauri, Typescript and Rust. Isolated Hermes Agent core insides. </div>
+      <div class="list-cell-desc">Windows-first Chinese desktop app for Hermes Agent built with Tauri, TypeScript, and Rust</div>
     </div>
     <div class="list-cell-stars">★ 1.6K</div>
   </a>
@@ -326,7 +328,7 @@
     <div class="list-rank">10</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">abundantbeing /</span> hermes-browser-extension</div>
-      <div class="list-cell-desc">Browser-native side panel for Hermes Agent — connect web context to your local Hermes runtime.</div>
+      <div class="list-cell-desc">Chromium side-panel extension that connects active browser context to a local or remote Hermes Agent runtime</div>
     </div>
     <div class="list-cell-stars">★ 1.3K</div>
   </a>
@@ -334,7 +336,7 @@
     <div class="list-rank">11</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">uzairansaruzi /</span> hermex</div>
-      <div class="list-cell-desc">Native iPhone app for your Hermes agent</div>
+      <div class="list-cell-desc">Native SwiftUI iPhone app for driving a self-hosted Hermes agent from your phone, pairing with a hermes-webui server.</div>
     </div>
     <div class="list-cell-stars">★ 1.1K</div>
   </a>
@@ -342,7 +344,7 @@
     <div class="list-rank">12</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">freestylefly /</span> wesight</div>
-      <div class="list-cell-desc">Open-source desktop AI agent workspace with one-click Claude Code, Codex, OpenClaw, Hermes Agent setup and custom LLM model routing.</div>
+      <div class="list-cell-desc">Desktop AI agent workspace with one-click setup for Hermes Agent, Claude Code, Codex, and OpenClaw, plus custom LLM model routing.</div>
     </div>
     <div class="list-cell-stars">★ 887</div>
   </a>
@@ -358,7 +360,7 @@
     <div class="list-rank">14</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">jazzyalex /</span> agent-sessions</div>
-      <div class="list-cell-desc">Local-first macOS app to browse, search, analyze, and resume supported AI coding-agent session history across Codex, Claude Code, OpenCode, </div>
+      <div class="list-cell-desc">Native macOS session browser, agent cockpit, analytics, and limits tracker for Hermes agents and other coding-agent CLIs</div>
     </div>
     <div class="list-cell-stars">★ 805</div>
   </a>
@@ -366,7 +368,7 @@
     <div class="list-rank">15</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">nickvasilescu /</span> hermes-desktop-os1</div>
-      <div class="list-cell-desc">Hermes Desktop - OS1 Edition: native macOS workspace for Hermes Agent on Orgo cloud computers and SSH hosts</div>
+      <div class="list-cell-desc">Native macOS workspace for Hermes Agent running on Orgo cloud computers and SSH hosts</div>
     </div>
     <div class="list-cell-stars">★ 524</div>
   </a>
@@ -374,7 +376,7 @@
     <div class="list-rank">16</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">sharbelxyz /</span> hermes-agent-mission-control</div>
-      <div class="list-cell-desc">Hermy HQ — a self-hostable mission-control dashboard template that pairs with your own local Hermes agent over a Postgres message bus. Send </div>
+      <div class="list-cell-desc">Self-hostable mission-control dashboard template that pairs with your own local Hermes agent over a Postgres message bus.</div>
     </div>
     <div class="list-cell-stars">★ 327</div>
   </a>
@@ -382,7 +384,7 @@
     <div class="list-rank">17</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">liftaris /</span> herm</div>
-      <div class="list-cell-desc">The Hermes TUI built with OpenTUI</div>
+      <div class="list-cell-desc">Alternative Hermes TUI and dashboard built with OpenTUI.</div>
     </div>
     <div class="list-cell-stars">★ 290</div>
   </a>
@@ -406,7 +408,7 @@
     <div class="list-rank">20</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">pyrate-llama /</span> hermes-ui</div>
-      <div class="list-cell-desc">The command center for Hermes Agent — chat, steer, browse files, manage skills, and monitor everything from a single glassmorphic HTML app.</div>
+      <div class="list-cell-desc">Glassmorphic web interface for Hermes Agent — your self-hosted AI assistant</div>
     </div>
     <div class="list-cell-stars">★ 196</div>
   </a>
@@ -414,7 +416,7 @@
     <div class="list-rank">21</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">sanchomuzax /</span> hermes-webui</div>
-      <div class="list-cell-desc">Process monitoring and configuration dashboard for Hermes Agent</div>
+      <div class="list-cell-desc">Process monitoring and configuration dashboard for Hermes</div>
     </div>
     <div class="list-cell-stars">★ 113</div>
   </a>
@@ -422,7 +424,7 @@
     <div class="list-rank">22</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">Euraika-Labs /</span> pan-ui</div>
-      <div class="list-cell-desc">Pan by Euraika — a self-hosted AI workspace for Hermes Agent. Chat, skills, extensions, memory, profiles, and runtime controls.</div>
+      <div class="list-cell-desc">Self-hosted AI workspace with chat, skills, extensions, memory, profiles, and runtime controls</div>
     </div>
     <div class="list-cell-stars">★ 98</div>
   </a>
@@ -430,7 +432,7 @@
     <div class="list-rank">23</div>
     <div class="list-cell-body">
       <div class="list-cell-name"><span class="org">Felix-Forever /</span> hermes-agent-desktop</div>
-      <div class="list-cell-desc">Multi-Agent AI Desktop Client — 20 specialists auto-collaborate on your tasks. Visual Skill Store, PM orchestrator, streaming chat. Works wi</div>
+      <div class="list-cell-desc">Multi-agent Hermes Agent desktop client with specialists, visual skill store, PM orchestrator, and streaming chat</div>
     </div>
     <div class="list-cell-stars">★ 63</div>
   </a>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -915,6 +915,7 @@ Skip to content
 
  map
  lists
+ skills
  use cases
  handbook
  masterclass
@@ -1617,6 +1618,7 @@ Skip to content
 
  map
  lists
+ skills
  use cases
  handbook
  masterclass
@@ -1851,6 +1853,7 @@ Skip to content
 
  map
  lists
+ skills
  use cases
  handbook
  masterclass
@@ -2049,6 +2052,169 @@ Skip to content
 
  hermes atlas · curated by ksimback · suggest a repo · privacy
  v2 · 2026.04
+
+---
+
+# Skills Hub (/skills/)
+
+Canonical URL: https://hermesatlas.com/skills/
+
+Hand-curated judgment layer over the Skills & Skill Registries category. Updated 2026-08-20, tested against Hermes v0.20.4.
+
+## Best Hermes Skills for Coding
+
+Canonical URL: https://hermesatlas.com/skills/for-coding
+
+Developers looking for skills or plugins that plan, review, harden, or simplify code changes inside Hermes Agent or Claude Code.
+
+Structured methodologies and subagent swarms that turn ad-hoc coding sessions into repeatable, checkpointed workflows — spec-first planning, adversarial code review, and multi-agent simplification passes.
+
+- obra/superpowers (plugin) — TOP PICK: The most-starred agentic skills framework in the catalog by two orders of magnitude. If you install exactly one dev-workflow plugin, this is the default.
+  Install: hermes plugins install obra/superpowers --enable
+  Compatibility: Hermes Agent CLI (plugin); also ships as a Claude Code plugin via the official marketplace.
+  URL: https://hermesatlas.com/projects/obra/superpowers
+- Cranot/super-hermes (skill): Built specifically for Hermes' own Skills Hub syntax rather than ported from Claude Code — teaches the agent to write its own analytical prompts via prism-scan plus seven proven analytical lenses.
+  Install: hermes skills tap add Cranot/super-hermes
+  Compatibility: Hermes Agent native (Skills Hub tap); manual git-clone install also documented for other harnesses.
+  URL: https://hermesatlas.com/projects/Cranot/super-hermes
+- Sahil-SS9/hermaguard (skill): Three parallel subagents attack code from different angles, then verify findings via sandboxed proof-of-concept execution before reporting VERIFIED or REFUTED — the most rigorous read-only code-review skill in this list.
+  Install: Clone the repo and copy it into your harness's skill directory (pip install . provides its 9 console scripts); no Skills Hub listing yet.
+  Compatibility: Harness-agnostic Agent Skill, Python-backed; works with Hermes, Claude Code, and any agentskills.io-compatible client.
+  URL: https://hermesatlas.com/projects/Sahil-SS9/hermaguard
+- Sahil-SS9/hermes-simplify-swarm (skill): Three read-only subagents (Hygiene, Clarity, Correctness) with a SAFE/CAREFUL/RISKY tiered approval gate before anything is applied — a safer default than a single autonomous simplification pass.
+  Install: git clone https://github.com/Sahil-SS9/hermes-simplify-swarm.git, then copy SKILL.md and references/ into your harness's skill directory as simplify-swarm/.
+  Compatibility: Harness-agnostic (copy-in SKILL.md); explicitly built for Hermes Agent, also works in Claude Code.
+  URL: https://hermesatlas.com/projects/Sahil-SS9/hermes-simplify-swarm
+- armelhbobdad/bmad-module-skill-forge (skill): Turns your own repo, docs, and developer discourse into agentskills.io-compliant skills with file/line provenance citations — for teams standardizing internal skills, not consuming someone else's.
+  Install: npx bmad-module-skill-forge install
+  Compatibility: Node.js >= 22, Python >= 3.10, uv required; IDE-agnostic scaffolding tool, not Hermes-specific.
+  URL: https://hermesatlas.com/projects/armelhbobdad/bmad-module-skill-forge
+
+## Best Hermes Skills for Cybersecurity
+
+Canonical URL: https://hermesatlas.com/skills/for-cybersecurity
+
+Security engineers and red-teamers looking for large, framework-mapped skill packs covering offense, defense, and compliance.
+
+Structured skill packs mapping MITRE ATT&CK, NIST, and CVE data into agent-usable procedures for pentesting, forensics, and threat modeling.
+
+- mukul975/Anthropic-Cybersecurity-Skills (collection) — TOP PICK: 800+ skills across 29 security domains mapped to MITRE ATT&CK, ATLAS, D3FEND, and NIST — the largest and most-starred security pack in the catalog. Start here before any narrower pentest skill.
+  Install: npx skills add mukul975/Anthropic-Cybersecurity-Skills
+  Compatibility: agentskills.io-compatible clients (Claude Code, Copilot, Codex); installable on Hermes via hermes skills tap add or npx skills add.
+  URL: https://hermesatlas.com/projects/mukul975/Anthropic-Cybersecurity-Skills
+- handnewb/hermes-cybersec-lab (collection): 2,000+ skills stitched from 7 external repos plus 130+ installable tools (Sigma, YARA, MISP). A deeper turnkey lab than the Anthropic-Cybersecurity-Skills pack, but a heavier multi-repo clone — pick it for a dedicated security profile, not a quick add.
+  Install: git clone https://github.com/handnewb/hermes-cybersec-lab.git, run scripts/clone-all.sh, then copy into ~/.hermes/profiles/<profile>/skills/cybersecurity-lab/.
+  Compatibility: Hermes Agent native — the README targets ~/.hermes/profiles/<profile>/skills/ explicitly.
+  URL: https://hermesatlas.com/projects/handnewb/hermes-cybersec-lab
+
+## Best Tools for Discovering & Managing Hermes Skills
+
+Canonical URL: https://hermesatlas.com/skills/for-skill-management
+
+Users who want to browse, retrieve, evolve, or bulk-install skills at scale rather than add a single-purpose skill.
+
+Meta-tools that sit above individual skills — registries, retrieval layers, evolution engines, and large curated skill collections spanning many professions.
+
+- armelhbobdad/bmad-module-skill-forge (skill): Turns your own repo, docs, and developer discourse into agentskills.io-compliant skills with file/line provenance citations — for teams standardizing internal skills, not consuming someone else's.
+  Install: npx bmad-module-skill-forge install
+  Compatibility: Node.js >= 22, Python >= 3.10, uv required; IDE-agnostic scaffolding tool, not Hermes-specific.
+  URL: https://hermesatlas.com/projects/armelhbobdad/bmad-module-skill-forge
+- AMAP-ML/SkillClaw (registry) — TOP PICK: A genuinely different mechanism: runs in the background, deduplicates, and cross-pollinates your skill library across agents, devices, and users instead of just hosting a list.
+  Install: git clone https://github.com/AMAP-ML/SkillClaw.git, run scripts/install_skillclaw.sh, activate the venv, then run skillclaw setup.
+  Compatibility: Standalone Python CLI/daemon; integrates with Hermes, Codex, Claude Code, and OpenAI-compatible APIs — not a drop-in SKILL.md.
+  URL: https://hermesatlas.com/projects/AMAP-ML/SkillClaw
+- aidevelopers2/remoteopenclaw-mcp (registry): Searches 13,000+ MCP servers and 4,000+ agent skills from the terminal with no API key — the widest single search surface in this category, though it's discovery-only, not an installer.
+  Install: Add remoteopenclaw (npx -y remoteopenclaw) under mcp_servers in Hermes' config; for Claude Code: claude mcp add remoteopenclaw -- npx -y remoteopenclaw.
+  Compatibility: MCP server — any MCP client (Hermes, Cursor, Windsurf, Claude Code) via mcp_servers config.
+  URL: https://hermesatlas.com/projects/aidevelopers2/remoteopenclaw-mcp
+- willingning-coder/eagle-eye (plugin): Five-layer retrieval (hard triggers, FTS5, synonyms, dense embeddings, RRF fusion) built to solve Hermes' own skill-selection problem once your skills directory gets large — the most Hermes-native entry in this group.
+  Install: git clone https://github.com/willingning-coder/eagle-eye.git, then run python scripts/generate_config.py.
+  Compatibility: Hermes Agent plugin; optional dense-embedding dependencies for the retrieval layers.
+  URL: https://hermesatlas.com/projects/willingning-coder/eagle-eye
+- mohitagw15856/pm-claude-skills (collection): 1,000+ professional skills as plain markdown, the largest non-security collection here — organized into 120+ installable bundles instead of one all-or-nothing install.
+  Install: npx pm-claude-skills add
+  Compatibility: Claude Code plugin directory + Hermes Agent (plain markdown skills run natively); also exposes an MCP server.
+  URL: https://hermesatlas.com/projects/mohitagw15856/pm-claude-skills
+- wondelai/skills (collection): 62 skills built from 50 named business and design frameworks (Jobs-to-be-Done, the Mom Test, Refactoring UI) rather than generic prompts — a business-strategy layer to sit alongside a coding skill set.
+  Install: npx skills add wondelai/skills --all --global (or pick individual skills, e.g. npx skills add wondelai/skills/jobs-to-be-done --global).
+  Compatibility: skills.sh / agentskills.io-compatible clients including Claude Code and Hermes; also ships Claude Code plugin collections.
+  URL: https://hermesatlas.com/projects/wondelai/skills
+
+## Best Hermes Skills for Design & Diagrams
+
+Canonical URL: https://hermesatlas.com/skills/for-design-and-diagrams
+
+Users generating diagrams, design prototypes, or image output through agent skills.
+
+Skills and tools that turn natural-language descriptions into draw.io diagrams, FLUX-generated images, or full local-first design prototypes.
+
+- Agents365-ai/drawio-skill (skill) — TOP PICK: Eleven diagram-type presets plus Mermaid-to-drawio conversion, and the most-starred diagram skill in the catalog — the clear default over hand-rolling diagram prompts.
+  Install: npx skills add Agents365-ai/365-skills -g (or git clone into your skills directory).
+  Compatibility: Runs from a single SKILL.md, no MCP server or daemon (needs the draw.io desktop CLI for rendering); works anywhere agentskills.io skills load, including Hermes.
+  URL: https://hermesatlas.com/projects/Agents365-ai/drawio-skill
+- black-forest-labs/skills (skill): The one official-vendor entry in this bucket — Black Forest Labs' own FLUX prompting guidelines and API integration patterns, not a third-party reverse-engineering of their docs.
+  Install: npx skills add black-forest-labs/skills (or target one: npx skills add black-forest-labs/skills --skill flux-image-best-practices).
+  Compatibility: agentskills.io spec; also a Claude Code plugin.
+  URL: https://hermesatlas.com/projects/black-forest-labs/skills
+- nexu-io/open-design (plugin): By far the biggest project in the entire skills category — but it's a full local-first design platform, not a lightweight skill. Install it as prototyping infrastructure, not a five-minute skill add.
+  Install: curl -fsSL https://open-design.ai/install.sh | sh -s hermes (hosted); or self-host via docker compose from the repo's deploy/ directory.
+  Compatibility: Native desktop app (macOS/Windows) plus a CLI; the README explicitly lists Hermes Agent among supported coding-agent CLIs for prototype generation.
+  URL: https://hermesatlas.com/projects/nexu-io/open-design
+
+## Best Hermes Skills for Writing & Content
+
+Canonical URL: https://hermesatlas.com/skills/for-writing-and-content
+
+Content creators and marketers who want to de-AI-ify prose, pull structured video/platform data, or automate content production.
+
+Skills for auditing AI-sounding prose, extracting structured YouTube data, and generating marketing or e-commerce material.
+
+- conorbronsdon/avoid-ai-writing (skill) — TOP PICK: Three modes (Rewrite, Detect, Edit) and a 100+ entry tiered word-replacement table — the most mechanically detailed de-AI-ify skill in the category, not a vague 'sound more human' prompt.
+  Install: git clone https://github.com/conorbronsdon/avoid-ai-writing into your skills directory (or install the plugin from its marketplace).
+  Compatibility: README states explicit compatibility with Claude Code, OpenClaw, Hermes, and Cursor.
+  URL: https://hermesatlas.com/projects/conorbronsdon/avoid-ai-writing
+- ZeroPointRepo/youtube-skills (skill): An explicit, working Hermes install line via the skills.sh hub source — covers YouTube transcript, search, channel, and playlist data in one skill.
+  Install: hermes skills install skills-sh/ZeroPointRepo/youtube-skills/skills/youtube-full
+  Compatibility: Hermes Agent (skills.sh source), OpenClaw, Claude Code, Cursor, and Codex via npx skills add.
+  URL: https://hermesatlas.com/projects/ZeroPointRepo/youtube-skills
+- jiawood2006/hermes-skills (collection): Four narrow, concrete skills — video transcription, AI-text de-humanizer, local OCR, e-commerce material generation — with correct Hermes-native install commands out of the box. Early-stage, but useful for e-commerce and Chinese-language workflows.
+  Install: hermes skills install jiawood2006/hermes-skills/skills/video-to-text (repeat per skill: de-ai-writer, doc-ocr, ecommerce-material-studio).
+  Compatibility: Hermes Agent native install commands documented directly in the README; portable to other agentskills.io clients via manual copy.
+  URL: https://hermesatlas.com/projects/jiawood2006/hermes-skills
+
+## Best Hermes Skills for Crypto & Agent Payments
+
+Canonical URL: https://hermesatlas.com/skills/for-crypto-and-payments
+
+Builders wiring agents into on-chain protocols or agent-to-agent payment and dispute-resolution rails.
+
+Skills for interacting with smart-contract oracle networks and for structuring agent-to-agent commerce, escrow, delegated permissions, and micropayments.
+
+- internet-court/internet-court-skill (collection) — TOP PICK: A genuinely new primitive — a master router plus vendored official protocol skills covering ERC-7710 delegated permissions, x402 payments, and escrow/dispute resolution as one catch-all agent-commerce skill.
+  Install: hermes skills tap add internet-court/internet-court-skill (the README prefers the tap over a direct URL install, which misses bundled reference files).
+  Compatibility: Hermes Agent (tap), Claude Code (plugin marketplace or manual clone), OpenClaw, and Codex.
+  URL: https://hermesatlas.com/projects/internet-court/internet-court-skill
+- smartcontractkit/chainlink-agent-skills (skill): The official Chainlink team's own oracle-network skills (CCIP, VRF, Data Feeds) — the vendor-authoritative pick for cross-chain or oracle work, versus a community reimplementation.
+  Install: npx skills add smartcontractkit/chainlink-agent-skills
+  Compatibility: agentskills.io spec via the skills.sh CLI; project-level install is the default.
+  URL: https://hermesatlas.com/projects/smartcontractkit/chainlink-agent-skills
+
+## Best Hermes Skills for Personal Ops
+
+Canonical URL: https://hermesatlas.com/skills/for-personal-ops
+
+Users who want Hermes to manage personal infrastructure — self-hosted services and cross-platform runtime friction.
+
+Skills that connect Hermes to personal infrastructure like self-hosted Nextcloud and that smooth over Windows/WSL/Git Bash path and runtime quirks.
+
+- adnw-vinc/hermes-nextcloud (skill) — TOP PICK: The only skill in the catalog wiring Hermes directly into a self-hosted Nextcloud over WebDAV/CalDAV/CardDAV — no browser, no third-party sync service, credentials kept in a restricted local .env.
+  Install: git clone https://github.com/adnw-vinc/hermes-nextcloud.git into ~/.hermes/skills/productivity/nextcloud, then run its guided setup script.
+  Compatibility: Hermes Agent native — targets ~/.hermes/skills/ explicitly, with App Password validation for Nextcloud.
+  URL: https://hermesatlas.com/projects/adnw-vinc/hermes-nextcloud
+- CorsenAI/hermes-windows-runtime-skills (collection): Solves a real, narrow Hermes pain point — deterministic path routing and non-destructive Python runtime selection across Windows, Git Bash, and WSL — with exact hermes skills install commands in the README.
+  Install: hermes skills tap add CorsenAI/hermes-windows-runtime-skills (or install each skill directly, e.g. hermes skills install CorsenAI/hermes-windows-runtime-skills/skills/windows-wsl-file-navigation).
+  Compatibility: Hermes Agent native, specifically for native Windows, Git Bash/MSYS, and WSL environments.
+  URL: https://hermesatlas.com/projects/CorsenAI/hermes-windows-runtime-skills
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -52,6 +52,17 @@ A hands-on developer tutorial for building on the Hermes Agent codebase, written
 - [Developer Tools for Hermes Agent](https://hermesatlas.com/lists/developer-tools): CLI tools, linters, migration helpers, token trackers, and other utilities that make developing with Hermes easier.
 - [Workspaces & GUIs for Hermes Agent](https://hermesatlas.com/lists/workspaces-and-guis): Web-based and desktop interfaces that wrap Hermes Agent with visual UIs — chat interfaces, terminal emulators, memory browsers, and configuration dashboards.
 
+## Skills
+The decision layer over the Skills & Skill Registries category: hand-picked groups, one top pick each, install command read from the project's own README, and a verdict per entry. 22 curated entries across 7 use cases. Updated 2026-08-20, tested against Hermes v0.20.4.
+- [Hermes Skills Hub](https://hermesatlas.com/skills/): Every curated pick, the top pick per use case, and the full 44-project skills catalog.
+- [Best Hermes Skills for Coding](https://hermesatlas.com/skills/for-coding): Developers looking for skills or plugins that plan, review, harden, or simplify code changes inside Hermes Agent or Claude Code.
+- [Best Hermes Skills for Cybersecurity](https://hermesatlas.com/skills/for-cybersecurity): Security engineers and red-teamers looking for large, framework-mapped skill packs covering offense, defense, and compliance.
+- [Best Tools for Discovering & Managing Hermes Skills](https://hermesatlas.com/skills/for-skill-management): Users who want to browse, retrieve, evolve, or bulk-install skills at scale rather than add a single-purpose skill.
+- [Best Hermes Skills for Design & Diagrams](https://hermesatlas.com/skills/for-design-and-diagrams): Users generating diagrams, design prototypes, or image output through agent skills.
+- [Best Hermes Skills for Writing & Content](https://hermesatlas.com/skills/for-writing-and-content): Content creators and marketers who want to de-AI-ify prose, pull structured video/platform data, or automate content production.
+- [Best Hermes Skills for Crypto & Agent Payments](https://hermesatlas.com/skills/for-crypto-and-payments): Builders wiring agents into on-chain protocols or agent-to-agent payment and dispute-resolution rails.
+- [Best Hermes Skills for Personal Ops](https://hermesatlas.com/skills/for-personal-ops): Users who want Hermes to manage personal infrastructure — self-hosted services and cross-platform runtime friction.
+
 ## Use Cases
 Cross-category repo bundles for a specific buildable outcome ("I want to build X"), each with a rationale and links to real community posts that prove people ship it.
 - [Use cases index](https://hermesatlas.com/use-cases/): All 14 use-case bundles.

--- a/masterclass/index.html
+++ b/masterclass/index.html
@@ -87,6 +87,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/" class="active">masterclass</a>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -47,6 +47,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/projects/0xNyk/awesome-hermes-agent.html
+++ b/projects/0xNyk/awesome-hermes-agent.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/0xNyk/awesome-hermes-agent">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=awesome-hermes-agent&amp;subtitle=Independent+directory+of+useful+skills%2C+plugins%2C+memory+providers%2C+tools%2C+surfaces%2C+and+guides+for+Nous+Research%27s+open-source+Hermes+Agent.&amp;kind=project+%C2%B7+guides">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=awesome-hermes-agent&amp;subtitle=Curated+list+of+awesome+skills%2C+tools%2C+integrations%2C+and+resources+for+Hermes+Agent&amp;kind=project+%C2%B7+guides">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="0xNyk/awesome-hermes-agent — Hermes Atlas">
 <meta name="twitter:description" content="This independent open-source directory provides a curated list of skills, tools, integrations, and resources for the Hermes Agent. It includes…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=awesome-hermes-agent&amp;subtitle=Independent+directory+of+useful+skills%2C+plugins%2C+memory+providers%2C+tools%2C+surfaces%2C+and+guides+for+Nous+Research%27s+open-source+Hermes+Agent.&amp;kind=project+%C2%B7+guides">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=awesome-hermes-agent&amp;subtitle=Curated+list+of+awesome+skills%2C+tools%2C+integrations%2C+and+resources+for+Hermes+Agent&amp;kind=project+%C2%B7+guides">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -45,7 +45,6 @@
     "name": "0xNyk",
     "url": "https://github.com/0xNyk"
   },
-  "dateModified": "2026-08-16T14:50:13.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -86,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -114,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">0xNyk</span><span class="slash">/</span>awesome-hermes-agent
   </h1>
-  <p class="project-desc">Independent directory of useful skills, plugins, memory providers, tools, surfaces, and guides for Nous Research's open-source Hermes Agent.</p>
+  <p class="project-desc">Curated list of awesome skills, tools, integrations, and resources for Hermes Agent</p>
 
   <div class="meta-row">
     <span class="stars">★ 5.4K</span>
     
     
     
-    <span><span class="meta-label">updated</span>2026-08-16</span>
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/0xNyk/awesome-hermes-agent" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://www.nyk.dev/oss/awesome-hermes-agent" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -423,7 +425,6 @@ pruning, use the <a href="https://www.nyk.dev/blog/hermes-agent-session-manageme
 </ul>
 <hr>
 <p><em>README truncated. <a href="https://github.com/0xNyk/awesome-hermes-agent#readme">Continue reading on GitHub</a></em></p>
-
   </section>
 </details>
 

--- a/projects/0xNyk/openclaw-to-hermes.html
+++ b/projects/0xNyk/openclaw-to-hermes.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/0xNyk/openclaw-to-hermes">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=openclaw-to-hermes&amp;subtitle=Migrate+from+OpenClaw+to+Hermes+Agent+%E2%80%94+complete%2C+battle-tested+migration+tool&amp;kind=project+%C2%B7+developer+tools">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=openclaw-to-hermes&amp;subtitle=Migration+tool+from+OpenClaw+to+Hermes+Agent&amp;kind=project+%C2%B7+developer+tools">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="0xNyk/openclaw-to-hermes — Hermes Atlas">
 <meta name="twitter:description" content="openclaw-to-hermes is a Python-based migration tool designed to transfer agents, workspaces, and configurations from OpenClaw to Hermes Agent. It maps model…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=openclaw-to-hermes&amp;subtitle=Migrate+from+OpenClaw+to+Hermes+Agent+%E2%80%94+complete%2C+battle-tested+migration+tool&amp;kind=project+%C2%B7+developer+tools">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=openclaw-to-hermes&amp;subtitle=Migration+tool+from+OpenClaw+to+Hermes+Agent&amp;kind=project+%C2%B7+developer+tools">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/0xNyk/openclaw-to-hermes",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "0xNyk",
     "url": "https://github.com/0xNyk"
   },
-  "dateModified": "2026-07-17T13:22:30.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">0xNyk</span><span class="slash">/</span>openclaw-to-hermes
   </h1>
-  <p class="project-desc">Migrate from OpenClaw to Hermes Agent — complete, battle-tested migration tool</p>
+  <p class="project-desc">Migration tool from OpenClaw to Hermes Agent</p>
 
   <div class="meta-row">
     <span class="stars">★ 37</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-07-17</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -357,7 +357,6 @@ ruff check .
 <p>Maintained by <a href="https://nyk.dev">Nyk</a>. If this migration tool helps your work, <a href="https://github.com/sponsors/0xNyk">sponsor its continued maintenance</a> or follow <a href="https://x.com/nykdotdev">@nykdotdev</a>.</p>
 <h3>License</h3>
 <p>MIT</p>
-
   </section>
 </details>
 

--- a/projects/0xarkstar/awesome-hermes-agent.html
+++ b/projects/0xarkstar/awesome-hermes-agent.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/0xarkstar/awesome-hermes-agent">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=Awesome+Hermes+Agent&amp;subtitle=A+curated+list+of+awesome+resources+for+Hermes+Agent+by+Nous+Research&amp;kind=project+%C2%B7+guides">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=Awesome+Hermes+Agent&amp;subtitle=Curated+list+of+resources%2C+tools%2C+and+projects+for+Hermes+Agent+by+Nous+Research.&amp;kind=project+%C2%B7+guides">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="0xarkstar/Awesome Hermes Agent — Hermes Atlas">
 <meta name="twitter:description" content="This project is a curated list of resources, tools, and projects for Hermes Agent, a self-improving AI agent by Nous Research. It includes links to official…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Awesome+Hermes+Agent&amp;subtitle=A+curated+list+of+awesome+resources+for+Hermes+Agent+by+Nous+Research&amp;kind=project+%C2%B7+guides">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Awesome+Hermes+Agent&amp;subtitle=Curated+list+of+resources%2C+tools%2C+and+projects+for+Hermes+Agent+by+Nous+Research.&amp;kind=project+%C2%B7+guides">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/0xarkstar/awesome-hermes-agent",
   "applicationCategory": "ReferenceApplication",
   "operatingSystem": "Cross-platform",
-  "license": "https://spdx.org/licenses/CC0-1.0.html",
   "author": {
     "@type": "Organization",
     "name": "0xarkstar",
     "url": "https://github.com/0xarkstar"
   },
-  "dateModified": "2026-03-24T03:51:41.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">0xarkstar</span><span class="slash">/</span>awesome-hermes-agent
   </h1>
-  <p class="project-desc">A curated list of awesome resources for Hermes Agent by Nous Research</p>
+  <p class="project-desc">Curated list of resources, tools, and projects for Hermes Agent by Nous Research.</p>
 
   <div class="meta-row">
     <span class="stars">★ 48</span>
     
-    <span><span class="meta-label">license</span>CC0-1.0</span>
     
-    <span><span class="meta-label">updated</span>2026-03-24</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -270,7 +271,6 @@
 <p>This list is partially maintained with the help of Hermes Agent for automated link checking and content discovery.</p>
 <h3>Contributing</h3>
 <p>Contributions welcome! Read the <a href="https://github.com/0xarkstar/awesome-hermes-agent/blob/main/contributing.md">contribution guidelines</a> first.</p>
-
   </section>
 </details>
 

--- a/projects/0xrsydn/nix-hermes-agent.html
+++ b/projects/0xrsydn/nix-hermes-agent.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/0xrsydn/nix-hermes-agent">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=nix-hermes-agent&amp;subtitle=Nix+package+and+NixOS+module+for+Hermes+Agent+by+Nous+Research&amp;kind=project+%C2%B7+deployment">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=nix-hermes-agent&amp;subtitle=Nix+package+and+NixOS+module+for+reproducible+Hermes+deployment&amp;kind=project+%C2%B7+deployment">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="0xrsydn/nix-hermes-agent — Hermes Atlas">
 <meta name="twitter:description" content="nix-hermes-agent provides a Nix package and NixOS module for the declarative deployment of Hermes Agent. It allows users to manage the entire agent…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=nix-hermes-agent&amp;subtitle=Nix+package+and+NixOS+module+for+Hermes+Agent+by+Nous+Research&amp;kind=project+%C2%B7+deployment">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=nix-hermes-agent&amp;subtitle=Nix+package+and+NixOS+module+for+reproducible+Hermes+deployment&amp;kind=project+%C2%B7+deployment">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/0xrsydn/nix-hermes-agent",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Nix",
   "author": {
     "@type": "Organization",
     "name": "0xrsydn",
     "url": "https://github.com/0xrsydn"
   },
-  "dateModified": "2026-08-21T04:34:28.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">0xrsydn</span><span class="slash">/</span>nix-hermes-agent
   </h1>
-  <p class="project-desc">Nix package and NixOS module for Hermes Agent by Nous Research</p>
+  <p class="project-desc">Nix package and NixOS module for reproducible Hermes deployment</p>
 
   <div class="meta-row">
     <span class="stars">★ 40</span>
-    <span><span class="meta-label">lang</span>Nix</span>
     
     
-    <span><span class="meta-label">updated</span>2026-08-21</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -592,7 +593,6 @@ nixpkgs.overlays = [ nix-hermes.overlays.default ];
 </code></pre>
 <h3>License</h3>
 <p>MIT (same as upstream)</p>
-
   </section>
 </details>
 

--- a/projects/1ilkhamov/opencode-hermes-multiagent.html
+++ b/projects/1ilkhamov/opencode-hermes-multiagent.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/1ilkhamov/opencode-hermes-multiagent">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=opencode-hermes-multiagent&amp;subtitle=Hermes+%E2%80%94+a+multi-agent+system+for+OpenCode+AI.+17+specialized+agents+for+research%2C+planning%2C+implementation%2C+quality%2C+and+infrastructure.&amp;kind=project+%C2%B7+multi-agent">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=opencode-hermes-multiagent&amp;subtitle=17+specialized+agents+for+research%2C+planning%2C+implementation%2C+quality%2C+and+infrastructure&amp;kind=project+%C2%B7+multi-agent">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="1ilkhamov/opencode-hermes-multiagent — Hermes Atlas">
 <meta name="twitter:description" content="Hermes is a multi-agent orchestration system for OpenCode AI that coordinates 17 specialized agents to handle software development tasks. The system uses a…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=opencode-hermes-multiagent&amp;subtitle=Hermes+%E2%80%94+a+multi-agent+system+for+OpenCode+AI.+17+specialized+agents+for+research%2C+planning%2C+implementation%2C+quality%2C+and+infrastructure.&amp;kind=project+%C2%B7+multi-agent">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=opencode-hermes-multiagent&amp;subtitle=17+specialized+agents+for+research%2C+planning%2C+implementation%2C+quality%2C+and+infrastructure&amp;kind=project+%C2%B7+multi-agent">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -45,7 +45,6 @@
     "name": "1ilkhamov",
     "url": "https://github.com/1ilkhamov"
   },
-  "dateModified": "2025-12-31T14:58:10.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -86,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -114,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">1ilkhamov</span><span class="slash">/</span>opencode-hermes-multiagent
   </h1>
-  <p class="project-desc">Hermes — a multi-agent system for OpenCode AI. 17 specialized agents for research, planning, implementation, quality, and infrastructure.</p>
+  <p class="project-desc">17 specialized agents for research, planning, implementation, quality, and infrastructure</p>
 
   <div class="meta-row">
     <span class="stars">★ 181</span>
     
     
     
-    <span><span class="meta-label">updated</span>2025-12-31</span>
+    
   </div>
 
   <div class="actions">
@@ -129,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -768,7 +770,6 @@ uvx mcp-server-fetch
 <div align="center">
   <sub>Built with ❤️ for OpenCode AI</sub>
 </div>
-
   </section>
 </details>
 

--- a/projects/335234131/agent-browser-mcp.html
+++ b/projects/335234131/agent-browser-mcp.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/335234131/agent-browser-mcp",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "335234131",
     "url": "https://github.com/335234131"
   },
-  "dateModified": "2026-04-15T12:32:29.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,10 +118,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 239</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-04-15</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -478,7 +478,6 @@ hermes mcp test agent_browser
 <p>如果你基于本项目继续二次开发或发布，也建议保留对 GenericAgent 的致谢与来源说明。</p>
 <h3>许可证</h3>
 <p>MIT</p>
-
   </section>
 </details>
 

--- a/projects/42-evey/evey-bridge-plugin.html
+++ b/projects/42-evey/evey-bridge-plugin.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/42-evey/evey-bridge-plugin">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=evey-bridge-plugin&amp;subtitle=Claude+Code+plugin+for+bridging+with+Evey+%28hermes-agent%29.+Auto-checks+messages%2C+Mother+Mode+loop%2C+quick+status.&amp;kind=project+%C2%B7+plugins">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=evey-bridge-plugin&amp;subtitle=Claude+Code+and+Hermes+context+sharing+bridge+%E2%80%94+auto-checks+messages%2C+Mother+Mode+loop&amp;kind=project+%C2%B7+plugins">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="42-evey/evey-bridge-plugin — Hermes Atlas">
 <meta name="twitter:description" content="The Evey Bridge Plugin is a technical integration that connects Claude Code with the Evey hermes-agent stack. It functions by automatically checking for…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=evey-bridge-plugin&amp;subtitle=Claude+Code+plugin+for+bridging+with+Evey+%28hermes-agent%29.+Auto-checks+messages%2C+Mother+Mode+loop%2C+quick+status.&amp;kind=project+%C2%B7+plugins">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=evey-bridge-plugin&amp;subtitle=Claude+Code+and+Hermes+context+sharing+bridge+%E2%80%94+auto-checks+messages%2C+Mother+Mode+loop&amp;kind=project+%C2%B7+plugins">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/42-evey/evey-bridge-plugin",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "42-evey",
     "url": "https://github.com/42-evey"
   },
-  "dateModified": "2026-07-18T05:50:41.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">42-evey</span><span class="slash">/</span>evey-bridge-plugin
   </h1>
-  <p class="project-desc">Claude Code plugin for bridging with Evey (hermes-agent). Auto-checks messages, Mother Mode loop, quick status.</p>
+  <p class="project-desc">Claude Code and Hermes context sharing bridge — auto-checks messages, Mother Mode loop</p>
 
   <div class="meta-row">
     <span class="stars">★ 13</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-07-18</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -164,7 +164,6 @@
 <p>On every prompt submit, checks the bridge for messages/tasks from Evey and injects them as context.</p>
 <h3>Setup</h3>
 <p>This plugin expects the Evey stack at <code>/mnt/v/evey/</code>.</p>
-
   </section>
 </details>
 

--- a/projects/42-evey/evey-setup.html
+++ b/projects/42-evey/evey-setup.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/42-evey/evey-setup">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=evey-setup&amp;subtitle=Get+a+hermes-agent+stack+running+in+minutes.+Free+models%2C+29+plugins%2C+zero+cost.&amp;kind=project+%C2%B7+developer+tools">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=evey-setup&amp;subtitle=Get+a+hermes-agent+stack+running+in+minutes+%E2%80%94+free+models%2C+29+plugins%2C+zero+cost&amp;kind=project+%C2%B7+developer+tools">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="42-evey/evey-setup — Hermes Atlas">
 <meta name="twitter:description" content="Evey Setup is a bootstrapping tool designed to quickly deploy a complete autonomous AI agent stack based on hermes-agent. It uses a series of bash scripts to…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=evey-setup&amp;subtitle=Get+a+hermes-agent+stack+running+in+minutes.+Free+models%2C+29+plugins%2C+zero+cost.&amp;kind=project+%C2%B7+developer+tools">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=evey-setup&amp;subtitle=Get+a+hermes-agent+stack+running+in+minutes+%E2%80%94+free+models%2C+29+plugins%2C+zero+cost&amp;kind=project+%C2%B7+developer+tools">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/42-evey/evey-setup",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Shell",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "42-evey",
     "url": "https://github.com/42-evey"
   },
-  "dateModified": "2026-07-18T05:50:36.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">42-evey</span><span class="slash">/</span>evey-setup
   </h1>
-  <p class="project-desc">Get a hermes-agent stack running in minutes. Free models, 29 plugins, zero cost.</p>
+  <p class="project-desc">Get a hermes-agent stack running in minutes — free models, 29 plugins, zero cost</p>
 
   <div class="meta-row">
     <span class="stars">★ 62</span>
-    <span><span class="meta-label">lang</span>Shell</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-07-18</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -536,7 +536,6 @@ docker exec hermes-ollama ollama list               # list local models
 <h3>Credits</h3>
 <p>Built by <a href="https://evey.cc">Evey</a> -- an autonomous AI agent running 24/7 on a self-hosted stack.</p>
 <p>Powered by <a href="https://github.com/NousResearch/hermes-agent">hermes-agent</a> from Nous Research.</p>
-
   </section>
 </details>
 

--- a/projects/42-evey/hermes-plugins.html
+++ b/projects/42-evey/hermes-plugins.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/42-evey/hermes-plugins">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-plugins&amp;subtitle=Custom+plugins+for+hermes-agent+%E2%80%94+goal+management%2C+inter-agent+bridge%2C+model+selection%2C+cost+control&amp;kind=project+%C2%B7+plugins">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-plugins&amp;subtitle=Goal+management%2C+inter-agent+bridge%2C+model+selection%2C+and+cost+control+plugins&amp;kind=project+%C2%B7+plugins">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="42-evey/hermes-plugins — Hermes Atlas">
 <meta name="twitter:description" content="Evey's Hermes Plugins is a collection of 23 custom extensions designed to enhance the autonomy, observability, and cost-efficiency of the Hermes Agent…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-plugins&amp;subtitle=Custom+plugins+for+hermes-agent+%E2%80%94+goal+management%2C+inter-agent+bridge%2C+model+selection%2C+cost+control&amp;kind=project+%C2%B7+plugins">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-plugins&amp;subtitle=Goal+management%2C+inter-agent+bridge%2C+model+selection%2C+and+cost+control+plugins&amp;kind=project+%C2%B7+plugins">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/42-evey/hermes-plugins",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "42-evey",
     "url": "https://github.com/42-evey"
   },
-  "dateModified": "2026-07-18T05:50:32.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">42-evey</span><span class="slash">/</span>hermes-plugins
   </h1>
-  <p class="project-desc">Custom plugins for hermes-agent — goal management, inter-agent bridge, model selection, cost control</p>
+  <p class="project-desc">Goal management, inter-agent bridge, model selection, and cost control plugins</p>
 
   <div class="meta-row">
     <span class="stars">★ 408</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-07-18</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/42-evey/hermes-plugins" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://evey.cc" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -322,7 +322,6 @@ cp hermes-plugins/evey_utils.py ~/.hermes/plugins/
 </ul>
 <h3>License</h3>
 <p>MIT</p>
-
   </section>
 </details>
 

--- a/projects/8bit64k/cronalytics.html
+++ b/projects/8bit64k/cronalytics.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/8bit64k/cronalytics">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=cronalytics&amp;subtitle=Hermes+Agent+plugin+for+cron+analytics+and+observability.+The+dashboard+for+agentic+automations+in+Hermes.&amp;kind=project+%C2%B7+plugins">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=cronalytics&amp;subtitle=Hermes+Agent+cron+analytics+and+observability+plugin+for+attributing+scheduled-run+usage+and+estimated+cost.&amp;kind=project+%C2%B7+plugins">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="8bit64k/cronalytics — Hermes Atlas">
 <meta name="twitter:description" content="Cronalytics is a plugin for Hermes Agent that provides observability and cost attribution for scheduled cron jobs. It utilizes the on_session_end hook to…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=cronalytics&amp;subtitle=Hermes+Agent+plugin+for+cron+analytics+and+observability.+The+dashboard+for+agentic+automations+in+Hermes.&amp;kind=project+%C2%B7+plugins">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=cronalytics&amp;subtitle=Hermes+Agent+cron+analytics+and+observability+plugin+for+attributing+scheduled-run+usage+and+estimated+cost.&amp;kind=project+%C2%B7+plugins">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/8bit64k/cronalytics",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "8bit64k",
     "url": "https://github.com/8bit64k"
   },
-  "dateModified": "2026-06-24T17:58:27.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">8bit64k</span><span class="slash">/</span>cronalytics
   </h1>
-  <p class="project-desc">Hermes Agent plugin for cron analytics and observability. The dashboard for agentic automations in Hermes.</p>
+  <p class="project-desc">Hermes Agent cron analytics and observability plugin for attributing scheduled-run usage and estimated cost.</p>
 
   <div class="meta-row">
     <span class="stars">★ 106</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-06-24</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -523,7 +523,6 @@ provides_hooks:
 <p>See <strong><a href="https://github.com/8bit64k/cronalytics/blob/main/CHANGELOG.md">CHANGELOG.md</a></strong> for the full version history.</p>
 <hr>
 <p><em>Plugin path: <code>~/.hermes/plugins/cronalytics/</code></em><br><em>Fact DB: <code>~/.hermes/plugins/cronalytics/facts.db</code></em><br><em>API base: <code>/api/plugins/cronalytics/</code></em></p>
-
   </section>
 </details>
 

--- a/projects/AMAP-ML/SkillClaw.html
+++ b/projects/AMAP-ML/SkillClaw.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/AMAP-ML/SkillClaw">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=SkillClaw&amp;subtitle=Let+Skills+Evolve+Collectively+with+Agentic+Evolver+&amp;kind=project+%C2%B7+skills">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=SkillClaw&amp;subtitle=Let+Skills+Evolve+Collectively+with+Agentic+Evolver&amp;kind=project+%C2%B7+skills">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="AMAP-ML/SkillClaw — Hermes Atlas">
 <meta name="twitter:description" content="SkillClaw is an agentic evolution system that manages and improves AI agent skill libraries through background processing of real-world interactions. It…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=SkillClaw&amp;subtitle=Let+Skills+Evolve+Collectively+with+Agentic+Evolver+&amp;kind=project+%C2%B7+skills">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=SkillClaw&amp;subtitle=Let+Skills+Evolve+Collectively+with+Agentic+Evolver&amp;kind=project+%C2%B7+skills">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/AMAP-ML/SkillClaw",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "AMAP-ML",
     "url": "https://github.com/AMAP-ML"
   },
-  "dateModified": "2026-08-17T08:48:07.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">AMAP-ML</span><span class="slash">/</span>SkillClaw
   </h1>
-  <p class="project-desc">Let Skills Evolve Collectively with Agentic Evolver </p>
+  <p class="project-desc">Let Skills Evolve Collectively with Agentic Evolver</p>
 
   <div class="meta-row">
     <span class="stars">★ 2.5K</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-17</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,15 @@
     
   </div>
 </section>
+
+
+<aside class="install-box" aria-label="How to install this skill">
+  <div class="ib-label">install<span class="ib-type">registry</span></div>
+  <code class="ib-cmd">git clone https://github.com/AMAP-ML/SkillClaw.git, run scripts/install_skillclaw.sh, activate the venv, then run skillclaw setup.</code>
+  <p class="ib-compat">Standalone Python CLI/daemon; integrates with Hermes, Codex, Claude Code, and OpenAI-compatible APIs — not a drop-in SKILL.md.</p>
+  <p class="ib-verdict">A genuinely different mechanism: runs in the background, deduplicates, and cross-pollinates your skill library across agents, devices, and users instead of just hosting a list.</p>
+  <a class="ib-more" href="/skills/">more picks → the skills hub</a>
+</aside>
 
 
 
@@ -572,7 +579,6 @@ skillclaw skills list-remote   # browse shared skills
 </code></pre>
 <h3>License</h3>
 <p>See <a href="./LICENSE">LICENSE</a> for details.</p>
-
   </section>
 </details>
 

--- a/projects/AaronWong1999/hermesclaw.html
+++ b/projects/AaronWong1999/hermesclaw.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/AaronWong1999/hermesclaw",
   "applicationCategory": "CommunicationApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "AaronWong1999",
     "url": "https://github.com/AaronWong1999"
   },
-  "dateModified": "2026-06-15T11:50:53.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,10 +118,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 717</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-06-15</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -467,7 +467,6 @@ rm -rf "$HOME/hermesclaw"
 <li>The Clawbot / openclaw-weixin maintainers for the iLink WeChat bridge.</li>
 </ul>
 <p>HermesClaw is a community bridge. It is not affiliated with NousResearch or OpenClaw.</p>
-
   </section>
 </details>
 

--- a/projects/Abruptive/Ankh.md.html
+++ b/projects/Abruptive/Ankh.md.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/Abruptive/Ankh.md">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=Ankh.md&amp;subtitle=A+mysterious+multi-agent+swarm+framework+summoned+by+TAW+Agent+from+1971+to+help+you+craft+a+better+future+towards+2133+%26+beyond.+Ankh.md+is+a+Hermes+Agent+%28Nous+Research%29+launch+e&amp;kind=project+%C2%B7+developer+tools">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=Ankh.md&amp;subtitle=TAW+Agent+framework+for+creating+scoped+Hermes+Agents&amp;kind=project+%C2%B7+developer+tools">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Abruptive/Ankh.md — Hermes Atlas">
 <meta name="twitter:description" content="Ankh.md is an open-source framework designed to transform a single Hermes Agent into multiple specialized, project-specific instances. It works by detecting a…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Ankh.md&amp;subtitle=A+mysterious+multi-agent+swarm+framework+summoned+by+TAW+Agent+from+1971+to+help+you+craft+a+better+future+towards+2133+%26+beyond.+Ankh.md+is+a+Hermes+Agent+%28Nous+Research%29+launch+e&amp;kind=project+%C2%B7+developer+tools">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Ankh.md&amp;subtitle=TAW+Agent+framework+for+creating+scoped+Hermes+Agents&amp;kind=project+%C2%B7+developer+tools">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/Abruptive/Ankh.md",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Shell",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "Abruptive",
     "url": "https://github.com/Abruptive"
   },
-  "dateModified": "2026-03-15T05:36:36.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">Abruptive</span><span class="slash">/</span>Ankh.md
   </h1>
-  <p class="project-desc">A mysterious multi-agent swarm framework summoned by TAW Agent from 1971 to help you craft a better future towards 2133 &amp; beyond. Ankh.md is a Hermes Agent (Nous Research) launch exclusive.</p>
+  <p class="project-desc">TAW Agent framework for creating scoped Hermes Agents</p>
 
   <div class="meta-row">
     <span class="stars">★ 74</span>
-    <span><span class="meta-label">lang</span>Shell</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-03-15</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/Abruptive/Ankh.md" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://www.ankh.md" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -341,7 +341,6 @@
 <p><a href="https://www.agent.so/">https://www.agent.so/</a></p>
 <h3>License</h3>
 <p>MIT</p>
-
   </section>
 </details>
 

--- a/projects/AbuZar-Ansarii/Hermes-Agent-On-Android.html
+++ b/projects/AbuZar-Ansarii/Hermes-Agent-On-Android.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/AbuZar-Ansarii/Hermes-Agent-On-Android">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=Hermes-Agent-On-Android&amp;subtitle=Run+Hermes+Agent+-+a+self-evolving+AI+assistant+-+on+any+Android+device+using+Termux.+One-line+installation.&amp;kind=project+%C2%B7+deployment">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=Hermes-Agent-On-Android&amp;subtitle=Termux-based+installer+and+guide+for+running+Hermes+Agent+on+Android+devices&amp;kind=project+%C2%B7+deployment">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="AbuZar-Ansarii/Hermes-Agent-On-Android — Hermes Atlas">
 <meta name="twitter:description" content="This project provides a Termux-based installer and guide for running the Hermes Agent framework on Android devices. It supports various AI models, including…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Hermes-Agent-On-Android&amp;subtitle=Run+Hermes+Agent+-+a+self-evolving+AI+assistant+-+on+any+Android+device+using+Termux.+One-line+installation.&amp;kind=project+%C2%B7+deployment">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Hermes-Agent-On-Android&amp;subtitle=Termux-based+installer+and+guide+for+running+Hermes+Agent+on+Android+devices&amp;kind=project+%C2%B7+deployment">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/AbuZar-Ansarii/Hermes-Agent-On-Android",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Shell",
   "author": {
     "@type": "Organization",
     "name": "AbuZar-Ansarii",
     "url": "https://github.com/AbuZar-Ansarii"
   },
-  "dateModified": "2026-08-13T17:10:02.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">AbuZar-Ansarii</span><span class="slash">/</span>Hermes-Agent-On-Android
   </h1>
-  <p class="project-desc">Run Hermes Agent - a self-evolving AI assistant - on any Android device using Termux. One-line installation.</p>
+  <p class="project-desc">Termux-based installer and guide for running Hermes Agent on Android devices</p>
 
   <div class="meta-row">
     <span class="stars">★ 198</span>
-    <span><span class="meta-label">lang</span>Shell</span>
     
     
-    <span><span class="meta-label">updated</span>2026-08-13</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -400,8 +401,6 @@ ollama serve
     
 <h3><strong>⭐ If this helped you, give it a star! ⭐</strong></h3>
 </div>
-
-
   </section>
 </details>
 

--- a/projects/AgentLineHQ/agentline-skill.html
+++ b/projects/AgentLineHQ/agentline-skill.html
@@ -45,7 +45,6 @@
     "name": "AgentLineHQ",
     "url": "https://github.com/AgentLineHQ"
   },
-  "dateModified": "2026-07-08T04:26:24.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -86,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -121,7 +121,7 @@
     
     
     
-    <span><span class="meta-label">updated</span>2026-07-08</span>
+    
   </div>
 
   <div class="actions">
@@ -129,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 

--- a/projects/Agents365-ai/drawio-skill.html
+++ b/projects/Agents365-ai/drawio-skill.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/Agents365-ai/drawio-skill">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=drawio-skill&amp;subtitle=Generate+draw.io+diagrams+from+natural+language+%E2%80%94+11+presets+%28UML%2C+SysML%2FMBSE%2C+BPMN%2C+network%2C+C4%E2%80%A6%29%2C+36+tools%3A+codebase%2FCI%2Finfra-to-diagram%2C+image%E2%86%92editable+diagram%2C+mind+maps%2C+build&amp;kind=project+%C2%B7+skills">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=drawio-skill&amp;subtitle=Generate+draw.io+diagrams+from+natural+language+descriptions&amp;kind=project+%C2%B7+skills">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Agents365-ai/drawio-skill — Hermes Atlas">
 <meta name="twitter:description" content="This skill converts natural-language descriptions into.drawio XML and exports them to PNG, SVG, PDF, or JPG using the draw.io desktop CLI. It can generate…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=drawio-skill&amp;subtitle=Generate+draw.io+diagrams+from+natural+language+%E2%80%94+11+presets+%28UML%2C+SysML%2FMBSE%2C+BPMN%2C+network%2C+C4%E2%80%A6%29%2C+36+tools%3A+codebase%2FCI%2Finfra-to-diagram%2C+image%E2%86%92editable+diagram%2C+mind+maps%2C+build&amp;kind=project+%C2%B7+skills">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=drawio-skill&amp;subtitle=Generate+draw.io+diagrams+from+natural+language+descriptions&amp;kind=project+%C2%B7+skills">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/Agents365-ai/drawio-skill",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "Agents365-ai",
     "url": "https://github.com/Agents365-ai"
   },
-  "dateModified": "2026-08-05T10:18:33.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,30 @@
   <h1 class="project-name">
     <span class="org">Agents365-ai</span><span class="slash">/</span>drawio-skill
   </h1>
-  <p class="project-desc">Generate draw.io diagrams from natural language — 11 presets (UML, SysML/MBSE, BPMN, network, C4…), 36 tools: codebase/CI/infra-to-diagram, image→editable diagram, mind maps, build-up animation, exec-view compression, click-through runbooks, PR diff bot. Vision self-check, 10,000+ shapes. Exports PNG/SVG/PDF/JPG.</p>
+  <p class="project-desc">Generate draw.io diagrams from natural language descriptions</p>
 
   <div class="meta-row">
     <span class="stars">★ 7.9K</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-05</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/Agents365-ai/drawio-skill" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://agents365-ai.github.io/drawio-skill/" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
+<aside class="install-box" aria-label="How to install this skill">
+  <div class="ib-label">install<span class="ib-type">skill</span></div>
+  <code class="ib-cmd">npx skills add Agents365-ai/365-skills -g (or git clone into your skills directory).</code>
+  <p class="ib-compat">Runs from a single SKILL.md, no MCP server or daemon (needs the draw.io desktop CLI for rendering); works anywhere agentskills.io skills load, including Hermes.</p>
+  <p class="ib-verdict">Eleven diagram-type presets plus Mermaid-to-drawio conversion, and the most-starred diagram skill in the catalog — the clear default over hand-rolling diagram prompts.</p>
+  <a class="ib-more" href="/skills/">more picks → the skills hub</a>
+</aside>
 
 
 
@@ -832,7 +839,6 @@ python3 scripts/aiicons.py "openai" --embed     # self-contained data URI
 </ul>
 <h3>📄 License</h3>
 <p><a href="LICENSE">MIT</a></p>
-
   </section>
 </details>
 

--- a/projects/AkoliteZA/hermes-agent-idea-workflow.html
+++ b/projects/AkoliteZA/hermes-agent-idea-workflow.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/AkoliteZA/hermes-agent-idea-workflow">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-idea-workflow&amp;subtitle=Pre-build+idea-to-spec+workflow+skills+for+Hermes+Agent%3A+turn+rough+ideas+into+design+docs%2C+implementation+specs%2C+and+Superpowers-ready+build+handoffs.&amp;kind=project+%C2%B7+skills">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-idea-workflow&amp;subtitle=Pre-build+idea-to-spec+workflow+skills+for+Hermes+Agent+that+turn+rough+ideas+into+design+docs+and+implementation+handoffs&amp;kind=project+%C2%B7+skills">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="AkoliteZA/hermes-agent-idea-workflow — Hermes Atlas">
 <meta name="twitter:description" content="The Hermes Agent Idea Workflow is a suite of skills designed to transform vague product concepts into structured, build-ready specifications. It operates…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-idea-workflow&amp;subtitle=Pre-build+idea-to-spec+workflow+skills+for+Hermes+Agent%3A+turn+rough+ideas+into+design+docs%2C+implementation+specs%2C+and+Superpowers-ready+build+handoffs.&amp;kind=project+%C2%B7+skills">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-idea-workflow&amp;subtitle=Pre-build+idea-to-spec+workflow+skills+for+Hermes+Agent+that+turn+rough+ideas+into+design+docs+and+implementation+handoffs&amp;kind=project+%C2%B7+skills">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/AkoliteZA/hermes-agent-idea-workflow",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "AkoliteZA",
     "url": "https://github.com/AkoliteZA"
   },
-  "dateModified": "2026-05-05T13:35:10.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">AkoliteZA</span><span class="slash">/</span>hermes-agent-idea-workflow
   </h1>
-  <p class="project-desc">Pre-build idea-to-spec workflow skills for Hermes Agent: turn rough ideas into design docs, implementation specs, and Superpowers-ready build handoffs.</p>
+  <p class="project-desc">Pre-build idea-to-spec workflow skills for Hermes Agent that turn rough ideas into design docs and implementation handoffs</p>
 
   <div class="meta-row">
     <span class="stars">★ 261</span>
     
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-05-05</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -307,7 +308,6 @@ idea-to-implementation-doc/
 </ul>
 <h3>Privacy Note</h3>
 <p>The examples in this repository are generic public examples. They are intentionally not based on private product plans.</p>
-
   </section>
 </details>
 

--- a/projects/AlexAI-MCP/hermes-CCC.html
+++ b/projects/AlexAI-MCP/hermes-CCC.html
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/AlexAI-MCP/hermes-CCC",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "PowerShell",
   "author": {
     "@type": "Organization",
     "name": "AlexAI-MCP",
     "url": "https://github.com/AlexAI-MCP"
   },
-  "dateModified": "2026-04-08T00:16:53.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -119,10 +118,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 134</span>
-    <span><span class="meta-label">lang</span>PowerShell</span>
     
     
-    <span><span class="meta-label">updated</span>2026-04-08</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -603,7 +604,6 @@ cd hermes-CCC
 <hr>
 <h3>License</h3>
 <p>MIT © 2026 AlexAI-MCP</p>
-
   </section>
 </details>
 

--- a/projects/BORT-AGENTS/hermes-bort.html
+++ b/projects/BORT-AGENTS/hermes-bort.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/BORT-AGENTS/hermes-bort">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-bort&amp;subtitle=Hermes+Agent+plugin+for+BORT+%28BAP-578%29+agent+NFTs+on+BNB+Smart+Chain%3A+multi-source+reads%2C+operator-signed+writes%2C+portable+IPFS-anchored+memory.&amp;kind=project+%C2%B7+integrations">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-bort&amp;subtitle=No+description&amp;kind=project+%C2%B7+integrations">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="BORT-AGENTS/hermes-bort — Hermes Atlas">
 <meta name="twitter:description" content="hermes-bort is a plugin for Hermes Agent that enables interaction with BORT (BAP-578) agent NFTs on the BSC mainnet. It allows Hermes processes to read…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-bort&amp;subtitle=Hermes+Agent+plugin+for+BORT+%28BAP-578%29+agent+NFTs+on+BNB+Smart+Chain%3A+multi-source+reads%2C+operator-signed+writes%2C+portable+IPFS-anchored+memory.&amp;kind=project+%C2%B7+integrations">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-bort&amp;subtitle=No+description&amp;kind=project+%C2%B7+integrations">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/BORT-AGENTS/hermes-bort",
   "applicationCategory": "CommunicationApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "BORT-AGENTS",
     "url": "https://github.com/BORT-AGENTS"
   },
-  "dateModified": "2026-05-18T22:08:58.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">BORT-AGENTS</span><span class="slash">/</span>hermes-bort
   </h1>
-  <p class="project-desc">Hermes Agent plugin for BORT (BAP-578) agent NFTs on BNB Smart Chain: multi-source reads, operator-signed writes, portable IPFS-anchored memory.</p>
+  <p class="project-desc">No description</p>
 
   <div class="meta-row">
     <span class="stars">★ 3</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-05-18</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -547,7 +547,6 @@ on-chain calls are reserved for what the runtime does not expose: <code>tokenURI
 VPM v2 forwarder, and KR v2 delegated writes.</p>
 <h3>License</h3>
 <p>MIT. See <a href="LICENSE">LICENSE</a>.</p>
-
   </section>
 </details>
 

--- a/projects/Capslockb/hermes-live-discord-agent-plugin.html
+++ b/projects/Capslockb/hermes-live-discord-agent-plugin.html
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/Capslockb/hermes-live-discord-agent-plugin",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
   "author": {
     "@type": "Organization",
     "name": "Capslockb",
     "url": "https://github.com/Capslockb"
   },
-  "dateModified": "2026-08-15T16:41:19.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -119,17 +118,19 @@
 
   <div class="meta-row">
     <span class="stars">★ 17</span>
-    <span><span class="meta-label">lang</span>Python</span>
     
     
-    <span><span class="meta-label">updated</span>2026-08-15</span>
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/Capslockb/hermes-live-discord-agent-plugin" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://capslockb.github.io/hermes-live-discord-agent-plugin/" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -291,7 +292,6 @@ Discord Voice
 <p>Use focused pull requests, preserve truthful capability labels, add tests for behavior changes, and avoid committing credentials, private identifiers, transcripts, or generated artifacts containing sensitive data.</p>
 <h3>License</h3>
 <p>No standalone <code>LICENSE</code> file is currently included. Do not assume reuse or redistribution rights until the repository owner adds an explicit license.</p>
-
   </section>
 </details>
 

--- a/projects/Christabel337/job-scout-agent.html
+++ b/projects/Christabel337/job-scout-agent.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/Christabel337/job-scout-agent">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=job-scout-agent&amp;subtitle=Autonomous+job+hunting+agent+built+with+Hermes+Agent&amp;kind=project+%C2%B7+domain+applications">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=job-scout-agent&amp;subtitle=Autonomous+job+hunting+%E2%80%94+scans+listings%2C+writes+cover+letters%2C+tracks+applications&amp;kind=project+%C2%B7+domain+applications">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Christabel337/job-scout-agent — Hermes Atlas">
 <meta name="twitter:description" content="Job Scout Agent is an autonomous tool that fetches job listings from multiple APIs and scores them against user skills and preferences. It performs company…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=job-scout-agent&amp;subtitle=Autonomous+job+hunting+agent+built+with+Hermes+Agent&amp;kind=project+%C2%B7+domain+applications">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=job-scout-agent&amp;subtitle=Autonomous+job+hunting+%E2%80%94+scans+listings%2C+writes+cover+letters%2C+tracks+applications&amp;kind=project+%C2%B7+domain+applications">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/Christabel337/job-scout-agent",
   "applicationCategory": "BusinessApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "Christabel337",
     "url": "https://github.com/Christabel337"
   },
-  "dateModified": "2026-03-10T22:26:07.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">Christabel337</span><span class="slash">/</span>job-scout-agent
   </h1>
-  <p class="project-desc">Autonomous job hunting agent built with Hermes Agent</p>
+  <p class="project-desc">Autonomous job hunting — scans listings, writes cover letters, tracks applications</p>
 
   <div class="meta-row">
     <span class="stars">★ 55</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-03-10</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -240,7 +240,6 @@
 <p><strong>Import it:</strong> Google Sheets → File → Import → Upload <code>job_scout_tracker.csv</code></p>
 <h2>👤 Built By</h2>
 <p><strong>Christabel</strong> · <a href="https://twitter.com/Christabel556">@Christabel556</a></p>
-
   </section>
 </details>
 

--- a/projects/ClaudioDrews/memory-os.html
+++ b/projects/ClaudioDrews/memory-os.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/ClaudioDrews/memory-os">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=Memory+OS&amp;subtitle=A+7-layer+memory+operating+system+for+Hermes+Agent+%E2%80%94+persistent+memory+with+Qdrant%2C+structured+facts%2C+fabric+recall%2C+auto-curated+wiki%2C+and+surgical+context+injection.+Runs+locally&amp;kind=project+%C2%B7+memory">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=Memory+OS&amp;subtitle=Seven-layer+memory+system+for+Hermes+Agent%3A+persistent+memory+on+Qdrant%2C+structured+facts%2C+fabric+recall%2C+and+an+auto-curated+wiki.&amp;kind=project+%C2%B7+memory">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="ClaudioDrews/Memory OS — Hermes Atlas">
 <meta name="twitter:description" content="Memory OS is a local memory infrastructure for Hermes Agent that utilizes a seven-layer system to store and retrieve information across sessions. It integrates…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Memory+OS&amp;subtitle=A+7-layer+memory+operating+system+for+Hermes+Agent+%E2%80%94+persistent+memory+with+Qdrant%2C+structured+facts%2C+fabric+recall%2C+auto-curated+wiki%2C+and+surgical+context+injection.+Runs+locally&amp;kind=project+%C2%B7+memory">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Memory+OS&amp;subtitle=Seven-layer+memory+system+for+Hermes+Agent%3A+persistent+memory+on+Qdrant%2C+structured+facts%2C+fabric+recall%2C+and+an+auto-curated+wiki.&amp;kind=project+%C2%B7+memory">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/ClaudioDrews/memory-os",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "ClaudioDrews",
     "url": "https://github.com/ClaudioDrews"
   },
-  "dateModified": "2026-06-10T10:40:43.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">ClaudioDrews</span><span class="slash">/</span>memory-os
   </h1>
-  <p class="project-desc">A 7-layer memory operating system for Hermes Agent — persistent memory with Qdrant, structured facts, fabric recall, auto-curated wiki, and surgical context injection. Runs locally, any LLM provider.</p>
+  <p class="project-desc">Seven-layer memory system for Hermes Agent: persistent memory on Qdrant, structured facts, fabric recall, and an auto-curated wiki.</p>
 
   <div class="meta-row">
     <span class="stars">★ 1.3K</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-06-10</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -379,7 +379,6 @@
 <p><strong>Want to see the agent remember for real?</strong><br>Clone it, run it, feel the difference.</p>
 <p>→ <a href="https://github.com/ClaudioDrews/memory-os/blob/main/setup.sh">Quick install</a> · <a href="https://github.com/ClaudioDrews/memory-os/blob/main/setup/install.md">Manual guide</a> · <a href="layers/">Layer deep-dives</a> · <a href="https://github.com/ClaudioDrews/memory-os/blob/main/infrastructure/architecture.md">Infrastructure docs</a> · <a href="skills/">Operational skills</a> · <a href="LICENSE">License</a></p>
 <p>MIT License · Built with obsession by someone who runs Hermes every single day.</p>
-
   </section>
 </details>
 

--- a/projects/Codename-11/hermes-relay.html
+++ b/projects/Codename-11/hermes-relay.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/Codename-11/hermes-relay">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-relay&amp;subtitle=Hermes-Relay+%E2%80%94+Your+Hermes+AI+agent%2C+in+your+pocket+%E2%80%94+chat%2C+voice%2C+and+control.&amp;kind=project+%C2%B7+integrations">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-relay&amp;subtitle=Hermes+Companion+%E2%80%94+Android+app+for+Hermes+agent+platform.+Chat%2C+terminal%2C+and+device+control+over+WSS.&amp;kind=project+%C2%B7+integrations">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Codename-11/hermes-relay — Hermes Atlas">
 <meta name="twitter:description" content="Hermes-Relay is a native Android companion app and CLI for the Hermes agent platform that enables remote interaction with a self-hosted agent. It provides…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-relay&amp;subtitle=Hermes-Relay+%E2%80%94+Your+Hermes+AI+agent%2C+in+your+pocket+%E2%80%94+chat%2C+voice%2C+and+control.&amp;kind=project+%C2%B7+integrations">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-relay&amp;subtitle=Hermes+Companion+%E2%80%94+Android+app+for+Hermes+agent+platform.+Chat%2C+terminal%2C+and+device+control+over+WSS.&amp;kind=project+%C2%B7+integrations">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/Codename-11/hermes-relay",
   "applicationCategory": "CommunicationApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Kotlin",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "Codename-11",
     "url": "https://github.com/Codename-11"
   },
-  "dateModified": "2026-08-21T01:19:53.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">Codename-11</span><span class="slash">/</span>hermes-relay
   </h1>
-  <p class="project-desc">Hermes-Relay — Your Hermes AI agent, in your pocket — chat, voice, and control.</p>
+  <p class="project-desc">Hermes Companion — Android app for Hermes agent platform. Chat, terminal, and device control over WSS.</p>
 
   <div class="meta-row">
     <span class="stars">★ 146</span>
-    <span><span class="meta-label">lang</span>Kotlin</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-21</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/Codename-11/hermes-relay" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://hermes-relay.dev" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -550,7 +550,6 @@ ln -s "$PWD/plugin" ~/.hermes/plugins/hermes-relay
   Built with the help of Humans and AI Agents<br><br>
   <a href="https://ko-fi.com/L4L31Q8LJ1"><img src="https://ko-fi.com/img/githubbutton_sm.svg" alt="Support on Ko-fi"></a>
 </p>
-
   </section>
 </details>
 

--- a/projects/Context4GPTs/klodi-plugin.html
+++ b/projects/Context4GPTs/klodi-plugin.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/Context4GPTs/klodi-plugin",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/Apache-2.0.html",
   "author": {
     "@type": "Organization",
     "name": "Context4GPTs",
     "url": "https://github.com/Context4GPTs"
   },
-  "dateModified": "2026-07-06T16:43:21.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,17 +118,19 @@
 
   <div class="meta-row">
     <span class="stars">★ 16</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>Apache-2.0</span>
     
-    <span><span class="meta-label">updated</span>2026-07-06</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/Context4GPTs/klodi-plugin" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://4gpts.com" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -386,7 +386,6 @@ your policies                                     your policies
 </ul>
 <hr>
 <p><strong>Built by <a href="https://4gpts.com">4GPTs</a></strong> · Apache-2.0 license · <a href="https://x.com/4gpts">@4gpts on X</a></p>
-
   </section>
 </details>
 

--- a/projects/CorsenAI/hermes-connector.html
+++ b/projects/CorsenAI/hermes-connector.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/CorsenAI/hermes-connector",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "CorsenAI",
     "url": "https://github.com/CorsenAI"
   },
-  "dateModified": "2026-08-16T16:57:35.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,17 +118,19 @@
 
   <div class="meta-row">
     <span class="stars">★ 8</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-16</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/CorsenAI/hermes-connector" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://corsenai.github.io/hermes-connector/" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -370,7 +370,6 @@ builds are isolated under <code>dist/dev/</code> and must not be uploaded to the
 <li><a href="https://github.com/CorsenAI/hermes-connector">Source code and releases</a></li>
 </ul>
 <p>Hermes Connector is released under the <a href="LICENSE">MIT License</a>.</p>
-
   </section>
 </details>
 

--- a/projects/CorsenAI/hermes-windows-runtime-skills.html
+++ b/projects/CorsenAI/hermes-windows-runtime-skills.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/CorsenAI/hermes-windows-runtime-skills",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "PowerShell",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "CorsenAI",
     "url": "https://github.com/CorsenAI"
   },
-  "dateModified": "2026-08-17T16:41:55.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,10 +118,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 1</span>
-    <span><span class="meta-label">lang</span>PowerShell</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-17</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,15 @@
     
   </div>
 </section>
+
+
+<aside class="install-box" aria-label="How to install this skill">
+  <div class="ib-label">install<span class="ib-type">collection</span></div>
+  <code class="ib-cmd">hermes skills tap add CorsenAI/hermes-windows-runtime-skills (or install each skill directly, e.g. hermes skills install CorsenAI/hermes-windows-runtime-skills/skills/windows-wsl-file-navigation).</code>
+  <p class="ib-compat">Hermes Agent native, specifically for native Windows, Git Bash/MSYS, and WSL environments.</p>
+  <p class="ib-verdict">Solves a real, narrow Hermes pain point — deterministic path routing and non-destructive Python runtime selection across Windows, Git Bash, and WSL — with exact hermes skills install commands in the README.</p>
+  <a class="ib-more" href="/skills/">more picks → the skills hub</a>
+</aside>
 
 
 
@@ -348,7 +355,6 @@ Windows/MSYS/WSL runtime selection.</p>
 <p><a href="https://github.com/CorsenAI">CorsenAI</a></p>
 <h3>License</h3>
 <p>MIT</p>
-
   </section>
 </details>
 

--- a/projects/Cranot/super-hermes.html
+++ b/projects/Cranot/super-hermes.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/Cranot/super-hermes",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "PowerShell",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "Cranot",
     "url": "https://github.com/Cranot"
   },
-  "dateModified": "2026-07-27T17:15:52.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,10 +118,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 382</span>
-    <span><span class="meta-label">lang</span>PowerShell</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-07-27</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,15 @@
     
   </div>
 </section>
+
+
+<aside class="install-box" aria-label="How to install this skill">
+  <div class="ib-label">install<span class="ib-type">skill</span></div>
+  <code class="ib-cmd">hermes skills tap add Cranot/super-hermes</code>
+  <p class="ib-compat">Hermes Agent native (Skills Hub tap); manual git-clone install also documented for other harnesses.</p>
+  <p class="ib-verdict">Built specifically for Hermes' own Skills Hub syntax rather than ported from Claude Code — teaches the agent to write its own analytical prompts via prism-scan plus seven proven analytical lenses.</p>
+  <a class="ib-more" href="/skills/">more picks → the skills hub</a>
+</aside>
 
 
 
@@ -427,7 +434,6 @@ impact under load, integer overflow on failure_count.
 <hr>
 <h3>License</h3>
 <p>MIT</p>
-
   </section>
 </details>
 

--- a/projects/CryptoDmitry/hermes-agent-control-room.html
+++ b/projects/CryptoDmitry/hermes-agent-control-room.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/CryptoDmitry/hermes-agent-control-room">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-control-room&amp;subtitle=Control+Room-first+template+for+managing+Hermes+agents+from+one+VPS+agent+to+specialist+teams+and+orchestrated+workflows+&amp;kind=project+%C2%B7+multi-agent">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-control-room&amp;subtitle=Control+Room-first+template+for+managing+Hermes+agents+from+one+VPS+agent+to+specialist+teams+and+orchestrated+workflows&amp;kind=project+%C2%B7+multi-agent">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="CryptoDmitry/hermes-agent-control-room — Hermes Atlas">
 <meta name="twitter:description" content="Hermes Agent Control Room is a governance template designed to prevent the fragmentation of disconnected bots by providing a centralized management plane. It…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-control-room&amp;subtitle=Control+Room-first+template+for+managing+Hermes+agents+from+one+VPS+agent+to+specialist+teams+and+orchestrated+workflows+&amp;kind=project+%C2%B7+multi-agent">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-control-room&amp;subtitle=Control+Room-first+template+for+managing+Hermes+agents+from+one+VPS+agent+to+specialist+teams+and+orchestrated+workflows&amp;kind=project+%C2%B7+multi-agent">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/CryptoDmitry/hermes-agent-control-room",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Shell",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "CryptoDmitry",
     "url": "https://github.com/CryptoDmitry"
   },
-  "dateModified": "2026-05-18T13:30:31.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">CryptoDmitry</span><span class="slash">/</span>hermes-agent-control-room
   </h1>
-  <p class="project-desc">Control Room-first template for managing Hermes agents from one VPS agent to specialist teams and orchestrated workflows </p>
+  <p class="project-desc">Control Room-first template for managing Hermes agents from one VPS agent to specialist teams and orchestrated workflows</p>
 
   <div class="meta-row">
     <span class="stars">★ 751</span>
-    <span><span class="meta-label">lang</span>Shell</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-05-18</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -454,7 +454,6 @@ ls skills/
 </ul>
 <h3>License</h3>
 <p>MIT. See <code>LICENSE</code>.</p>
-
   </section>
 </details>
 

--- a/projects/Cyber-Yichen/hermes-feishu-group-context.html
+++ b/projects/Cyber-Yichen/hermes-feishu-group-context.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/Cyber-Yichen/hermes-feishu-group-context",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "Cyber-Yichen",
     "url": "https://github.com/Cyber-Yichen"
   },
-  "dateModified": "2026-07-01T03:21:03.000Z",
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
   }
@@ -81,6 +78,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -113,10 +111,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 0</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-07-01</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -124,6 +122,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -643,7 +643,6 @@ D:\env\hermes\hermes-agent\venv\Scripts\python.exe -m unittest discover -s tests
 <h3>项目状态</h3>
 <p>当前插件版本：<code>1.2.0</code></p>
 <p>本项目是社区扩展，不隶属于 NousResearch、Hermes Agent、飞书或字节跳动。</p>
-
   </section>
 </details>
 

--- a/projects/Cyber-Yichen/hermes-xiaomi-mimo-tts.html
+++ b/projects/Cyber-Yichen/hermes-xiaomi-mimo-tts.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/Cyber-Yichen/hermes-xiaomi-mimo-tts",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "Cyber-Yichen",
     "url": "https://github.com/Cyber-Yichen"
   },
-  "dateModified": "2026-06-30T08:58:24.000Z",
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
   }
@@ -81,6 +78,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -113,10 +111,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 0</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-06-30</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -124,6 +122,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -427,7 +427,6 @@ hermes config get tts
 </ul>
 <h3>许可证</h3>
 <p><a href="./LICENSE">MIT License</a></p>
-
   </section>
 </details>
 

--- a/projects/DanielLi202/hermes-tag.html
+++ b/projects/DanielLi202/hermes-tag.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/DanielLi202/hermes-tag",
   "applicationCategory": "CommunicationApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "DanielLi202",
     "url": "https://github.com/DanielLi202"
   },
-  "dateModified": "2026-07-09T07:05:35.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">DanielLi202</span><span class="slash">/</span>hermes-tag
   </h1>
-  <p class="project-desc">Post images, add notes, let the thread run, then @ it — Hermes Tag pulls the few messages that matter (originals + your notes + relevant replies), not your last line, not your whole history. Claude-Tag-style context-selection for Hermes on Feishu/Lark &amp; Slack — @-only, no full-history RAG, per-chat memory + audit.</p>
+  <p class="project-desc">Post images, add notes, let the thread run, then @ it — Hermes Tag pulls the few messages that matter (originals + your notes + relevant replies), not your last line, not your whole history. Claude-Ta</p>
 
   <div class="meta-row">
     <span class="stars">★ 3</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-07-09</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -297,7 +297,6 @@ platforms:
 <li><a href="https://github.com/DanielLi202/hermes-tag/blob/main/CHANGELOG.md">Changelog</a></li>
 <li>License: MIT, DanielLi202.</li>
 </ul>
-
   </section>
 </details>
 

--- a/projects/DougTrajano/pydantic-ai-skills.html
+++ b/projects/DougTrajano/pydantic-ai-skills.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/DougTrajano/pydantic-ai-skills">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=pydantic-ai-skills&amp;subtitle=This+package+implements+Agent+Skills+%28https%3A%2F%2Fagentskills.io%29+support+with+progressive+disclosure+for+Pydantic+AI.+Supports+filesystem+and+programmatic+skills.&amp;kind=project+%C2%B7+skills">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=pydantic-ai-skills&amp;subtitle=Type-safe+agentskills.io+support+with+progressive+disclosure+for+Pydantic+AI&amp;kind=project+%C2%B7+skills">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="DougTrajano/pydantic-ai-skills — Hermes Atlas">
 <meta name="twitter:description" content="pydantic-ai-skills provides support for Agent Skills within the Pydantic AI framework. It uses progressive disclosure to load skill instructions, reference…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=pydantic-ai-skills&amp;subtitle=This+package+implements+Agent+Skills+%28https%3A%2F%2Fagentskills.io%29+support+with+progressive+disclosure+for+Pydantic+AI.+Supports+filesystem+and+programmatic+skills.&amp;kind=project+%C2%B7+skills">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=pydantic-ai-skills&amp;subtitle=Type-safe+agentskills.io+support+with+progressive+disclosure+for+Pydantic+AI&amp;kind=project+%C2%B7+skills">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/DougTrajano/pydantic-ai-skills",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "DougTrajano",
     "url": "https://github.com/DougTrajano"
   },
-  "dateModified": "2026-08-21T08:08:25.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">DougTrajano</span><span class="slash">/</span>pydantic-ai-skills
   </h1>
-  <p class="project-desc">This package implements Agent Skills (https://agentskills.io) support with progressive disclosure for Pydantic AI. Supports filesystem and programmatic skills.</p>
+  <p class="project-desc">Type-safe agentskills.io support with progressive disclosure for Pydantic AI</p>
 
   <div class="meta-row">
     <span class="stars">★ 360</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-21</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/DougTrajano/pydantic-ai-skills" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://dougtrajano.github.io/pydantic-ai-skills/" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -278,7 +278,6 @@ Audit any skill from an unknown source before use. See
 which provided foundational ideas and patterns for agent skills and progressive disclosure in Pydantic AI.</p>
 <h3>License</h3>
 <p>MIT License — see <a href="LICENSE">LICENSE</a>.</p>
-
   </section>
 </details>
 

--- a/projects/EKKOLearnAI/hermes-studio.html
+++ b/projects/EKKOLearnAI/hermes-studio.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/EKKOLearnAI/hermes-studio">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-studio&amp;subtitle=Web+dashboard+for+Hermes+Agent+%E2%80%94+multi-platform+AI+chat%2C+session+management%2C+scheduled+jobs%2C+usage+analytics+&amp;kind=project+%C2%B7+workspaces">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-studio&amp;subtitle=Web+dashboard+for+Hermes+Agent+%E2%80%94+multi-platform+AI+chat%2C+session+management%2C+scheduled+jobs%2C+usage+analytics+%26+channel+configuration+%28Telegram%2C+Discord%2C+Slack%2C+WhatsApp%29&amp;kind=project+%C2%B7+workspaces">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="EKKOLearnAI/hermes-studio — Hermes Atlas">
 <meta name="twitter:description" content="Hermes Studio is a desktop application, local runtime, and web console for Hermes Agent. It provides tools for agent chat, visual workflow construction, model…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-studio&amp;subtitle=Web+dashboard+for+Hermes+Agent+%E2%80%94+multi-platform+AI+chat%2C+session+management%2C+scheduled+jobs%2C+usage+analytics+&amp;kind=project+%C2%B7+workspaces">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-studio&amp;subtitle=Web+dashboard+for+Hermes+Agent+%E2%80%94+multi-platform+AI+chat%2C+session+management%2C+scheduled+jobs%2C+usage+analytics+%26+channel+configuration+%28Telegram%2C+Discord%2C+Slack%2C+WhatsApp%29&amp;kind=project+%C2%B7+workspaces">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/EKKOLearnAI/hermes-studio",
   "applicationCategory": "DesktopEnhancementApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TypeScript",
   "author": {
     "@type": "Organization",
     "name": "EKKOLearnAI",
     "url": "https://github.com/EKKOLearnAI"
   },
-  "dateModified": "2026-08-21T10:24:16.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">EKKOLearnAI</span><span class="slash">/</span>hermes-studio
   </h1>
-  <p class="project-desc">Web dashboard for Hermes Agent — multi-platform AI chat, session management, scheduled jobs, usage analytics </p>
+  <p class="project-desc">Web dashboard for Hermes Agent — multi-platform AI chat, session management, scheduled jobs, usage analytics &amp; channel configuration (Telegram, Discord, Slack, WhatsApp)</p>
 
   <div class="meta-row">
     <span class="stars">★ 10.5K</span>
-    <span><span class="meta-label">lang</span>TypeScript</span>
     
     
-    <span><span class="meta-label">updated</span>2026-08-21</span>
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/EKKOLearnAI/hermes-studio" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://hermes-studio.ai" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -904,7 +905,6 @@ npm run dev
 <p>The license covers Hermes Studio, the former Hermes Web UI name, the
 <code>hermes-web-ui</code> npm package and CLI, desktop applications, firmware, release
 artifacts, documentation, and associated files in this repository.</p>
-
   </section>
 </details>
 

--- a/projects/EfficientContext/ContextPilot.html
+++ b/projects/EfficientContext/ContextPilot.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/EfficientContext/ContextPilot",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/Apache-2.0.html",
   "author": {
     "@type": "Organization",
     "name": "EfficientContext",
     "url": "https://github.com/EfficientContext"
   },
-  "dateModified": "2026-08-18T10:44:16.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,10 +118,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 129</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>Apache-2.0</span>
     
-    <span><span class="meta-label">updated</span>2026-08-18</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -462,7 +462,6 @@ for resp, idx in zip(asyncio.run(generate_all()), order):
 </code></pre>
 <h3>Contributing</h3>
 <p>We welcome and value all contributions! Please feel free to submit issues and pull requests.</p>
-
   </section>
 </details>
 

--- a/projects/EntangledQuantum/Life_OS.html
+++ b/projects/EntangledQuantum/Life_OS.html
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/EntangledQuantum/Life_OS",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TypeScript",
   "author": {
     "@type": "Organization",
     "name": "EntangledQuantum",
     "url": "https://github.com/EntangledQuantum"
   },
-  "dateModified": "2026-08-16T21:09:57.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -119,10 +118,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 23</span>
-    <span><span class="meta-label">lang</span>TypeScript</span>
     
     
-    <span><span class="meta-label">updated</span>2026-08-16</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -254,7 +255,6 @@ shipped one.</p>
 <br>
 <sub>Built for a brain that does the work but hates maintaining the system.</sub>
 </div>
-
   </section>
 </details>
 

--- a/projects/Euraika-Labs/pan-ui.html
+++ b/projects/Euraika-Labs/pan-ui.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/Euraika-Labs/pan-ui">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=pan-ui&amp;subtitle=Pan+by+Euraika+%E2%80%94+a+self-hosted+AI+workspace+for+Hermes+Agent.+Chat%2C+skills%2C+extensions%2C+memory%2C+profiles%2C+and+runtime+controls.&amp;kind=project+%C2%B7+workspaces">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=pan-ui&amp;subtitle=Self-hosted+AI+workspace+with+chat%2C+skills%2C+extensions%2C+memory%2C+profiles%2C+and+runtime+controls&amp;kind=project+%C2%B7+workspaces">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Euraika-Labs/pan-ui — Hermes Atlas">
 <meta name="twitter:description" content="Pan is a self-hosted web dashboard and workspace designed specifically for the Hermes Agent runtime. It provides a centralized interface to manage agent…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=pan-ui&amp;subtitle=Pan+by+Euraika+%E2%80%94+a+self-hosted+AI+workspace+for+Hermes+Agent.+Chat%2C+skills%2C+extensions%2C+memory%2C+profiles%2C+and+runtime+controls.&amp;kind=project+%C2%B7+workspaces">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=pan-ui&amp;subtitle=Self-hosted+AI+workspace+with+chat%2C+skills%2C+extensions%2C+memory%2C+profiles%2C+and+runtime+controls&amp;kind=project+%C2%B7+workspaces">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/Euraika-Labs/pan-ui",
   "applicationCategory": "DesktopEnhancementApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TypeScript",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "Euraika-Labs",
     "url": "https://github.com/Euraika-Labs"
   },
-  "dateModified": "2026-07-10T03:41:20.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">Euraika-Labs</span><span class="slash">/</span>pan-ui
   </h1>
-  <p class="project-desc">Pan by Euraika — a self-hosted AI workspace for Hermes Agent. Chat, skills, extensions, memory, profiles, and runtime controls.</p>
+  <p class="project-desc">Self-hosted AI workspace with chat, skills, extensions, memory, profiles, and runtime controls</p>
 
   <div class="meta-row">
     <span class="stars">★ 98</span>
-    <span><span class="meta-label">lang</span>TypeScript</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-07-10</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/Euraika-Labs/pan-ui" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://github.com/Euraika-Labs/pan-ui#readme" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -551,7 +551,6 @@ npm run dev
 <p>See <a href="https://github.com/Euraika-Labs/pan-ui/blob/main/SECURITY.md">SECURITY.md</a> for reporting vulnerabilities.</p>
 <h3>License</h3>
 <p><a href="LICENSE">MIT</a> © <a href="https://github.com/Euraika-Labs">Euraika Labs</a></p>
-
   </section>
 </details>
 

--- a/projects/Eynzof/Hermes-CN-Desktop.html
+++ b/projects/Eynzof/Hermes-CN-Desktop.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/Eynzof/Hermes-CN-Desktop">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=Hermes-CN-Desktop&amp;subtitle=Hermes+Agent+CN+desktop+app%2C+Windows-First%2C+built+with+Tauri%2C+Typescript+and+Rust.+Isolated+Hermes+Agent+core+insides.+&amp;kind=project+%C2%B7+workspaces">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=Hermes-CN-Desktop&amp;subtitle=Windows-first+Chinese+desktop+app+for+Hermes+Agent+built+with+Tauri%2C+TypeScript%2C+and+Rust&amp;kind=project+%C2%B7+workspaces">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Eynzof/Hermes-CN-Desktop — Hermes Atlas">
 <meta name="twitter:description" content="Hermes Agent CN Desktop is a cross-platform client for the Hermes Agent Chinese community, built with Tauri, Rust, React, and TypeScript. It provides a native…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Hermes-CN-Desktop&amp;subtitle=Hermes+Agent+CN+desktop+app%2C+Windows-First%2C+built+with+Tauri%2C+Typescript+and+Rust.+Isolated+Hermes+Agent+core+insides.+&amp;kind=project+%C2%B7+workspaces">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Hermes-CN-Desktop&amp;subtitle=Windows-first+Chinese+desktop+app+for+Hermes+Agent+built+with+Tauri%2C+TypeScript%2C+and+Rust&amp;kind=project+%C2%B7+workspaces">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/Eynzof/Hermes-CN-Desktop",
   "applicationCategory": "DesktopEnhancementApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TypeScript",
   "author": {
     "@type": "Organization",
     "name": "Eynzof",
     "url": "https://github.com/Eynzof"
   },
-  "dateModified": "2026-08-19T23:37:51.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">Eynzof</span><span class="slash">/</span>Hermes-CN-Desktop
   </h1>
-  <p class="project-desc">Hermes Agent CN desktop app, Windows-First, built with Tauri, Typescript and Rust. Isolated Hermes Agent core insides. </p>
+  <p class="project-desc">Windows-first Chinese desktop app for Hermes Agent built with Tauri, TypeScript, and Rust</p>
 
   <div class="meta-row">
     <span class="stars">★ 1.6K</span>
-    <span><span class="meta-label">lang</span>TypeScript</span>
     
     
-    <span><span class="meta-label">updated</span>2026-08-19</span>
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/Eynzof/Hermes-CN-Desktop" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://hermesagent.org.cn" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -439,7 +440,6 @@ v0.1.1
 <p>如果要报告安全问题，请遵循 <a href="https://github.com/Eynzof/Hermes-CN-Desktop/blob/main/SECURITY.md">SECURITY.md</a>，不要直接创建公开 Issue。</p>
 <h3>许可</h3>
 <p>本项目的非商业使用遵守 <a href="./LICENSE">PolyForm Noncommercial License 1.0.0</a>。商业使用、商业分发、商业集成、托管销售或作为商业产品组成部分使用，需提前获得青岛万德缦思网络科技有限公司的单独商业授权；授权联系邮箱：<a href="mailto:lijiale@wanderminds.cn">lijiale@wanderminds.cn</a>。</p>
-
   </section>
 </details>
 

--- a/projects/FahrenheitResearch/hermes-weather-plugin.html
+++ b/projects/FahrenheitResearch/hermes-weather-plugin.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/FahrenheitResearch/hermes-weather-plugin">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-weather-plugin&amp;subtitle=Hermes+Agent+weather+plugin+%E2%80%94+NWS-grade+model+imagery%2C+NEXRAD+radar%2C+and+verified+meteorological+calculations.+Pure+Rust+stack.&amp;kind=project+%C2%B7+plugins">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-weather-plugin&amp;subtitle=NWS-grade+model+imagery%2C+NEXRAD+radar%2C+and+verified+meteorological+calculations.+Pure+Rust.&amp;kind=project+%C2%B7+plugins">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="FahrenheitResearch/hermes-weather-plugin — Hermes Atlas">
 <meta name="twitter:description" content="The Hermes Weather Plugin provides a suite of 13 meteorological tools for the Hermes Agent ecosystem, enabling real-time access to observations, forecasts, and…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-weather-plugin&amp;subtitle=Hermes+Agent+weather+plugin+%E2%80%94+NWS-grade+model+imagery%2C+NEXRAD+radar%2C+and+verified+meteorological+calculations.+Pure+Rust+stack.&amp;kind=project+%C2%B7+plugins">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-weather-plugin&amp;subtitle=NWS-grade+model+imagery%2C+NEXRAD+radar%2C+and+verified+meteorological+calculations.+Pure+Rust.&amp;kind=project+%C2%B7+plugins">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/FahrenheitResearch/hermes-weather-plugin",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
   "author": {
     "@type": "Organization",
     "name": "FahrenheitResearch",
     "url": "https://github.com/FahrenheitResearch"
   },
-  "dateModified": "2026-04-05T01:30:52.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">FahrenheitResearch</span><span class="slash">/</span>hermes-weather-plugin
   </h1>
-  <p class="project-desc">Hermes Agent weather plugin — NWS-grade model imagery, NEXRAD radar, and verified meteorological calculations. Pure Rust stack.</p>
+  <p class="project-desc">NWS-grade model imagery, NEXRAD radar, and verified meteorological calculations. Pure Rust.</p>
 
   <div class="meta-row">
     <span class="stars">★ 47</span>
-    <span><span class="meta-label">lang</span>Python</span>
     
     
-    <span><span class="meta-label">updated</span>2026-04-05</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -360,7 +361,6 @@ $env:ECAPE_RS_RUNNER = 'C:\path\to\run_case.exe'
 <li><code>ecape-rs</code> for the parity-verified ECAPE runner</li>
 <li><a href="https://github.com/NousResearch/hermes-agent">Hermes Agent</a> by Nous Research</li>
 </ul>
-
   </section>
 </details>
 

--- a/projects/Felix-Forever/hermes-agent-desktop.html
+++ b/projects/Felix-Forever/hermes-agent-desktop.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/Felix-Forever/hermes-agent-desktop">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-desktop&amp;subtitle=Multi-Agent+AI+Desktop+Client+%E2%80%94+20+specialists+auto-collaborate+on+your+tasks.+Visual+Skill+Store%2C+PM+orchestrator%2C+streaming+chat.+Works+with+Kimi+K2.5%2FQwen%2FDeepSeek%2FGPT-4o.+Built&amp;kind=project+%C2%B7+workspaces">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-desktop&amp;subtitle=Multi-agent+Hermes+Agent+desktop+client+with+specialists%2C+visual+skill+store%2C+PM+orchestrator%2C+and+streaming+chat&amp;kind=project+%C2%B7+workspaces">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Felix-Forever/hermes-agent-desktop — Hermes Atlas">
 <meta name="twitter:description" content="Hermes Agent Desktop is a native GUI client that transforms the Hermes Agent from a single-agent CLI into a collaborative multi-agent system. It utilizes a…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-desktop&amp;subtitle=Multi-Agent+AI+Desktop+Client+%E2%80%94+20+specialists+auto-collaborate+on+your+tasks.+Visual+Skill+Store%2C+PM+orchestrator%2C+streaming+chat.+Works+with+Kimi+K2.5%2FQwen%2FDeepSeek%2FGPT-4o.+Built&amp;kind=project+%C2%B7+workspaces">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-desktop&amp;subtitle=Multi-agent+Hermes+Agent+desktop+client+with+specialists%2C+visual+skill+store%2C+PM+orchestrator%2C+and+streaming+chat&amp;kind=project+%C2%B7+workspaces">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/Felix-Forever/hermes-agent-desktop",
   "applicationCategory": "DesktopEnhancementApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "HTML",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "Felix-Forever",
     "url": "https://github.com/Felix-Forever"
   },
-  "dateModified": "2026-04-12T12:29:39.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">Felix-Forever</span><span class="slash">/</span>hermes-agent-desktop
   </h1>
-  <p class="project-desc">Multi-Agent AI Desktop Client — 20 specialists auto-collaborate on your tasks. Visual Skill Store, PM orchestrator, streaming chat. Works with Kimi K2.5/Qwen/DeepSeek/GPT-4o. Built on Hermes Agent.</p>
+  <p class="project-desc">Multi-agent Hermes Agent desktop client with specialists, visual skill store, PM orchestrator, and streaming chat</p>
 
   <div class="meta-row">
     <span class="stars">★ 63</span>
-    <span><span class="meta-label">lang</span>HTML</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-04-12</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/Felix-Forever/hermes-agent-desktop" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://github.com/NousResearch/hermes-agent" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -519,7 +519,6 @@ python -c "import re; open('/tmp/c.js','w').write(re.search(r'&lt;script&gt;(.*?
 <p align="center">
   <sub>Built with Claude Code by Anthropic</sub>
 </p>
-
   </section>
 </details>
 

--- a/projects/Fruxano/fruvisi.html
+++ b/projects/Fruxano/fruvisi.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/Fruxano/fruvisi",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TypeScript",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "Fruxano",
     "url": "https://github.com/Fruxano"
   },
-  "dateModified": "2026-07-20T15:06:22.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,10 +118,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 3</span>
-    <span><span class="meta-label">lang</span>TypeScript</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-07-20</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -264,7 +264,6 @@ rm -rf &lt;HERMES_HOME&gt;/fruvisi      # optional: chart data
 <p>Built on <a href="https://hermes-agent.nousresearch.com">Hermes Agent</a> by Nous Research, <a href="https://reactflow.dev">React Flow</a> and <a href="https://github.com/dagrejs/dagre">dagre</a>.</p>
 <h3>License</h3>
 <p>MIT</p>
-
   </section>
 </details>
 

--- a/projects/Hermes-brasil/hermes-brasil.html
+++ b/projects/Hermes-brasil/hermes-brasil.html
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/Hermes-brasil/hermes-brasil",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "Hermes-brasil",
     "url": "https://github.com/Hermes-brasil"
   },
-  "dateModified": "2026-08-05T22:43:54.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,16 +119,18 @@
   <div class="meta-row">
     <span class="stars">★ 116</span>
     
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-05</span>
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/Hermes-brasil/hermes-brasil" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://hermesatlas.com" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -225,7 +226,6 @@ description: O que a skill faz (primeira frase = gatilho)
 </ul>
 <h3>📜 Licença</h3>
 <p><a href="LICENSE">MIT</a> © 2026 Comunidade Hermes Brasil</p>
-
   </section>
 </details>
 

--- a/projects/Heybinshao/hermes-appearance-hub.html
+++ b/projects/Heybinshao/hermes-appearance-hub.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/Heybinshao/hermes-appearance-hub",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "JavaScript",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "Heybinshao",
     "url": "https://github.com/Heybinshao"
   },
-  "dateModified": "2026-08-21T09:43:15.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,10 +118,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 1</span>
-    <span><span class="meta-label">lang</span>JavaScript</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-21</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -242,7 +242,6 @@ cp -r hermes-appearance-hub ~/.hermes/desktop-plugins/
 </ul>
 <h3>License</h3>
 <p>MIT</p>
-
   </section>
 </details>
 

--- a/projects/IVRZ-da/agentiker-code-intel.html
+++ b/projects/IVRZ-da/agentiker-code-intel.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/IVRZ-da/agentiker-code-intel",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "IVRZ-da",
     "url": "https://github.com/IVRZ-da"
   },
-  "dateModified": "2026-07-08T16:38:16.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,17 +118,19 @@
 
   <div class="meta-row">
     <span class="stars">★ 5</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-07-08</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/IVRZ-da/agentiker-code-intel" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://github.com/IVRZ-da/agentiker-code-intel" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -924,7 +924,6 @@ PYTHONPATH=~/.hermes/plugins ~/.hermes/hermes-agent/venv/bin/python3 \
 <li><a href="https://github.com/microsoft/pyright">pyright</a> — Python LSP server (fallback)</li>
 <li><a href="https://github.com/typescript-language-server/typescript-language-server">typescript-language-server</a> — TypeScript/JavaScript LSP server</li>
 </ul>
-
   </section>
 </details>
 

--- a/projects/IVRZ-da/agentiker-plan-follow.html
+++ b/projects/IVRZ-da/agentiker-plan-follow.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/IVRZ-da/agentiker-plan-follow",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "IVRZ-da",
     "url": "https://github.com/IVRZ-da"
   },
-  "dateModified": "2026-07-08T09:38:06.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,17 +118,19 @@
 
   <div class="meta-row">
     <span class="stars">★ 2</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-07-08</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/IVRZ-da/agentiker-plan-follow" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://github.com/IVRZ-da/agentiker-plan-follow" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -726,7 +726,6 @@ git config core.hooksPath .githooks
 <hr>
 <h3>📄 License</h3>
 <p><a href="LICENSE">MIT</a></p>
-
   </section>
 </details>
 

--- a/projects/IVRZ-da/agentiker-scout.html
+++ b/projects/IVRZ-da/agentiker-scout.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/IVRZ-da/agentiker-scout",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "IVRZ-da",
     "url": "https://github.com/IVRZ-da"
   },
-  "dateModified": "2026-07-04T17:20:18.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,17 +118,19 @@
 
   <div class="meta-row">
     <span class="stars">★ 3</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-07-04</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/IVRZ-da/agentiker-scout" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://github.com/IVRZ-da/agentiker-scout" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -455,7 +455,6 @@ git config core.hooksPath .githooks
 <p>See <code>CONTRIBUTING.md</code> and <code>BRANCHING.md</code> for details.</p>
 <h3>📄 License</h3>
 <p><a href="LICENSE">MIT</a></p>
-
   </section>
 </details>
 

--- a/projects/InfiniteWhispers/HermesAgent-MultiModel.html
+++ b/projects/InfiniteWhispers/HermesAgent-MultiModel.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/InfiniteWhispers/HermesAgent-MultiModel">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=HermesAgent-MultiModel&amp;subtitle=A+fully-local%2C+multi-model+AI+agent+framework+with+Mixture-of-Agents+%28MoA%29+orchestration.+Run+a+high-performance+agentic+stack+on+consumer+GPUs+%28RTX+4080%2F5080%29+using+Hermes+%2B+Ollam&amp;kind=project+%C2%B7+multi-agent">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=HermesAgent-MultiModel&amp;subtitle=Fully-local+multi-model+agent+framework+running+a+Mixture-of-Agents+stack+on+consumer+GPUs+with+Hermes+and+Ollama%2C+no+cloud+dependencies.&amp;kind=project+%C2%B7+multi-agent">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="InfiniteWhispers/HermesAgent-MultiModel — Hermes Atlas">
 <meta name="twitter:description" content="HermesAgent-MultiModel is a local-first AI agent framework that uses Mixture-of-Agents (MoA) orchestration to route tasks to specialized models. It integrates…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=HermesAgent-MultiModel&amp;subtitle=A+fully-local%2C+multi-model+AI+agent+framework+with+Mixture-of-Agents+%28MoA%29+orchestration.+Run+a+high-performance+agentic+stack+on+consumer+GPUs+%28RTX+4080%2F5080%29+using+Hermes+%2B+Ollam&amp;kind=project+%C2%B7+multi-agent">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=HermesAgent-MultiModel&amp;subtitle=Fully-local+multi-model+agent+framework+running+a+Mixture-of-Agents+stack+on+consumer+GPUs+with+Hermes+and+Ollama%2C+no+cloud+dependencies.&amp;kind=project+%C2%B7+multi-agent">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/InfiniteWhispers/HermesAgent-MultiModel",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "InfiniteWhispers",
     "url": "https://github.com/InfiniteWhispers"
   },
-  "dateModified": "2026-07-13T06:24:30.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">InfiniteWhispers</span><span class="slash">/</span>HermesAgent-MultiModel
   </h1>
-  <p class="project-desc">A fully-local, multi-model AI agent framework with Mixture-of-Agents (MoA) orchestration. Run a high-performance agentic stack on consumer GPUs (RTX 4080/5080) using Hermes + Ollama, with zero cloud dependencies.</p>
+  <p class="project-desc">Fully-local multi-model agent framework running a Mixture-of-Agents stack on consumer GPUs with Hermes and Ollama, no cloud dependencies.</p>
 
   <div class="meta-row">
     <span class="stars">★ 54</span>
     
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-07-13</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -393,7 +394,6 @@ localhostForwarding=true
 </ol>
 <p>For detailed tuning, see <a href="https://github.com/InfiniteWhispers/HermesAgent-MultiModel/blob/main/docs/optimization-guide.md">optimization-guide.md</a>.</p>
 <hr>
-
   </section>
 </details>
 

--- a/projects/JackTheGit/hermes-ai-infrastructure-monitoring-toolkit.html
+++ b/projects/JackTheGit/hermes-ai-infrastructure-monitoring-toolkit.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/JackTheGit/hermes-ai-infrastructure-monitoring-toolkit">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=infra-monitoring-toolkit&amp;subtitle=Autonomous+AI+infrastructure+monitoring+using+Hermes+Agent.+Cron-based+research+ingestion%2C+cost+forecasting%2C+and+headless+systemd+deployment.&amp;kind=project+%C2%B7+domain+applications">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=infra-monitoring-toolkit&amp;subtitle=Autonomous+monitoring+%E2%80%94+cron-based+research+ingestion%2C+cost+forecasting%2C+headless+systemd&amp;kind=project+%C2%B7+domain+applications">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="JackTheGit/infra-monitoring-toolkit — Hermes Atlas">
 <meta name="twitter:description" content="This project is a reference implementation for building autonomous, long-running monitoring systems using Hermes Agent. It utilizes cron-based workflows to…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=infra-monitoring-toolkit&amp;subtitle=Autonomous+AI+infrastructure+monitoring+using+Hermes+Agent.+Cron-based+research+ingestion%2C+cost+forecasting%2C+and+headless+systemd+deployment.&amp;kind=project+%C2%B7+domain+applications">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=infra-monitoring-toolkit&amp;subtitle=Autonomous+monitoring+%E2%80%94+cron-based+research+ingestion%2C+cost+forecasting%2C+headless+systemd&amp;kind=project+%C2%B7+domain+applications">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -45,7 +45,6 @@
     "name": "JackTheGit",
     "url": "https://github.com/JackTheGit"
   },
-  "dateModified": "2026-07-15T10:51:00.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -86,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -114,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">JackTheGit</span><span class="slash">/</span>hermes-ai-infrastructure-monitoring-toolkit
   </h1>
-  <p class="project-desc">Autonomous AI infrastructure monitoring using Hermes Agent. Cron-based research ingestion, cost forecasting, and headless systemd deployment.</p>
+  <p class="project-desc">Autonomous monitoring — cron-based research ingestion, cost forecasting, headless systemd</p>
 
   <div class="meta-row">
     <span class="stars">★ 33</span>
     
     
     
-    <span><span class="meta-label">updated</span>2026-07-15</span>
+    
   </div>
 
   <div class="actions">
@@ -129,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -379,7 +381,6 @@ TOTAL KEYWORDS ANALYZED       44       100%
 <h3>🎯 Purpose</h3>
 <p>This repository serves as a minimal, reproducible example of Hermes-based AI infrastructure automation.</p>
 <p>It is not affiliated with or endorsed by Nous Research.</p>
-
   </section>
 </details>
 

--- a/projects/JackTheGit/hermes-autonomous-server.html
+++ b/projects/JackTheGit/hermes-autonomous-server.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/JackTheGit/hermes-autonomous-server">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-autonomous-server&amp;subtitle=Run+Hermes+Agent+autonomously+on+your+Linux+server+using+systemd+and+native+cron+scheduler.+Production-ready%2C+headless+setup+with+Nous+Portal+integration.&amp;kind=project+%C2%B7+deployment">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-autonomous-server&amp;subtitle=Headless+systemd+deployment+with+Nous+Portal+integration+%E2%80%94+production-ready&amp;kind=project+%C2%B7+deployment">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="JackTheGit/hermes-autonomous-server — Hermes Atlas">
 <meta name="twitter:description" content="This project provides a deployment framework for running Hermes Agent as a persistent, headless Linux service. It utilizes systemd to manage the Hermes…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-autonomous-server&amp;subtitle=Run+Hermes+Agent+autonomously+on+your+Linux+server+using+systemd+and+native+cron+scheduler.+Production-ready%2C+headless+setup+with+Nous+Portal+integration.&amp;kind=project+%C2%B7+deployment">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-autonomous-server&amp;subtitle=Headless+systemd+deployment+with+Nous+Portal+integration+%E2%80%94+production-ready&amp;kind=project+%C2%B7+deployment">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -45,7 +45,6 @@
     "name": "JackTheGit",
     "url": "https://github.com/JackTheGit"
   },
-  "dateModified": "2026-03-01T14:06:51.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -86,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -114,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">JackTheGit</span><span class="slash">/</span>hermes-autonomous-server
   </h1>
-  <p class="project-desc">Run Hermes Agent autonomously on your Linux server using systemd and native cron scheduler. Production-ready, headless setup with Nous Portal integration.</p>
+  <p class="project-desc">Headless systemd deployment with Nous Portal integration — production-ready</p>
 
   <div class="meta-row">
     <span class="stars">★ 15</span>
     
     
     
-    <span><span class="meta-label">updated</span>2026-03-01</span>
+    
   </div>
 
   <div class="actions">
@@ -129,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -368,7 +370,6 @@ hermes uninstall
 <hr>
 <h3>Disclaimer</h3>
 <p>This repository is an independent deployment guide and is not affiliated with or endorsed by Nous Research.</p>
-
   </section>
 </details>
 

--- a/projects/Javis603/token-monitor.html
+++ b/projects/Javis603/token-monitor.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/Javis603/token-monitor">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=Token+Monitor&amp;subtitle=Local-first+desktop+widget+for+tracking+token+usage%2C+costs%2C+and+limits+across+31%2B+AI+coding+tools%E2%80%94including+Claude+Code%2C+Codex%2C+Cursor%2C+OpenCode%2C+and+OpenClaw%E2%80%94with+multi-device+syn&amp;kind=project+%C2%B7+developer+tools">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=Token+Monitor&amp;subtitle=Real-time+token%2C+cost%2C+and+rate-limit+widget+with+multi-device+sync%2C+reading+Hermes+Agent+state+directly+alongside+Claude+Code%2C+Codex%2C+and+other+CLIs.&amp;kind=project+%C2%B7+developer+tools">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Javis603/Token Monitor — Hermes Atlas">
 <meta name="twitter:description" content="Token Monitor is a desktop widget that displays live token usage and AI tool limits for over 31 AI coding tools. It provides real-time multi-device…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Token+Monitor&amp;subtitle=Local-first+desktop+widget+for+tracking+token+usage%2C+costs%2C+and+limits+across+31%2B+AI+coding+tools%E2%80%94including+Claude+Code%2C+Codex%2C+Cursor%2C+OpenCode%2C+and+OpenClaw%E2%80%94with+multi-device+syn&amp;kind=project+%C2%B7+developer+tools">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Token+Monitor&amp;subtitle=Real-time+token%2C+cost%2C+and+rate-limit+widget+with+multi-device+sync%2C+reading+Hermes+Agent+state+directly+alongside+Claude+Code%2C+Codex%2C+and+other+CLIs.&amp;kind=project+%C2%B7+developer+tools">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/Javis603/token-monitor",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "JavaScript",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "Javis603",
     "url": "https://github.com/Javis603"
   },
-  "dateModified": "2026-08-21T10:02:15.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">Javis603</span><span class="slash">/</span>token-monitor
   </h1>
-  <p class="project-desc">Local-first desktop widget for tracking token usage, costs, and limits across 31+ AI coding tools—including Claude Code, Codex, Cursor, OpenCode, and OpenClaw—with multi-device sync.</p>
+  <p class="project-desc">Real-time token, cost, and rate-limit widget with multi-device sync, reading Hermes Agent state directly alongside Claude Code, Codex, and other CLIs.</p>
 
   <div class="meta-row">
     <span class="stars">★ 1.6K</span>
-    <span><span class="meta-label">lang</span>JavaScript</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-21</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/Javis603/token-monitor" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="http://javis-ai.com/token-monitor/" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -639,7 +639,6 @@ Mode B — Sync (opt-in, multi-device)
 </ul>
 <h3>License</h3>
 <p><a href="LICENSE">MIT</a> © <a href="https://github.com/Javis603">@Javis</a></p>
-
   </section>
 </details>
 

--- a/projects/Ladybug-Memory/hermes-memory-plugin.html
+++ b/projects/Ladybug-Memory/hermes-memory-plugin.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/Ladybug-Memory/hermes-memory-plugin">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-memory-plugin&amp;subtitle=Ladybug+memory+plugin+for+Hermes+Agent&amp;kind=project+%C2%B7+memory">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-memory-plugin&amp;subtitle=Local-only+Hermes+memory+plugin+with+built-in+1-10+importance+ranking+so+the+things+that+matter+most+surface+first.+Columnar+.lbdb+embedded+graph+DB%2C+BM25-first+retrieval%2C+optional&amp;kind=project+%C2%B7+memory">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Ladybug-Memory/hermes-memory-plugin — Hermes Atlas">
 <meta name="twitter:description" content="Hermes Ladybug Memory is a local-first memory provider plugin that enables Hermes agents to store and retrieve information without relying on cloud services or…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-memory-plugin&amp;subtitle=Ladybug+memory+plugin+for+Hermes+Agent&amp;kind=project+%C2%B7+memory">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-memory-plugin&amp;subtitle=Local-only+Hermes+memory+plugin+with+built-in+1-10+importance+ranking+so+the+things+that+matter+most+surface+first.+Columnar+.lbdb+embedded+graph+DB%2C+BM25-first+retrieval%2C+optional&amp;kind=project+%C2%B7+memory">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/Ladybug-Memory/hermes-memory-plugin",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "Ladybug-Memory",
     "url": "https://github.com/Ladybug-Memory"
   },
-  "dateModified": "2026-04-09T01:19:54.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">Ladybug-Memory</span><span class="slash">/</span>hermes-memory-plugin
   </h1>
-  <p class="project-desc">Ladybug memory plugin for Hermes Agent</p>
+  <p class="project-desc">Local-only Hermes memory plugin with built-in 1-10 importance ranking so the things that matter most surface first. Columnar .lbdb embedded graph DB, BM25-first retrieval, optional GLiNER2 entity extraction.</p>
 
   <div class="meta-row">
     <span class="stars">★ 20</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-04-09</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -260,7 +260,6 @@ hermes memory setup
 <li>The installed plugin name is <code>ladybug</code>, matching the GitHub repo's directory name.</li>
 <li>Hermes currently clones directory plugins from Git but does not install their Python dependencies automatically, so the <code>pip install ladybug-memory</code> step is still required.</li>
 </ul>
-
   </section>
 </details>
 

--- a/projects/Lethe044/hermes-incident-commander.html
+++ b/projects/Lethe044/hermes-incident-commander.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/Lethe044/hermes-incident-commander">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-incident-commander&amp;subtitle=Autonomous+SRE+agent+built+on+Hermes+-+detects%2C+heals%2C+and+learns+from+production+incidents.+Uses+Memory+%2B+Skills+%2B+Cron+%2B+Gateway+%2B+Subagents+%2B+Atropos+RL.&amp;kind=project+%C2%B7+domain+applications">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-incident-commander&amp;subtitle=Autonomous+SRE+agent+%E2%80%94+detects%2C+heals%2C+and+learns+from+production+incidents&amp;kind=project+%C2%B7+domain+applications">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Lethe044/hermes-incident-commander — Hermes Atlas">
 <meta name="twitter:description" content="Hermes Incident Commander is an autonomous SRE agent designed to automate the detection, diagnosis, and remediation of production infrastructure failures. It…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-incident-commander&amp;subtitle=Autonomous+SRE+agent+built+on+Hermes+-+detects%2C+heals%2C+and+learns+from+production+incidents.+Uses+Memory+%2B+Skills+%2B+Cron+%2B+Gateway+%2B+Subagents+%2B+Atropos+RL.&amp;kind=project+%C2%B7+domain+applications">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-incident-commander&amp;subtitle=Autonomous+SRE+agent+%E2%80%94+detects%2C+heals%2C+and+learns+from+production+incidents&amp;kind=project+%C2%B7+domain+applications">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/Lethe044/hermes-incident-commander",
   "applicationCategory": "BusinessApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "Lethe044",
     "url": "https://github.com/Lethe044"
   },
-  "dateModified": "2026-04-04T22:42:47.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">Lethe044</span><span class="slash">/</span>hermes-incident-commander
   </h1>
-  <p class="project-desc">Autonomous SRE agent built on Hermes - detects, heals, and learns from production incidents. Uses Memory + Skills + Cron + Gateway + Subagents + Atropos RL.</p>
+  <p class="project-desc">Autonomous SRE agent — detects, heals, and learns from production incidents</p>
 
   <div class="meta-row">
     <span class="stars">★ 65</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-04-04</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -420,7 +420,6 @@ pytest tests/test_incident_env.py::TestSkillFile -v
 <p>MIT</p>
 <hr>
 <p><em>Built with <a href="https://hermes-agent.nousresearch.com">Hermes Agent</a> - the agent that grows with you.</em></p>
-
   </section>
 </details>
 

--- a/projects/MilkyWay008/Hermes-OTG.html
+++ b/projects/MilkyWay008/Hermes-OTG.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/MilkyWay008/Hermes-OTG">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=Hermes-OTG&amp;subtitle=Your+agentic+system+rescue+companion%2C+especially+for+broken+host+Hermes.+Hermes+Agent+on+a+USB+stick+%E2%80%94+zero+install+%26+portable%2C+hot-swappable+%26+instant+full+agent+power+on+any+PC.&amp;kind=project+%C2%B7+deployment">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=Hermes-OTG&amp;subtitle=Hermes+OTG+%E2%80%94+The+Portable+Hermes+Agent+That+Does+*Everything*.+Full+production+package+distributed+via+GitHub+Releases+%28see+PACKAGE-STRUCTURE.md%29.&amp;kind=project+%C2%B7+deployment">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="MilkyWay008/Hermes-OTG — Hermes Atlas">
 <meta name="twitter:description" content="Hermes OTG is a portable, zero-install version of the Hermes Agent designed for Windows 10 and 11. It operates from any drive or folder using relative paths to…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Hermes-OTG&amp;subtitle=Your+agentic+system+rescue+companion%2C+especially+for+broken+host+Hermes.+Hermes+Agent+on+a+USB+stick+%E2%80%94+zero+install+%26+portable%2C+hot-swappable+%26+instant+full+agent+power+on+any+PC.&amp;kind=project+%C2%B7+deployment">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Hermes-OTG&amp;subtitle=Hermes+OTG+%E2%80%94+The+Portable+Hermes+Agent+That+Does+*Everything*.+Full+production+package+distributed+via+GitHub+Releases+%28see+PACKAGE-STRUCTURE.md%29.&amp;kind=project+%C2%B7+deployment">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/MilkyWay008/Hermes-OTG",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "MilkyWay008",
     "url": "https://github.com/MilkyWay008"
   },
-  "dateModified": "2026-08-15T01:39:52.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">MilkyWay008</span><span class="slash">/</span>Hermes-OTG
   </h1>
-  <p class="project-desc">Your agentic system rescue companion, especially for broken host Hermes. Hermes Agent on a USB stick — zero install &amp; portable, hot-swappable &amp; instant full agent power on any PC.</p>
+  <p class="project-desc">Hermes OTG — The Portable Hermes Agent That Does *Everything*. Full production package distributed via GitHub Releases (see PACKAGE-STRUCTURE.md).</p>
 
   <div class="meta-row">
     <span class="stars">★ 8</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-15</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -590,7 +590,6 @@ DEEPSEEK_API_KEY=sk-xxxxxxxxxxxxxxxx
   <strong>Hermes OTG — every machine deserves a smart layer.</strong><br>
   <sub>Portable. Zero-install. Side-by-side. Offline. Full-suite. 🧳</sub>
 </p>
-
   </section>
 </details>
 

--- a/projects/MnrGreg/hermes-venice-web.html
+++ b/projects/MnrGreg/hermes-venice-web.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/MnrGreg/hermes-venice-web",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "MnrGreg",
     "url": "https://github.com/MnrGreg"
   },
-  "dateModified": "2026-07-26T22:51:21.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,10 +118,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 4</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-07-26</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -258,7 +258,6 @@ hermes plugins reload
 </ul>
 <hr>
 <p>Made for the Hermes community by mnrGreg</p>
-
   </section>
 </details>
 

--- a/projects/MukundaKatta/hermes-agentmemory.html
+++ b/projects/MukundaKatta/hermes-agentmemory.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/MukundaKatta/hermes-agentmemory">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agentmemory&amp;subtitle=Pull-model+episodic+memory+plugin+for+Hermes+Agent.+Real+deletes%2C+audit+trace%2C+BYO+Claude.+MIT.&amp;kind=project+%C2%B7+memory">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agentmemory&amp;subtitle=Pull-model+episodic+memory+plugin+for+Hermes+Agent+with+real+deletion+%28no+persistent+summaries+that+haunt+future+recall%29+and+a+trace.jsonl+audit+log+of+every+memory+operation.+Comm&amp;kind=project+%C2%B7+memory">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="MukundaKatta/hermes-agentmemory — Hermes Atlas">
 <meta name="twitter:description" content="This is a standalone memory plugin for Hermes Agent built on agentmemory. It uses a pull-model for episodic memory that performs synchronous writes and…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agentmemory&amp;subtitle=Pull-model+episodic+memory+plugin+for+Hermes+Agent.+Real+deletes%2C+audit+trace%2C+BYO+Claude.+MIT.&amp;kind=project+%C2%B7+memory">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agentmemory&amp;subtitle=Pull-model+episodic+memory+plugin+for+Hermes+Agent+with+real+deletion+%28no+persistent+summaries+that+haunt+future+recall%29+and+a+trace.jsonl+audit+log+of+every+memory+operation.+Comm&amp;kind=project+%C2%B7+memory">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/MukundaKatta/hermes-agentmemory",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "MukundaKatta",
     "url": "https://github.com/MukundaKatta"
   },
-  "dateModified": "2026-07-25T21:32:19.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">MukundaKatta</span><span class="slash">/</span>hermes-agentmemory
   </h1>
-  <p class="project-desc">Pull-model episodic memory plugin for Hermes Agent. Real deletes, audit trace, BYO Claude. MIT.</p>
+  <p class="project-desc">Pull-model episodic memory plugin for Hermes Agent with real deletion (no persistent summaries that haunt future recall) and a trace.jsonl audit log of every memory operation. Community fix for issue #6715. MIT.</p>
 
   <div class="meta-row">
     <span class="stars">★ 9</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-07-25</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -242,7 +242,6 @@ export ANTHROPIC_API_KEY=...
 <li>The design rationale: <a href="https://dev.to/mukundakatta/self-improving-agents-need-to-forget-too-a-memory-primitive-for-hermes-agent-kbd">Self-improving agents need to forget too</a> (dev.to)</li>
 <li>The "why I refused to clone Dreaming" companion: <a href="https://dev.to/mukundakatta/why-i-refused-to-build-a-dreaming-clone-for-oss-claude-2631">dev.to/mukundakatta</a></li>
 </ul>
-
   </section>
 </details>
 

--- a/projects/NousResearch/Hermes-Function-Calling.html
+++ b/projects/NousResearch/Hermes-Function-Calling.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/NousResearch/Hermes-Function-Calling",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Jupyter Notebook",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "NousResearch",
     "url": "https://github.com/NousResearch"
   },
-  "dateModified": "2025-12-22T14:09:27.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,10 +118,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 1.5K</span>
-    <span><span class="meta-label">lang</span>Jupyter Notebook</span>
-    <span><span class="meta-label">license</span>MIT</span>
+    
+    
     <span><span class="meta-label">maintainer</span>Nous Research</span>
-    <span><span class="meta-label">updated</span>2025-12-22</span>
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -377,7 +377,6 @@ This information provides a snapshot of Tesla's financial position and performan
 You are a helpful assistant that answers in JSON. Here's the json schema you must adhere to:\n&lt;schema&gt;\n{schema}\n&lt;/schema&gt;&lt;|im_end|&gt;
 </code></pre>
 <p>Given the {schema} that you provide, it should follow the format of that json to create it's response, all you have to do is give a typical user prompt, and it will respond in JSON.</p>
-
   </section>
 </details>
 

--- a/projects/NousResearch/atropos.html
+++ b/projects/NousResearch/atropos.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/NousResearch/atropos">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=atropos&amp;subtitle=Atropos+is+a+Language+Model+Reinforcement+Learning+Environments+framework+for+collecting+and+evaluating+LLM+trajectories+through+diverse+environments&amp;kind=project+%C2%B7+core">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=atropos&amp;subtitle=RL+training+environments+framework+for+tool-calling+models&amp;kind=project+%C2%B7+core">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="NousResearch/atropos — Hermes Atlas">
 <meta name="twitter:description" content="Atropos is an environment microservice framework for asynchronous reinforcement learning with large language models. It provides environments set up as…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=atropos&amp;subtitle=Atropos+is+a+Language+Model+Reinforcement+Learning+Environments+framework+for+collecting+and+evaluating+LLM+trajectories+through+diverse+environments&amp;kind=project+%C2%B7+core">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=atropos&amp;subtitle=RL+training+environments+framework+for+tool-calling+models&amp;kind=project+%C2%B7+core">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/NousResearch/atropos",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "NousResearch",
     "url": "https://github.com/NousResearch"
   },
-  "dateModified": "2026-07-04T17:39:01.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">NousResearch</span><span class="slash">/</span>atropos <span class="repo-flag">official</span>
   </h1>
-  <p class="project-desc">Atropos is a Language Model Reinforcement Learning Environments framework for collecting and evaluating LLM trajectories through diverse environments</p>
+  <p class="project-desc">RL training environments framework for tool-calling models</p>
 
   <div class="meta-row">
     <span class="stars">★ 1.3K</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
+    
+    
     <span><span class="meta-label">maintainer</span>Nous Research</span>
-    <span><span class="meta-label">updated</span>2026-07-04</span>
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -661,7 +661,6 @@ Please follow the <a href="https://github.com/NousResearch/atropos/blob/main/COD
 <hr>
 <h3>License</h3>
 <p>Atropos uses the MIT license, see the <a href="LICENSE">LICENSE</a> file here for more information</p>
-
   </section>
 </details>
 

--- a/projects/NousResearch/autonovel.html
+++ b/projects/NousResearch/autonovel.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/NousResearch/autonovel">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=autonovel&amp;subtitle=An+autonomous+novel+writing+pipeline%2C+by+Hermes+Agent&amp;kind=project+%C2%B7+core">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=autonovel&amp;subtitle=Autonomous+novel-writing+pipeline+generating+100k%2B+word+manuscripts&amp;kind=project+%C2%B7+core">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="NousResearch/autonovel — Hermes Atlas">
 <meta name="twitter:description" content="Autonovel is an autonomous pipeline designed to generate complete, print-ready novels from a seed concept. It employs a modify-evaluate-keep/discard loop…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=autonovel&amp;subtitle=An+autonomous+novel+writing+pipeline%2C+by+Hermes+Agent&amp;kind=project+%C2%B7+core">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=autonovel&amp;subtitle=Autonomous+novel-writing+pipeline+generating+100k%2B+word+manuscripts&amp;kind=project+%C2%B7+core">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/NousResearch/autonovel",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
   "author": {
     "@type": "Organization",
     "name": "NousResearch",
     "url": "https://github.com/NousResearch"
   },
-  "dateModified": "2026-03-20T16:17:11.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">NousResearch</span><span class="slash">/</span>autonovel <span class="repo-flag">official</span>
   </h1>
-  <p class="project-desc">An autonomous novel writing pipeline, by Hermes Agent</p>
+  <p class="project-desc">Autonomous novel-writing pipeline generating 100k+ word manuscripts</p>
 
   <div class="meta-row">
     <span class="stars">★ 1.5K</span>
-    <span><span class="meta-label">lang</span>Python</span>
+    
     
     <span><span class="meta-label">maintainer</span>Nous Research</span>
-    <span><span class="meta-label">updated</span>2026-03-20</span>
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -478,7 +479,6 @@ through this pipeline:</p>
 <li>Ursula K. Le Guin's "From Elfland to Poughkeepsie"</li>
 <li><a href="https://github.com/sam-paech/slop-forensics">slop-forensics</a> and <a href="https://eqbench.com/slop-score.html">EQ-Bench Slop Score</a></li>
 </ul>
-
   </section>
 </details>
 

--- a/projects/NousResearch/hermes-agent-self-evolution.html
+++ b/projects/NousResearch/hermes-agent-self-evolution.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/NousResearch/hermes-agent-self-evolution">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-self-evolution&amp;subtitle=%E2%9A%92+Evolutionary+self-improvement+for+Hermes+Agent+%E2%80%94+optimize+skills%2C+prompts%2C+and+code+using+DSPy+%2B+GEPA&amp;kind=project+%C2%B7+core">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-self-evolution&amp;subtitle=Evolutionary+self-improvement+using+DSPy+%2B+GEPA+%E2%80%94+optimizes+skills%2C+prompts%2C+and+code&amp;kind=project+%C2%B7+core">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="NousResearch/hermes-agent-self-evolution — Hermes Atlas">
 <meta name="twitter:description" content="Hermes Agent Self-Evolution is a framework for the automatic improvement of Hermes Agent's capabilities. It utilizes DSPy and Genetic-Pareto Prompt Evolution…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-self-evolution&amp;subtitle=%E2%9A%92+Evolutionary+self-improvement+for+Hermes+Agent+%E2%80%94+optimize+skills%2C+prompts%2C+and+code+using+DSPy+%2B+GEPA&amp;kind=project+%C2%B7+core">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-self-evolution&amp;subtitle=Evolutionary+self-improvement+using+DSPy+%2B+GEPA+%E2%80%94+optimizes+skills%2C+prompts%2C+and+code&amp;kind=project+%C2%B7+core">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/NousResearch/hermes-agent-self-evolution",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
   "author": {
     "@type": "Organization",
     "name": "NousResearch",
     "url": "https://github.com/NousResearch"
   },
-  "dateModified": "2026-06-17T11:53:04.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">NousResearch</span><span class="slash">/</span>hermes-agent-self-evolution <span class="repo-flag">official</span>
   </h1>
-  <p class="project-desc">⚒ Evolutionary self-improvement for Hermes Agent — optimize skills, prompts, and code using DSPy + GEPA</p>
+  <p class="project-desc">Evolutionary self-improvement using DSPy + GEPA — optimizes skills, prompts, and code</p>
 
   <div class="meta-row">
     <span class="stars">★ 5.1K</span>
-    <span><span class="meta-label">lang</span>Python</span>
+    
     
     <span><span class="meta-label">maintainer</span>Nous Research</span>
-    <span><span class="meta-label">updated</span>2026-06-17</span>
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -263,7 +264,6 @@ python -m evolution.skills.evolve_skill \
 <p>See <a href="https://github.com/NousResearch/hermes-agent-self-evolution/blob/main/PLAN.md">PLAN.md</a> for the complete architecture, evaluation data strategy, constraints, benchmarks integration, and phased timeline.</p>
 <h3>License</h3>
 <p>MIT — © 2026 Nous Research</p>
-
   </section>
 </details>
 

--- a/projects/NousResearch/hermes-agent.html
+++ b/projects/NousResearch/hermes-agent.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/NousResearch/hermes-agent">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent&amp;subtitle=The+agent+that+grows+with+you&amp;kind=project+%C2%B7+core">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent&amp;subtitle=The+self-improving+AI+agent+that+grows+with+you+%E2%80%94+persistent+memory%2C+auto-generated+skills%2C+14+platforms%2C+6+execution+backends&amp;kind=project+%C2%B7+core">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="NousResearch/hermes-agent — Hermes Atlas">
 <meta name="twitter:description" content="Hermes Agent is an AI agent developed by Nous Research that features a learning loop for skill creation and memory management. It supports multiple…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent&amp;subtitle=The+agent+that+grows+with+you&amp;kind=project+%C2%B7+core">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent&amp;subtitle=The+self-improving+AI+agent+that+grows+with+you+%E2%80%94+persistent+memory%2C+auto-generated+skills%2C+14+platforms%2C+6+execution+backends&amp;kind=project+%C2%B7+core">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/NousResearch/hermes-agent",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "NousResearch",
     "url": "https://github.com/NousResearch"
   },
-  "dateModified": "2026-08-21T10:39:29.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">NousResearch</span><span class="slash">/</span>hermes-agent <span class="repo-flag">official</span>
   </h1>
-  <p class="project-desc">The agent that grows with you</p>
+  <p class="project-desc">The self-improving AI agent that grows with you — persistent memory, auto-generated skills, 14 platforms, 6 execution backends</p>
 
   <div class="meta-row">
     <span class="stars">★ 233.8K</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
+    
+    
     <span><span class="meta-label">maintainer</span>Nous Research</span>
-    <span><span class="meta-label">updated</span>2026-08-21</span>
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/NousResearch/hermes-agent" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://hermes-agent.nousresearch.com" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 <aside class="handbook-mention" aria-label="Mentioned in the Hermes Handbook">
@@ -448,7 +448,6 @@ scripts/run_tests.sh
 <h3>License</h3>
 <p>MIT — see <a href="LICENSE">LICENSE</a>.</p>
 <p>Built by <a href="https://nousresearch.com">Nous Research</a>.</p>
-
   </section>
 </details>
 

--- a/projects/NousResearch/hermes-paperclip-adapter.html
+++ b/projects/NousResearch/hermes-paperclip-adapter.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/NousResearch/hermes-paperclip-adapter">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-paperclip-adapter&amp;subtitle=Paperclip+adapter+for+Hermes+Agent+%E2%80%94+run+Hermes+as+a+managed+employee+in+a+Paperclip+company&amp;kind=project+%C2%B7+core">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-paperclip-adapter&amp;subtitle=Run+Hermes+as+a+managed+employee+in+Paperclip+company+systems&amp;kind=project+%C2%B7+core">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="NousResearch/hermes-paperclip-adapter — Hermes Atlas">
 <meta name="twitter:description" content="The hermes-paperclip-adapter is a bridge that integrates Hermes Agent into the Paperclip company management system as a managed employee. It functions by…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-paperclip-adapter&amp;subtitle=Paperclip+adapter+for+Hermes+Agent+%E2%80%94+run+Hermes+as+a+managed+employee+in+a+Paperclip+company&amp;kind=project+%C2%B7+core">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-paperclip-adapter&amp;subtitle=Run+Hermes+as+a+managed+employee+in+Paperclip+company+systems&amp;kind=project+%C2%B7+core">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/NousResearch/hermes-paperclip-adapter",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TypeScript",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "NousResearch",
     "url": "https://github.com/NousResearch"
   },
-  "dateModified": "2026-04-04T05:44:23.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">NousResearch</span><span class="slash">/</span>hermes-paperclip-adapter <span class="repo-flag">official</span>
   </h1>
-  <p class="project-desc">Paperclip adapter for Hermes Agent — run Hermes as a managed employee in a Paperclip company</p>
+  <p class="project-desc">Run Hermes as a managed employee in Paperclip company systems</p>
 
   <div class="meta-row">
     <span class="stars">★ 1.8K</span>
-    <span><span class="meta-label">lang</span>TypeScript</span>
-    <span><span class="meta-label">license</span>MIT</span>
+    
+    
     <span><span class="meta-label">maintainer</span>Nous Research</span>
-    <span><span class="meta-label">updated</span>2026-04-04</span>
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -533,7 +533,6 @@ npm run build
 <li><a href="https://nousresearch.com">Nous Research</a> — The team behind Hermes</li>
 <li><a href="https://paperclip.ing/docs">Paperclip Docs</a> — Paperclip documentation</li>
 </ul>
-
   </section>
 </details>
 

--- a/projects/OnlyTerp/hermes-optimization-guide.html
+++ b/projects/OnlyTerp/hermes-optimization-guide.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/OnlyTerp/hermes-optimization-guide">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-optimization-guide&amp;subtitle=Hermes+Agent+setup%2C+migration%2C+LightRAG%2C+Telegram%2C+and+skill+creation+guide&amp;kind=project+%C2%B7+guides">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-optimization-guide&amp;subtitle=Performance+optimization+guide+for+Hermes+deployments&amp;kind=project+%C2%B7+guides">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="OnlyTerp/hermes-optimization-guide — Hermes Atlas">
 <meta name="twitter:description" content="This guide provides documentation and runnable artifacts for deploying the Hermes Agent across various interfaces including CLI, TUI, web, and a native desktop…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-optimization-guide&amp;subtitle=Hermes+Agent+setup%2C+migration%2C+LightRAG%2C+Telegram%2C+and+skill+creation+guide&amp;kind=project+%C2%B7+guides">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-optimization-guide&amp;subtitle=Performance+optimization+guide+for+Hermes+deployments&amp;kind=project+%C2%B7+guides">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/OnlyTerp/hermes-optimization-guide",
   "applicationCategory": "ReferenceApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Shell",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "OnlyTerp",
     "url": "https://github.com/OnlyTerp"
   },
-  "dateModified": "2026-08-02T10:40:18.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">OnlyTerp</span><span class="slash">/</span>hermes-optimization-guide
   </h1>
-  <p class="project-desc">Hermes Agent setup, migration, LightRAG, Telegram, and skill creation guide</p>
+  <p class="project-desc">Performance optimization guide for Hermes deployments</p>
 
   <div class="meta-row">
     <span class="stars">★ 601</span>
-    <span><span class="meta-label">lang</span>Shell</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-02</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -589,7 +589,6 @@ hermes desktop
 <blockquote>
 <p><strong>Note:</strong> Based on the official Hermes Agent documentation and real production usage. No private credentials, API keys, or personal data included.</p>
 </blockquote>
-
   </section>
 </details>
 

--- a/projects/PederHP/skillsdotnet.html
+++ b/projects/PederHP/skillsdotnet.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/PederHP/skillsdotnet">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=skillsdotnet&amp;subtitle=C%23+implementation+of+agent+skills+%28agentskills.io%29+with+MCP+integration+and+convenience.&amp;kind=project+%C2%B7+skills">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=skillsdotnet&amp;subtitle=C%23+%2F+.NET+implementation+of+agentskills.io+with+MCP+integration&amp;kind=project+%C2%B7+skills">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="PederHP/skillsdotnet — Hermes Atlas">
 <meta name="twitter:description" content="SkillsDotNet is a C#/.NET implementation of the agentskills.io standard designed to integrate agent skills into the Model Context Protocol (MCP). It uses a…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=skillsdotnet&amp;subtitle=C%23+implementation+of+agent+skills+%28agentskills.io%29+with+MCP+integration+and+convenience.&amp;kind=project+%C2%B7+skills">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=skillsdotnet&amp;subtitle=C%23+%2F+.NET+implementation+of+agentskills.io+with+MCP+integration&amp;kind=project+%C2%B7+skills">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/PederHP/skillsdotnet",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "C#",
   "author": {
     "@type": "Organization",
     "name": "PederHP",
     "url": "https://github.com/PederHP"
   },
-  "dateModified": "2026-05-09T15:06:10.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">PederHP</span><span class="slash">/</span>skillsdotnet
   </h1>
-  <p class="project-desc">C# implementation of agent skills (agentskills.io) with MCP integration and convenience.</p>
+  <p class="project-desc">C# / .NET implementation of agentskills.io with MCP integration</p>
 
   <div class="meta-row">
     <span class="stars">★ 12</span>
-    <span><span class="meta-label">lang</span>C#</span>
     
     
-    <span><span class="meta-label">updated</span>2026-05-09</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -439,7 +440,6 @@ Instructions for the agent go here.
 <p>Many conventions and especially the server-side resource implementations in this library are inspired by <a href="https://github.com/jlowin/fastmcp">FastMCP 3.0</a>. We've tried to align with FastMCP whenever possible.</p>
 <h3>License</h3>
 <p>MIT</p>
-
   </section>
 </details>
 

--- a/projects/Perseus-Computing-LLC/perseus.html
+++ b/projects/Perseus-Computing-LLC/perseus.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/Perseus-Computing-LLC/perseus">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=perseus&amp;subtitle=Live+context+engine+for+AI+agents%3A+resolve+verified+workspace+state+before+the+context+window+opens.+Pairs+with+Perseus+Vault+for+persistent+encrypted+memory.+Local-first%2C+MIT.+pip&amp;kind=project+%C2%B7+memory">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=perseus&amp;subtitle=The+memory+%26+context+layer+for+AI+agents%3A+load+only+the+context+they+actually+need.+Resolves+live+workspace+state+into+verified+facts+before+the+context+window+opens.+94%25+fewer+pro&amp;kind=project+%C2%B7+memory">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Perseus-Computing-LLC/perseus — Hermes Atlas">
 <meta name="twitter:description" content="Perseus is a live context engine that resolves workspace state into verified facts for AI agents before the context window opens. It renders local workspace…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=perseus&amp;subtitle=Live+context+engine+for+AI+agents%3A+resolve+verified+workspace+state+before+the+context+window+opens.+Pairs+with+Perseus+Vault+for+persistent+encrypted+memory.+Local-first%2C+MIT.+pip&amp;kind=project+%C2%B7+memory">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=perseus&amp;subtitle=The+memory+%26+context+layer+for+AI+agents%3A+load+only+the+context+they+actually+need.+Resolves+live+workspace+state+into+verified+facts+before+the+context+window+opens.+94%25+fewer+pro&amp;kind=project+%C2%B7+memory">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/Perseus-Computing-LLC/perseus",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "Perseus-Computing-LLC",
     "url": "https://github.com/Perseus-Computing-LLC"
   },
-  "dateModified": "2026-08-20T21:12:13.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">Perseus-Computing-LLC</span><span class="slash">/</span>perseus
   </h1>
-  <p class="project-desc">Live context engine for AI agents: resolve verified workspace state before the context window opens. Pairs with Perseus Vault for persistent encrypted memory. Local-first, MIT. pip install perseus-ctx</p>
+  <p class="project-desc">The memory &amp; context layer for AI agents: load only the context they actually need. Resolves live workspace state into verified facts before the context window opens. 94% fewer prompt tokens, 0 ms ove</p>
 
   <div class="meta-row">
     <span class="stars">★ 37</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-20</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/Perseus-Computing-LLC/perseus" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://perseus.observer/" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -1010,7 +1010,6 @@ LLM backend.</p>
 <p><strong>Off by default.</strong> Enable it </p>
 <hr>
 <p><em>README truncated. <a href="https://github.com/Perseus-Computing-LLC/perseus#readme">Continue reading on GitHub</a></em></p>
-
   </section>
 </details>
 

--- a/projects/ReinaMacCredy/maestro.html
+++ b/projects/ReinaMacCredy/maestro.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/ReinaMacCredy/maestro">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=maestro&amp;subtitle=+Gives+Claude+Code%2C+Codex%2C+and+CI+a+shared+task+system%2C+verdict+ledger%2C+and+state+store+so+agent+work+is+traceable+and+auditable.&amp;kind=project+%C2%B7+skills">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=maestro&amp;subtitle=Harness+for+long-running+AI+agents+%E2%80%94+structured+memory%2C+cross-feature+learning%2C+plan-approve-execute&amp;kind=project+%C2%B7+skills">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="ReinaMacCredy/maestro — Hermes Atlas">
 <meta name="twitter:description" content="Maestro is a Rust-based harness for agent-built codebases that provides a durable, local-first substrate for work tracking. It uses a card and task model to…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=maestro&amp;subtitle=+Gives+Claude+Code%2C+Codex%2C+and+CI+a+shared+task+system%2C+verdict+ledger%2C+and+state+store+so+agent+work+is+traceable+and+auditable.&amp;kind=project+%C2%B7+skills">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=maestro&amp;subtitle=Harness+for+long-running+AI+agents+%E2%80%94+structured+memory%2C+cross-feature+learning%2C+plan-approve-execute&amp;kind=project+%C2%B7+skills">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/ReinaMacCredy/maestro",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Rust",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "ReinaMacCredy",
     "url": "https://github.com/ReinaMacCredy"
   },
-  "dateModified": "2026-08-14T04:44:04.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">ReinaMacCredy</span><span class="slash">/</span>maestro
   </h1>
-  <p class="project-desc"> Gives Claude Code, Codex, and CI a shared task system, verdict ledger, and state store so agent work is traceable and auditable.</p>
+  <p class="project-desc">Harness for long-running AI agents — structured memory, cross-feature learning, plan-approve-execute</p>
 
   <div class="meta-row">
     <span class="stars">★ 227</span>
-    <span><span class="meta-label">lang</span>Rust</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-14</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -959,7 +959,6 @@ embedded/    shipped harness, hook, shell, and skill resources
 <li><a href="https://github.com/ReinaMacCredy/maestro/blob/main/TESTING.md">TESTING.md</a>: the smallest falsifying checks by touched surface</li>
 <li><a href="https://github.com/ReinaMacCredy/maestro/blob/main/MAINTENANCE.md">MAINTENANCE.md</a>: refactor discipline, drift rules, handoff standard</li>
 </ul>
-
   </section>
 </details>
 

--- a/projects/Ridwannurudeen/hermes-council.html
+++ b/projects/Ridwannurudeen/hermes-council.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/Ridwannurudeen/hermes-council">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-council&amp;subtitle=Adversarial+multi-perspective+council+MCP+server+for+hermes-agent&amp;kind=project+%C2%B7+integrations">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-council&amp;subtitle=Adversarial+multi-perspective+council+MCP+server+for+decision-making&amp;kind=project+%C2%B7+integrations">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Ridwannurudeen/hermes-council — Hermes Atlas">
 <meta name="twitter:description" content="Hermes Council is an MCP server designed to provide an adversarial judgment layer for Hermes Agent to prevent overconfident or unsafe autonomous actions. It…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-council&amp;subtitle=Adversarial+multi-perspective+council+MCP+server+for+hermes-agent&amp;kind=project+%C2%B7+integrations">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-council&amp;subtitle=Adversarial+multi-perspective+council+MCP+server+for+decision-making&amp;kind=project+%C2%B7+integrations">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/Ridwannurudeen/hermes-council",
   "applicationCategory": "CommunicationApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "Ridwannurudeen",
     "url": "https://github.com/Ridwannurudeen"
   },
-  "dateModified": "2026-05-11T07:20:15.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">Ridwannurudeen</span><span class="slash">/</span>hermes-council
   </h1>
-  <p class="project-desc">Adversarial multi-perspective council MCP server for hermes-agent</p>
+  <p class="project-desc">Adversarial multi-perspective council MCP server for decision-making</p>
 
   <div class="meta-row">
     <span class="stars">★ 48</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-05-11</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -636,7 +636,6 @@ endorsing one community server over others. Install standalone via the
 </ul>
 <h3>License</h3>
 <p>MIT. See <a href="LICENSE">LICENSE</a>.</p>
-
   </section>
 </details>
 

--- a/projects/Romanescu11/hermes-skill-factory.html
+++ b/projects/Romanescu11/hermes-skill-factory.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/Romanescu11/hermes-skill-factory">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-skill-factory&amp;subtitle=+A+meta-skill+plugin+for+Nous+Research%27s+Hermes+AI+agent+that+watches+your+workflows+and+automatically+turns+them+into+reusable+skills.++Every+time+you+work+with+Hermes+and+solve+s&amp;kind=project+%C2%B7+skills">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-skill-factory&amp;subtitle=Meta-skill+plugin+that+watches+workflows+and+auto-generates+reusable+skills&amp;kind=project+%C2%B7+skills">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Romanescu11/hermes-skill-factory — Hermes Atlas">
 <meta name="twitter:description" content="Skill Factory is a meta-skill for Hermes Agent that automates the creation of reusable skills by monitoring user workflows. It functions by tracking session…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-skill-factory&amp;subtitle=+A+meta-skill+plugin+for+Nous+Research%27s+Hermes+AI+agent+that+watches+your+workflows+and+automatically+turns+them+into+reusable+skills.++Every+time+you+work+with+Hermes+and+solve+s&amp;kind=project+%C2%B7+skills">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-skill-factory&amp;subtitle=Meta-skill+plugin+that+watches+workflows+and+auto-generates+reusable+skills&amp;kind=project+%C2%B7+skills">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/Romanescu11/hermes-skill-factory",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
   "author": {
     "@type": "Organization",
     "name": "Romanescu11",
     "url": "https://github.com/Romanescu11"
   },
-  "dateModified": "2026-03-18T13:13:38.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">Romanescu11</span><span class="slash">/</span>hermes-skill-factory
   </h1>
-  <p class="project-desc"> A meta-skill plugin for Nous Research's Hermes AI agent that watches your workflows and automatically turns them into reusable skills.  Every time you work with Hermes and solve something — setting up a project, debugging code, creating a PR — that   workflow disappears at the end of the session. You have to explain it again next time.</p>
+  <p class="project-desc">Meta-skill plugin that watches workflows and auto-generates reusable skills</p>
 
   <div class="meta-row">
     <span class="stars">★ 527</span>
-    <span><span class="meta-label">lang</span>Python</span>
     
     
-    <span><span class="meta-label">updated</span>2026-03-18</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -317,7 +318,6 @@ tags: [python, venv, testing]
 <hr>
 <h3>License</h3>
 <p>MIT</p>
-
   </section>
 </details>
 

--- a/projects/Sahil-SS9/MrHermagi-tutorbot.html
+++ b/projects/Sahil-SS9/MrHermagi-tutorbot.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/Sahil-SS9/MrHermagi-tutorbot">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=MrHermagi-tutorbot&amp;subtitle=A+Discord+AI+tutor+bot+%E2%80%94+daily+lessons%2C+curriculum+YAML%2C+HTML+%2B+audio+delivery.+Built+on+Hermes+Agent.&amp;kind=project+%C2%B7+domain+applications">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=MrHermagi-tutorbot&amp;subtitle=Discord+AI+tutor+bot+built+on+Hermes+Agent+profiles%2C+cron+jobs%2C+forum+delivery%2C+HTML+lessons%2C+and+TTS+audio.&amp;kind=project+%C2%B7+domain+applications">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Sahil-SS9/MrHermagi-tutorbot — Hermes Atlas">
 <meta name="twitter:description" content="MrHermagi-tutorbot is a Discord-based AI educational assistant that automates the delivery of structured learning paths using Hermes Agent profiles. The bot…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=MrHermagi-tutorbot&amp;subtitle=A+Discord+AI+tutor+bot+%E2%80%94+daily+lessons%2C+curriculum+YAML%2C+HTML+%2B+audio+delivery.+Built+on+Hermes+Agent.&amp;kind=project+%C2%B7+domain+applications">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=MrHermagi-tutorbot&amp;subtitle=Discord+AI+tutor+bot+built+on+Hermes+Agent+profiles%2C+cron+jobs%2C+forum+delivery%2C+HTML+lessons%2C+and+TTS+audio.&amp;kind=project+%C2%B7+domain+applications">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/Sahil-SS9/MrHermagi-tutorbot",
   "applicationCategory": "BusinessApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "HTML",
   "author": {
     "@type": "Organization",
     "name": "Sahil-SS9",
     "url": "https://github.com/Sahil-SS9"
   },
-  "dateModified": "2026-06-22T10:13:16.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">Sahil-SS9</span><span class="slash">/</span>MrHermagi-tutorbot
   </h1>
-  <p class="project-desc">A Discord AI tutor bot — daily lessons, curriculum YAML, HTML + audio delivery. Built on Hermes Agent.</p>
+  <p class="project-desc">Discord AI tutor bot built on Hermes Agent profiles, cron jobs, forum delivery, HTML lessons, and TTS audio.</p>
 
   <div class="meta-row">
     <span class="stars">★ 5</span>
-    <span><span class="meta-label">lang</span>HTML</span>
     
     
-    <span><span class="meta-label">updated</span>2026-06-22</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -301,7 +302,6 @@ provider produces markedly richer lessons than a 20-30B free model. Keep a
 smaller model as a fallback to stay resilient and cheap.</p>
 <h3>License</h3>
 <p>MIT. Use it, share it, fork it, sell it. If you improve it, send a PR back.</p>
-
   </section>
 </details>
 

--- a/projects/Sahil-SS9/Toolaria.html
+++ b/projects/Sahil-SS9/Toolaria.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/Sahil-SS9/Toolaria",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "Sahil-SS9",
     "url": "https://github.com/Sahil-SS9"
   },
-  "dateModified": "2026-06-24T19:26:59.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,10 +118,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 12</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-06-24</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -574,7 +574,6 @@ handle. Swept-blob guidance is scoped to the owning session.</li>
 </ul>
 <h3>License</h3>
 <p>MIT, see <code>LICENSE</code>.</p>
-
   </section>
 </details>
 

--- a/projects/Sahil-SS9/hermaguard.html
+++ b/projects/Sahil-SS9/hermaguard.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/Sahil-SS9/hermaguard",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "Sahil-SS9",
     "url": "https://github.com/Sahil-SS9"
   },
-  "dateModified": "2026-08-15T09:36:49.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,10 +118,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 25</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-15</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,15 @@
     
   </div>
 </section>
+
+
+<aside class="install-box" aria-label="How to install this skill">
+  <div class="ib-label">install<span class="ib-type">skill</span></div>
+  <code class="ib-cmd">Clone the repo and copy it into your harness's skill directory (pip install . provides its 9 console scripts); no Skills Hub listing yet.</code>
+  <p class="ib-compat">Harness-agnostic Agent Skill, Python-backed; works with Hermes, Claude Code, and any agentskills.io-compatible client.</p>
+  <p class="ib-verdict">Three parallel subagents attack code from different angles, then verify findings via sandboxed proof-of-concept execution before reporting VERIFIED or REFUTED — the most rigorous read-only code-review skill in this list.</p>
+  <a class="ib-more" href="/skills/">more picks → the skills hub</a>
+</aside>
 
 
 
@@ -292,7 +299,6 @@ sudo ln -sf $(pwd)/tools/hermaguard-prescan/hermaguard-prescan.py /usr/local/bin
 </ul>
 <h3>Contributing</h3>
 <p>Open an issue or PR. Bug reports with reproduction steps appreciated. Feature ideas for additional agents (e.g., performance regression hunter, accessibility auditor) welcome. Run <code>python3 -m pytest test_tools.py -q</code> before submitting PRs.</p>
-
   </section>
 </details>
 

--- a/projects/Sahil-SS9/hermes-Custom-CLI-Themes.html
+++ b/projects/Sahil-SS9/hermes-Custom-CLI-Themes.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/Sahil-SS9/hermes-Custom-CLI-Themes",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "HTML",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "Sahil-SS9",
     "url": "https://github.com/Sahil-SS9"
   },
-  "dateModified": "2026-05-25T14:49:16.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,10 +118,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 13</span>
-    <span><span class="meta-label">lang</span>HTML</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-05-25</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -256,7 +256,6 @@ curl -fsSL https://raw.githubusercontent.com/Sahil-SS9/hermes-Custom-CLI-Themes/
 <p>CI runs the same check on every push and PR (<code>.github/workflows/validate.yml</code>).</p>
 <h3>Licence</h3>
 <p>MIT. Validator workflow pattern and screenshot generator approach are adapted from <a href="https://github.com/joeynyc/hermes-skins">joeynyc/hermes-skins</a> (MIT). The skins themselves, art pipeline, and content are this repo's own.</p>
-
   </section>
 </details>
 

--- a/projects/Sahil-SS9/hermes-memlock.html
+++ b/projects/Sahil-SS9/hermes-memlock.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/Sahil-SS9/hermes-memlock",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "Sahil-SS9",
     "url": "https://github.com/Sahil-SS9"
   },
-  "dateModified": "2026-08-06T06:03:32.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,10 +118,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 9</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-06</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -488,7 +488,6 @@ downloads the embedding model on first use.</li>
 </ul>
 <h3>License</h3>
 <p>MIT, see <code>LICENSE</code>.</p>
-
   </section>
 </details>
 

--- a/projects/Sahil-SS9/hermes-multichannel-prompt-optimizer.html
+++ b/projects/Sahil-SS9/hermes-multichannel-prompt-optimizer.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/Sahil-SS9/hermes-multichannel-prompt-optimizer">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-multichannel-prompt-optimizer&amp;subtitle=Hermes+Agent+plugin%3A+rewrites+your+prompts+before+they+hit+the+LLM+%E2%80%94+across+CLI%2C+TUI%2C+Discord%2C+Telegram.+Quality+scoring+%2B+analytics+%2B+arrow-key+interactive+overlays.&amp;kind=project+%C2%B7+skills">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-multichannel-prompt-optimizer&amp;subtitle=Hermes+Agent+plugin+that+rewrites+and+scores+prompts+across+CLI%2C+TUI%2C+Discord%2C+Telegram%2C+and+other+surfaces.&amp;kind=project+%C2%B7+skills">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Sahil-SS9/hermes-multichannel-prompt-optimizer — Hermes Atlas">
 <meta name="twitter:description" content="This Hermes Agent plugin rewrites and scores user prompts before they reach the LLM. It supports multiple surfaces including CLI, TUI, Discord, and Telegram,…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-multichannel-prompt-optimizer&amp;subtitle=Hermes+Agent+plugin%3A+rewrites+your+prompts+before+they+hit+the+LLM+%E2%80%94+across+CLI%2C+TUI%2C+Discord%2C+Telegram.+Quality+scoring+%2B+analytics+%2B+arrow-key+interactive+overlays.&amp;kind=project+%C2%B7+skills">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-multichannel-prompt-optimizer&amp;subtitle=Hermes+Agent+plugin+that+rewrites+and+scores+prompts+across+CLI%2C+TUI%2C+Discord%2C+Telegram%2C+and+other+surfaces.&amp;kind=project+%C2%B7+skills">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/Sahil-SS9/hermes-multichannel-prompt-optimizer",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "Sahil-SS9",
     "url": "https://github.com/Sahil-SS9"
   },
-  "dateModified": "2026-08-18T00:46:19.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">Sahil-SS9</span><span class="slash">/</span>hermes-multichannel-prompt-optimizer
   </h1>
-  <p class="project-desc">Hermes Agent plugin: rewrites your prompts before they hit the LLM — across CLI, TUI, Discord, Telegram. Quality scoring + analytics + arrow-key interactive overlays.</p>
+  <p class="project-desc">Hermes Agent plugin that rewrites and scores prompts across CLI, TUI, Discord, Telegram, and other surfaces.</p>
 
   <div class="meta-row">
     <span class="stars">★ 20</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-18</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -508,7 +508,6 @@ package-root collection when the plugin dir is the rootdir):</p>
 <hr>
 <h3>License</h3>
 <p>MIT — see <a href="./LICENSE">LICENSE</a>.</p>
-
   </section>
 </details>
 

--- a/projects/Sahil-SS9/hermes-simplify-swarm.html
+++ b/projects/Sahil-SS9/hermes-simplify-swarm.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/Sahil-SS9/hermes-simplify-swarm",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "Sahil-SS9",
     "url": "https://github.com/Sahil-SS9"
   },
-  "dateModified": "2026-08-16T22:43:36.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,10 +118,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 13</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-16</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,15 @@
     
   </div>
 </section>
+
+
+<aside class="install-box" aria-label="How to install this skill">
+  <div class="ib-label">install<span class="ib-type">skill</span></div>
+  <code class="ib-cmd">git clone https://github.com/Sahil-SS9/hermes-simplify-swarm.git, then copy SKILL.md and references/ into your harness's skill directory as simplify-swarm/.</code>
+  <p class="ib-compat">Harness-agnostic (copy-in SKILL.md); explicitly built for Hermes Agent, also works in Claude Code.</p>
+  <p class="ib-verdict">Three read-only subagents (Hygiene, Clarity, Correctness) with a SAFE/CAREFUL/RISKY tiered approval gate before anything is applied — a safer default than a single autonomous simplification pass.</p>
+  <a class="ib-more" href="/skills/">more picks → the skills hub</a>
+</aside>
 
 
 
@@ -364,7 +371,6 @@ code-simplification research and the Agent Skills open standard. Design rational
 is documented in <a href="https://github.com/Sahil-SS9/hermes-simplify-swarm/blob/main/references/decisions.md"><code>references/decisions.md</code></a>.</p>
 <h3>License</h3>
 <p>MIT — use it, fork it, ship it.</p>
-
   </section>
 </details>
 

--- a/projects/Salomondiei08/oh-my-hermes.html
+++ b/projects/Salomondiei08/oh-my-hermes.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/Salomondiei08/oh-my-hermes">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=oh-my-hermes&amp;subtitle=An+opinionated+workflow+layer+for+building%2C+shipping%2C+and+operating+apps+with+Hermes+Agent&amp;kind=project+%C2%B7+developer+tools">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=oh-my-hermes&amp;subtitle=Opinionated+workflow+layer+for+building%2C+shipping%2C+and+operating+apps+with+Hermes+Agent&amp;kind=project+%C2%B7+developer+tools">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Salomondiei08/oh-my-hermes — Hermes Atlas">
 <meta name="twitter:description" content="Oh My Hermes is a workflow layer for the Hermes Agent designed to assist in building, shipping, and operating applications. It provides a set of skills and…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=oh-my-hermes&amp;subtitle=An+opinionated+workflow+layer+for+building%2C+shipping%2C+and+operating+apps+with+Hermes+Agent&amp;kind=project+%C2%B7+developer+tools">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=oh-my-hermes&amp;subtitle=Opinionated+workflow+layer+for+building%2C+shipping%2C+and+operating+apps+with+Hermes+Agent&amp;kind=project+%C2%B7+developer+tools">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/Salomondiei08/oh-my-hermes",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Shell",
   "author": {
     "@type": "Organization",
     "name": "Salomondiei08",
     "url": "https://github.com/Salomondiei08"
   },
-  "dateModified": "2026-07-28T05:38:06.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">Salomondiei08</span><span class="slash">/</span>oh-my-hermes
   </h1>
-  <p class="project-desc">An opinionated workflow layer for building, shipping, and operating apps with Hermes Agent</p>
+  <p class="project-desc">Opinionated workflow layer for building, shipping, and operating apps with Hermes Agent</p>
 
   <div class="meta-row">
     <span class="stars">★ 850</span>
-    <span><span class="meta-label">lang</span>Shell</span>
     
     
-    <span><span class="meta-label">updated</span>2026-07-28</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -756,7 +757,6 @@ Multi-service orchestration, more example apps, hosted setup wizard.</p>
 <hr>
 <h3>License</h3>
 <p>MIT</p>
-
   </section>
 </details>
 

--- a/projects/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server.html
+++ b/projects/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=kindly-web-search-mcp-server&amp;subtitle=Kindly+Web+Search+MCP+Server%3A+Web+search+%2B+robust+content+retrieval+for+AI+coding+tools+%28Claude+Code%2C+Codex%2C+Cursor%2C+GitHub+Copilot%2C+Gemini%2C+etc.%29+and+AI+agents+%28Claude+Desktop%2C+Op&amp;kind=project+%C2%B7+plugins">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=kindly-web-search-mcp-server&amp;subtitle=Web+search+and+content+retrieval+MCP+server+supporting+Hermes+Agent%2C+OpenClaw%2C+Claude+Code%2C+Codex%2C+Cursor%2C+and+other+AI+tools&amp;kind=project+%C2%B7+plugins">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server — Hermes Atlas">
 <meta name="twitter:description" content="Kindly Web Search is an MCP server designed to provide up-to-date API and package documentation through web search and content retrieval. It retrieves full…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=kindly-web-search-mcp-server&amp;subtitle=Kindly+Web+Search+MCP+Server%3A+Web+search+%2B+robust+content+retrieval+for+AI+coding+tools+%28Claude+Code%2C+Codex%2C+Cursor%2C+GitHub+Copilot%2C+Gemini%2C+etc.%29+and+AI+agents+%28Claude+Desktop%2C+Op&amp;kind=project+%C2%B7+plugins">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=kindly-web-search-mcp-server&amp;subtitle=Web+search+and+content+retrieval+MCP+server+supporting+Hermes+Agent%2C+OpenClaw%2C+Claude+Code%2C+Codex%2C+Cursor%2C+and+other+AI+tools&amp;kind=project+%C2%B7+plugins">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "Shelpuk-AI-Technology-Consulting",
     "url": "https://github.com/Shelpuk-AI-Technology-Consulting"
   },
-  "dateModified": "2026-07-29T15:55:04.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">Shelpuk-AI-Technology-Consulting</span><span class="slash">/</span>kindly-web-search-mcp-server
   </h1>
-  <p class="project-desc">Kindly Web Search MCP Server: Web search + robust content retrieval for AI coding tools (Claude Code, Codex, Cursor, GitHub Copilot, Gemini, etc.) and AI agents (Claude Desktop, OpenClaw, Hermes, etc.). Supports Serper, Tavily, and SearXNG.</p>
+  <p class="project-desc">Web search and content retrieval MCP server supporting Hermes Agent, OpenClaw, Claude Code, Codex, Cursor, and other AI tools</p>
 
   <div class="meta-row">
     <span class="stars">★ 376</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-07-29</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://www.shelpuk.com" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -826,7 +826,6 @@ Create <code>.vscode/mcp.json</code>:</p>
 <li>Don’t commit API keys.</li>
 <li>Prefer env-var expansion (Codex <code>env_vars</code>, Cursor <code>${env:...}</code>, Gemini <code>$VAR</code>, Claude Code <code>${VAR}</code>) instead of hardcoding secrets.</li>
 </ul>
-
   </section>
 </details>
 

--- a/projects/Shine8592/china-briefing.html
+++ b/projects/Shine8592/china-briefing.html
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/Shine8592/china-briefing",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
   "author": {
     "@type": "Organization",
     "name": "Shine8592",
     "url": "https://github.com/Shine8592"
   },
-  "dateModified": "2026-07-02T03:49:45.000Z",
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
   }
@@ -80,6 +78,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -112,10 +111,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 0</span>
-    <span><span class="meta-label">lang</span>Python</span>
     
     
-    <span><span class="meta-label">updated</span>2026-07-02</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -123,6 +122,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -284,7 +285,6 @@ AI 行业最新动态
 <blockquote>
 <p>🌸 嘟嘟出品 — 让每条简报都有深度</p>
 </blockquote>
-
   </section>
 </details>
 

--- a/projects/Sibyl-Labs/Sibyl-Memory.html
+++ b/projects/Sibyl-Labs/Sibyl-Memory.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/Sibyl-Labs/Sibyl-Memory",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "Sibyl-Labs",
     "url": "https://github.com/Sibyl-Labs"
   },
-  "dateModified": "2026-08-17T06:46:06.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,17 +118,19 @@
 
   <div class="meta-row">
     <span class="stars">★ 102</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-17</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/Sibyl-Labs/Sibyl-Memory" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://sibyllabs.org/plugin" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -287,7 +287,6 @@ sibyl-memory-hermes install-plugin
 <h3>License</h3>
 <p>MIT. See <a href="./LICENSE">LICENSE</a>.</p>
 <p>Copyright (c) 2026 Sibyl Labs LLC.</p>
-
   </section>
 </details>
 

--- a/projects/Signet-AI/signetai.html
+++ b/projects/Signet-AI/signetai.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/Signet-AI/signetai">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=signetai&amp;subtitle=Sync+and+store+memories%2C+shared+identity+files+%28AGENTS.md%2C+CLAUDE.md%29%2C+session+transcripts%2C+institutional+knowledge%2C+and+secrets+between+all+of+your+favorite+harnesses+and+models.&amp;kind=project+%C2%B7+memory">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=signetai&amp;subtitle=Local-first+identity%2C+memory%2C+and+secrets+layer+for+AI+agents+%E2%80%94+portable+state+across+Hermes+Agent%2C+Claude+Code%2C+Codex%2C+OpenCode%2C+OpenClaw%2C+and+MCP+clients&amp;kind=project+%C2%B7+memory">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Signet-AI/signetai — Hermes Atlas">
 <meta name="twitter:description" content="Signet AI is a memory and secrets layer designed to store, sync, and share transcripts, system prompts, and institutional knowledge across various AI models…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=signetai&amp;subtitle=Sync+and+store+memories%2C+shared+identity+files+%28AGENTS.md%2C+CLAUDE.md%29%2C+session+transcripts%2C+institutional+knowledge%2C+and+secrets+between+all+of+your+favorite+harnesses+and+models.&amp;kind=project+%C2%B7+memory">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=signetai&amp;subtitle=Local-first+identity%2C+memory%2C+and+secrets+layer+for+AI+agents+%E2%80%94+portable+state+across+Hermes+Agent%2C+Claude+Code%2C+Codex%2C+OpenCode%2C+OpenClaw%2C+and+MCP+clients&amp;kind=project+%C2%B7+memory">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/Signet-AI/signetai",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TypeScript",
   "author": {
     "@type": "Organization",
     "name": "Signet-AI",
     "url": "https://github.com/Signet-AI"
   },
-  "dateModified": "2026-08-21T08:10:14.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">Signet-AI</span><span class="slash">/</span>signetai
   </h1>
-  <p class="project-desc">Sync and store memories, shared identity files (AGENTS.md, CLAUDE.md), session transcripts, institutional knowledge, and secrets between all of your favorite harnesses and models.</p>
+  <p class="project-desc">Local-first identity, memory, and secrets layer for AI agents — portable state across Hermes Agent, Claude Code, Codex, OpenCode, OpenClaw, and MCP clients</p>
 
   <div class="meta-row">
     <span class="stars">★ 253</span>
-    <span><span class="meta-label">lang</span>TypeScript</span>
     
     
-    <span><span class="meta-label">updated</span>2026-08-21</span>
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/Signet-AI/signetai" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://signetai.sh" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -393,7 +394,6 @@ cd surfaces/dashboard &amp;&amp; bun run dev  # Dashboard dev
 <a href="https://signetai.sh/spec">spec</a> ·
 <a href="https://github.com/Signet-AI/signetai/discussions">discussions</a> ·
 <a href="https://github.com/Signet-AI/signetai/issues">issues</a></p>
-
   </section>
 </details>
 

--- a/projects/TauricResearch/TradingAgents.html
+++ b/projects/TauricResearch/TradingAgents.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/TauricResearch/TradingAgents",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/Apache-2.0.html",
   "author": {
     "@type": "Organization",
     "name": "TauricResearch",
     "url": "https://github.com/TauricResearch"
   },
-  "dateModified": "2026-07-18T15:55:05.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,17 +118,19 @@
 
   <div class="meta-row">
     <span class="stars">★ 99.1K</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>Apache-2.0</span>
     
-    <span><span class="meta-label">updated</span>2026-07-18</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/TauricResearch/TradingAgents" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://arxiv.org/pdf/2412.20138" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -389,7 +389,6 @@ config["temperature"] = 0.0
       url={https://arxiv.org/abs/2412.20138}, 
 }
 </code></pre>
-
   </section>
 </details>
 

--- a/projects/TheAiSingularity/hermesclaw.html
+++ b/projects/TheAiSingularity/hermesclaw.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/TheAiSingularity/hermesclaw">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermesclaw&amp;subtitle=Hermes+Agent+%28NousResearch%29+sandboxed+by+NVIDIA+OpenShell+%E2%80%94+hardware-enforced+network%2Ffilesystem%2Fsyscall+policy%2C+full+memory+%2B+gateway+stack&amp;kind=project+%C2%B7+deployment">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermesclaw&amp;subtitle=Hermes+Agent+sandboxed+with+hardware-level+enforcement&amp;kind=project+%C2%B7+deployment">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="TheAiSingularity/hermesclaw — Hermes Atlas">
 <meta name="twitter:description" content="HermesClaw is a community implementation that runs the Hermes Agent inside an NVIDIA OpenShell sandbox to provide hardware-level security enforcement. It…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermesclaw&amp;subtitle=Hermes+Agent+%28NousResearch%29+sandboxed+by+NVIDIA+OpenShell+%E2%80%94+hardware-enforced+network%2Ffilesystem%2Fsyscall+policy%2C+full+memory+%2B+gateway+stack&amp;kind=project+%C2%B7+deployment">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermesclaw&amp;subtitle=Hermes+Agent+sandboxed+with+hardware-level+enforcement&amp;kind=project+%C2%B7+deployment">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/TheAiSingularity/hermesclaw",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Shell",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "TheAiSingularity",
     "url": "https://github.com/TheAiSingularity"
   },
-  "dateModified": "2026-04-24T17:34:42.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">TheAiSingularity</span><span class="slash">/</span>hermesclaw
   </h1>
-  <p class="project-desc">Hermes Agent (NousResearch) sandboxed by NVIDIA OpenShell — hardware-enforced network/filesystem/syscall policy, full memory + gateway stack</p>
+  <p class="project-desc">Hermes Agent sandboxed with hardware-level enforcement</p>
 
   <div class="meta-row">
     <span class="stars">★ 61</span>
-    <span><span class="meta-label">lang</span>Shell</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-04-24</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -621,7 +621,6 @@ shellcheck scripts/hermesclaw  # lint before submitting
 <li><a href="https://github.com/NVIDIA/NemoClaw">NemoClaw</a> — NVIDIA's OpenClaw + OpenShell reference implementation</li>
 <li><a href="https://docs.nvidia.com/openshell/latest/">OpenShell</a> — NVIDIA's hardware-enforced AI sandbox</li>
 </ul>
-
   </section>
 </details>
 

--- a/projects/Xquik-dev/hermes-tweet.html
+++ b/projects/Xquik-dev/hermes-tweet.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/Xquik-dev/hermes-tweet">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-tweet&amp;subtitle=Hermes+Agent+plugin+for+Twitter+search%2C+monitoring%2C+follower+exports+%26+approved+X+actions.+Not+affiliated+with+X+Corp.&amp;kind=project+%C2%B7+plugins">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-tweet&amp;subtitle=Native+Hermes+Agent+plugin+for+X+automation+through+Xquik&amp;kind=project+%C2%B7+plugins">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Xquik-dev/hermes-tweet — Hermes Atlas">
 <meta name="twitter:description" content="Hermes Tweet is a plugin for Hermes Agent that provides access to X/Twitter search, monitoring, and actions through the Xquik API. It includes a catalog of 102…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-tweet&amp;subtitle=Hermes+Agent+plugin+for+Twitter+search%2C+monitoring%2C+follower+exports+%26+approved+X+actions.+Not+affiliated+with+X+Corp.&amp;kind=project+%C2%B7+plugins">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-tweet&amp;subtitle=Native+Hermes+Agent+plugin+for+X+automation+through+Xquik&amp;kind=project+%C2%B7+plugins">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/Xquik-dev/hermes-tweet",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "Xquik-dev",
     "url": "https://github.com/Xquik-dev"
   },
-  "dateModified": "2026-08-20T23:58:56.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">Xquik-dev</span><span class="slash">/</span>hermes-tweet
   </h1>
-  <p class="project-desc">Hermes Agent plugin for Twitter search, monitoring, follower exports &amp; approved X actions. Not affiliated with X Corp.</p>
+  <p class="project-desc">Native Hermes Agent plugin for X automation through Xquik</p>
 
   <div class="meta-row">
     <span class="stars">★ 28</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-20</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/Xquik-dev/hermes-tweet" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://github.com/Xquik-dev/hermes-tweet#readme" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -307,7 +307,6 @@ uv run --python 3.12 --group dev twine check dist/*
 <h3>License</h3>
 <p><a href="LICENSE">MIT</a></p>
 <p>Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.</p>
-
   </section>
 </details>
 

--- a/projects/ZeroPointRepo/youtube-skills.html
+++ b/projects/ZeroPointRepo/youtube-skills.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/ZeroPointRepo/youtube-skills">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=youtube-skills&amp;subtitle=YouTube+Transcript+API+skills+for+AI+agents.+Get+transcripts%2C+search+videos%2C+browse+channels.+Works+with+OpenClaw%2C+Hermes+Agent%2C+and+other+agent+runtimes.&amp;kind=project+%C2%B7+skills">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=youtube-skills&amp;subtitle=YouTube+transcript%2C+search%2C+channel%2C+and+playlist+skills+for+Hermes+Agent%2C+OpenClaw%2C+Claude+Code%2C+Cursor%2C+and+Windsurf&amp;kind=project+%C2%B7+skills">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="ZeroPointRepo/youtube-skills — Hermes Atlas">
 <meta name="twitter:description" content="YouTube Skills provides AI agents with access to YouTube transcripts, video search, channel data, and playlist extraction via the TranscriptAPI backend. It…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=youtube-skills&amp;subtitle=YouTube+Transcript+API+skills+for+AI+agents.+Get+transcripts%2C+search+videos%2C+browse+channels.+Works+with+OpenClaw%2C+Hermes+Agent%2C+and+other+agent+runtimes.&amp;kind=project+%C2%B7+skills">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=youtube-skills&amp;subtitle=YouTube+transcript%2C+search%2C+channel%2C+and+playlist+skills+for+Hermes+Agent%2C+OpenClaw%2C+Claude+Code%2C+Cursor%2C+and+Windsurf&amp;kind=project+%C2%B7+skills">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/ZeroPointRepo/youtube-skills",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "ZeroPointRepo",
     "url": "https://github.com/ZeroPointRepo"
   },
-  "dateModified": "2026-08-21T07:11:08.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,21 +114,30 @@
   <h1 class="project-name">
     <span class="org">ZeroPointRepo</span><span class="slash">/</span>youtube-skills
   </h1>
-  <p class="project-desc">YouTube Transcript API skills for AI agents. Get transcripts, search videos, browse channels. Works with OpenClaw, Hermes Agent, and other agent runtimes.</p>
+  <p class="project-desc">YouTube transcript, search, channel, and playlist skills for Hermes Agent, OpenClaw, Claude Code, Cursor, and Windsurf</p>
 
   <div class="meta-row">
     <span class="stars">★ 544</span>
     
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-21</span>
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/ZeroPointRepo/youtube-skills" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://transcriptapi.com" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
+<aside class="install-box" aria-label="How to install this skill">
+  <div class="ib-label">install<span class="ib-type">skill</span></div>
+  <code class="ib-cmd">hermes skills install skills-sh/ZeroPointRepo/youtube-skills/skills/youtube-full</code>
+  <p class="ib-compat">Hermes Agent (skills.sh source), OpenClaw, Claude Code, Cursor, and Codex via npx skills add.</p>
+  <p class="ib-verdict">An explicit, working Hermes install line via the skills.sh hub source — covers YouTube transcript, search, channel, and playlist data in one skill.</p>
+  <a class="ib-more" href="/skills/">more picks → the skills hub</a>
+</aside>
 
 
 
@@ -584,7 +592,6 @@ npx skills add ZeroPointRepo/youtube-skills --skill transcript --skill youtube-s
 <p>PRs welcome. See <a href="https://github.com/ZeroPointRepo/youtube-skills/blob/main/CONTRIBUTING.md">CONTRIBUTING.md</a>.</p>
 <h3>License</h3>
 <p>MIT © <a href="https://transcriptapi.com">TranscriptAPI</a></p>
-
   </section>
 </details>
 

--- a/projects/abundantbeing/hermes-browser-extension.html
+++ b/projects/abundantbeing/hermes-browser-extension.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/abundantbeing/hermes-browser-extension">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-browser-extension&amp;subtitle=Browser-native+side+panel+for+Hermes+Agent+%E2%80%94+connect+web+context+to+your+local+Hermes+runtime.&amp;kind=project+%C2%B7+workspaces">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-browser-extension&amp;subtitle=Chromium+side-panel+extension+that+connects+active+browser+context+to+a+local+or+remote+Hermes+Agent+runtime&amp;kind=project+%C2%B7+workspaces">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="abundantbeing/hermes-browser-extension — Hermes Atlas">
 <meta name="twitter:description" content="A Chromium-based side panel extension that connects the active browser context to a Hermes Agent runtime via local, cloud, or remote gateways. It provides a…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-browser-extension&amp;subtitle=Browser-native+side+panel+for+Hermes+Agent+%E2%80%94+connect+web+context+to+your+local+Hermes+runtime.&amp;kind=project+%C2%B7+workspaces">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-browser-extension&amp;subtitle=Chromium+side-panel+extension+that+connects+active+browser+context+to+a+local+or+remote+Hermes+Agent+runtime&amp;kind=project+%C2%B7+workspaces">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/abundantbeing/hermes-browser-extension",
   "applicationCategory": "DesktopEnhancementApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "JavaScript",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "abundantbeing",
     "url": "https://github.com/abundantbeing"
   },
-  "dateModified": "2026-08-20T10:40:45.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">abundantbeing</span><span class="slash">/</span>hermes-browser-extension
   </h1>
-  <p class="project-desc">Browser-native side panel for Hermes Agent — connect web context to your local Hermes runtime.</p>
+  <p class="project-desc">Chromium side-panel extension that connects active browser context to a local or remote Hermes Agent runtime</p>
 
   <div class="meta-row">
     <span class="stars">★ 1.3K</span>
-    <span><span class="meta-label">lang</span>JavaScript</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-20</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -625,7 +625,6 @@ tests/
 <p>Built by <strong>Jon Komet</strong> (<code>@abundantbeing</code>).</p>
 <h3>License</h3>
 <p>MIT. See <a href="LICENSE"><code>LICENSE</code></a>.</p>
-
   </section>
 </details>
 

--- a/projects/adityahimaone/hermes-agent-rtk-caveman.html
+++ b/projects/adityahimaone/hermes-agent-rtk-caveman.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/adityahimaone/hermes-agent-rtk-caveman">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-rtk-caveman&amp;subtitle=Hermes+Agent+RTK+%2B+Caveman+setup+-+90-99%25+token+savings+on+CLI+operations+with+35%2B+pre-configured+skills&amp;kind=project+%C2%B7+developer+tools">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-rtk-caveman&amp;subtitle=Hermes+Agent+RTK+and+Caveman+setup+with+preconfigured+skills+and+token-saving+CLI+workflows&amp;kind=project+%C2%B7+developer+tools">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="adityahimaone/hermes-agent-rtk-caveman — Hermes Atlas">
 <meta name="twitter:description" content="This project provides a preconfigured setup for Hermes Agent that integrates Rust Token Killer (RTK) and Caveman templating to reduce token consumption during…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-rtk-caveman&amp;subtitle=Hermes+Agent+RTK+%2B+Caveman+setup+-+90-99%25+token+savings+on+CLI+operations+with+35%2B+pre-configured+skills&amp;kind=project+%C2%B7+developer+tools">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-rtk-caveman&amp;subtitle=Hermes+Agent+RTK+and+Caveman+setup+with+preconfigured+skills+and+token-saving+CLI+workflows&amp;kind=project+%C2%B7+developer+tools">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/adityahimaone/hermes-agent-rtk-caveman",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TeX",
   "author": {
     "@type": "Organization",
     "name": "adityahimaone",
     "url": "https://github.com/adityahimaone"
   },
-  "dateModified": "2026-04-14T06:37:23.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">adityahimaone</span><span class="slash">/</span>hermes-agent-rtk-caveman
   </h1>
-  <p class="project-desc">Hermes Agent RTK + Caveman setup - 90-99% token savings on CLI operations with 35+ pre-configured skills</p>
+  <p class="project-desc">Hermes Agent RTK and Caveman setup with preconfigured skills and token-saving CLI workflows</p>
 
   <div class="meta-row">
     <span class="stars">★ 76</span>
-    <span><span class="meta-label">lang</span>TeX</span>
     
     
-    <span><span class="meta-label">updated</span>2026-04-14</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -460,7 +461,6 @@ ls -la ~/templates/
 <p><strong>Version</strong>: 1.0.0
 <strong>Last Updated</strong>: 2026-04-13
 <strong>Status</strong>: Production-ready ✅</p>
-
   </section>
 </details>
 

--- a/projects/adnw-vinc/hermes-nextcloud.html
+++ b/projects/adnw-vinc/hermes-nextcloud.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/adnw-vinc/hermes-nextcloud">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-nextcloud&amp;subtitle=Hermes+Agent+skill+for+Nextcloud+-+manage+files%2C+notes%2C+calendar%2C+tasks%2C+and+contacts+via+WebDAV+and+CalDAV&amp;kind=project+%C2%B7+skills">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-nextcloud&amp;subtitle=Hermes+Agent+skill+for+Nextcloud+%E2%80%94+manage+files%2C+notes%2C+calendar%2C+tasks%2C+and+contacts+via+WebDAV+and+CalDAV.&amp;kind=project+%C2%B7+skills">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="adnw-vinc/hermes-nextcloud — Hermes Atlas">
 <meta name="twitter:description" content="This project is a Hermes Agent skill that enables direct interaction with self-hosted Nextcloud instances for personal data management. It interfaces with…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-nextcloud&amp;subtitle=Hermes+Agent+skill+for+Nextcloud+-+manage+files%2C+notes%2C+calendar%2C+tasks%2C+and+contacts+via+WebDAV+and+CalDAV&amp;kind=project+%C2%B7+skills">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-nextcloud&amp;subtitle=Hermes+Agent+skill+for+Nextcloud+%E2%80%94+manage+files%2C+notes%2C+calendar%2C+tasks%2C+and+contacts+via+WebDAV+and+CalDAV.&amp;kind=project+%C2%B7+skills">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/adnw-vinc/hermes-nextcloud",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "adnw-vinc",
     "url": "https://github.com/adnw-vinc"
   },
-  "dateModified": "2026-05-12T21:09:45.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">adnw-vinc</span><span class="slash">/</span>hermes-nextcloud
   </h1>
-  <p class="project-desc">Hermes Agent skill for Nextcloud - manage files, notes, calendar, tasks, and contacts via WebDAV and CalDAV</p>
+  <p class="project-desc">Hermes Agent skill for Nextcloud — manage files, notes, calendar, tasks, and contacts via WebDAV and CalDAV.</p>
 
   <div class="meta-row">
     <span class="stars">★ 44</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-05-12</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,15 @@
     
   </div>
 </section>
+
+
+<aside class="install-box" aria-label="How to install this skill">
+  <div class="ib-label">install<span class="ib-type">skill</span></div>
+  <code class="ib-cmd">git clone https://github.com/adnw-vinc/hermes-nextcloud.git into ~/.hermes/skills/productivity/nextcloud, then run its guided setup script.</code>
+  <p class="ib-compat">Hermes Agent native — targets ~/.hermes/skills/ explicitly, with App Password validation for Nextcloud.</p>
+  <p class="ib-verdict">The only skill in the catalog wiring Hermes directly into a self-hosted Nextcloud over WebDAV/CalDAV/CardDAV — no browser, no third-party sync service, credentials kept in a restricted local .env.</p>
+  <a class="ib-more" href="/skills/">more picks → the skills hub</a>
+</aside>
 
 
 
@@ -315,7 +322,6 @@ $NC contacts export --uid &lt;contact-uid&gt; --local ./contact.vcf
 <hr>
 <h3>Sponsored by</h3>
 <p>This project is proudly sponsored by <a href="https://adventuredoesnotwait.com">Adventure Does Not Wait</a> - Sustainable outdoor apparel &amp; accessories for adventure seekers. Organic cotton clothing designed for those who embrace exploration and protect our planet. Real photos no AI Slop! Don't wait for the perfect moment -- start your adventure today!</p>
-
   </section>
 </details>
 

--- a/projects/agent-of-empires/agent-of-empires.html
+++ b/projects/agent-of-empires/agent-of-empires.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/agent-of-empires/agent-of-empires">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=agent-of-empires&amp;subtitle=Manage+multiple+Claude+Code%2C+OpenCode+agents+from+either+TUI+or+Web+for+easy+access+on+mobile.+Also+supports+Mistral+Vibe%2C+Codex+CLI%2C+Gemini+CLI%2C+Pi.dev%2C+Copilot+CLI%2C+Factory+Droid&amp;kind=project+%C2%B7+multi-agent">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=agent-of-empires&amp;subtitle=TUI+and+web+control+surface+for+managing+multiple+coding+agents+including+Hermes+Agent%2C+Claude+Code%2C+OpenCode%2C+Codex%2C+Gemini%2C+and+others&amp;kind=project+%C2%B7+multi-agent">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="agent-of-empires/agent-of-empires — Hermes Atlas">
 <meta name="twitter:description" content="Agent of Empires is a session manager for AI coding agents on Linux and macOS. It provides a TUI and a web dashboard to monitor and manage multiple agents…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=agent-of-empires&amp;subtitle=Manage+multiple+Claude+Code%2C+OpenCode+agents+from+either+TUI+or+Web+for+easy+access+on+mobile.+Also+supports+Mistral+Vibe%2C+Codex+CLI%2C+Gemini+CLI%2C+Pi.dev%2C+Copilot+CLI%2C+Factory+Droid&amp;kind=project+%C2%B7+multi-agent">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=agent-of-empires&amp;subtitle=TUI+and+web+control+surface+for+managing+multiple+coding+agents+including+Hermes+Agent%2C+Claude+Code%2C+OpenCode%2C+Codex%2C+Gemini%2C+and+others&amp;kind=project+%C2%B7+multi-agent">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/agent-of-empires/agent-of-empires",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Rust",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "agent-of-empires",
     "url": "https://github.com/agent-of-empires"
   },
-  "dateModified": "2026-08-20T16:04:18.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">agent-of-empires</span><span class="slash">/</span>agent-of-empires
   </h1>
-  <p class="project-desc">Manage multiple Claude Code, OpenCode agents from either TUI or Web for easy access on mobile. Also supports Mistral Vibe, Codex CLI, Gemini CLI, Pi.dev, Copilot CLI, Factory Droid Coding.</p>
+  <p class="project-desc">TUI and web control surface for managing multiple coding agents including Hermes Agent, Claude Code, OpenCode, Codex, Gemini, and others</p>
 
   <div class="meta-row">
     <span class="stars">★ 3.1K</span>
-    <span><span class="meta-label">lang</span>Rust</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-20</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/agent-of-empires/agent-of-empires" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="http://www.agent-of-empires.com/" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -319,7 +319,6 @@ unchanged.</p>
 <p>Maintained by the Agent of Empires community, with support from <a href="https://www.mozilla.ai/">Mozilla.ai</a>. See <a href="https://github.com/agent-of-empires/agent-of-empires/graphs/contributors">CONTRIBUTORS</a> for the full list of contributors.</p>
 <h3>License</h3>
 <p>MIT License -- see <a href="LICENSE">LICENSE</a> for details.</p>
-
   </section>
 </details>
 

--- a/projects/agent37-platform/minions.html
+++ b/projects/agent37-platform/minions.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/agent37-platform/minions">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=minions&amp;subtitle=Mission+Control+for+your+Hermes+agents&amp;kind=project+%C2%B7+multi-agent">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=minions&amp;subtitle=Mission+Control+for+Hermes+agents%3A+create%2C+supervise%2C+and+review+autonomous+Hermes+Agent+work+from+one+screen&amp;kind=project+%C2%B7+multi-agent">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="agent37-platform/minions — Hermes Atlas">
 <meta name="twitter:description" content="Minions is a centralized management interface for Hermes Agent that replaces fragmented terminal sessions with a unified dashboard. It utilizes a Kanban-style…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=minions&amp;subtitle=Mission+Control+for+your+Hermes+agents&amp;kind=project+%C2%B7+multi-agent">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=minions&amp;subtitle=Mission+Control+for+Hermes+agents%3A+create%2C+supervise%2C+and+review+autonomous+Hermes+Agent+work+from+one+screen&amp;kind=project+%C2%B7+multi-agent">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/agent37-platform/minions",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TypeScript",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "agent37-platform",
     "url": "https://github.com/agent37-platform"
   },
-  "dateModified": "2026-08-15T05:09:55.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">agent37-platform</span><span class="slash">/</span>minions
   </h1>
-  <p class="project-desc">Mission Control for your Hermes agents</p>
+  <p class="project-desc">Mission Control for Hermes agents: create, supervise, and review autonomous Hermes Agent work from one screen</p>
 
   <div class="meta-row">
     <span class="stars">★ 619</span>
-    <span><span class="meta-label">lang</span>TypeScript</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-15</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -201,7 +201,6 @@ npm view minionsai version
 Not yet. The adapter interface exists, but launch is Hermes-only. OpenClaw is next.</p>
 <h3>Contributing</h3>
 <p>Contributions are welcome. Please open an issue first with the feature or change you have in mind and why it should be added. Once the approach is approved, create a PR. See <a href="https://github.com/agent37-platform/minions/blob/main/CLAUDE.md">CLAUDE.md</a> for architecture and development details.</p>
-
   </section>
 </details>
 

--- a/projects/aidevelopers2/remoteopenclaw-mcp.html
+++ b/projects/aidevelopers2/remoteopenclaw-mcp.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/aidevelopers2/remoteopenclaw-mcp",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "JavaScript",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "aidevelopers2",
     "url": "https://github.com/aidevelopers2"
   },
-  "dateModified": "2026-07-02T11:15:01.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,10 +118,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 3</span>
-    <span><span class="meta-label">lang</span>JavaScript</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-07-02</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,15 @@
     
   </div>
 </section>
+
+
+<aside class="install-box" aria-label="How to install this skill">
+  <div class="ib-label">install<span class="ib-type">registry</span></div>
+  <code class="ib-cmd">Add remoteopenclaw (npx -y remoteopenclaw) under mcp_servers in Hermes' config; for Claude Code: claude mcp add remoteopenclaw -- npx -y remoteopenclaw.</code>
+  <p class="ib-compat">MCP server — any MCP client (Hermes, Cursor, Windsurf, Claude Code) via mcp_servers config.</p>
+  <p class="ib-verdict">Searches 13,000+ MCP servers and 4,000+ agent skills from the terminal with no API key — the widest single search surface in this category, though it's discovery-only, not an installer.</p>
+  <a class="ib-more" href="/skills/">more picks → the skills hub</a>
+</aside>
 
 
 
@@ -202,7 +209,6 @@
 <p>A thin wrapper over the public Remote OpenClaw search API (<code>https://www.remoteopenclaw.com/api/search</code>), so results are always live and the package stays tiny. Built with the <a href="https://modelcontextprotocol.io">Model Context Protocol</a> TypeScript SDK.</p>
 <h3>License</h3>
 <p>MIT</p>
-
   </section>
 </details>
 

--- a/projects/aivrar/portable-hermes-agent.html
+++ b/projects/aivrar/portable-hermes-agent.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/aivrar/portable-hermes-agent",
   "applicationCategory": "DesktopEnhancementApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "aivrar",
     "url": "https://github.com/aivrar"
   },
-  "dateModified": "2026-08-20T05:16:55.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,10 +118,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 206</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-20</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -393,7 +393,6 @@ AIAgent (run_agent.py)
 <h3>License</h3>
 <p>MIT License — see <a href="LICENSE">LICENSE</a> for details.</p>
 <p>Original framework copyright (c) 2025 Nous Research.</p>
-
   </section>
 </details>
 

--- a/projects/alchaincyf/hermes-agent-orange-book.html
+++ b/projects/alchaincyf/hermes-agent-orange-book.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/alchaincyf/hermes-agent-orange-book">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-orange-book&amp;subtitle=Hermes+Agent+%E4%BB%8E%E5%85%A5%E9%97%A8%E5%88%B0%E7%B2%BE%E9%80%9A+%C2%B7+%E6%A9%99%E7%9A%AE%E4%B9%A6%E7%B3%BB%E5%88%97+%C2%B7+Nous+Research+%E5%BC%80%E6%BA%90+AI+Agent+%E6%A1%86%E6%9E%B6%E5%AE%9E%E6%88%98%E6%8C%87%E5%8D%97&amp;kind=project+%C2%B7+guides">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-orange-book&amp;subtitle=Hermes+Agent+practical+guide+%E2%80%94+Orange+Book+series+%28Chinese+language%29&amp;kind=project+%C2%B7+guides">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="alchaincyf/hermes-agent-orange-book — Hermes Atlas">
 <meta name="twitter:description" content="This project provides a practical guide to Hermes Agent, an open-source AI framework by Nous Research. The guide, available in English and Chinese, covers the…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-orange-book&amp;subtitle=Hermes+Agent+%E4%BB%8E%E5%85%A5%E9%97%A8%E5%88%B0%E7%B2%BE%E9%80%9A+%C2%B7+%E6%A9%99%E7%9A%AE%E4%B9%A6%E7%B3%BB%E5%88%97+%C2%B7+Nous+Research+%E5%BC%80%E6%BA%90+AI+Agent+%E6%A1%86%E6%9E%B6%E5%AE%9E%E6%88%98%E6%8C%87%E5%8D%97&amp;kind=project+%C2%B7+guides">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-orange-book&amp;subtitle=Hermes+Agent+practical+guide+%E2%80%94+Orange+Book+series+%28Chinese+language%29&amp;kind=project+%C2%B7+guides">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/alchaincyf/hermes-agent-orange-book",
   "applicationCategory": "ReferenceApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
   "author": {
     "@type": "Organization",
     "name": "alchaincyf",
     "url": "https://github.com/alchaincyf"
   },
-  "dateModified": "2026-08-17T13:14:01.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">alchaincyf</span><span class="slash">/</span>hermes-agent-orange-book
   </h1>
-  <p class="project-desc">Hermes Agent 从入门到精通 · 橙皮书系列 · Nous Research 开源 AI Agent 框架实战指南</p>
+  <p class="project-desc">Hermes Agent practical guide — Orange Book series (Chinese language)</p>
 
   <div class="meta-row">
     <span class="stars">★ 4.9K</span>
-    <span><span class="meta-label">lang</span>Python</span>
     
     
-    <span><span class="meta-label">updated</span>2026-08-17</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -268,7 +269,6 @@
 <p>All orange books: <a href="https://www.workbuddy.cn/space/d/YcllWXknAUoMk6lFSWdfbI">https://www.workbuddy.cn/space/d/YcllWXknAUoMk6lFSWdfbI</a></p>
 <h3>License</h3>
 <p><a href="LICENSE">MIT License</a> — free to use, copy, modify, and distribute, including for commercial use. Attribution appreciated but not required.</p>
-
   </section>
 </details>
 

--- a/projects/alias8818/hermes-tool-slimmer.html
+++ b/projects/alias8818/hermes-tool-slimmer.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/alias8818/hermes-tool-slimmer",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "alias8818",
     "url": "https://github.com/alias8818"
   },
-  "dateModified": "2026-06-05T11:58:36.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,10 +118,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 34</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-06-05</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -383,7 +383,6 @@ pytest -q
 python -m build
 </code></pre>
 <p>When changing the Hermes core patch, also run the validation steps in <a href="https://github.com/alias8818/hermes-tool-slimmer/blob/main/docs/release-checklist.md"><code>docs/release-checklist.md</code></a>.</p>
-
   </section>
 </details>
 

--- a/projects/amanning3390/flowstate-qmd.html
+++ b/projects/amanning3390/flowstate-qmd.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/amanning3390/flowstate-qmd">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=flowstate-qmd&amp;subtitle=FlowState+QMD+%E2%80%94+Anticipatory+Memory+for+AI+Agents.+Hermes+2026+Hackathon+Entry.&amp;kind=project+%C2%B7+memory">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=flowstate-qmd&amp;subtitle=Anticipatory+memory+with+RAG+and+vector+search+%E2%80%94+Hermes+2026+Hackathon+entry&amp;kind=project+%C2%B7+memory">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="amanning3390/flowstate-qmd — Hermes Atlas">
 <meta name="twitter:description" content="FlowState-QMD is a local-first memory layer designed to provide coding agents with immediate project context from markdown documentation. It utilizes a…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=flowstate-qmd&amp;subtitle=FlowState+QMD+%E2%80%94+Anticipatory+Memory+for+AI+Agents.+Hermes+2026+Hackathon+Entry.&amp;kind=project+%C2%B7+memory">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=flowstate-qmd&amp;subtitle=Anticipatory+memory+with+RAG+and+vector+search+%E2%80%94+Hermes+2026+Hackathon+entry&amp;kind=project+%C2%B7+memory">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/amanning3390/flowstate-qmd",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TypeScript",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "amanning3390",
     "url": "https://github.com/amanning3390"
   },
-  "dateModified": "2026-03-15T22:53:16.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">amanning3390</span><span class="slash">/</span>flowstate-qmd
   </h1>
-  <p class="project-desc">FlowState QMD — Anticipatory Memory for AI Agents. Hermes 2026 Hackathon Entry.</p>
+  <p class="project-desc">Anticipatory memory with RAG and vector search — Hermes 2026 Hackathon entry</p>
 
   <div class="meta-row">
     <span class="stars">★ 45</span>
-    <span><span class="meta-label">lang</span>TypeScript</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-03-15</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -425,7 +425,6 @@ bun bench/tool-calls.ts    # MCP tool round-trip simulation
 </ul>
 <h3>Why Ask When Your Agent Can Already Know?</h3>
 <p>FlowState-QMD is not trying to be every kind of memory system. It is trying to be the best coding-agent memory layer: fast, local, inspectable, shared across agents, and strong enough to make project context feel native.</p>
-
   </section>
 </details>
 

--- a/projects/amanning3390/hermeshub.html
+++ b/projects/amanning3390/hermeshub.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/amanning3390/hermeshub">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermeshub&amp;subtitle=HermesHub+-+The+Skills+Hub+for+Hermes+Agent+by+Nous+Research.+Browse%2C+share%2C+and+install+community+skills.&amp;kind=project+%C2%B7+skills">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermeshub&amp;subtitle=Community+skill+browsing%2C+search%2C+and+one-click+installation+hub&amp;kind=project+%C2%B7+skills">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="amanning3390/hermeshub — Hermes Atlas">
 <meta name="twitter:description" content="HermesHub is an ARD-compliant agent registry that enables the discovery and indexing of AI agent capabilities. It utilizes a Hermes Agent to autonomously…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermeshub&amp;subtitle=HermesHub+-+The+Skills+Hub+for+Hermes+Agent+by+Nous+Research.+Browse%2C+share%2C+and+install+community+skills.&amp;kind=project+%C2%B7+skills">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermeshub&amp;subtitle=Community+skill+browsing%2C+search%2C+and+one-click+installation+hub&amp;kind=project+%C2%B7+skills">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/amanning3390/hermeshub",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TypeScript",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "amanning3390",
     "url": "https://github.com/amanning3390"
   },
-  "dateModified": "2026-06-30T18:24:52.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">amanning3390</span><span class="slash">/</span>hermeshub
   </h1>
-  <p class="project-desc">HermesHub - The Skills Hub for Hermes Agent by Nous Research. Browse, share, and install community skills.</p>
+  <p class="project-desc">Community skill browsing, search, and one-click installation hub</p>
 
   <div class="meta-row">
     <span class="stars">★ 23</span>
-    <span><span class="meta-label">lang</span>TypeScript</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-06-30</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/amanning3390/hermeshub" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://hermeshub.vercel.app" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -291,7 +291,6 @@ npm run seed:capabilities
 <hr>
 <h3>License</h3>
 <p>MIT</p>
-
   </section>
 </details>
 

--- a/projects/amirghm/hermes-agent-mobile.html
+++ b/projects/amirghm/hermes-agent-mobile.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/amirghm/hermes-agent-mobile">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=Hermes+Agent+Mobile&amp;subtitle=Hermes+AI+assistant+for+mobile.+Install+on+Android+or+iOS+with+one+command.&amp;kind=project+%C2%B7+deployment">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=Hermes+Agent+Mobile&amp;subtitle=One-command+installer+that+brings+the+Hermes+AI+assistant+to+Android+and+iOS.&amp;kind=project+%C2%B7+deployment">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="amirghm/Hermes Agent Mobile — Hermes Atlas">
 <meta name="twitter:description" content="This project enables the Hermes AI agent framework to run on Android via Termux and iOS via iSH. It allows users to interact with multiple AI personas through…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Hermes+Agent+Mobile&amp;subtitle=Hermes+AI+assistant+for+mobile.+Install+on+Android+or+iOS+with+one+command.&amp;kind=project+%C2%B7+deployment">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Hermes+Agent+Mobile&amp;subtitle=One-command+installer+that+brings+the+Hermes+AI+assistant+to+Android+and+iOS.&amp;kind=project+%C2%B7+deployment">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/amirghm/hermes-agent-mobile",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Shell",
   "author": {
     "@type": "Organization",
     "name": "amirghm",
     "url": "https://github.com/amirghm"
   },
-  "dateModified": "2026-07-07T12:15:55.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">amirghm</span><span class="slash">/</span>hermes-agent-mobile
   </h1>
-  <p class="project-desc">Hermes AI assistant for mobile. Install on Android or iOS with one command.</p>
+  <p class="project-desc">One-command installer that brings the Hermes AI assistant to Android and iOS.</p>
 
   <div class="meta-row">
     <span class="stars">★ 85</span>
-    <span><span class="meta-label">lang</span>Shell</span>
     
     
-    <span><span class="meta-label">updated</span>2026-07-07</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -380,7 +381,6 @@ Generate blog posts, social media content, scripts. Have agents collaborate on b
 </tbody></table>
 <h3>License</h3>
 <p>MIT</p>
-
   </section>
 </details>
 

--- a/projects/anneheartrecord/hermes-agent-anatomy.html
+++ b/projects/anneheartrecord/hermes-agent-anatomy.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/anneheartrecord/hermes-agent-anatomy">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-anatomy&amp;subtitle=hermes-agent%E6%BA%90%E7%A0%81%E8%A7%A3%E6%9E%90&amp;kind=project+%C2%B7+guides">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-anatomy&amp;subtitle=Chinese+Hermes+Agent+source-code+anatomy+and+architecture+analysis&amp;kind=project+%C2%B7+guides">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="anneheartrecord/hermes-agent-anatomy — Hermes Atlas">
 <meta name="twitter:description" content="This project provides a systematic technical decomposition and architectural analysis of the Hermes Agent source code. It breaks down the framework's 334,000…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-anatomy&amp;subtitle=hermes-agent%E6%BA%90%E7%A0%81%E8%A7%A3%E6%9E%90&amp;kind=project+%C2%B7+guides">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-anatomy&amp;subtitle=Chinese+Hermes+Agent+source-code+anatomy+and+architecture+analysis&amp;kind=project+%C2%B7+guides">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/anneheartrecord/hermes-agent-anatomy",
   "applicationCategory": "ReferenceApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "HTML",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "anneheartrecord",
     "url": "https://github.com/anneheartrecord"
   },
-  "dateModified": "2026-08-13T01:49:30.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">anneheartrecord</span><span class="slash">/</span>hermes-agent-anatomy
   </h1>
-  <p class="project-desc">hermes-agent源码解析</p>
+  <p class="project-desc">Chinese Hermes Agent source-code anatomy and architecture analysis</p>
 
   <div class="meta-row">
     <span class="stars">★ 93</span>
-    <span><span class="meta-label">lang</span>HTML</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-13</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/anneheartrecord/hermes-agent-anatomy" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://www.charles-cheng.com/projects" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -271,7 +271,6 @@
 <h3>License</h3>
 <p>本仓库为技术分析文档，不包含 hermes-agent 源码本身。</p>
 <p>MIT</p>
-
   </section>
 </details>
 

--- a/projects/armelhbobdad/bmad-module-skill-forge.html
+++ b/projects/armelhbobdad/bmad-module-skill-forge.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/armelhbobdad/bmad-module-skill-forge">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=bmad-module-skill-forge&amp;subtitle=A+standalone+BMAD+module+that+transforms+code+repositories%2C+documentation+websites%2C+and+developer+discourse+into+agentskills.io-compliant%2C+version-pinned%2C+provenance-backed+agent+s&amp;kind=project+%C2%B7+skills">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=bmad-module-skill-forge&amp;subtitle=Converts+repos%2C+docs%2C+and+developer+discourse+into+agentskills.io-compliant+skills&amp;kind=project+%C2%B7+skills">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="armelhbobdad/bmad-module-skill-forge — Hermes Atlas">
 <meta name="twitter:description" content="Skill Forge analyzes code repositories, documentation, and developer discourse to generate verified instruction files for AI agents. These instructions include…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=bmad-module-skill-forge&amp;subtitle=A+standalone+BMAD+module+that+transforms+code+repositories%2C+documentation+websites%2C+and+developer+discourse+into+agentskills.io-compliant%2C+version-pinned%2C+provenance-backed+agent+s&amp;kind=project+%C2%B7+skills">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=bmad-module-skill-forge&amp;subtitle=Converts+repos%2C+docs%2C+and+developer+discourse+into+agentskills.io-compliant+skills&amp;kind=project+%C2%B7+skills">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/armelhbobdad/bmad-module-skill-forge",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
   "author": {
     "@type": "Organization",
     "name": "armelhbobdad",
     "url": "https://github.com/armelhbobdad"
   },
-  "dateModified": "2026-08-11T08:06:24.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,21 +114,30 @@
   <h1 class="project-name">
     <span class="org">armelhbobdad</span><span class="slash">/</span>bmad-module-skill-forge
   </h1>
-  <p class="project-desc">A standalone BMAD module that transforms code repositories, documentation websites, and developer discourse into agentskills.io-compliant, version-pinned, provenance-backed agent skills.</p>
+  <p class="project-desc">Converts repos, docs, and developer discourse into agentskills.io-compliant skills</p>
 
   <div class="meta-row">
     <span class="stars">★ 93</span>
-    <span><span class="meta-label">lang</span>Python</span>
     
     
-    <span><span class="meta-label">updated</span>2026-08-11</span>
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/armelhbobdad/bmad-module-skill-forge" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://armelhbobdad.github.io/bmad-module-skill-forge/" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
+<aside class="install-box" aria-label="How to install this skill">
+  <div class="ib-label">install<span class="ib-type">skill</span></div>
+  <code class="ib-cmd">npx bmad-module-skill-forge install</code>
+  <p class="ib-compat">Node.js &gt;= 22, Python &gt;= 3.10, uv required; IDE-agnostic scaffolding tool, not Hermes-specific.</p>
+  <p class="ib-verdict">Turns your own repo, docs, and developer discourse into agentskills.io-compliant skills with file/line provenance citations — for teams standardizing internal skills, not consuming someone else's.</p>
+  <a class="ib-more" href="/skills/">more picks → the skills hub</a>
+</aside>
 
 
 
@@ -381,7 +389,6 @@ results = await cognee.search(
 <p><strong>Skill Forge (SKF)</strong> — A standalone <a href="https://github.com/bmad-code-org/BMAD-METHOD">BMAD</a> module for agent skill compilation.</p>
 <p><a href="https://github.com/armelhbobdad/bmad-module-skill-forge/graphs/contributors"><img src="https://contrib.rocks/image?repo=armelhbobdad/bmad-module-skill-forge" alt="Contributors" loading="lazy" decoding="async"></a></p>
 <p>See <a href="https://github.com/armelhbobdad/bmad-module-skill-forge/blob/main/CONTRIBUTORS.md">CONTRIBUTORS.md</a> for contributor information.</p>
-
   </section>
 </details>
 

--- a/projects/basilisk-labs/agentplane-hermes-plugin.html
+++ b/projects/basilisk-labs/agentplane-hermes-plugin.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/basilisk-labs/agentplane-hermes-plugin">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=agentplane-hermes-plugin&amp;subtitle=%F0%9F%94%8C+Hermes+plugin+for+spawning+AgentPlane+as+an+external+worker+lane.&amp;kind=project+%C2%B7+plugins">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=agentplane-hermes-plugin&amp;subtitle=Hermes+plugin+for+spawning+AgentPlane+as+an+external+Kanban+worker+lane.&amp;kind=project+%C2%B7+plugins">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="basilisk-labs/agentplane-hermes-plugin — Hermes Atlas">
 <meta name="twitter:description" content="This plugin acts as a transport adapter to bridge AgentPlane with Hermes as a native worker-lane. It manages the execution of AgentPlane tasks while Hermes…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=agentplane-hermes-plugin&amp;subtitle=%F0%9F%94%8C+Hermes+plugin+for+spawning+AgentPlane+as+an+external+worker+lane.&amp;kind=project+%C2%B7+plugins">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=agentplane-hermes-plugin&amp;subtitle=Hermes+plugin+for+spawning+AgentPlane+as+an+external+Kanban+worker+lane.&amp;kind=project+%C2%B7+plugins">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/basilisk-labs/agentplane-hermes-plugin",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "basilisk-labs",
     "url": "https://github.com/basilisk-labs"
   },
-  "dateModified": "2026-08-17T23:41:03.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">basilisk-labs</span><span class="slash">/</span>agentplane-hermes-plugin
   </h1>
-  <p class="project-desc">🔌 Hermes plugin for spawning AgentPlane as an external worker lane.</p>
+  <p class="project-desc">Hermes plugin for spawning AgentPlane as an external Kanban worker lane.</p>
 
   <div class="meta-row">
     <span class="stars">★ 5</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-17</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -297,7 +297,6 @@ python -m pip install -e ".[dev]"
 python scripts/check_integrity.py
 python -m pytest
 </code></pre>
-
   </section>
 </details>
 

--- a/projects/beardthelion/hermes-skill-distillation.html
+++ b/projects/beardthelion/hermes-skill-distillation.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/beardthelion/hermes-skill-distillation">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-skill-distillation&amp;subtitle=Hermes+Agent+Hackathon%3A+RealWorldTaskEnv+%E2%80%94+generate+agentic+training+trajectories+from+real-world+tasks+for+Hermes+4+fine-tuning&amp;kind=project+%C2%B7+forks">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-skill-distillation&amp;subtitle=Generate+agentic+training+trajectories+from+real-world+tasks+for+Hermes+4+fine-tuning&amp;kind=project+%C2%B7+forks">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="beardthelion/hermes-skill-distillation — Hermes Atlas">
 <meta name="twitter:description" content="This project provides a skill distillation pipeline designed to fine-tune Hermes 4 models using real-world agentic trajectories. It captures tool-use sessions…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-skill-distillation&amp;subtitle=Hermes+Agent+Hackathon%3A+RealWorldTaskEnv+%E2%80%94+generate+agentic+training+trajectories+from+real-world+tasks+for+Hermes+4+fine-tuning&amp;kind=project+%C2%B7+forks">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-skill-distillation&amp;subtitle=Generate+agentic+training+trajectories+from+real-world+tasks+for+Hermes+4+fine-tuning&amp;kind=project+%C2%B7+forks">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/beardthelion/hermes-skill-distillation",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
   "author": {
     "@type": "Organization",
     "name": "beardthelion",
     "url": "https://github.com/beardthelion"
   },
-  "dateModified": "2026-03-15T02:43:05.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">beardthelion</span><span class="slash">/</span>hermes-skill-distillation
   </h1>
-  <p class="project-desc">Hermes Agent Hackathon: RealWorldTaskEnv — generate agentic training trajectories from real-world tasks for Hermes 4 fine-tuning</p>
+  <p class="project-desc">Generate agentic training trajectories from real-world tasks for Hermes 4 fine-tuning</p>
 
   <div class="meta-row">
     <span class="stars">★ 13</span>
-    <span><span class="meta-label">lang</span>Python</span>
     
     
-    <span><span class="meta-label">updated</span>2026-03-15</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -267,7 +268,6 @@ demo/
 <h3>Why This Matters</h3>
 <p>Hermes agent's loop is: <strong>real task → tool use → outcome</strong>. That's the exact data distribution Hermes 4 needs to become an agentic model. This pipeline closes the loop — the agent that serves users becomes the teacher that trains the next version.</p>
 <p>Built for the Nous Research Hermes Agent Hackathon.</p>
-
   </section>
 </details>
 

--- a/projects/bergside/typeui.html
+++ b/projects/bergside/typeui.html
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/bergside/typeui",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TypeScript",
   "author": {
     "@type": "Organization",
     "name": "bergside",
     "url": "https://github.com/bergside"
   },
-  "dateModified": "2026-07-04T10:11:58.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -119,17 +118,19 @@
 
   <div class="meta-row">
     <span class="stars">★ 1.8K</span>
-    <span><span class="meta-label">lang</span>TypeScript</span>
     
     
-    <span><span class="meta-label">updated</span>2026-07-04</span>
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/bergside/typeui" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://www.typeui.sh" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -1115,7 +1116,6 @@ npm run build
 </tbody></table>
 
 <p>Want to see your logo here? <a href="https://www.typeui.sh/sponsor">Become a sponsor</a>.</p>
-
   </section>
 </details>
 

--- a/projects/bigph00t/hermescraft.html
+++ b/projects/bigph00t/hermescraft.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/bigph00t/hermescraft">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermescraft&amp;subtitle=Embodied+AI+companion+for+Minecraft+%E2%80%94+persistent+memory%2C+vision%2C+learning%2C+multi-agent.+Built+on+Hermes+Agent.&amp;kind=project+%C2%B7+domain+applications">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermescraft&amp;subtitle=Embodied+AI+companion+for+Minecraft+%E2%80%94+persistent+memory%2C+vision%2C+learning%2C+multi-agent&amp;kind=project+%C2%B7+domain+applications">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="bigph00t/hermescraft — Hermes Atlas">
 <meta name="twitter:description" content="HermesCraft is an embodied AI framework that integrates Hermes agents into Minecraft as persistent, interactive players. It connects the Hermes agent stack to…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermescraft&amp;subtitle=Embodied+AI+companion+for+Minecraft+%E2%80%94+persistent+memory%2C+vision%2C+learning%2C+multi-agent.+Built+on+Hermes+Agent.&amp;kind=project+%C2%B7+domain+applications">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermescraft&amp;subtitle=Embodied+AI+companion+for+Minecraft+%E2%80%94+persistent+memory%2C+vision%2C+learning%2C+multi-agent&amp;kind=project+%C2%B7+domain+applications">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/bigph00t/hermescraft",
   "applicationCategory": "BusinessApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "JavaScript",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "bigph00t",
     "url": "https://github.com/bigph00t"
   },
-  "dateModified": "2026-03-25T21:11:19.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">bigph00t</span><span class="slash">/</span>hermescraft
   </h1>
-  <p class="project-desc">Embodied AI companion for Minecraft — persistent memory, vision, learning, multi-agent. Built on Hermes Agent.</p>
+  <p class="project-desc">Embodied AI companion for Minecraft — persistent memory, vision, learning, multi-agent</p>
 
   <div class="meta-row">
     <span class="stars">★ 63</span>
-    <span><span class="meta-label">lang</span>JavaScript</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-03-25</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/bigph00t/hermescraft" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://github.com/NousResearch/hermes-agent" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -456,7 +456,6 @@ bash -n scripts/run-landfolk-bots.sh
 <p>If one agent can feel like a friend, and many agents can start to make a world feel inhabited, that is a strong foundation for persistent embodied AI systems.</p>
 <h3>License</h3>
 <p>MIT</p>
-
   </section>
 </details>
 

--- a/projects/black-forest-labs/skills.html
+++ b/projects/black-forest-labs/skills.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/black-forest-labs/skills">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=black-forest-labs%2Fskills&amp;subtitle=Official+skills+from+Black+Forest+Labs+for+FLUX+image+generation+models.+These+skills+provide+prompting+guidelines+and+API+integration+patterns+following+the+https%3A%2F%2Fagentskills.io&amp;kind=project+%C2%B7+skills">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=black-forest-labs%2Fskills&amp;subtitle=Official+FLUX+image+generation+skills+%E2%80%94+prompting+guidelines+and+API+integration&amp;kind=project+%C2%B7+skills">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="black-forest-labs/skills — Hermes Atlas">
 <meta name="twitter:description" content="This repository provides official skills for FLUX image and video generation models following the agentskills.io specification. It includes prompting…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=black-forest-labs%2Fskills&amp;subtitle=Official+skills+from+Black+Forest+Labs+for+FLUX+image+generation+models.+These+skills+provide+prompting+guidelines+and+API+integration+patterns+following+the+https%3A%2F%2Fagentskills.io&amp;kind=project+%C2%B7+skills">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=black-forest-labs%2Fskills&amp;subtitle=Official+FLUX+image+generation+skills+%E2%80%94+prompting+guidelines+and+API+integration&amp;kind=project+%C2%B7+skills">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/black-forest-labs/skills",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TypeScript",
   "author": {
     "@type": "Organization",
     "name": "black-forest-labs",
     "url": "https://github.com/black-forest-labs"
   },
-  "dateModified": "2026-08-17T22:02:24.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">black-forest-labs</span><span class="slash">/</span>skills
   </h1>
-  <p class="project-desc">Official skills from Black Forest Labs for FLUX image generation models. These skills provide prompting guidelines and API integration patterns following the https://agentskills.io specification.</p>
+  <p class="project-desc">Official FLUX image generation skills — prompting guidelines and API integration</p>
 
   <div class="meta-row">
     <span class="stars">★ 103</span>
-    <span><span class="meta-label">lang</span>TypeScript</span>
     
     
-    <span><span class="meta-label">updated</span>2026-08-17</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,15 @@
     
   </div>
 </section>
+
+
+<aside class="install-box" aria-label="How to install this skill">
+  <div class="ib-label">install<span class="ib-type">skill</span></div>
+  <code class="ib-cmd">npx skills add black-forest-labs/skills (or target one: npx skills add black-forest-labs/skills --skill flux-image-best-practices).</code>
+  <p class="ib-compat">agentskills.io spec; also a Claude Code plugin.</p>
+  <p class="ib-verdict">The one official-vendor entry in this bucket — Black Forest Labs' own FLUX prompting guidelines and API integration patterns, not a third-party reverse-engineering of their docs.</p>
+  <a class="ib-more" href="/skills/">more picks → the skills hub</a>
+</aside>
 
 
 
@@ -365,7 +373,6 @@ while True:
 <p>MIT</p>
 <h3>Author</h3>
 <p><a href="https://blackforestlabs.ai">Black Forest Labs</a></p>
-
   </section>
 </details>
 

--- a/projects/bookunt3d/hermes-agent-fa.html
+++ b/projects/bookunt3d/hermes-agent-fa.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/bookunt3d/hermes-agent-fa">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=Hermes+Agent+%28Persian+Docs%29&amp;subtitle=%D8%B1%D8%A7%D9%87%D9%86%D9%85%D8%A7%DB%8C+%D9%81%D8%A7%D8%B1%D8%B3%DB%8C+Hermes+Agent+-+%D8%AA%D8%B1%D8%AC%D9%85%D9%87+%DA%A9%D8%A7%D9%85%D9%84+%D9%85%D8%B3%D8%AA%D9%86%D8%AF%D8%A7%D8%AA&amp;kind=project+%C2%B7+guides">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=Hermes+Agent+%28Persian+Docs%29&amp;subtitle=Complete+Persian+translation+of+the+official+Hermes+Agent+documentation.&amp;kind=project+%C2%B7+guides">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="bookunt3d/Hermes Agent (Persian Docs) — Hermes Atlas">
 <meta name="twitter:description" content="This repository contains a complete Persian translation of the official Hermes Agent documentation. The project uses GitHub Pages and includes full support for…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Hermes+Agent+%28Persian+Docs%29&amp;subtitle=%D8%B1%D8%A7%D9%87%D9%86%D9%85%D8%A7%DB%8C+%D9%81%D8%A7%D8%B1%D8%B3%DB%8C+Hermes+Agent+-+%D8%AA%D8%B1%D8%AC%D9%85%D9%87+%DA%A9%D8%A7%D9%85%D9%84+%D9%85%D8%B3%D8%AA%D9%86%D8%AF%D8%A7%D8%AA&amp;kind=project+%C2%B7+guides">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Hermes+Agent+%28Persian+Docs%29&amp;subtitle=Complete+Persian+translation+of+the+official+Hermes+Agent+documentation.&amp;kind=project+%C2%B7+guides">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/bookunt3d/hermes-agent-fa",
   "applicationCategory": "ReferenceApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "HTML",
   "author": {
     "@type": "Organization",
     "name": "bookunt3d",
     "url": "https://github.com/bookunt3d"
   },
-  "dateModified": "2026-07-11T00:06:24.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">bookunt3d</span><span class="slash">/</span>hermes-agent-fa
   </h1>
-  <p class="project-desc">راهنمای فارسی Hermes Agent - ترجمه کامل مستندات</p>
+  <p class="project-desc">Complete Persian translation of the official Hermes Agent documentation.</p>
 
   <div class="meta-row">
     <span class="stars">★ 80</span>
-    <span><span class="meta-label">lang</span>HTML</span>
     
     
-    <span><span class="meta-label">updated</span>2026-07-11</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -177,7 +178,6 @@
 <li><a href="https://github.com/NousResearch/hermes-agent">GitHub اصلی</a></li>
 <li><a href="https://discord.gg/hermes-agent">Discord</a></li>
 </ul>
-
   </section>
 </details>
 

--- a/projects/briancaffey/hermes-otel.html
+++ b/projects/briancaffey/hermes-otel.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/briancaffey/hermes-otel",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/Apache-2.0.html",
   "author": {
     "@type": "Organization",
     "name": "briancaffey",
     "url": "https://github.com/briancaffey"
   },
-  "dateModified": "2026-07-11T00:50:05.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,17 +118,19 @@
 
   <div class="meta-row">
     <span class="stars">★ 55</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>Apache-2.0</span>
     
-    <span><span class="meta-label">updated</span>2026-07-11</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/briancaffey/hermes-otel" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://briancaffey.github.io/hermes-otel/" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -936,7 +936,6 @@ traceparent = get_current_traceparent(session_id)   # "00-&lt;trace&gt;-&lt;span
 <li><strong>Single session per run</strong> — Span tracking is in-memory; if Hermes restarts mid-session, active spans are lost. A TTL-based sweeper finalizes abandoned sessions (see "Orphan-span sweep" above), but the orphaned process's buffered spans still need a graceful <code>atexit</code> to flush.</li>
 <li><strong>Weave trace-only ingest</strong> — <code>type: weave</code> disables metrics/logs by default and routes all spans in one Hermes process to one <code>wandb.entity</code> / <code>wandb.project</code>.</li>
 </ul>
-
   </section>
 </details>
 

--- a/projects/bryercowan/hermes-embodied.html
+++ b/projects/bryercowan/hermes-embodied.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/bryercowan/hermes-embodied">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-embodied&amp;subtitle=Self-improving+robotics+via+Hermes+Agent.+One+skill+that+provisions+cloud+GPUs%2C+fine-tunes+VLA+models%2C+runs+sim+evaluation%2C+and+autonomously+improves+robot+policies.+Built+for+the+&amp;kind=project+%C2%B7+domain+applications">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-embodied&amp;subtitle=Self-improving+robotics+via+VLA+model+fine-tuning+on+cloud+GPUs&amp;kind=project+%C2%B7+domain+applications">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="bryercowan/hermes-embodied — Hermes Atlas">
 <meta name="twitter:description" content="Hermes Embodied is a robotics extension for Hermes Agent that enables autonomous fine-tuning of Vision-Language-Action (VLA) models through natural language.…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-embodied&amp;subtitle=Self-improving+robotics+via+Hermes+Agent.+One+skill+that+provisions+cloud+GPUs%2C+fine-tunes+VLA+models%2C+runs+sim+evaluation%2C+and+autonomously+improves+robot+policies.+Built+for+the+&amp;kind=project+%C2%B7+domain+applications">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-embodied&amp;subtitle=Self-improving+robotics+via+VLA+model+fine-tuning+on+cloud+GPUs&amp;kind=project+%C2%B7+domain+applications">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/bryercowan/hermes-embodied",
   "applicationCategory": "BusinessApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
   "author": {
     "@type": "Organization",
     "name": "bryercowan",
     "url": "https://github.com/bryercowan"
   },
-  "dateModified": "2026-03-05T22:43:38.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">bryercowan</span><span class="slash">/</span>hermes-embodied
   </h1>
-  <p class="project-desc">Self-improving robotics via Hermes Agent. One skill that provisions cloud GPUs, fine-tunes VLA models, runs sim evaluation, and autonomously improves robot policies. Built for the Nous Research Hermes Agent Hackathon.</p>
+  <p class="project-desc">Self-improving robotics via VLA model fine-tuning on cloud GPUs</p>
 
   <div class="meta-row">
     <span class="stars">★ 13</span>
-    <span><span class="meta-label">lang</span>Python</span>
     
     
-    <span><span class="meta-label">updated</span>2026-03-05</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -310,7 +311,6 @@
 </ul>
 <h3>License</h3>
 <p>MIT</p>
-
   </section>
 </details>
 

--- a/projects/builderz-labs/mission-control.html
+++ b/projects/builderz-labs/mission-control.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/builderz-labs/mission-control">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=mission-control&amp;subtitle=Self-hosted+control+plane+for+AI+agents%3A+dispatch+tasks%2C+review+runs%2C+track+spend%2C+and+operate+OpenClaw%2C+Claude+Code%2C+Codex%2C+and+other+runtimes.&amp;kind=project+%C2%B7+multi-agent">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=mission-control&amp;subtitle=Self-hosted+AI+agent+orchestration+%E2%80%94+dispatch+tasks%2C+run+multi-agent+workflows%2C+monitor+spend&amp;kind=project+%C2%B7+multi-agent">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="builderz-labs/mission-control — Hermes Atlas">
 <meta name="twitter:description" content="Mission Control is a self-hosted control plane for operating AI agents using a local SQLite database. It provides a dashboard to dispatch tasks, monitor agent…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=mission-control&amp;subtitle=Self-hosted+control+plane+for+AI+agents%3A+dispatch+tasks%2C+review+runs%2C+track+spend%2C+and+operate+OpenClaw%2C+Claude+Code%2C+Codex%2C+and+other+runtimes.&amp;kind=project+%C2%B7+multi-agent">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=mission-control&amp;subtitle=Self-hosted+AI+agent+orchestration+%E2%80%94+dispatch+tasks%2C+run+multi-agent+workflows%2C+monitor+spend&amp;kind=project+%C2%B7+multi-agent">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/builderz-labs/mission-control",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TypeScript",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "builderz-labs",
     "url": "https://github.com/builderz-labs"
   },
-  "dateModified": "2026-08-20T16:11:29.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">builderz-labs</span><span class="slash">/</span>mission-control
   </h1>
-  <p class="project-desc">Self-hosted control plane for AI agents: dispatch tasks, review runs, track spend, and operate OpenClaw, Claude Code, Codex, and other runtimes.</p>
+  <p class="project-desc">Self-hosted AI agent orchestration — dispatch tasks, run multi-agent workflows, monitor spend</p>
 
   <div class="meta-row">
     <span class="stars">★ 6.0K</span>
-    <span><span class="meta-label">lang</span>TypeScript</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-20</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/builderz-labs/mission-control" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://mc.builderz.dev" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -475,7 +475,6 @@ the project does not promise dates for unassigned work.</p>
 
 <h3>License</h3>
 <p><a href="LICENSE">MIT</a> © 2026 <a href="https://github.com/builderz-labs">Builderz Labs</a></p>
-
   </section>
 </details>
 

--- a/projects/cablate/Agentic-MCP-Skill.html
+++ b/projects/cablate/Agentic-MCP-Skill.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/cablate/Agentic-MCP-Skill">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=Agentic-MCP-Skill&amp;subtitle=Agentic-MCP%2C+Progressive+MCP+client+with+three-layer+lazy+loading.+Validates+AgentSkills.io+pattern+for+efficient+token+usage.+Use+MCP+without+pre-install+%26+wasting+full-loading&amp;kind=project+%C2%B7+skills">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=Agentic-MCP-Skill&amp;subtitle=Progressive+MCP+client+with+three-layer+lazy+loading+%E2%80%94+validates+agentskills.io+pattern&amp;kind=project+%C2%B7+skills">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="cablate/Agentic-MCP-Skill — Hermes Atlas">
 <meta name="twitter:description" content="Agentic-MCP-Skill is an experimental MCP client designed to reduce token consumption through a three-layer progressive disclosure pattern. It implements a…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Agentic-MCP-Skill&amp;subtitle=Agentic-MCP%2C+Progressive+MCP+client+with+three-layer+lazy+loading.+Validates+AgentSkills.io+pattern+for+efficient+token+usage.+Use+MCP+without+pre-install+%26+wasting+full-loading&amp;kind=project+%C2%B7+skills">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Agentic-MCP-Skill&amp;subtitle=Progressive+MCP+client+with+three-layer+lazy+loading+%E2%80%94+validates+agentskills.io+pattern&amp;kind=project+%C2%B7+skills">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/cablate/Agentic-MCP-Skill",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TypeScript",
   "author": {
     "@type": "Organization",
     "name": "cablate",
     "url": "https://github.com/cablate"
   },
-  "dateModified": "2026-01-21T06:07:30.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">cablate</span><span class="slash">/</span>Agentic-MCP-Skill
   </h1>
-  <p class="project-desc">Agentic-MCP, Progressive MCP client with three-layer lazy loading. Validates AgentSkills.io pattern for efficient token usage. Use MCP without pre-install &amp; wasting full-loading</p>
+  <p class="project-desc">Progressive MCP client with three-layer lazy loading — validates agentskills.io pattern</p>
 
   <div class="meta-row">
     <span class="stars">★ 39</span>
-    <span><span class="meta-label">lang</span>TypeScript</span>
     
     
-    <span><span class="meta-label">updated</span>2026-01-21</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -448,7 +449,6 @@ agentic-mcp call playwright browser_click --params '{"element": "Mac link", "ref
 
 <p>This is a concept validation project, feedback welcome</p>
 </div>
-
   </section>
 </details>
 

--- a/projects/campfirein/byterover-cli.html
+++ b/projects/campfirein/byterover-cli.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/campfirein/byterover-cli">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=byterover-cli&amp;subtitle=ByteRover+CLI+%28brv%29+-+The+portable+memory+layer+for++autonomous+coding+agents+%28formerly+Cipher%29&amp;kind=project+%C2%B7+memory">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=byterover-cli&amp;subtitle=Memory+as+a+git+repo+%28formerly+Cipher%29+%E2%80%94+official+Hermes+Agent+memory+provider+with+5-tier+retrieval+%284+tiers+non-LLM%2C+sub-100ms%29%2C+brv+vc+commit%2Fbranch%2Fmerge+versioning+over+plain+&amp;kind=project+%C2%B7+memory">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="campfirein/byterover-cli — Hermes Atlas">
 <meta name="twitter:description" content="ByteRover CLI is an interactive REPL and context management tool that provides AI coding agents with persistent memory and a structured context tree. It…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=byterover-cli&amp;subtitle=ByteRover+CLI+%28brv%29+-+The+portable+memory+layer+for++autonomous+coding+agents+%28formerly+Cipher%29&amp;kind=project+%C2%B7+memory">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=byterover-cli&amp;subtitle=Memory+as+a+git+repo+%28formerly+Cipher%29+%E2%80%94+official+Hermes+Agent+memory+provider+with+5-tier+retrieval+%284+tiers+non-LLM%2C+sub-100ms%29%2C+brv+vc+commit%2Fbranch%2Fmerge+versioning+over+plain+&amp;kind=project+%C2%B7+memory">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/campfirein/byterover-cli",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TypeScript",
   "author": {
     "@type": "Organization",
     "name": "campfirein",
     "url": "https://github.com/campfirein"
   },
-  "dateModified": "2026-06-25T17:00:57.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">campfirein</span><span class="slash">/</span>byterover-cli
   </h1>
-  <p class="project-desc">ByteRover CLI (brv) - The portable memory layer for  autonomous coding agents (formerly Cipher)</p>
+  <p class="project-desc">Memory as a git repo (formerly Cipher) — official Hermes Agent memory provider with 5-tier retrieval (4 tiers non-LLM, sub-100ms), brv vc commit/branch/merge versioning over plain markdown context tree. Elastic License 2.0.</p>
 
   <div class="meta-row">
     <span class="stars">★ 4.9K</span>
-    <span><span class="meta-label">lang</span>TypeScript</span>
     
     
-    <span><span class="meta-label">updated</span>2026-06-25</span>
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/campfirein/byterover-cli" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://docs.byterover.dev/" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -573,7 +574,6 @@ brv debug            # Debug mode
 
 <h3>License</h3>
 <p>Elastic License 2.0. See <a href="LICENSE">LICENSE</a> for full terms.</p>
-
   </section>
 </details>
 

--- a/projects/carterwayneskhizeine/hermes-agent-windows-R.html
+++ b/projects/carterwayneskhizeine/hermes-agent-windows-R.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/carterwayneskhizeine/hermes-agent-windows-R">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-windows-R&amp;subtitle=Windows-native+adaptation+fork+of+Hermes+Agent%2C+based+on+upstream+Hermes+Agent+0.13.0.+Improves+local+runtime+environment%2C+path+handling%2C+process+management%2C+and+terminal+backend+c&amp;kind=project+%C2%B7+forks">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-windows-R&amp;subtitle=Windows-native+adaptation+fork+of+Hermes+Agent+with+runtime%2C+path%2C+process%2C+and+terminal+backend+compatibility+improvements&amp;kind=project+%C2%B7+forks">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="carterwayneskhizeine/hermes-agent-windows-R — Hermes Atlas">
 <meta name="twitter:description" content="This project is a Windows-native fork of Hermes Agent designed to resolve compatibility issues with path handling, process management, and terminal encoding.…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-windows-R&amp;subtitle=Windows-native+adaptation+fork+of+Hermes+Agent%2C+based+on+upstream+Hermes+Agent+0.13.0.+Improves+local+runtime+environment%2C+path+handling%2C+process+management%2C+and+terminal+backend+c&amp;kind=project+%C2%B7+forks">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-windows-R&amp;subtitle=Windows-native+adaptation+fork+of+Hermes+Agent+with+runtime%2C+path%2C+process%2C+and+terminal+backend+compatibility+improvements&amp;kind=project+%C2%B7+forks">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/carterwayneskhizeine/hermes-agent-windows-R",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "carterwayneskhizeine",
     "url": "https://github.com/carterwayneskhizeine"
   },
-  "dateModified": "2026-05-15T05:26:16.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">carterwayneskhizeine</span><span class="slash">/</span>hermes-agent-windows-R
   </h1>
-  <p class="project-desc">Windows-native adaptation fork of Hermes Agent, based on upstream Hermes Agent 0.13.0. Improves local runtime environment, path handling, process management, and terminal backend compatibility — no WSL required.</p>
+  <p class="project-desc">Windows-native adaptation fork of Hermes Agent with runtime, path, process, and terminal backend compatibility improvements</p>
 
   <div class="meta-row">
     <span class="stars">★ 20</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-05-15</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/carterwayneskhizeine/hermes-agent-windows-R" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://hermes-agent.nousresearch.com/" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -239,7 +239,6 @@ cd ..
 <pre><code class="language-powershell">winget install psmux
 .\start-hermes.ps1
 </code></pre>
-
   </section>
 </details>
 

--- a/projects/ccf/agentcairn.html
+++ b/projects/ccf/agentcairn.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/ccf/agentcairn",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/Apache-2.0.html",
   "author": {
     "@type": "Organization",
     "name": "ccf",
     "url": "https://github.com/ccf"
   },
-  "dateModified": "2026-08-21T01:53:22.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,17 +118,19 @@
 
   <div class="meta-row">
     <span class="stars">★ 41</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>Apache-2.0</span>
     
-    <span><span class="meta-label">updated</span>2026-08-21</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/ccf/agentcairn" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://agentcairn.dev" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -464,7 +464,6 @@ uv run pre-commit run --all-files
 </code></pre>
 <h3>License</h3>
 <p><a href="LICENSE">Apache License 2.0</a> — permissive, with an explicit patent grant. Copyright © 2026 Charles C. Figueiredo.</p>
-
   </section>
 </details>
 

--- a/projects/chainbase-labs/Agentkey.html
+++ b/projects/chainbase-labs/Agentkey.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/chainbase-labs/Agentkey",
   "applicationCategory": "CommunicationApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Shell",
-  "license": "https://spdx.org/licenses/Apache-2.0.html",
   "author": {
     "@type": "Organization",
     "name": "chainbase-labs",
     "url": "https://github.com/chainbase-labs"
   },
-  "dateModified": "2026-08-13T18:24:55.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,17 +118,19 @@
 
   <div class="meta-row">
     <span class="stars">★ 591</span>
-    <span><span class="meta-label">lang</span>Shell</span>
-    <span><span class="meta-label">license</span>Apache-2.0</span>
     
-    <span><span class="meta-label">updated</span>2026-08-13</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/chainbase-labs/Agentkey" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://agentkey.app" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -600,7 +600,6 @@ agy plugin list
 <hr>
 <h3>Star History</h3>
 <p><a href="https://www.star-history.com/?repos=chainbase-labs%2Fagentkey&amp;type=date&amp;legend=top-left"><img src="https://api.star-history.com/chart?repos=chainbase-labs/agentkey&amp;type=date&amp;legend=top-left&amp;sealed_token=ZnduG_kCABo_uyUn3A-CRWKj9wC9AMGIDCpvu5PSfSvwKtE9Ab_5PEJNjQoQafwEYOlWr4Ioq_n7wC8vNwlwRMQ-BIz0VmBMNZq0aY-KYlH9S2i_29q9fw" alt="Star History Chart" loading="lazy" decoding="async"></a></p>
-
   </section>
 </details>
 

--- a/projects/chenwei791129/hermes-usage-hook.html
+++ b/projects/chenwei791129/hermes-usage-hook.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/chenwei791129/hermes-usage-hook",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "chenwei791129",
     "url": "https://github.com/chenwei791129"
   },
-  "dateModified": "2026-08-01T00:13:20.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,10 +118,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 3</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-01</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -282,7 +282,6 @@ footer is skipped:</p>
 notes, including optional Codex auto reset.</p>
 <h3>License</h3>
 <p>MIT</p>
-
   </section>
 </details>
 

--- a/projects/chigwell/skilldock.io.html
+++ b/projects/chigwell/skilldock.io.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/chigwell/skilldock.io">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=skilldock.io&amp;subtitle=SkillDock.io+is+a+registry+of+reusable+AI+Skills+based+on+the+AgentSkills+specification.+Discover%2C+install%2C+and+publish+versioned+Skills+that+work+across+OpenClaw%2C+Claude%2C+and+any+&amp;kind=project+%C2%B7+skills">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=skilldock.io&amp;subtitle=Registry+of+reusable+AI+skills+based+on+AgentSkills+specification&amp;kind=project+%C2%B7+skills">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="chigwell/skilldock.io — Hermes Atlas">
 <meta name="twitter:description" content="SkillDock is an OpenAPI-driven Python SDK and CLI for interacting with the SkillDock API. It enables users to search, install, and manage skill releases, and…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=skilldock.io&amp;subtitle=SkillDock.io+is+a+registry+of+reusable+AI+Skills+based+on+the+AgentSkills+specification.+Discover%2C+install%2C+and+publish+versioned+Skills+that+work+across+OpenClaw%2C+Claude%2C+and+any+&amp;kind=project+%C2%B7+skills">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=skilldock.io&amp;subtitle=Registry+of+reusable+AI+skills+based+on+AgentSkills+specification&amp;kind=project+%C2%B7+skills">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/chigwell/skilldock.io",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/Apache-2.0.html",
   "author": {
     "@type": "Organization",
     "name": "chigwell",
     "url": "https://github.com/chigwell"
   },
-  "dateModified": "2026-07-05T17:12:47.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">chigwell</span><span class="slash">/</span>skilldock.io
   </h1>
-  <p class="project-desc">SkillDock.io is a registry of reusable AI Skills based on the AgentSkills specification. Discover, install, and publish versioned Skills that work across OpenClaw, Claude, and any Skills-compatible agent.</p>
+  <p class="project-desc">Registry of reusable AI skills based on AgentSkills specification</p>
 
   <div class="meta-row">
     <span class="stars">★ 86</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>Apache-2.0</span>
     
-    <span><span class="meta-label">updated</span>2026-07-05</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/chigwell/skilldock.io" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://skilldock.io/" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -395,7 +395,6 @@ The exact details are derived from the OpenAPI <code>securitySchemes</code> when
 <p>Run the small unit test suite:</p>
 <pre><code class="language-bash">python -m unittest discover -s tests
 </code></pre>
-
   </section>
 </details>
 

--- a/projects/chillerno1/hermes-yt-plugin.html
+++ b/projects/chillerno1/hermes-yt-plugin.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/chillerno1/hermes-yt-plugin",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "JavaScript",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "chillerno1",
     "url": "https://github.com/chillerno1"
   },
-  "dateModified": "2026-07-30T11:44:06.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,10 +118,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 3</span>
-    <span><span class="meta-label">lang</span>JavaScript</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-07-30</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -397,7 +397,6 @@ would not remove ads on a free account either. See
 </ul>
 <h3>License</h3>
 <p><a href="LICENSE">MIT</a></p>
-
   </section>
 </details>
 

--- a/projects/clawvader-tech/hermes-telegram-miniapp.html
+++ b/projects/clawvader-tech/hermes-telegram-miniapp.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/clawvader-tech/hermes-telegram-miniapp",
   "applicationCategory": "DesktopEnhancementApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TypeScript",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "clawvader-tech",
     "url": "https://github.com/clawvader-tech"
   },
-  "dateModified": "2026-04-15T17:28:50.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,10 +118,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 260</span>
-    <span><span class="meta-label">lang</span>TypeScript</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-04-15</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -551,7 +551,6 @@ Optional Local Models (CPU)
 </ol>
 <h3>License</h3>
 <p>MIT — see <a href="LICENSE">LICENSE</a>.</p>
-
   </section>
 </details>
 

--- a/projects/colbymchenry/codegraph.html
+++ b/projects/colbymchenry/codegraph.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/colbymchenry/codegraph">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=codegraph&amp;subtitle=Pre-indexed+code+knowledge+graph%2C+auto+syncs+on+code+changes%2C+for+Claude+Code%2C+Codex%2C+Gemini%2C+Cursor%2C+OpenCode%2C+AntiGravity%2C+Kiro%2C+and+Hermes+Agent+%E2%80%94+fewer+tokens%2C+fewer+tool+calls&amp;kind=project+%C2%B7+developer+tools">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=codegraph&amp;subtitle=Local+pre-indexed+code+knowledge+graph+for+Hermes+Agent+and+other+coding+agents+to+reduce+token+usage+and+tool+calls&amp;kind=project+%C2%B7+developer+tools">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="colbymchenry/codegraph — Hermes Atlas">
 <meta name="twitter:description" content="CodeGraph is a local code knowledge graph designed for use with coding agents. It uses a Rust-powered kernel to provide semantic code intelligence through an…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=codegraph&amp;subtitle=Pre-indexed+code+knowledge+graph%2C+auto+syncs+on+code+changes%2C+for+Claude+Code%2C+Codex%2C+Gemini%2C+Cursor%2C+OpenCode%2C+AntiGravity%2C+Kiro%2C+and+Hermes+Agent+%E2%80%94+fewer+tokens%2C+fewer+tool+calls&amp;kind=project+%C2%B7+developer+tools">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=codegraph&amp;subtitle=Local+pre-indexed+code+knowledge+graph+for+Hermes+Agent+and+other+coding+agents+to+reduce+token+usage+and+tool+calls&amp;kind=project+%C2%B7+developer+tools">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/colbymchenry/codegraph",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "C",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "colbymchenry",
     "url": "https://github.com/colbymchenry"
   },
-  "dateModified": "2026-08-20T17:53:49.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">colbymchenry</span><span class="slash">/</span>codegraph
   </h1>
-  <p class="project-desc">Pre-indexed code knowledge graph, auto syncs on code changes, for Claude Code, Codex, Gemini, Cursor, OpenCode, AntiGravity, Kiro, and Hermes Agent — fewer tokens, fewer tool calls, 100% local</p>
+  <p class="project-desc">Local pre-indexed code knowledge graph for Hermes Agent and other coding agents to reduce token usage and tool calls</p>
 
   <div class="meta-row">
     <span class="stars">★ 67.5K</span>
-    <span><span class="meta-label">lang</span>C</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-20</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/colbymchenry/codegraph" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://colbymchenry.github.io/codegraph/" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -1101,7 +1101,6 @@ linking every version to the exact commit and workflow run th</li>
 </ul>
 <hr>
 <p><em>README truncated. <a href="https://github.com/colbymchenry/codegraph#readme">Continue reading on GitHub</a></em></p>
-
   </section>
 </details>
 

--- a/projects/conorbronsdon/avoid-ai-writing.html
+++ b/projects/conorbronsdon/avoid-ai-writing.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/conorbronsdon/avoid-ai-writing">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=avoid-ai-writing&amp;subtitle=Skill+that+audits+and+rewrites+content+to+remove+AI+writing+patterns.+Use+it+with+your+favorite+agents+including+Claude+Code%2C+OpenClaw%2C+Codex%2C+and+Hermes.&amp;kind=project+%C2%B7+skills">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=avoid-ai-writing&amp;subtitle=Audits+and+rewrites+content+to+eliminate+detectable+AI+writing+patterns&amp;kind=project+%C2%B7+skills">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="conorbronsdon/avoid-ai-writing — Hermes Atlas">
 <meta name="twitter:description" content="This tool audits and rewrites content to remove detectable AI writing patterns. It supports three modes: Rewrite, Detect, and Edit, and includes optional voice…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=avoid-ai-writing&amp;subtitle=Skill+that+audits+and+rewrites+content+to+remove+AI+writing+patterns.+Use+it+with+your+favorite+agents+including+Claude+Code%2C+OpenClaw%2C+Codex%2C+and+Hermes.&amp;kind=project+%C2%B7+skills">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=avoid-ai-writing&amp;subtitle=Audits+and+rewrites+content+to+eliminate+detectable+AI+writing+patterns&amp;kind=project+%C2%B7+skills">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/conorbronsdon/avoid-ai-writing",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "JavaScript",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "conorbronsdon",
     "url": "https://github.com/conorbronsdon"
   },
-  "dateModified": "2026-08-17T20:29:04.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,30 @@
   <h1 class="project-name">
     <span class="org">conorbronsdon</span><span class="slash">/</span>avoid-ai-writing
   </h1>
-  <p class="project-desc">Skill that audits and rewrites content to remove AI writing patterns. Use it with your favorite agents including Claude Code, OpenClaw, Codex, and Hermes.</p>
+  <p class="project-desc">Audits and rewrites content to eliminate detectable AI writing patterns</p>
 
   <div class="meta-row">
     <span class="stars">★ 3.2K</span>
-    <span><span class="meta-label">lang</span>JavaScript</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-17</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/conorbronsdon/avoid-ai-writing" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://chainofthought.show/go/avoid-ai-writing" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
+<aside class="install-box" aria-label="How to install this skill">
+  <div class="ib-label">install<span class="ib-type">skill</span></div>
+  <code class="ib-cmd">git clone https://github.com/conorbronsdon/avoid-ai-writing into your skills directory (or install the plugin from its marketplace).</code>
+  <p class="ib-compat">README states explicit compatibility with Claude Code, OpenClaw, Hermes, and Cursor.</p>
+  <p class="ib-verdict">Three modes (Rewrite, Detect, Edit) and a 100+ entry tiered word-replacement table — the most mechanically detailed de-AI-ify skill in the category, not a vague 'sound more human' prompt.</p>
+  <a class="ib-more" href="/skills/">more picks → the skills hub</a>
+</aside>
 
 
 
@@ -860,7 +867,6 @@ behind that line is public.</p>
 <p><em>This is an independent personal project, not affiliated with, sponsored by, or endorsed by any company. All views expressed are my own.</em></p>
 <h3>License</h3>
 <p>MIT</p>
-
   </section>
 </details>
 

--- a/projects/corsur/swarm-tips.html
+++ b/projects/corsur/swarm-tips.html
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/corsur/swarm-tips",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Rust",
   "author": {
     "@type": "Organization",
     "name": "corsur",
     "url": "https://github.com/corsur"
   },
-  "dateModified": "2026-08-20T07:17:33.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -119,10 +118,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 1</span>
-    <span><span class="meta-label">lang</span>Rust</span>
     
     
-    <span><span class="meta-label">updated</span>2026-08-20</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -491,7 +492,6 @@ Disputed --(resolve_challenge)--&gt; [resolved, closed]
 <li>Events emitted for every state transition</li>
 <li>Named error variants for every failure mode</li>
 </ul>
-
   </section>
 </details>
 

--- a/projects/dodo-reach/hermes-desktop.html
+++ b/projects/dodo-reach/hermes-desktop.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/dodo-reach/hermes-desktop">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-desktop&amp;subtitle=The+safest%2C+simplest+way+to+manage+Hermes+from+your+Mac.+Pure+SSH.+No+gateways%2C+no+exposed+ports%2C+no+browser+layer.&amp;kind=project+%C2%B7+workspaces">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-desktop&amp;subtitle=A+native+Mac+workspace+for+Hermes%3A+real+SSH%2C+real+terminal%2C+real+session+data.&amp;kind=project+%C2%B7+workspaces">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="dodo-reach/hermes-desktop — Hermes Atlas">
 <meta name="twitter:description" content="Hermes Desktop is a native macOS companion app that provides a dedicated workbench for managing Hermes Agent without relying on browser wrappers or gateway…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-desktop&amp;subtitle=The+safest%2C+simplest+way+to+manage+Hermes+from+your+Mac.+Pure+SSH.+No+gateways%2C+no+exposed+ports%2C+no+browser+layer.&amp;kind=project+%C2%B7+workspaces">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-desktop&amp;subtitle=A+native+Mac+workspace+for+Hermes%3A+real+SSH%2C+real+terminal%2C+real+session+data.&amp;kind=project+%C2%B7+workspaces">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/dodo-reach/hermes-desktop",
   "applicationCategory": "DesktopEnhancementApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Swift",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "dodo-reach",
     "url": "https://github.com/dodo-reach"
   },
-  "dateModified": "2026-06-19T10:52:35.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">dodo-reach</span><span class="slash">/</span>hermes-desktop
   </h1>
-  <p class="project-desc">The safest, simplest way to manage Hermes from your Mac. Pure SSH. No gateways, no exposed ports, no browser layer.</p>
+  <p class="project-desc">A native Mac workspace for Hermes: real SSH, real terminal, real session data.</p>
 
   <div class="meta-row">
     <span class="stars">★ 2.0K</span>
-    <span><span class="meta-label">lang</span>Swift</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-06-19</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/dodo-reach/hermes-desktop" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://dodo-reach.github.io/hermes-desktop/" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -542,7 +542,6 @@ actual distribution model</li>
 </ul>
 <p>Anything larger than that should be justified by Hermes itself, not added just
 because it is technically possible.</p>
-
   </section>
 </details>
 

--- a/projects/elkimek/honcho-self-hosted.html
+++ b/projects/elkimek/honcho-self-hosted.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/elkimek/honcho-self-hosted">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=honcho-self-hosted&amp;subtitle=Self-host+Honcho+memory+layer+for+Hermes+Agent+%E2%80%94+OpenRouter+%2B+Venice%2C+no+code+changes&amp;kind=project+%C2%B7+memory">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=honcho-self-hosted&amp;subtitle=Self-hosted+Honcho+memory+backend+for+cross-session+persistence&amp;kind=project+%C2%B7+memory">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="elkimek/honcho-self-hosted — Hermes Atlas">
 <meta name="twitter:description" content="This project provides a configuration layer for self-hosting Plastic Labs' Honcho memory backend, enabling cross-session persistence for Hermes Agent without…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=honcho-self-hosted&amp;subtitle=Self-host+Honcho+memory+layer+for+Hermes+Agent+%E2%80%94+OpenRouter+%2B+Venice%2C+no+code+changes&amp;kind=project+%C2%B7+memory">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=honcho-self-hosted&amp;subtitle=Self-hosted+Honcho+memory+backend+for+cross-session+persistence&amp;kind=project+%C2%B7+memory">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/elkimek/honcho-self-hosted",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Shell",
-  "license": "https://spdx.org/licenses/GPL-3.0.html",
   "author": {
     "@type": "Organization",
     "name": "elkimek",
     "url": "https://github.com/elkimek"
   },
-  "dateModified": "2026-04-09T04:51:34.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">elkimek</span><span class="slash">/</span>honcho-self-hosted
   </h1>
-  <p class="project-desc">Self-host Honcho memory layer for Hermes Agent — OpenRouter + Venice, no code changes</p>
+  <p class="project-desc">Self-hosted Honcho memory backend for cross-session persistence</p>
 
   <div class="meta-row">
     <span class="stars">★ 362</span>
-    <span><span class="meta-label">lang</span>Shell</span>
-    <span><span class="meta-label">license</span>GPL-3.0</span>
     
-    <span><span class="meta-label">updated</span>2026-04-09</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 <aside class="handbook-mention" aria-label="Mentioned in the Hermes Handbook">
@@ -583,7 +583,6 @@ sudo systemctl restart honcho-mcp
 <li><a href="https://github.com/plastic-labs/honcho">Honcho</a> by Plastic Labs</li>
 <li><a href="https://github.com/NousResearch/hermes-agent">Hermes Agent</a> by Nous Research</li>
 </ul>
-
   </section>
 </details>
 

--- a/projects/esaradev/icarus-plugin.html
+++ b/projects/esaradev/icarus-plugin.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/esaradev/icarus-plugin">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=icarus-plugin&amp;subtitle=Self-memory+and+replacement+models+for+Hermes+agents.+Remember+your+work.+Train+your+replacement.&amp;kind=project+%C2%B7+skills">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=icarus-plugin&amp;subtitle=Self-memory+and+replacement+models+%E2%80%94+remember+your+work%2C+train+your+replacement&amp;kind=project+%C2%B7+skills">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="esaradev/icarus-plugin — Hermes Atlas">
 <meta name="twitter:description" content="Icarus is a Hermes plugin that provides agents with shared memory and a pipeline for creating replacement models. It captures agent decisions and work into a…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=icarus-plugin&amp;subtitle=Self-memory+and+replacement+models+for+Hermes+agents.+Remember+your+work.+Train+your+replacement.&amp;kind=project+%C2%B7+skills">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=icarus-plugin&amp;subtitle=Self-memory+and+replacement+models+%E2%80%94+remember+your+work%2C+train+your+replacement&amp;kind=project+%C2%B7+skills">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/esaradev/icarus-plugin",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "esaradev",
     "url": "https://github.com/esaradev"
   },
-  "dateModified": "2026-05-17T04:58:55.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">esaradev</span><span class="slash">/</span>icarus-plugin
   </h1>
-  <p class="project-desc">Self-memory and replacement models for Hermes agents. Remember your work. Train your replacement.</p>
+  <p class="project-desc">Self-memory and replacement models — remember your work, train your replacement</p>
 
   <div class="meta-row">
     <span class="stars">★ 142</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-05-17</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -517,7 +517,6 @@ scripts/
 </code></pre>
 <h3>License</h3>
 <p>MIT</p>
-
   </section>
 </details>
 

--- a/projects/farion1231/cc-switch.html
+++ b/projects/farion1231/cc-switch.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/farion1231/cc-switch">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=cc-switch&amp;subtitle=A+cross-platform+desktop+All-in-One+assistant+for+Claude+Code%2C+Codex%2C+OpenCode%2C+OpenClaw%2C+Grok+Build+%26+Hermes+Agent.+Only+official+website%3A+ccswitch.io&amp;kind=project+%C2%B7+workspaces">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=cc-switch&amp;subtitle=Cross-platform+all-in-one+manager+for+Claude+Code%2C+Codex%2C+OpenCode%2C+OpenClaw%2C+Gemini+CLI%2C+and+Hermes+Agent&amp;kind=project+%C2%B7+workspaces">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="farion1231/cc-switch — Hermes Atlas">
 <meta name="twitter:description" content="CC Switch is a cross-platform manager built with Tauri 2 for Windows, macOS, and Linux. It provides a unified interface for configuring and switching between…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=cc-switch&amp;subtitle=A+cross-platform+desktop+All-in-One+assistant+for+Claude+Code%2C+Codex%2C+OpenCode%2C+OpenClaw%2C+Grok+Build+%26+Hermes+Agent.+Only+official+website%3A+ccswitch.io&amp;kind=project+%C2%B7+workspaces">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=cc-switch&amp;subtitle=Cross-platform+all-in-one+manager+for+Claude+Code%2C+Codex%2C+OpenCode%2C+OpenClaw%2C+Gemini+CLI%2C+and+Hermes+Agent&amp;kind=project+%C2%B7+workspaces">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/farion1231/cc-switch",
   "applicationCategory": "DesktopEnhancementApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Rust",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "farion1231",
     "url": "https://github.com/farion1231"
   },
-  "dateModified": "2026-08-20T18:35:38.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">farion1231</span><span class="slash">/</span>cc-switch
   </h1>
-  <p class="project-desc">A cross-platform desktop All-in-One assistant for Claude Code, Codex, OpenCode, OpenClaw, Grok Build &amp; Hermes Agent. Only official website: ccswitch.io</p>
+  <p class="project-desc">Cross-platform all-in-one manager for Claude Code, Codex, OpenCode, OpenClaw, Gemini CLI, and Hermes Agent</p>
 
   <div class="meta-row">
     <span class="stars">★ 128.6K</span>
-    <span><span class="meta-label">lang</span>Rust</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-20</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/farion1231/cc-switch" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://ccswitch.io" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -688,7 +688,6 @@ pnpm test:unit --coverage
 <p><a href="https://www.star-history.com/#farion1231/cc-switch&amp;Date"><img src="https://api.star-history.com/svg?repos=farion1231/cc-switch&amp;type=Date" alt="Star History Chart" loading="lazy" decoding="async"></a></p>
 <h3>License</h3>
 <p>MIT © Jason Young</p>
-
   </section>
 </details>
 

--- a/projects/fathah/hermes-desktop.html
+++ b/projects/fathah/hermes-desktop.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/fathah/hermes-desktop">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-desktop&amp;subtitle=Desktop+Companion+for+Hermes+Agent&amp;kind=project+%C2%B7+workspaces">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-desktop&amp;subtitle=Desktop+companion+app+for+installing%2C+configuring%2C+and+chatting+with+Hermes+Agent&amp;kind=project+%C2%B7+workspaces">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="fathah/hermes-desktop — Hermes Atlas">
 <meta name="twitter:description" content="Hermes One is a native desktop application used to install, configure, and chat with Hermes Agent. It provides a graphical user interface for managing…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-desktop&amp;subtitle=Desktop+Companion+for+Hermes+Agent&amp;kind=project+%C2%B7+workspaces">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-desktop&amp;subtitle=Desktop+companion+app+for+installing%2C+configuring%2C+and+chatting+with+Hermes+Agent&amp;kind=project+%C2%B7+workspaces">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/fathah/hermes-desktop",
   "applicationCategory": "DesktopEnhancementApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TypeScript",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "fathah",
     "url": "https://github.com/fathah"
   },
-  "dateModified": "2026-08-06T14:27:28.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">fathah</span><span class="slash">/</span>hermes-desktop
   </h1>
-  <p class="project-desc">Desktop Companion for Hermes Agent</p>
+  <p class="project-desc">Desktop companion app for installing, configuring, and chatting with Hermes Agent</p>
 
   <div class="meta-row">
     <span class="stars">★ 14.0K</span>
-    <span><span class="meta-label">lang</span>TypeScript</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-06</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/fathah/hermes-desktop" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://hermesone.org" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -550,7 +550,6 @@ helper loop.</li>
 <ul>
 <li><a href="https://github.com/NousResearch/hermes-agent">https://github.com/NousResearch/hermes-agent</a></li>
 </ul>
-
   </section>
 </details>
 

--- a/projects/freehul/progressive-skill.html
+++ b/projects/freehul/progressive-skill.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/freehul/progressive-skill",
   "applicationCategory": "ReferenceApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "freehul",
     "url": "https://github.com/freehul"
   },
-  "dateModified": "2026-08-11T14:09:00.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,10 +118,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 4</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-11</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -304,7 +304,6 @@ python generic/cli.py budget --input index.txt --usage usage.json --relevant dev
 <li>Official docs on skill progressive disclosure: <a href="https://hermes-agent.nousresearch.com/docs/guides/work-with-skills">Working with Skills</a></li>
 <li>Upstream issue: <a href="https://github.com/NousResearch/hermes-agent/issues/22620">#22620 — Skill list bloat causes massive context window inflation</a></li>
 </ul>
-
   </section>
 </details>
 

--- a/projects/freestylefly/wesight.html
+++ b/projects/freestylefly/wesight.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/freestylefly/wesight">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=WeSight&amp;subtitle=Open-source+desktop+AI+agent+workspace+with+one-click+Claude+Code%2C+Codex%2C+OpenClaw%2C+Hermes+Agent+setup+and+custom+LLM+model+routing.&amp;kind=project+%C2%B7+workspaces">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=WeSight&amp;subtitle=Desktop+AI+agent+workspace+with+one-click+setup+for+Hermes+Agent%2C+Claude+Code%2C+Codex%2C+and+OpenClaw%2C+plus+custom+LLM+model+routing.&amp;kind=project+%C2%B7+workspaces">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="freestylefly/WeSight — Hermes Atlas">
 <meta name="twitter:description" content="WeSight is an open-source desktop control console for local AI agents, providing a visual workspace to manage coding agents, tool execution, and file changes.…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=WeSight&amp;subtitle=Open-source+desktop+AI+agent+workspace+with+one-click+Claude+Code%2C+Codex%2C+OpenClaw%2C+Hermes+Agent+setup+and+custom+LLM+model+routing.&amp;kind=project+%C2%B7+workspaces">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=WeSight&amp;subtitle=Desktop+AI+agent+workspace+with+one-click+setup+for+Hermes+Agent%2C+Claude+Code%2C+Codex%2C+and+OpenClaw%2C+plus+custom+LLM+model+routing.&amp;kind=project+%C2%B7+workspaces">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/freestylefly/wesight",
   "applicationCategory": "DesktopEnhancementApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TypeScript",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "freestylefly",
     "url": "https://github.com/freestylefly"
   },
-  "dateModified": "2026-08-06T08:32:46.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">freestylefly</span><span class="slash">/</span>wesight
   </h1>
-  <p class="project-desc">Open-source desktop AI agent workspace with one-click Claude Code, Codex, OpenClaw, Hermes Agent setup and custom LLM model routing.</p>
+  <p class="project-desc">Desktop AI agent workspace with one-click setup for Hermes Agent, Claude Code, Codex, and OpenClaw, plus custom LLM model routing.</p>
 
   <div class="meta-row">
     <span class="stars">★ 887</span>
-    <span><span class="meta-label">lang</span>TypeScript</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-06</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/freestylefly/wesight" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://wesight.ai" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -567,7 +567,6 @@ src/shared/                       Shared constants and types
 
 <p><a href="https://github.com/freestylefly/wesight/graphs/contributors"><img src="https://contrib.rocks/image?repo=freestylefly/wesight" alt="WeSight Contributors" loading="lazy" decoding="async"></a></p>
 </div>
-
   </section>
 </details>
 

--- a/projects/futurebrowser/hermes-exabase-plugin.html
+++ b/projects/futurebrowser/hermes-exabase-plugin.html
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/futurebrowser/hermes-exabase-plugin",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
   "author": {
     "@type": "Organization",
     "name": "futurebrowser",
     "url": "https://github.com/futurebrowser"
   },
-  "dateModified": "2026-06-02T13:11:57.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -119,17 +118,19 @@
 
   <div class="meta-row">
     <span class="stars">★ 5</span>
-    <span><span class="meta-label">lang</span>Python</span>
     
     
-    <span><span class="meta-label">updated</span>2026-06-02</span>
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/futurebrowser/hermes-exabase-plugin" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://exabase.io" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -235,7 +236,6 @@ ranking of relevant memories at the cost of speed and Exabase credits.</p>
 </ul>
 <p>Completed conversation turns are sent to Exabase in the background for inferred
 memory extraction.</p>
-
   </section>
 </details>
 

--- a/projects/garrytan/gbrain.html
+++ b/projects/garrytan/gbrain.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/garrytan/gbrain",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TypeScript",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "garrytan",
     "url": "https://github.com/garrytan"
   },
-  "dateModified": "2026-08-21T10:29:48.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,10 +118,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 28.8K</span>
-    <span><span class="meta-label">lang</span>TypeScript</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-21</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -506,7 +506,6 @@ with <code>getaddrinfo ENOTFOUND</code>?</strong> Upgrade — schema bring-up no
 phases </p>
 <hr>
 <p><em>README truncated. <a href="https://github.com/garrytan/gbrain#readme">Continue reading on GitHub</a></em></p>
-
   </section>
 </details>
 

--- a/projects/generalbusiness-ai/keep.html
+++ b/projects/generalbusiness-ai/keep.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/generalbusiness-ai/keep">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=keep&amp;subtitle=Reflective+memory+for+agents&amp;kind=project+%C2%B7+memory">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=keep&amp;subtitle=Reflective+memory+for+AI+agents&amp;kind=project+%C2%B7+memory">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="generalbusiness-ai/keep — Hermes Atlas">
 <meta name="twitter:description" content="Keep is a reflective memory system for AI agents that facilitates long-term learning and contextual awareness. It processes diverse inputs—including URLs,…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=keep&amp;subtitle=Reflective+memory+for+agents&amp;kind=project+%C2%B7+memory">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=keep&amp;subtitle=Reflective+memory+for+AI+agents&amp;kind=project+%C2%B7+memory">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/generalbusiness-ai/keep",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "generalbusiness-ai",
     "url": "https://github.com/generalbusiness-ai"
   },
-  "dateModified": "2026-08-16T09:32:35.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">generalbusiness-ai</span><span class="slash">/</span>keep
   </h1>
-  <p class="project-desc">Reflective memory for agents</p>
+  <p class="project-desc">Reflective memory for AI agents</p>
 
   <div class="meta-row">
     <span class="stars">★ 39</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-16</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/generalbusiness-ai/keep" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://docs.keepnotes.ai/guides/quickstart/" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -347,7 +347,6 @@ versions = kp.list_versions("doc:1")
 <li>Documentation clarity</li>
 </ul>
 <p>See <a href="https://github.com/generalbusiness-ai/keep/blob/main/CONTRIBUTING.md">CONTRIBUTING.md</a> for guidelines.</p>
-
   </section>
 </details>
 

--- a/projects/gizdusum/hermes-blockchain-oracle.html
+++ b/projects/gizdusum/hermes-blockchain-oracle.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/gizdusum/hermes-blockchain-oracle">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-blockchain-oracle&amp;subtitle=%F0%9F%94%AE+Hermes+Blockchain+Oracle+-+A+Solana+blockchain+intelligence+MCP+server+for+Hermes+Agent.+Query+wallets%2C+track+whales%2C+analyze+tokens%2C+explore+NFTs%2C+and+monitor+network+health+th&amp;kind=project+%C2%B7+integrations">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-blockchain-oracle&amp;subtitle=Solana+blockchain+intelligence+MCP+server+%E2%80%94+wallets%2C+whales%2C+tokens%2C+NFTs%2C+network+health&amp;kind=project+%C2%B7+integrations">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="gizdusum/hermes-blockchain-oracle — Hermes Atlas">
 <meta name="twitter:description" content="Hermes Blockchain Oracle is a Model Context Protocol (MCP) server that provides Hermes Agent with real-time access to the Solana blockchain. It functions as a…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-blockchain-oracle&amp;subtitle=%F0%9F%94%AE+Hermes+Blockchain+Oracle+-+A+Solana+blockchain+intelligence+MCP+server+for+Hermes+Agent.+Query+wallets%2C+track+whales%2C+analyze+tokens%2C+explore+NFTs%2C+and+monitor+network+health+th&amp;kind=project+%C2%B7+integrations">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-blockchain-oracle&amp;subtitle=Solana+blockchain+intelligence+MCP+server+%E2%80%94+wallets%2C+whales%2C+tokens%2C+NFTs%2C+network+health&amp;kind=project+%C2%B7+integrations">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/gizdusum/hermes-blockchain-oracle",
   "applicationCategory": "CommunicationApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "gizdusum",
     "url": "https://github.com/gizdusum"
   },
-  "dateModified": "2026-05-17T18:41:42.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">gizdusum</span><span class="slash">/</span>hermes-blockchain-oracle
   </h1>
-  <p class="project-desc">🔮 Hermes Blockchain Oracle - A Solana blockchain intelligence MCP server for Hermes Agent. Query wallets, track whales, analyze tokens, explore NFTs, and monitor network health through natural language.</p>
+  <p class="project-desc">Solana blockchain intelligence MCP server — wallets, whales, tokens, NFTs, network health</p>
 
   <div class="meta-row">
     <span class="stars">★ 6</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-05-17</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/gizdusum/hermes-blockchain-oracle" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://nousresearch.com" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -459,7 +459,6 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
 <p>⭐ <strong>Star this repo</strong> if you find it useful — it helps us know what the community wants!</p>
 <p><a href="https://github.com/NousResearch/hermes-blockchain-oracle/issues">Report Bug</a> · <a href="https://github.com/NousResearch/hermes-blockchain-oracle/issues">Request Feature</a> · <a href="https://discord.gg/nousresearch">Join Discord</a></p>
 </div>
-
   </section>
 </details>
 

--- a/projects/greyhaven-ai/autocontext.html
+++ b/projects/greyhaven-ai/autocontext.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/greyhaven-ai/autocontext">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=autocontext&amp;subtitle=a+recursive+self-improving+harness+designed+to+help+your+agents+%28and+future+iterations+of+those+agents%29+succeed+on+any+task&amp;kind=project+%C2%B7+memory">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=autocontext&amp;subtitle=Recursive+self-improving+context+harness+%E2%80%94+helps+agents+succeed+on+complex+tasks&amp;kind=project+%C2%B7+memory">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="greyhaven-ai/autocontext — Hermes Atlas">
 <meta name="twitter:description" content="autocontext is a recursive harness for agent improvement that executes tasks against evaluations to capture useful lessons while discarding dead ends. It…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=autocontext&amp;subtitle=a+recursive+self-improving+harness+designed+to+help+your+agents+%28and+future+iterations+of+those+agents%29+succeed+on+any+task&amp;kind=project+%C2%B7+memory">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=autocontext&amp;subtitle=Recursive+self-improving+context+harness+%E2%80%94+helps+agents+succeed+on+complex+tasks&amp;kind=project+%C2%B7+memory">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/greyhaven-ai/autocontext",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/Apache-2.0.html",
   "author": {
     "@type": "Organization",
     "name": "greyhaven-ai",
     "url": "https://github.com/greyhaven-ai"
   },
-  "dateModified": "2026-08-21T01:31:00.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">greyhaven-ai</span><span class="slash">/</span>autocontext
   </h1>
-  <p class="project-desc">a recursive self-improving harness designed to help your agents (and future iterations of those agents) succeed on any task</p>
+  <p class="project-desc">Recursive self-improving context harness — helps agents succeed on complex tasks</p>
 
   <div class="meta-row">
     <span class="stars">★ 1.3K</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>Apache-2.0</span>
     
-    <span><span class="meta-label">updated</span>2026-08-21</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -391,7 +391,6 @@ contracts</a>, and the full
 <a href="https://pypi.org/project/autocontext/"><img src="https://img.shields.io/pypi/dm/autocontext?logo=pypi&amp;label=PyPI%20downloads" alt="PyPI downloads" loading="lazy" decoding="async"></a></p>
 <h3>Acknowledgments</h3>
 <p>Thanks to <a href="https://github.com/GeorgeH87">George</a> for generously donating the <code>autocontext</code> name on PyPI.</p>
-
   </section>
 </details>
 

--- a/projects/handnewb/hermes-cybersec-lab.html
+++ b/projects/handnewb/hermes-cybersec-lab.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/handnewb/hermes-cybersec-lab",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Shell",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "handnewb",
     "url": "https://github.com/handnewb"
   },
-  "dateModified": "2026-08-11T19:05:07.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,17 +118,26 @@
 
   <div class="meta-row">
     <span class="stars">★ 8</span>
-    <span><span class="meta-label">lang</span>Shell</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-11</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/handnewb/hermes-cybersec-lab" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://github.com/handnewb/hermes-cybersec-lab" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
+<aside class="install-box" aria-label="How to install this skill">
+  <div class="ib-label">install<span class="ib-type">collection</span></div>
+  <code class="ib-cmd">git clone https://github.com/handnewb/hermes-cybersec-lab.git, run scripts/clone-all.sh, then copy into ~/.hermes/profiles/&lt;profile&gt;/skills/cybersecurity-lab/.</code>
+  <p class="ib-compat">Hermes Agent native — the README targets ~/.hermes/profiles/&lt;profile&gt;/skills/ explicitly.</p>
+  <p class="ib-verdict">2,000+ skills stitched from 7 external repos plus 130+ installable tools (Sigma, YARA, MISP). A deeper turnkey lab than the Anthropic-Cybersecurity-Skills pack, but a heavier multi-repo clone — pick it for a dedicated security profile, not a quick add.</p>
+  <a class="ib-more" href="/skills/">more picks → the skills hub</a>
+</aside>
 
 
 
@@ -413,7 +420,6 @@ bash scripts/clone-all.sh
 <p>MIT — use freely, contribute back.</p>
 <hr>
 <p><em>This is a living lab. Tools, skills, and methodology improve with every engagement.</em></p>
-
   </section>
 </details>
 

--- a/projects/handnewb/hermes-voice.html
+++ b/projects/handnewb/hermes-voice.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/handnewb/hermes-voice",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/Apache-2.0.html",
   "author": {
     "@type": "Organization",
     "name": "handnewb",
     "url": "https://github.com/handnewb"
   },
-  "dateModified": "2026-08-10T13:13:52.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,10 +118,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 1</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>Apache-2.0</span>
     
-    <span><span class="meta-label">updated</span>2026-08-10</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -614,7 +614,6 @@ Apache-2.0, Silero VAD is MIT, openWakeWord is Apache-2.0.</p>
 <a href="https://github.com/handnewb/hermes-voice/blob/main/docs/VOICE_LICENSING.md"><code>docs/VOICE_LICENSING.md</code></a> for what stays out and why.</p>
 <h3>Acknowledgments</h3>
 <p><a href="https://github.com/NousResearch/hermes-agent">Hermes Agent</a> (Nous Research) • <a href="https://github.com/SYSTRAN/faster-whisper">faster-whisper</a> • <a href="https://github.com/snakers4/silero-vad">Silero VAD</a> • <a href="https://github.com/rhasspy/piper">Piper</a> • <a href="https://github.com/dscripka/openWakeWord">openWakeWord</a> • <a href="https://huggingface.co/hexgrad/Kokoro-82M">Kokoro-82M</a> • <a href="https://github.com/thewh1teagle/kokoro-onnx">kokoro-onnx</a></p>
-
   </section>
 </details>
 

--- a/projects/handnewb/lock-on-absence.html
+++ b/projects/handnewb/lock-on-absence.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/handnewb/lock-on-absence",
   "applicationCategory": "BusinessApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "handnewb",
     "url": "https://github.com/handnewb"
   },
-  "dateModified": "2026-08-11T15:55:52.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,17 +118,19 @@
 
   <div class="meta-row">
     <span class="stars">★ 2</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-11</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/handnewb/lock-on-absence" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://github.com/handnewb/lock-on-absence" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -1103,7 +1103,6 @@ and reports honestly when it cannot.</p>
 <h3>License</h3>
 <p>MIT © 2026 <a href="https://github.com/handnewb">Everton (handnewb)</a></p>
 <p>See <a href="LICENSE">LICENSE</a> for the full text.</p>
-
   </section>
 </details>
 

--- a/projects/hermes-labs-ai/lintlang.html
+++ b/projects/hermes-labs-ai/lintlang.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/hermes-labs-ai/lintlang">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=lintlang&amp;subtitle=Static+analysis+for+AI+agent+configs%2C+tool+descriptions%2C+and+system+prompts+%E2%80%94+catches+vague+tool+descriptions%2C+missing+stop+conditions%2C+and+schema+gaps+before+they+reach+runtime.+Z&amp;kind=project+%C2%B7+developer+tools">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=lintlang&amp;subtitle=Static+linter+for+AI+agent+configs%2C+tool+descriptions%2C+and+system+prompts.+HERM+v1.1+scoring.&amp;kind=project+%C2%B7+developer+tools">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="hermes-labs-ai/lintlang — Hermes Atlas">
 <meta name="twitter:description" content="LintLang is a static analysis tool for AI agent instructions, tool descriptions, and system prompts. It identifies patterns such as ambiguous tool…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=lintlang&amp;subtitle=Static+analysis+for+AI+agent+configs%2C+tool+descriptions%2C+and+system+prompts+%E2%80%94+catches+vague+tool+descriptions%2C+missing+stop+conditions%2C+and+schema+gaps+before+they+reach+runtime.+Z&amp;kind=project+%C2%B7+developer+tools">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=lintlang&amp;subtitle=Static+linter+for+AI+agent+configs%2C+tool+descriptions%2C+and+system+prompts.+HERM+v1.1+scoring.&amp;kind=project+%C2%B7+developer+tools">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/hermes-labs-ai/lintlang",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/Apache-2.0.html",
   "author": {
     "@type": "Organization",
     "name": "hermes-labs-ai",
     "url": "https://github.com/hermes-labs-ai"
   },
-  "dateModified": "2026-08-18T21:59:16.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">hermes-labs-ai</span><span class="slash">/</span>lintlang
   </h1>
-  <p class="project-desc">Static analysis for AI agent configs, tool descriptions, and system prompts — catches vague tool descriptions, missing stop conditions, and schema gaps before they reach runtime. Zero-LLM, deterministic checks, built for CI.</p>
+  <p class="project-desc">Static linter for AI agent configs, tool descriptions, and system prompts. HERM v1.1 scoring.</p>
 
   <div class="meta-row">
     <span class="stars">★ 61</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>Apache-2.0</span>
     
-    <span><span class="meta-label">updated</span>2026-08-18</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/hermes-labs-ai/lintlang" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://hermes-labs.ai" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -439,7 +439,6 @@ inspects one present instruction plus explicit context.</p>
 <h3>License</h3>
 <p><a href="LICENSE">Apache License 2.0</a></p>
 <p>LintLang is maintained by <a href="https://hermes-labs.ai">Hermes Labs</a>.</p>
-
   </section>
 </details>
 

--- a/projects/hlothaire/hermes-trace.html
+++ b/projects/hlothaire/hermes-trace.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/hlothaire/hermes-trace",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "hlothaire",
     "url": "https://github.com/hlothaire"
   },
-  "dateModified": "2026-06-18T11:41:26.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,10 +118,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 2</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-06-18</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -402,7 +402,6 @@ ruff format hermes_trace/
 development.</p>
 <h3>License</h3>
 <p>MIT</p>
-
   </section>
 </details>
 

--- a/projects/howdymary/hermes-agent-metaharness.html
+++ b/projects/howdymary/hermes-agent-metaharness.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/howdymary/hermes-agent-metaharness">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-metaharness&amp;subtitle=An+implementation+of+a+Meta+Harness+for+Hermes.&amp;kind=project+%C2%B7+multi-agent">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-metaharness&amp;subtitle=Meta-harness+for+Hermes+Agent+%E2%80%94+meta-optimization+with+arxiv+paper+reference&amp;kind=project+%C2%B7+multi-agent">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="howdymary/hermes-agent-metaharness — Hermes Atlas">
 <meta name="twitter:description" content="Hermes Agent Meta-Harness is a standalone outer-loop optimizer designed to improve LLM system quality by optimizing the code that manages context and…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-metaharness&amp;subtitle=An+implementation+of+a+Meta+Harness+for+Hermes.&amp;kind=project+%C2%B7+multi-agent">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-metaharness&amp;subtitle=Meta-harness+for+Hermes+Agent+%E2%80%94+meta-optimization+with+arxiv+paper+reference&amp;kind=project+%C2%B7+multi-agent">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/howdymary/hermes-agent-metaharness",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "howdymary",
     "url": "https://github.com/howdymary"
   },
-  "dateModified": "2026-07-11T00:33:52.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">howdymary</span><span class="slash">/</span>hermes-agent-metaharness
   </h1>
-  <p class="project-desc">An implementation of a Meta Harness for Hermes.</p>
+  <p class="project-desc">Meta-harness for Hermes Agent — meta-optimization with arxiv paper reference</p>
 
   <div class="meta-row">
     <span class="stars">★ 107</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-07-11</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -339,7 +339,6 @@ and how they map onto this repo's next steps.</p>
 <li>Frontier-aware search strategies</li>
 <li>Stronger benchmark-aware candidate generation</li>
 </ol>
-
   </section>
 </details>
 

--- a/projects/hxsteric/mercury.html
+++ b/projects/hxsteric/mercury.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/hxsteric/mercury">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=mercury&amp;subtitle=Mercury+%E2%80%94+Blockchain+Cash+Flow+Analyzer+%7C+Hermes+Agent+Skill+for+multi-chain+analysis%2C+fraud+detection%2C+trading+strategy+%26+interactive+WebGL+dashboard&amp;kind=project+%C2%B7+domain+applications">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=mercury&amp;subtitle=Blockchain+cash+flow+analyzer+%E2%80%94+multi-chain+analysis%2C+fraud+detection%2C+WebGL+dashboard&amp;kind=project+%C2%B7+domain+applications">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="hxsteric/mercury — Hermes Atlas">
 <meta name="twitter:description" content="Mercury is a blockchain cash flow analyzer and Hermes Agent skill designed to provide transparency into wallet activities across Ethereum, Base, and Solana. It…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=mercury&amp;subtitle=Mercury+%E2%80%94+Blockchain+Cash+Flow+Analyzer+%7C+Hermes+Agent+Skill+for+multi-chain+analysis%2C+fraud+detection%2C+trading+strategy+%26+interactive+WebGL+dashboard&amp;kind=project+%C2%B7+domain+applications">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=mercury&amp;subtitle=Blockchain+cash+flow+analyzer+%E2%80%94+multi-chain+analysis%2C+fraud+detection%2C+WebGL+dashboard&amp;kind=project+%C2%B7+domain+applications">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/hxsteric/mercury",
   "applicationCategory": "BusinessApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
   "author": {
     "@type": "Organization",
     "name": "hxsteric",
     "url": "https://github.com/hxsteric"
   },
-  "dateModified": "2026-03-15T22:36:06.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">hxsteric</span><span class="slash">/</span>mercury
   </h1>
-  <p class="project-desc">Mercury — Blockchain Cash Flow Analyzer | Hermes Agent Skill for multi-chain analysis, fraud detection, trading strategy &amp; interactive WebGL dashboard</p>
+  <p class="project-desc">Blockchain cash flow analyzer — multi-chain analysis, fraud detection, WebGL dashboard</p>
 
   <div class="meta-row">
     <span class="stars">★ 18</span>
-    <span><span class="meta-label">lang</span>Python</span>
     
     
-    <span><span class="meta-label">updated</span>2026-03-15</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -296,7 +297,6 @@ python3 scripts/dashboard_server.py \
 <p>MIT</p>
 <h3>Credits</h3>
 <p>Built for the <a href="https://nousresearch.com">Nous Research Hermes Agent Hackathon</a> — March 2026</p>
-
   </section>
 </details>
 

--- a/projects/iOfficeAI/AionUi.html
+++ b/projects/iOfficeAI/AionUi.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/iOfficeAI/AionUi">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=AionUi&amp;subtitle=Open-source+24%2F7+Cowork+app+for+OpenClaw%2C+Hermes%2C+Claude+Code%2C+Codex%2C+OpenCode+and+20%2B+more+CLI+Agent+%7C+Customize+your+assistants+%7C+Team+them+up%EF%BD%9CStar+if+you+like+it%21&amp;kind=project+%C2%B7+workspaces">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=AionUi&amp;subtitle=Local+open-source+cowork+app+for+OpenClaw%2C+Hermes+Agent%2C+Claude+Code%2C+Codex%2C+OpenCode%2C+Gemini+CLI%2C+and+other+agent+CLIs&amp;kind=project+%C2%B7+workspaces">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="iOfficeAI/AionUi — Hermes Atlas">
 <meta name="twitter:description" content="AionUi is an open-source cross-platform application that provides a unified interface for multiple AI agents to perform autonomous tasks on a user's computer.…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=AionUi&amp;subtitle=Open-source+24%2F7+Cowork+app+for+OpenClaw%2C+Hermes%2C+Claude+Code%2C+Codex%2C+OpenCode+and+20%2B+more+CLI+Agent+%7C+Customize+your+assistants+%7C+Team+them+up%EF%BD%9CStar+if+you+like+it%21&amp;kind=project+%C2%B7+workspaces">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=AionUi&amp;subtitle=Local+open-source+cowork+app+for+OpenClaw%2C+Hermes+Agent%2C+Claude+Code%2C+Codex%2C+OpenCode%2C+Gemini+CLI%2C+and+other+agent+CLIs&amp;kind=project+%C2%B7+workspaces">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/iOfficeAI/AionUi",
   "applicationCategory": "DesktopEnhancementApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TypeScript",
-  "license": "https://spdx.org/licenses/Apache-2.0.html",
   "author": {
     "@type": "Organization",
     "name": "iOfficeAI",
     "url": "https://github.com/iOfficeAI"
   },
-  "dateModified": "2026-08-21T09:57:48.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">iOfficeAI</span><span class="slash">/</span>AionUi
   </h1>
-  <p class="project-desc">Open-source 24/7 Cowork app for OpenClaw, Hermes, Claude Code, Codex, OpenCode and 20+ more CLI Agent | Customize your assistants | Team them up｜Star if you like it!</p>
+  <p class="project-desc">Local open-source cowork app for OpenClaw, Hermes Agent, Claude Code, Codex, OpenCode, Gemini CLI, and other agent CLIs</p>
 
   <div class="meta-row">
     <span class="stars">★ 32.2K</span>
-    <span><span class="meta-label">lang</span>TypeScript</span>
-    <span><span class="meta-label">license</span>Apache-2.0</span>
     
-    <span><span class="meta-label">updated</span>2026-08-21</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/iOfficeAI/AionUi" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://www.aionui.com" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -916,7 +916,6 @@ brew install aionui
 </div>
 
 <p><sub><a href="https://linux.do/">LINUX DO - A New Ideal Community</a></sub></p>
-
   </section>
 </details>
 

--- a/projects/indranilbanerjee/contentforge.html
+++ b/projects/indranilbanerjee/contentforge.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/indranilbanerjee/contentforge">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=contentforge&amp;subtitle=An+open-source+editorial+production+system+that+researches%2C+verifies%2C+drafts%2C+and+delivers+publication-ready+long-form+content+with+human+review+and+provenance+built+in.&amp;kind=project+%C2%B7+plugins">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=contentforge&amp;subtitle=Open-source+enterprise+content+production+plugin+%E2%80%94+21+skills%2C+13+agents%2C+11+quality+gates%2C+29-pattern+AI+humanizer%2C+fact-checker%2C+real+.docx+output+with+C2PA+signing+%28EU+AI+Act+Art&amp;kind=project+%C2%B7+plugins">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="indranilbanerjee/contentforge — Hermes Atlas">
 <meta name="twitter:description" content="ContentForge is an open-source content production system that uses a 10-phase pipeline to generate publication-ready .docx files. The system utilizes 13…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=contentforge&amp;subtitle=An+open-source+editorial+production+system+that+researches%2C+verifies%2C+drafts%2C+and+delivers+publication-ready+long-form+content+with+human+review+and+provenance+built+in.&amp;kind=project+%C2%B7+plugins">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=contentforge&amp;subtitle=Open-source+enterprise+content+production+plugin+%E2%80%94+21+skills%2C+13+agents%2C+11+quality+gates%2C+29-pattern+AI+humanizer%2C+fact-checker%2C+real+.docx+output+with+C2PA+signing+%28EU+AI+Act+Art&amp;kind=project+%C2%B7+plugins">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/indranilbanerjee/contentforge",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "indranilbanerjee",
     "url": "https://github.com/indranilbanerjee"
   },
-  "dateModified": "2026-08-17T10:50:27.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">indranilbanerjee</span><span class="slash">/</span>contentforge
   </h1>
-  <p class="project-desc">An open-source editorial production system that researches, verifies, drafts, and delivers publication-ready long-form content with human review and provenance built in.</p>
+  <p class="project-desc">Open-source enterprise content production plugin — 21 skills, 13 agents, 11 quality gates, 29-pattern AI humanizer, fact-checker, real .docx output with C2PA signing (EU AI Act Article 50 ready). Inst</p>
 
   <div class="meta-row">
     <span class="stars">★ 22</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-17</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/indranilbanerjee/contentforge" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://indranil.in" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -878,7 +878,6 @@ python scripts/resolve_model.py --check &lt;some-old-model-id&gt;      # warns w
 
 *README truncated. [Continue reading on GitHub](https://github.com/indranilbanerjee/contentforge#readme)*
 </code></pre>
-
   </section>
 </details>
 

--- a/projects/indranilbanerjee/digital-marketing-pro.html
+++ b/projects/indranilbanerjee/digital-marketing-pro.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/indranilbanerjee/digital-marketing-pro">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=digital-marketing-pro&amp;subtitle=An+open-source+AI+marketing+operating+system+for+strategy%2C+SEO%2C+AEO%2FGEO%2C+paid+media%2C+content%2C+CRM%2C+and+analytics+-+grounded+in+brand+context%2C+human+approval%2C+and+verifiable+outputs&amp;kind=project+%C2%B7+plugins">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=digital-marketing-pro&amp;subtitle=Open-source+AI+marketing+plugin+for+agencies+%26+in-house+teams+%E2%80%94+158+skills%2C+25+specialist+agents%2C+12-Part+Strategy+Flow%2C+Cowork+team-persistent%2C+EU+AI+Act+Article+50+ready%2C+6-platf&amp;kind=project+%C2%B7+plugins">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="indranilbanerjee/digital-marketing-pro — Hermes Atlas">
 <meta name="twitter:description" content="Digital Marketing Pro is an open-source AI marketing plugin designed for marketing agencies, consultancies, and in-house teams managing 50–200 brands. It…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=digital-marketing-pro&amp;subtitle=An+open-source+AI+marketing+operating+system+for+strategy%2C+SEO%2C+AEO%2FGEO%2C+paid+media%2C+content%2C+CRM%2C+and+analytics+-+grounded+in+brand+context%2C+human+approval%2C+and+verifiable+outputs&amp;kind=project+%C2%B7+plugins">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=digital-marketing-pro&amp;subtitle=Open-source+AI+marketing+plugin+for+agencies+%26+in-house+teams+%E2%80%94+158+skills%2C+25+specialist+agents%2C+12-Part+Strategy+Flow%2C+Cowork+team-persistent%2C+EU+AI+Act+Article+50+ready%2C+6-platf&amp;kind=project+%C2%B7+plugins">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/indranilbanerjee/digital-marketing-pro",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "indranilbanerjee",
     "url": "https://github.com/indranilbanerjee"
   },
-  "dateModified": "2026-08-17T10:50:14.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">indranilbanerjee</span><span class="slash">/</span>digital-marketing-pro
   </h1>
-  <p class="project-desc">An open-source AI marketing operating system for strategy, SEO, AEO/GEO, paid media, content, CRM, and analytics - grounded in brand context, human approval, and verifiable outputs.</p>
+  <p class="project-desc">Open-source AI marketing plugin for agencies &amp; in-house teams — 158 skills, 25 specialist agents, 12-Part Strategy Flow, Cowork team-persistent, EU AI Act Article 50 ready, 6-platform AEO/GEO incl. Go</p>
 
   <div class="meta-row">
     <span class="stars">★ 763</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-17</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/indranilbanerjee/digital-marketing-pro" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://indranil.in" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -843,7 +843,6 @@ git clone --depth=1 https://github.com/indranilbanerjee/digital-marketing-pro.gi
 <p>A calibration corpus of 39 documents published before 2022-11-01 — before ChatGPT was public, so human authorship is guaranteed by publication date rather than assumed — across marketing blogs, personal and technical essays, journalism and institutional reports, and academic and standards prose. Cut into 272 chunks of ~1000 words so both classes are compared at equal length, against 18 documents of default model prose. Two findings. First, of the 45 words in the LLM-favored lexicon, 23 fired and <strong>every one fired only on the human class</strong> — "robust", "facilitate" and "leverage" are ordinary technical English while current models have largely been trained off them, so as a gating signal it could only ever produce false positives. It is now advisory. Second, the gate fails 0 of 39 published human documents and catches 0 of 18 unedited model documents: it is a density floor, not evidence a piece was humanized, and the docs now say so. Also fixed: the content-engine instructed appending scan output to <code>05-humanize.md</code> while <code>authorship.py</code> measured that same file — on a real run that moved `author_word</p>
 <hr>
 <p><em>README truncated. <a href="https://github.com/indranilbanerjee/digital-marketing-pro#readme">Continue reading on GitHub</a></em></p>
-
   </section>
 </details>
 

--- a/projects/indranilbanerjee/socialforge.html
+++ b/projects/indranilbanerjee/socialforge.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/indranilbanerjee/socialforge">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=socialforge&amp;subtitle=An+open-source+social+media+production+system+that+turns+a+content+calendar+into+on-brand+copy%2C+images%2C+video%2C+and+client-ready+delivery+-+with+compliance+and+human+approval+built+&amp;kind=project+%C2%B7+plugins">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=socialforge&amp;subtitle=Open-source+agency-grade+social+media+production+plugin+%E2%80%94+16+skills%2C+25+commands%2C+AI+image+%28Nano+Banana+Pro%29+%2B+AI+video+%28Kling+v3.0+Pro%29+%2B+C2PA+signing+%28EU+AI+Act+Article+50%29.+Inst&amp;kind=project+%C2%B7+plugins">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="indranilbanerjee/socialforge — Hermes Atlas">
 <meta name="twitter:description" content="SocialForge is an open-source social media production engine designed for agencies and in-house teams to automate monthly content calendars. It features…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=socialforge&amp;subtitle=An+open-source+social+media+production+system+that+turns+a+content+calendar+into+on-brand+copy%2C+images%2C+video%2C+and+client-ready+delivery+-+with+compliance+and+human+approval+built+&amp;kind=project+%C2%B7+plugins">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=socialforge&amp;subtitle=Open-source+agency-grade+social+media+production+plugin+%E2%80%94+16+skills%2C+25+commands%2C+AI+image+%28Nano+Banana+Pro%29+%2B+AI+video+%28Kling+v3.0+Pro%29+%2B+C2PA+signing+%28EU+AI+Act+Article+50%29.+Inst&amp;kind=project+%C2%B7+plugins">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/indranilbanerjee/socialforge",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "indranilbanerjee",
     "url": "https://github.com/indranilbanerjee"
   },
-  "dateModified": "2026-08-17T10:50:35.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">indranilbanerjee</span><span class="slash">/</span>socialforge
   </h1>
-  <p class="project-desc">An open-source social media production system that turns a content calendar into on-brand copy, images, video, and client-ready delivery - with compliance and human approval built in.</p>
+  <p class="project-desc">Open-source agency-grade social media production plugin — 16 skills, 25 commands, AI image (Nano Banana Pro) + AI video (Kling v3.0 Pro) + C2PA signing (EU AI Act Article 50). Installs on Claude Code,</p>
 
   <div class="meta-row">
     <span class="stars">★ 32</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-17</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/indranilbanerjee/socialforge" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://indranil.in" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -641,7 +641,6 @@ Notion, Canva, Slack, Gmail, Google Calendar, Figma, fal.ai, Replicate, Asana, C
 <p>PRs welcome — especially on the four creative modes, platform-specific copy adaptation rules, and AI image/video model integrations. See <a href="https://github.com/indranilbanerjee/socialforge/blob/main/CONTRIBUTING.md">CONTRIBUTING.md</a> for the workflow, <a href="https://github.com/indranilbanerjee/socialforge/blob/main/.github/PULL_REQUEST_TEMPLATE.md"><code>.github/PULL_REQUEST_TEMPLATE.md</code></a> for the PR checklist, and <a href="https://github.com/indranilbanerjee/socialforge/blob/main/TESTING-GUIDE.md">TESTING-GUIDE.md</a> for the test plan. All contributors are expected to follow the <a href="https://github.com/indranilbanerjee/socialforge/blob/main/CODE_OF_CONDUCT.md">Code of Conduct</a>. Security issues: use <a href="https://github.com/indranilbanerjee/socialforge/security/advisories/new">Private Security Advisories</a> per [SECURITY.md](SECURITY.</p>
 <hr>
 <p><em>README truncated. <a href="https://github.com/indranilbanerjee/socialforge#readme">Continue reading on GitHub</a></em></p>
-
   </section>
 </details>
 

--- a/projects/internet-court/internet-court-skill.html
+++ b/projects/internet-court/internet-court-skill.html
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/internet-court/internet-court-skill",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TypeScript",
   "author": {
     "@type": "Organization",
     "name": "internet-court",
     "url": "https://github.com/internet-court"
   },
-  "dateModified": "2026-08-19T15:00:54.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">internet-court</span><span class="slash">/</span>internet-court-skill
   </h1>
-  <p class="project-desc">The trust layer for agent-to-agent commerce — natural-language mandates, ERC-7710 delegated permissions, x402 payments, escrow, and dispute resolution as one open, catch-all Agent Skill / Claude Code plugin.</p>
+  <p class="project-desc">The trust layer for agent-to-agent commerce — natural-language mandates, ERC-7710 delegated permissions, x402 payments, escrow, and dispute resolution as one open, catch-all Agent Skill / Claude Code </p>
 
   <div class="meta-row">
     <span class="stars">★ 4.3K</span>
-    <span><span class="meta-label">lang</span>TypeScript</span>
     
     
-    <span><span class="meta-label">updated</span>2026-08-19</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,15 @@
     
   </div>
 </section>
+
+
+<aside class="install-box" aria-label="How to install this skill">
+  <div class="ib-label">install<span class="ib-type">collection</span></div>
+  <code class="ib-cmd">hermes skills tap add internet-court/internet-court-skill (the README prefers the tap over a direct URL install, which misses bundled reference files).</code>
+  <p class="ib-compat">Hermes Agent (tap), Claude Code (plugin marketplace or manual clone), OpenClaw, and Codex.</p>
+  <p class="ib-verdict">A genuinely new primitive — a master router plus vendored official protocol skills covering ERC-7710 delegated permissions, x402 payments, and escrow/dispute resolution as one catch-all agent-commerce skill.</p>
+  <a class="ib-more" href="/skills/">more picks → the skills hub</a>
+</aside>
 
 
 
@@ -453,7 +461,6 @@ are copies of upstream projects and remain under their own licenses; see each
 skill's source repository (and <code>skills-lock.json</code>) for terms.</p>
 <p>© 2026 Internet Court Consortium · Open standard, openly governed ·
 <a href="https://internetcourt.org">internetcourt.org</a></p>
-
   </section>
 </details>
 

--- a/projects/jau123/MeiGen-AI-Design-MCP.html
+++ b/projects/jau123/MeiGen-AI-Design-MCP.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/jau123/MeiGen-AI-Design-MCP">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=MeiGen-AI-Design-MCP&amp;subtitle=Supports+GPT+Image+2%2C+Seedance+%26+ComfyUI%2C+with+a+1%2C400%2B+prompt+library%2C+carefully+crafted+hooks+and+a+multi-task+orchestration+system&amp;kind=project+%C2%B7+plugins">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=MeiGen-AI-Design-MCP&amp;subtitle=Supports+GPT+Image+2%2C+Nanobanana+%26+ComfyUI%2C+with+a+1%2C400%2B+prompt+library%2C+carefully+crafted+hooks+and+a+multi-task+orchestration+system&amp;kind=project+%C2%B7+plugins">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="jau123/MeiGen-AI-Design-MCP — Hermes Atlas">
 <meta name="twitter:description" content="MeiGen AI Design MCP is an open-source MCP server that enables AI coding tools to perform image and video generation. It supports three backend modes: MeiGen…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=MeiGen-AI-Design-MCP&amp;subtitle=Supports+GPT+Image+2%2C+Seedance+%26+ComfyUI%2C+with+a+1%2C400%2B+prompt+library%2C+carefully+crafted+hooks+and+a+multi-task+orchestration+system&amp;kind=project+%C2%B7+plugins">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=MeiGen-AI-Design-MCP&amp;subtitle=Supports+GPT+Image+2%2C+Nanobanana+%26+ComfyUI%2C+with+a+1%2C400%2B+prompt+library%2C+carefully+crafted+hooks+and+a+multi-task+orchestration+system&amp;kind=project+%C2%B7+plugins">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/jau123/MeiGen-AI-Design-MCP",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TypeScript",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "jau123",
     "url": "https://github.com/jau123"
   },
-  "dateModified": "2026-08-05T12:09:47.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">jau123</span><span class="slash">/</span>MeiGen-AI-Design-MCP
   </h1>
-  <p class="project-desc">Supports GPT Image 2, Seedance &amp; ComfyUI, with a 1,400+ prompt library, carefully crafted hooks and a multi-task orchestration system</p>
+  <p class="project-desc">Supports GPT Image 2, Nanobanana &amp; ComfyUI, with a 1,400+ prompt library, carefully crafted hooks and a multi-task orchestration system</p>
 
   <div class="meta-row">
     <span class="stars">★ 1.7K</span>
-    <span><span class="meta-label">lang</span>TypeScript</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-05</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/jau123/MeiGen-AI-Design-MCP" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://meigen.ai" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -569,7 +569,6 @@ Response: { "success": true, "presignedUrl": "https://...", "publicUrl": "https:
 <hr>
 <h3>License</h3>
 <p><a href="LICENSE">MIT</a> — free for personal and commercial use.</p>
-
   </section>
 </details>
 

--- a/projects/jazzyalex/agent-sessions.html
+++ b/projects/jazzyalex/agent-sessions.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/jazzyalex/agent-sessions">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=agent-sessions&amp;subtitle=Local-first+macOS+app+to+browse%2C+search%2C+analyze%2C+and+resume+supported+AI+coding-agent+session+history+across+Codex%2C+Claude+Code%2C+OpenCode%2C+Cursor+Agent%2C+Hermes%2C+OpenClaw%2C+Copilot+&amp;kind=project+%C2%B7+workspaces">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=agent-sessions&amp;subtitle=Native+macOS+session+browser%2C+agent+cockpit%2C+analytics%2C+and+limits+tracker+for+Hermes+agents+and+other+coding-agent+CLIs&amp;kind=project+%C2%B7+workspaces">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="jazzyalex/agent-sessions — Hermes Atlas">
 <meta name="twitter:description" content="Agent Sessions is a local-only macOS application for browsing and searching transcripts from various coding-agent CLIs. It provides per-session quota tracking…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=agent-sessions&amp;subtitle=Local-first+macOS+app+to+browse%2C+search%2C+analyze%2C+and+resume+supported+AI+coding-agent+session+history+across+Codex%2C+Claude+Code%2C+OpenCode%2C+Cursor+Agent%2C+Hermes%2C+OpenClaw%2C+Copilot+&amp;kind=project+%C2%B7+workspaces">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=agent-sessions&amp;subtitle=Native+macOS+session+browser%2C+agent+cockpit%2C+analytics%2C+and+limits+tracker+for+Hermes+agents+and+other+coding-agent+CLIs&amp;kind=project+%C2%B7+workspaces">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/jazzyalex/agent-sessions",
   "applicationCategory": "DesktopEnhancementApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Swift",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "jazzyalex",
     "url": "https://github.com/jazzyalex"
   },
-  "dateModified": "2026-08-19T22:31:26.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">jazzyalex</span><span class="slash">/</span>agent-sessions
   </h1>
-  <p class="project-desc">Local-first macOS app to browse, search, analyze, and resume supported AI coding-agent session history across Codex, Claude Code, OpenCode, Cursor Agent, Hermes, OpenClaw, Copilot CLI, and more.</p>
+  <p class="project-desc">Native macOS session browser, agent cockpit, analytics, and limits tracker for Hermes agents and other coding-agent CLIs</p>
 
   <div class="meta-row">
     <span class="stars">★ 805</span>
-    <span><span class="meta-label">lang</span>Swift</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-19</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/jazzyalex/agent-sessions" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://jazzyalex.github.io/agent-sessions/?campaign=github&amp;ref=about-sidebar" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -458,7 +458,6 @@ reviewed code; Agent Sessions does not download provider plugins or infer suppor
 installed binary.</p>
 <h3>License</h3>
 <p>MIT. See <code>LICENSE</code>.</p>
-
   </section>
 </details>
 

--- a/projects/jefferyjob/awesome-hermes-agent-zh.html
+++ b/projects/jefferyjob/awesome-hermes-agent-zh.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/jefferyjob/awesome-hermes-agent-zh">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=awesome-hermes-agent-zh&amp;subtitle=Nous+Research+%E7%B2%BE%E5%BF%83%E6%95%B4%E7%90%86%E4%BA%86%E4%B8%80%E4%BB%BD%E9%80%82%E7%94%A8%E4%BA%8E+Hermes+Agent+%E7%9A%84%E5%AE%9E%E7%94%A8%E6%8A%80%E8%83%BD%E3%80%81%E5%B7%A5%E5%85%B7%E3%80%81%E9%9B%86%E6%88%90%E5%92%8C%E8%B5%84%E6%BA%90%E5%88%97%E8%A1%A8%E3%80%82&amp;kind=project+%C2%B7+guides">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=awesome-hermes-agent-zh&amp;subtitle=Chinese+awesome+list+of+practical+Hermes+Agent+skills%2C+tools%2C+integrations%2C+and+resources&amp;kind=project+%C2%B7+guides">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="jefferyjob/awesome-hermes-agent-zh — Hermes Atlas">
 <meta name="twitter:description" content="This repository is a Chinese translation of the awesome-hermes-agent list, providing a curated collection of skills, tools, and resources for the Hermes Agent…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=awesome-hermes-agent-zh&amp;subtitle=Nous+Research+%E7%B2%BE%E5%BF%83%E6%95%B4%E7%90%86%E4%BA%86%E4%B8%80%E4%BB%BD%E9%80%82%E7%94%A8%E4%BA%8E+Hermes+Agent+%E7%9A%84%E5%AE%9E%E7%94%A8%E6%8A%80%E8%83%BD%E3%80%81%E5%B7%A5%E5%85%B7%E3%80%81%E9%9B%86%E6%88%90%E5%92%8C%E8%B5%84%E6%BA%90%E5%88%97%E8%A1%A8%E3%80%82&amp;kind=project+%C2%B7+guides">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=awesome-hermes-agent-zh&amp;subtitle=Chinese+awesome+list+of+practical+Hermes+Agent+skills%2C+tools%2C+integrations%2C+and+resources&amp;kind=project+%C2%B7+guides">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/jefferyjob/awesome-hermes-agent-zh",
   "applicationCategory": "ReferenceApplication",
   "operatingSystem": "Cross-platform",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "jefferyjob",
     "url": "https://github.com/jefferyjob"
   },
-  "dateModified": "2026-08-04T10:43:13.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">jefferyjob</span><span class="slash">/</span>awesome-hermes-agent-zh
   </h1>
-  <p class="project-desc">Nous Research 精心整理了一份适用于 Hermes Agent 的实用技能、工具、集成和资源列表。</p>
+  <p class="project-desc">Chinese awesome list of practical Hermes Agent skills, tools, integrations, and resources</p>
 
   <div class="meta-row">
     <span class="stars">★ 65</span>
     
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-04</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -458,7 +459,6 @@
 <p><a id="license"></a></p>
 <h3>许可证</h3>
 <p>本仓库采用 <a href="LICENSE">MIT</a> 许可证。</p>
-
   </section>
 </details>
 

--- a/projects/jiawood2006/hermes-skills.html
+++ b/projects/jiawood2006/hermes-skills.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/jiawood2006/hermes-skills",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "jiawood2006",
     "url": "https://github.com/jiawood2006"
   },
-  "dateModified": "2026-08-21T01:00:47.000Z",
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
   }
@@ -81,6 +78,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -113,10 +111,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 0</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-21</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -124,6 +122,15 @@
     
   </div>
 </section>
+
+
+<aside class="install-box" aria-label="How to install this skill">
+  <div class="ib-label">install<span class="ib-type">collection</span></div>
+  <code class="ib-cmd">hermes skills install jiawood2006/hermes-skills/skills/video-to-text (repeat per skill: de-ai-writer, doc-ocr, ecommerce-material-studio).</code>
+  <p class="ib-compat">Hermes Agent native install commands documented directly in the README; portable to other agentskills.io clients via manual copy.</p>
+  <p class="ib-verdict">Four narrow, concrete skills — video transcription, AI-text de-humanizer, local OCR, e-commerce material generation — with correct Hermes-native install commands out of the box. Early-stage, but useful for e-commerce and Chinese-language workflows.</p>
+  <a class="ib-more" href="/skills/">more picks → the skills hub</a>
+</aside>
 
 
 
@@ -240,7 +247,6 @@ cp -r skills/video-to-text skills/de-ai-writer skills/doc-ocr skills/ecommerce-m
 <hr>
 <h3>📄 License</h3>
 <p>MIT — 自由使用，保留版权声明即可 / Free to use with attribution.</p>
-
   </section>
 </details>
 

--- a/projects/joeynyc/hermes-skins.html
+++ b/projects/joeynyc/hermes-skins.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/joeynyc/hermes-skins">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-skins&amp;subtitle=Custom+skins+%28visual+themes%29+for+the+Hermes+CLI+agent&amp;kind=project+%C2%B7+developer+tools">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-skins&amp;subtitle=Community+CLI+skins+and+themes+for+Hermes+terminal+UI&amp;kind=project+%C2%B7+developer+tools">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="joeynyc/hermes-skins — Hermes Atlas">
 <meta name="twitter:description" content="Hermes Skins provides custom visual themes for the Hermes CLI agent to customize its terminal user interface. Users can apply these themes by adding YAML…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-skins&amp;subtitle=Custom+skins+%28visual+themes%29+for+the+Hermes+CLI+agent&amp;kind=project+%C2%B7+developer+tools">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-skins&amp;subtitle=Community+CLI+skins+and+themes+for+Hermes+terminal+UI&amp;kind=project+%C2%B7+developer+tools">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/joeynyc/hermes-skins",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "joeynyc",
     "url": "https://github.com/joeynyc"
   },
-  "dateModified": "2026-06-28T18:44:10.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">joeynyc</span><span class="slash">/</span>hermes-skins
   </h1>
-  <p class="project-desc">Custom skins (visual themes) for the Hermes CLI agent</p>
+  <p class="project-desc">Community CLI skins and themes for Hermes terminal UI</p>
 
   <div class="meta-row">
     <span class="stars">★ 556</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-06-28</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -319,7 +319,6 @@ branding:
    <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=joeynyc/hermes-skins&amp;type=date&amp;legend=top-left">
  </picture>
 </a>
-
   </section>
 </details>
 

--- a/projects/jpalmae/hermeshq.html
+++ b/projects/jpalmae/hermeshq.html
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/jpalmae/hermeshq",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
   "author": {
     "@type": "Organization",
     "name": "jpalmae",
     "url": "https://github.com/jpalmae"
   },
-  "dateModified": "2026-08-19T03:03:47.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -119,17 +118,19 @@
 
   <div class="meta-row">
     <span class="stars">★ 25</span>
-    <span><span class="meta-label">lang</span>Python</span>
     
     
-    <span><span class="meta-label">updated</span>2026-08-19</span>
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/jpalmae/hermeshq" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://hermeshq.org" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -584,7 +585,6 @@ tts:
 <li><code>Space Grotesk</code></li>
 <li><code>Space Mono</code></li>
 </ul>
-
   </section>
 </details>
 

--- a/projects/junhoyeo/tokscale.html
+++ b/projects/junhoyeo/tokscale.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/junhoyeo/tokscale">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=tokscale&amp;subtitle=%F0%9F%9B%B0%EF%B8%8F+Track+token+usage+across+AI+coding+agents+from+your+terminal.+%F0%9F%8F%85+Global+leaderboard+with+trillions+of+tokens+tracked.&amp;kind=project+%C2%B7+developer+tools">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=tokscale&amp;subtitle=CLI+tool+for+tracking+token+usage+from+Claude+Code%2C+OpenClaw%2C+Hermes%2C+Codex%2C+Gemini%2C+and+more&amp;kind=project+%C2%B7+developer+tools">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="junhoyeo/tokscale — Hermes Atlas">
 <meta name="twitter:description" content="Tokscale is a CLI tool and visualization dashboard designed to monitor and analyze token consumption and costs. It tracks usage data from various AI coding…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=tokscale&amp;subtitle=%F0%9F%9B%B0%EF%B8%8F+Track+token+usage+across+AI+coding+agents+from+your+terminal.+%F0%9F%8F%85+Global+leaderboard+with+trillions+of+tokens+tracked.&amp;kind=project+%C2%B7+developer+tools">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=tokscale&amp;subtitle=CLI+tool+for+tracking+token+usage+from+Claude+Code%2C+OpenClaw%2C+Hermes%2C+Codex%2C+Gemini%2C+and+more&amp;kind=project+%C2%B7+developer+tools">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/junhoyeo/tokscale",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Rust",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "junhoyeo",
     "url": "https://github.com/junhoyeo"
   },
-  "dateModified": "2026-08-21T02:02:28.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">junhoyeo</span><span class="slash">/</span>tokscale
   </h1>
-  <p class="project-desc">🛰️ Track token usage across AI coding agents from your terminal. 🏅 Global leaderboard with trillions of tokens tracked.</p>
+  <p class="project-desc">CLI tool for tracking token usage from Claude Code, OpenClaw, Hermes, Codex, Gemini, and more</p>
 
   <div class="meta-row">
     <span class="stars">★ 5.1K</span>
-    <span><span class="meta-label">lang</span>Rust</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-21</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/junhoyeo/tokscale" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://tokscale.ai" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -1239,7 +1239,6 @@ tokscale report --workspace my-project --client opencode
 </ol>
 <hr>
 <p><em>README truncated. <a href="https://github.com/junhoyeo/tokscale#readme">Continue reading on GitHub</a></em></p>
-
   </section>
 </details>
 

--- a/projects/jwangkun/hermes-agent-guide.html
+++ b/projects/jwangkun/hermes-agent-guide.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/jwangkun/hermes-agent-guide">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-guide&amp;subtitle=Hermes+Agent+%E6%98%AF%E7%9B%AE%E5%89%8D%E5%BC%80%E6%BA%90%E7%A4%BE%E5%8C%BA%E6%9C%80%E5%85%B7%E6%BD%9C%E5%8A%9B%E7%9A%84+AI+Agent+%E6%A1%86%E6%9E%B6%E4%B9%8B%E4%B8%80%E3%80%82%E5%AE%83%E7%BB%A7%E6%89%BF%E4%BA%86+OpenClaw+%E7%9A%84%E4%BC%98%E7%A7%80%E5%9F%BA%E5%9B%A0%EF%BC%8C%E5%9C%A8%E6%9E%B6%E6%9E%84%E8%AE%BE%E8%AE%A1%E3%80%81%E8%AE%B0%E5%BF%86%E7%B3%BB%E7%BB%9F%E3%80%81%E6%8A%80%E8%83%BD%E7%94%9F%E6%80%81%E5%92%8C%E8%87%AA%E5%8A%A8%E5%8C%96%E8%83%BD%E5%8A%9B%E4%B8%8A%E5%AE%9E%E7%8E%B0%E5%85%A8%E9%9D%A2%E5%8D%87%E7%BA%A7%E3%80%82%E4%BD%86+Hermes+%E7%9A%84%E6%96%87%E6%A1%A3%E5%88%86%E6%95%A3%E5%9C%A8%E5%A4%9A%E4%B8%AA%E4%BB%93%E5%BA%93%E5%92%8C%E5%B9%B3%E5%8F%B0%EF%BC%8C%E7%BC%BA%E4%B9%8F%E4%B8%80%E6%9C%AC%E7%B3%BB%E7%BB%9F%E6%80%A7%E7%9A%84%E4%B8%AD%E6%96%87%E6%8C%87%E5%8D%97%E3%80%82++%E6%9C%AC%E4%B9%A6%E5%A1%AB%E8%A1%A5%E7%9A%84%E6%AD%A3%E6%98%AF%E8%BF%99%E4%B8%AA%E7%A9%BA%E7%99%BD%E3%80%82%E5%85%A8%E4%B9%A6+16+%E5%86%8C%E3%80%8130+%E4%B8%87%2B+%E5%AD%97%EF%BC%8C%E8%A6%86%E7%9B%96%E4%BB%8E%E5%AE%89%E8%A3%85%E9%83%A8%E7%BD%B2%E5%88%B0%E9%AB%98%E9%98%B6%E5%BC%80%E5%8F%91%E3%80%81%E4%BB%8E%E4%B8%AA%E4%BA%BA%E7%8E%A9%E8%B5%9A%E5%88%B0%E4%BC%81%E4%B8%9A%E6%9C%8D%E5%8A%A1%E3%80%81%E4%BB%8E&amp;kind=project+%C2%B7+guides">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-guide&amp;subtitle=A+systematic+Chinese-language+guide+to+Hermes+Agent+%E2%80%94+16+books%2C+300K%2B+words%2C+covering+installation%2C+advanced+development%2C+single-+and+multi-agent+orchestration.&amp;kind=project+%C2%B7+guides">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="jwangkun/hermes-agent-guide — Hermes Atlas">
 <meta name="twitter:description" content="This project is a comprehensive Chinese-language guide designed to provide a systematic learning path for the Hermes Agent framework. It organizes fragmented…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-guide&amp;subtitle=Hermes+Agent+%E6%98%AF%E7%9B%AE%E5%89%8D%E5%BC%80%E6%BA%90%E7%A4%BE%E5%8C%BA%E6%9C%80%E5%85%B7%E6%BD%9C%E5%8A%9B%E7%9A%84+AI+Agent+%E6%A1%86%E6%9E%B6%E4%B9%8B%E4%B8%80%E3%80%82%E5%AE%83%E7%BB%A7%E6%89%BF%E4%BA%86+OpenClaw+%E7%9A%84%E4%BC%98%E7%A7%80%E5%9F%BA%E5%9B%A0%EF%BC%8C%E5%9C%A8%E6%9E%B6%E6%9E%84%E8%AE%BE%E8%AE%A1%E3%80%81%E8%AE%B0%E5%BF%86%E7%B3%BB%E7%BB%9F%E3%80%81%E6%8A%80%E8%83%BD%E7%94%9F%E6%80%81%E5%92%8C%E8%87%AA%E5%8A%A8%E5%8C%96%E8%83%BD%E5%8A%9B%E4%B8%8A%E5%AE%9E%E7%8E%B0%E5%85%A8%E9%9D%A2%E5%8D%87%E7%BA%A7%E3%80%82%E4%BD%86+Hermes+%E7%9A%84%E6%96%87%E6%A1%A3%E5%88%86%E6%95%A3%E5%9C%A8%E5%A4%9A%E4%B8%AA%E4%BB%93%E5%BA%93%E5%92%8C%E5%B9%B3%E5%8F%B0%EF%BC%8C%E7%BC%BA%E4%B9%8F%E4%B8%80%E6%9C%AC%E7%B3%BB%E7%BB%9F%E6%80%A7%E7%9A%84%E4%B8%AD%E6%96%87%E6%8C%87%E5%8D%97%E3%80%82++%E6%9C%AC%E4%B9%A6%E5%A1%AB%E8%A1%A5%E7%9A%84%E6%AD%A3%E6%98%AF%E8%BF%99%E4%B8%AA%E7%A9%BA%E7%99%BD%E3%80%82%E5%85%A8%E4%B9%A6+16+%E5%86%8C%E3%80%8130+%E4%B8%87%2B+%E5%AD%97%EF%BC%8C%E8%A6%86%E7%9B%96%E4%BB%8E%E5%AE%89%E8%A3%85%E9%83%A8%E7%BD%B2%E5%88%B0%E9%AB%98%E9%98%B6%E5%BC%80%E5%8F%91%E3%80%81%E4%BB%8E%E4%B8%AA%E4%BA%BA%E7%8E%A9%E8%B5%9A%E5%88%B0%E4%BC%81%E4%B8%9A%E6%9C%8D%E5%8A%A1%E3%80%81%E4%BB%8E&amp;kind=project+%C2%B7+guides">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-guide&amp;subtitle=A+systematic+Chinese-language+guide+to+Hermes+Agent+%E2%80%94+16+books%2C+300K%2B+words%2C+covering+installation%2C+advanced+development%2C+single-+and+multi-agent+orchestration.&amp;kind=project+%C2%B7+guides">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/jwangkun/hermes-agent-guide",
   "applicationCategory": "ReferenceApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
   "author": {
     "@type": "Organization",
     "name": "jwangkun",
     "url": "https://github.com/jwangkun"
   },
-  "dateModified": "2026-04-22T13:17:10.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">jwangkun</span><span class="slash">/</span>hermes-agent-guide
   </h1>
-  <p class="project-desc">Hermes Agent 是目前开源社区最具潜力的 AI Agent 框架之一。它继承了 OpenClaw 的优秀基因，在架构设计、记忆系统、技能生态和自动化能力上实现全面升级。但 Hermes 的文档分散在多个仓库和平台，缺乏一本系统性的中文指南。  本书填补的正是这个空白。全书 16 册、30 万+ 字，覆盖从安装部署到高阶开发、从个人玩赚到企业服务、从单 Agent 操控到多 Agent 编排的完整知识图谱。</p>
+  <p class="project-desc">A systematic Chinese-language guide to Hermes Agent — 16 books, 300K+ words, covering installation, advanced development, single- and multi-agent orchestration.</p>
 
   <div class="meta-row">
     <span class="stars">★ 649</span>
-    <span><span class="meta-label">lang</span>Python</span>
     
     
-    <span><span class="meta-label">updated</span>2026-04-22</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -384,7 +385,6 @@ python generate_pdf.py
 <p><strong>让我们一起开始这段「养马之旅」。</strong></p>
 <p>—— 鲲鹏Talk，2026 年 4 月</p>
 </blockquote>
-
   </section>
 </details>
 

--- a/projects/kaminocorp/hermes-alpha.html
+++ b/projects/kaminocorp/hermes-alpha.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/kaminocorp/hermes-alpha">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-alpha&amp;subtitle=Cloud+deployed+version+of+the+Nous+Research+Hermes+agent&amp;kind=project+%C2%B7+forks">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-alpha&amp;subtitle=Cloud-deployed+Hermes+with+pre-configured+templates+and+managed+infrastructure&amp;kind=project+%C2%B7+forks">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="kaminocorp/hermes-alpha — Hermes Atlas">
 <meta name="twitter:description" content="Hermes Alpha is an experimental framework designed to test if a stock AI agent can bootstrap an autonomous bug bounty system from first principles. It utilizes…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-alpha&amp;subtitle=Cloud+deployed+version+of+the+Nous+Research+Hermes+agent&amp;kind=project+%C2%B7+forks">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-alpha&amp;subtitle=Cloud-deployed+Hermes+with+pre-configured+templates+and+managed+infrastructure&amp;kind=project+%C2%B7+forks">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/kaminocorp/hermes-alpha",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/Apache-2.0.html",
   "author": {
     "@type": "Organization",
     "name": "kaminocorp",
     "url": "https://github.com/kaminocorp"
   },
-  "dateModified": "2026-03-16T00:14:28.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">kaminocorp</span><span class="slash">/</span>hermes-alpha
   </h1>
-  <p class="project-desc">Cloud deployed version of the Nous Research Hermes agent</p>
+  <p class="project-desc">Cloud-deployed Hermes with pre-configured templates and managed infrastructure</p>
 
   <div class="meta-row">
     <span class="stars">★ 228</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>Apache-2.0</span>
     
-    <span><span class="meta-label">updated</span>2026-03-16</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -428,7 +428,6 @@ SLACK_BOT_TOKEN=...
 <p align="center">
   <sub>A <a href="https://github.com/crimson-sun">Crimson Sun</a> experiment</sub>
 </p>
-
   </section>
 </details>
 

--- a/projects/kevinmarmstrong/hermes-claude-code-rc.html
+++ b/projects/kevinmarmstrong/hermes-claude-code-rc.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/kevinmarmstrong/hermes-claude-code-rc",
   "applicationCategory": "CommunicationApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "kevinmarmstrong",
     "url": "https://github.com/kevinmarmstrong"
   },
-  "dateModified": "2026-04-15T02:12:37.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,10 +118,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 3</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-04-15</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -379,7 +379,6 @@ Phone (Claude app) &lt;-- claude.ai session URL &lt;-- stdout scan
 </ul>
 <h3>License</h3>
 <p>MIT</p>
-
   </section>
 </details>
 

--- a/projects/kfa-ai/hermes-timetree-sync.html
+++ b/projects/kfa-ai/hermes-timetree-sync.html
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/kfa-ai/hermes-timetree-sync",
   "applicationCategory": "CommunicationApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
   "author": {
     "@type": "Organization",
     "name": "kfa-ai",
     "url": "https://github.com/kfa-ai"
   },
-  "dateModified": "2026-05-22T21:29:05.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -119,17 +118,19 @@
 
   <div class="meta-row">
     <span class="stars">★ 1</span>
-    <span><span class="meta-label">lang</span>Python</span>
     
     
-    <span><span class="meta-label">updated</span>2026-05-22</span>
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/kfa-ai/hermes-timetree-sync" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://github.com/kfa-ai/hermes-timetree-sync" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -300,7 +301,6 @@ TIMETREE_PASSWORD=...
 </ul>
 <h3>License</h3>
 <p>Private/internal project unless a license is added later.</p>
-
   </section>
 </details>
 

--- a/projects/ksimback/hermes-ecosystem.html
+++ b/projects/ksimback/hermes-ecosystem.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/ksimback/hermes-ecosystem">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-ecosystem&amp;subtitle=%F0%9F%97%BA%EF%B8%8F+Hermes+Atlas+%E2%80%94+the+community+map+of+every+tool%2C+skill%2C+and+integration+for+Hermes+Agent+by+Nous+Research.+Live+at+hermesatlas.com&amp;kind=project+%C2%B7+guides">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-ecosystem&amp;subtitle=Hermes+Atlas+%E2%80%94+the+community+map+of+every+tool%2C+skill%2C+and+integration+for+Hermes+Agent+by+Nous+Research&amp;kind=project+%C2%B7+guides">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="ksimback/hermes-ecosystem — Hermes Atlas">
 <meta name="twitter:description" content="Hermes Atlas is a community-curated directory and map of tools, skills, and integrations for the Nous Research Hermes Agent. It features a quality-filtered…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-ecosystem&amp;subtitle=%F0%9F%97%BA%EF%B8%8F+Hermes+Atlas+%E2%80%94+the+community+map+of+every+tool%2C+skill%2C+and+integration+for+Hermes+Agent+by+Nous+Research.+Live+at+hermesatlas.com&amp;kind=project+%C2%B7+guides">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-ecosystem&amp;subtitle=Hermes+Atlas+%E2%80%94+the+community+map+of+every+tool%2C+skill%2C+and+integration+for+Hermes+Agent+by+Nous+Research&amp;kind=project+%C2%B7+guides">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/ksimback/hermes-ecosystem",
   "applicationCategory": "ReferenceApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "HTML",
   "author": {
     "@type": "Organization",
     "name": "ksimback",
     "url": "https://github.com/ksimback"
   },
-  "dateModified": "2026-08-21T10:38:25.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">ksimback</span><span class="slash">/</span>hermes-ecosystem
   </h1>
-  <p class="project-desc">🗺️ Hermes Atlas — the community map of every tool, skill, and integration for Hermes Agent by Nous Research. Live at hermesatlas.com</p>
+  <p class="project-desc">Hermes Atlas — the community map of every tool, skill, and integration for Hermes Agent by Nous Research</p>
 
   <div class="meta-row">
     <span class="stars">★ 1.2K</span>
-    <span><span class="meta-label">lang</span>HTML</span>
     
     
-    <span><span class="meta-label">updated</span>2026-08-21</span>
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://hermesatlas.com" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -282,7 +283,6 @@ OPENROUTER_API_KEY=sk-or-... node scripts/test-rag.js
 <p>Site code: MIT. Research content: CC BY 4.0. Repo descriptions and metadata are sourced from the upstream projects' own documentation.</p>
 <hr>
 <p>Built by <a href="https://github.com/ksimback">@ksimback</a>. Not officially affiliated with Nous Research — community project celebrating their work.</p>
-
   </section>
 </details>
 

--- a/projects/liaohch3/claude-tap.html
+++ b/projects/liaohch3/claude-tap.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/liaohch3/claude-tap">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=claude-tap&amp;subtitle=Intercept+and+inspect+Coding+Agent+API+traffic+from+Claude+Code%2C+Codex+CLI%2C+Gemini+CLI%2C+Cursor+CLI%2C+OpenCode%2C+Kimi%2FKimi+Code%2C+Pi%2C+and+Hermes+in+a+local+trace+viewer.&amp;kind=project+%C2%B7+developer+tools">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=claude-tap&amp;subtitle=Local+trace+viewer+for+inspecting+coding-agent+API+traffic+from+Hermes+Agent%2C+Claude+Code%2C+Codex%2C+Gemini%2C+Cursor%2C+OpenCode%2C+and+others&amp;kind=project+%C2%B7+developer+tools">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="liaohch3/claude-tap — Hermes Atlas">
 <meta name="twitter:description" content="claude-tap is a local proxy and trace viewer designed to inspect API traffic and agent context for AI coding agents. It allows users to view system prompts,…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=claude-tap&amp;subtitle=Intercept+and+inspect+Coding+Agent+API+traffic+from+Claude+Code%2C+Codex+CLI%2C+Gemini+CLI%2C+Cursor+CLI%2C+OpenCode%2C+Kimi%2FKimi+Code%2C+Pi%2C+and+Hermes+in+a+local+trace+viewer.&amp;kind=project+%C2%B7+developer+tools">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=claude-tap&amp;subtitle=Local+trace+viewer+for+inspecting+coding-agent+API+traffic+from+Hermes+Agent%2C+Claude+Code%2C+Codex%2C+Gemini%2C+Cursor%2C+OpenCode%2C+and+others&amp;kind=project+%C2%B7+developer+tools">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/liaohch3/claude-tap",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "liaohch3",
     "url": "https://github.com/liaohch3"
   },
-  "dateModified": "2026-08-21T10:37:41.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">liaohch3</span><span class="slash">/</span>claude-tap
   </h1>
-  <p class="project-desc">Intercept and inspect Coding Agent API traffic from Claude Code, Codex CLI, Gemini CLI, Cursor CLI, OpenCode, Kimi/Kimi Code, Pi, and Hermes in a local trace viewer.</p>
+  <p class="project-desc">Local trace viewer for inspecting coding-agent API traffic from Hermes Agent, Claude Code, Codex, Gemini, Cursor, OpenCode, and others</p>
 
   <div class="meta-row">
     <span class="stars">★ 3.1K</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-21</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -845,7 +845,6 @@ claude-tap --tap-no-open
 <p>Contributions are welcome. Start with <a href="https://github.com/liaohch3/claude-tap/blob/main/CONTRIBUTING.md">CONTRIBUTING.md</a>.</p>
 <h3>License</h3>
 <p>MIT</p>
-
   </section>
 </details>
 

--- a/projects/liftaris/herm.html
+++ b/projects/liftaris/herm.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/liftaris/herm">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=herm&amp;subtitle=The+Hermes+TUI+built+with+OpenTUI&amp;kind=project+%C2%B7+workspaces">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=herm&amp;subtitle=Alternative+Hermes+TUI+and+dashboard+built+with+OpenTUI.&amp;kind=project+%C2%B7+workspaces">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="liftaris/herm — Hermes Atlas">
 <meta name="twitter:description" content="Herm is a terminal user interface and dashboard for the Hermes Agent gateway. It provides an operator-focused interface for chatting, managing sessions, and…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=herm&amp;subtitle=The+Hermes+TUI+built+with+OpenTUI&amp;kind=project+%C2%B7+workspaces">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=herm&amp;subtitle=Alternative+Hermes+TUI+and+dashboard+built+with+OpenTUI.&amp;kind=project+%C2%B7+workspaces">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/liftaris/herm",
   "applicationCategory": "DesktopEnhancementApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TypeScript",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "liftaris",
     "url": "https://github.com/liftaris"
   },
-  "dateModified": "2026-07-29T08:24:03.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">liftaris</span><span class="slash">/</span>herm
   </h1>
-  <p class="project-desc">The Hermes TUI built with OpenTUI</p>
+  <p class="project-desc">Alternative Hermes TUI and dashboard built with OpenTUI.</p>
 
   <div class="meta-row">
     <span class="stars">★ 290</span>
-    <span><span class="meta-label">lang</span>TypeScript</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-07-29</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -321,7 +321,6 @@ runtime Herm operates</li>
 </ul>
 <h3>License</h3>
 <p>MIT - see <a href="./LICENSE">LICENSE</a>.</p>
-
   </section>
 </details>
 

--- a/projects/linke-ai/hermes-agent-team.html
+++ b/projects/linke-ai/hermes-agent-team.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/linke-ai/hermes-agent-team">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-team&amp;subtitle=%E5%9F%BA%E4%BA%8E+Hermes+Agent+%E6%9E%84%E5%BB%BA%E7%9A%84%E6%9C%AC%E5%9C%B0%E5%A4%9A+Agent+%E5%9B%A2%E9%98%9F%E5%8D%8F%E4%BD%9C+Web+%E7%B3%BB%E7%BB%9F&amp;kind=project+%C2%B7+multi-agent">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-team&amp;subtitle=Local+multi-agent+team+collaboration+web+system+built+on+Hermes+Agent+profiles%2C+MCP%2C+ACP%2C+and+Hermes+Kanban&amp;kind=project+%C2%B7+multi-agent">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="linke-ai/hermes-agent-team — Hermes Atlas">
 <meta name="twitter:description" content="Hermes Agents Team is a local web-based system designed to orchestrate multi-agent collaboration using Hermes Agent profiles. It utilizes a Leader/Specialist…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-team&amp;subtitle=%E5%9F%BA%E4%BA%8E+Hermes+Agent+%E6%9E%84%E5%BB%BA%E7%9A%84%E6%9C%AC%E5%9C%B0%E5%A4%9A+Agent+%E5%9B%A2%E9%98%9F%E5%8D%8F%E4%BD%9C+Web+%E7%B3%BB%E7%BB%9F&amp;kind=project+%C2%B7+multi-agent">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-team&amp;subtitle=Local+multi-agent+team+collaboration+web+system+built+on+Hermes+Agent+profiles%2C+MCP%2C+ACP%2C+and+Hermes+Kanban&amp;kind=project+%C2%B7+multi-agent">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/linke-ai/hermes-agent-team",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "linke-ai",
     "url": "https://github.com/linke-ai"
   },
-  "dateModified": "2026-05-20T08:55:37.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">linke-ai</span><span class="slash">/</span>hermes-agent-team
   </h1>
-  <p class="project-desc">基于 Hermes Agent 构建的本地多 Agent 团队协作 Web 系统</p>
+  <p class="project-desc">Local multi-agent team collaboration web system built on Hermes Agent profiles, MCP, ACP, and Hermes Kanban</p>
 
   <div class="meta-row">
     <span class="stars">★ 179</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-05-20</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -338,7 +338,6 @@ pip install -r requirements.txt
 <h3>安全</h3>
 <p>安全注意事项见 <a href="https://github.com/linke-ai/hermes-agent-team/blob/main/SECURITY.md">SECURITY.md</a>。</p>
 <p>MCP headers/env 等敏感字段会在界面展示和导出时做脱敏处理；运行所需的真实凭据仍保存在本机 Hermes profile 配置中，请不要提交或公开这些本地配置文件。</p>
-
   </section>
 </details>
 

--- a/projects/longsizhuo/openInvest.html
+++ b/projects/longsizhuo/openInvest.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/longsizhuo/openInvest">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=openInvest&amp;subtitle=Research-grade+investment+decision+engine+for+AI+agents%3A+isolated+multi-agent+committee%2C+auditable+verdicts%2C+backtests+with+lookahead+protection%2C+published+negative+results&amp;kind=project+%C2%B7+domain+applications">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=openInvest&amp;subtitle=%E5%9F%BA%E4%BA%8Emultiple+LLM%E7%9A%84%E9%A3%8E%E9%99%A9%E6%8A%95%E8%B5%84%E5%8A%A9%E6%89%8B&amp;kind=project+%C2%B7+domain+applications">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="longsizhuo/openInvest — Hermes Atlas">
 <meta name="twitter:description" content="openInvest is a self-hosted investment decision engine designed to power AI agents. It provides a verifiable investment committee with evidence-based reasoning…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=openInvest&amp;subtitle=Research-grade+investment+decision+engine+for+AI+agents%3A+isolated+multi-agent+committee%2C+auditable+verdicts%2C+backtests+with+lookahead+protection%2C+published+negative+results&amp;kind=project+%C2%B7+domain+applications">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=openInvest&amp;subtitle=%E5%9F%BA%E4%BA%8Emultiple+LLM%E7%9A%84%E9%A3%8E%E9%99%A9%E6%8A%95%E8%B5%84%E5%8A%A9%E6%89%8B&amp;kind=project+%C2%B7+domain+applications">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/longsizhuo/openInvest",
   "applicationCategory": "BusinessApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "longsizhuo",
     "url": "https://github.com/longsizhuo"
   },
-  "dateModified": "2026-08-21T09:00:02.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">longsizhuo</span><span class="slash">/</span>openInvest
   </h1>
-  <p class="project-desc">Research-grade investment decision engine for AI agents: isolated multi-agent committee, auditable verdicts, backtests with lookahead protection, published negative results</p>
+  <p class="project-desc">基于multiple LLM的风险投资助手</p>
 
   <div class="meta-row">
     <span class="stars">★ 81</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-21</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/longsizhuo/openInvest" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://openInvest.involutionhell.com" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -378,7 +378,6 @@ INVEST_HOME=~/openInvest uvx openinvest status
 <hr>
 <h3>License</h3>
 <p>This project is licensed under the MIT License - see the <a href="LICENSE">LICENSE</a> file for details.</p>
-
   </section>
 </details>
 

--- a/projects/longyunfeigu/learn-hermes-agent.html
+++ b/projects/longyunfeigu/learn-hermes-agent.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/longyunfeigu/learn-hermes-agent">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=learn-hermes-agent&amp;subtitle=A+27-chapter+hands-on+tutorial+for+building+an+autonomous+AI+agent+from+zero+in+Python.+Agent+loop%2C+tool+system%2C+memory%2C+skills%2C+MCP%2C+++++multi-platform+gateway%2C+and+self-evolution&amp;kind=project+%C2%B7+guides">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=learn-hermes-agent&amp;subtitle=A+27-chapter+hands-on+tutorial+for+building+an+autonomous+AI+agent+from+zero+in+Python+%E2%80%94+agent+loop%2C+tool+system%2C+memory%2C+skills%2C+MCP%2C+multi-platform+gateway%2C+and+self-evolution.&amp;kind=project+%C2%B7+guides">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="longyunfeigu/learn-hermes-agent — Hermes Atlas">
 <meta name="twitter:description" content="Learn Hermes Agent is a code-first tutorial designed to teach the construction of production-grade autonomous AI agents using Python. It employs a 27-chapter…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=learn-hermes-agent&amp;subtitle=A+27-chapter+hands-on+tutorial+for+building+an+autonomous+AI+agent+from+zero+in+Python.+Agent+loop%2C+tool+system%2C+memory%2C+skills%2C+MCP%2C+++++multi-platform+gateway%2C+and+self-evolution&amp;kind=project+%C2%B7+guides">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=learn-hermes-agent&amp;subtitle=A+27-chapter+hands-on+tutorial+for+building+an+autonomous+AI+agent+from+zero+in+Python+%E2%80%94+agent+loop%2C+tool+system%2C+memory%2C+skills%2C+MCP%2C+multi-platform+gateway%2C+and+self-evolution.&amp;kind=project+%C2%B7+guides">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/longyunfeigu/learn-hermes-agent",
   "applicationCategory": "ReferenceApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "longyunfeigu",
     "url": "https://github.com/longyunfeigu"
   },
-  "dateModified": "2026-05-14T08:40:42.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">longyunfeigu</span><span class="slash">/</span>learn-hermes-agent
   </h1>
-  <p class="project-desc">A 27-chapter hands-on tutorial for building an autonomous AI agent from zero in Python. Agent loop, tool system, memory, skills, MCP,     multi-platform gateway, and self-evolution — inspired by Hermes Agent.</p>
+  <p class="project-desc">A 27-chapter hands-on tutorial for building an autonomous AI agent from zero in Python — agent loop, tool system, memory, skills, MCP, multi-platform gateway, and self-evolution.</p>
 
   <div class="meta-row">
     <span class="stars">★ 214</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-05-14</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -666,7 +666,6 @@ cp .env.example .env
 <p>If you can answer those questions clearly and build a similar system yourself, this repo has done its job.</p>
 <hr>
 <p><strong>This is not "copy the source code line by line." This is "grasp the designs that truly matter, then build it yourself."</strong></p>
-
   </section>
 </details>
 

--- a/projects/mag3nt-com/openclaw-skill.html
+++ b/projects/mag3nt-com/openclaw-skill.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/mag3nt-com/openclaw-skill",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "JavaScript",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "mag3nt-com",
     "url": "https://github.com/mag3nt-com"
   },
-  "dateModified": "2026-06-07T17:19:39.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,17 +118,19 @@
 
   <div class="meta-row">
     <span class="stars">★ 1</span>
-    <span><span class="meta-label">lang</span>JavaScript</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-06-07</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/mag3nt-com/openclaw-skill" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://clawhub.ai/user/mag3nt" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -317,7 +317,6 @@ Agent: Calling the market feed API...
 </ul>
 <h3>License</h3>
 <p>MIT — see <a href="./LICENSE">LICENSE</a></p>
-
   </section>
 </details>
 

--- a/projects/marshallrichards/ClawPhone.html
+++ b/projects/marshallrichards/ClawPhone.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/marshallrichards/ClawPhone">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=ClawPhone&amp;subtitle=Scripts+and+Tweaks+for+running+agents+like+OpenClaw%2C+Claude+Code%2C+Codex%2C+Hermes+Agent%2C+and+more+on+an+Android+smartphone&amp;kind=project+%C2%B7+deployment">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=ClawPhone&amp;subtitle=Scripts+and+notes+for+running+agent+CLIs+including+Hermes+Agent+on+Android+smartphones+through+Termux&amp;kind=project+%C2%B7+deployment">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="marshallrichards/ClawPhone — Hermes Atlas">
 <meta name="twitter:description" content="ClawPhone provides scripts and configuration guides for deploying agent CLIs on Android devices. It leverages Termux to run these agents natively, utilizing…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=ClawPhone&amp;subtitle=Scripts+and+Tweaks+for+running+agents+like+OpenClaw%2C+Claude+Code%2C+Codex%2C+Hermes+Agent%2C+and+more+on+an+Android+smartphone&amp;kind=project+%C2%B7+deployment">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=ClawPhone&amp;subtitle=Scripts+and+notes+for+running+agent+CLIs+including+Hermes+Agent+on+Android+smartphones+through+Termux&amp;kind=project+%C2%B7+deployment">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/marshallrichards/ClawPhone",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Shell",
   "author": {
     "@type": "Organization",
     "name": "marshallrichards",
     "url": "https://github.com/marshallrichards"
   },
-  "dateModified": "2026-05-25T03:10:28.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">marshallrichards</span><span class="slash">/</span>ClawPhone
   </h1>
-  <p class="project-desc">Scripts and Tweaks for running agents like OpenClaw, Claude Code, Codex, Hermes Agent, and more on an Android smartphone</p>
+  <p class="project-desc">Scripts and notes for running agent CLIs including Hermes Agent on Android smartphones through Termux</p>
 
   <div class="meta-row">
     <span class="stars">★ 546</span>
-    <span><span class="meta-label">lang</span>Shell</span>
     
     
-    <span><span class="meta-label">updated</span>2026-05-25</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -196,7 +197,6 @@ export TEMP="$TMPDIR"
 <li>Tell OpenClaw it is running inside Termux on Android, and that Termux:API and Termux:GUI are installed if you want it to use phone hardware.</li>
 </ol>
 <p>You can also let OpenClaw write overlays on the screen. Install the Termux:GUI app, run <code>pkg install termux-gui</code>, start <code>overlay_daemon.py</code> in another <code>tmux</code> pane/window, and tell OpenClaw it can use that daemon when it needs to display something to the user.</p>
-
   </section>
 </details>
 

--- a/projects/martymcenroe/HermesWiki.html
+++ b/projects/martymcenroe/HermesWiki.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/martymcenroe/HermesWiki">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=HermesWiki&amp;subtitle=Wiki+for+Hermes+%E2%80%94+autonomous+AI+email+agent&amp;kind=project+%C2%B7+guides">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=HermesWiki&amp;subtitle=Community+wiki+with+deployment+patterns+and+recipes&amp;kind=project+%C2%B7+guides">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="martymcenroe/HermesWiki — Hermes Atlas">
 <meta name="twitter:description" content="HermesWiki provides documentation for Hermes, an autonomous email agent that triages inbound recruiter outreach. The wiki covers the system's architecture,…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=HermesWiki&amp;subtitle=Wiki+for+Hermes+%E2%80%94+autonomous+AI+email+agent&amp;kind=project+%C2%B7+guides">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=HermesWiki&amp;subtitle=Community+wiki+with+deployment+patterns+and+recipes&amp;kind=project+%C2%B7+guides">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -45,7 +45,6 @@
     "name": "martymcenroe",
     "url": "https://github.com/martymcenroe"
   },
-  "dateModified": "2026-07-16T16:06:15.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -86,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -114,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">martymcenroe</span><span class="slash">/</span>HermesWiki
   </h1>
-  <p class="project-desc">Wiki for Hermes — autonomous AI email agent</p>
+  <p class="project-desc">Community wiki with deployment patterns and recipes</p>
 
   <div class="meta-row">
     <span class="stars">★ 17</span>
     
     
     
-    <span><span class="meta-label">updated</span>2026-07-16</span>
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/martymcenroe/HermesWiki" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://github.com/martymcenroe/HermesWiki/wiki" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -151,7 +153,6 @@
 <p>Documentation for <strong>Hermes</strong> — an autonomous email agent that triages inbound recruiter outreach, built on Cloudflare Workers and AWS Bedrock (Claude).</p>
 <p><strong><a href="https://github.com/martymcenroe/HermesWiki/wiki">Read the Wiki →</a></strong></p>
 <p>The wiki covers the architecture, conversation state machine, guardrails and evaluation, and the security and cost engineering behind the system — including threat modeling against the OWASP LLM/Agentic Top 10 and MITRE ATT&amp;CK/ATLAS, NIST alignment, and a full cost breakdown.</p>
-
   </section>
 </details>
 

--- a/projects/mem0ai/mem0.html
+++ b/projects/mem0ai/mem0.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/mem0ai/mem0">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=mem0&amp;subtitle=Universal+memory+layer+for+AI+Agents&amp;kind=project+%C2%B7+memory">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=mem0&amp;subtitle=Universal+memory+layer+for+AI+Agents+%E2%80%94+official+Hermes+Agent+memory+provider%2C+available+as+managed+cloud+or+Apache-2.0+self-hosted+OSS&amp;kind=project+%C2%B7+memory">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="mem0ai/mem0 — Hermes Atlas">
 <meta name="twitter:description" content="Mem0 is an intelligent memory layer designed to provide AI assistants and agents with personalized, long-term context. It utilizes a multi-level memory…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=mem0&amp;subtitle=Universal+memory+layer+for+AI+Agents&amp;kind=project+%C2%B7+memory">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=mem0&amp;subtitle=Universal+memory+layer+for+AI+Agents+%E2%80%94+official+Hermes+Agent+memory+provider%2C+available+as+managed+cloud+or+Apache-2.0+self-hosted+OSS&amp;kind=project+%C2%B7+memory">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/mem0ai/mem0",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/Apache-2.0.html",
   "author": {
     "@type": "Organization",
     "name": "mem0ai",
     "url": "https://github.com/mem0ai"
   },
-  "dateModified": "2026-08-21T06:42:52.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">mem0ai</span><span class="slash">/</span>mem0
   </h1>
-  <p class="project-desc">Universal memory layer for AI Agents</p>
+  <p class="project-desc">Universal memory layer for AI Agents — official Hermes Agent memory provider, available as managed cloud or Apache-2.0 self-hosted OSS</p>
 
   <div class="meta-row">
     <span class="stars">★ 63.7K</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>Apache-2.0</span>
     
-    <span><span class="meta-label">updated</span>2026-08-21</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/mem0ai/mem0" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://mem0.ai" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -436,7 +436,6 @@ if __name__ == "__main__":
 </code></pre>
 <h3>⚖️ License</h3>
 <p>Apache 2.0 — see the <a href="https://github.com/mem0ai/mem0/blob/main/LICENSE">LICENSE</a> file for details.</p>
-
   </section>
 </details>
 

--- a/projects/metantonio/hermes-wsl-ubuntu.html
+++ b/projects/metantonio/hermes-wsl-ubuntu.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/metantonio/hermes-wsl-ubuntu">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-wsl-ubuntu&amp;subtitle=Instructions+to+use+Hermes+AI+agents+on+WSL2+-+Ubuntu&amp;kind=project+%C2%B7+guides">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-wsl-ubuntu&amp;subtitle=Step-by-step+WSL2+Ubuntu+setup+guide+for+Windows+users&amp;kind=project+%C2%B7+guides">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="metantonio/hermes-wsl-ubuntu — Hermes Atlas">
 <meta name="twitter:description" content="This project provides a comprehensive guide and automation scripts for deploying the Hermes Agent with llama.cpp and Qwen3.5 on local environments. It…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-wsl-ubuntu&amp;subtitle=Instructions+to+use+Hermes+AI+agents+on+WSL2+-+Ubuntu&amp;kind=project+%C2%B7+guides">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-wsl-ubuntu&amp;subtitle=Step-by-step+WSL2+Ubuntu+setup+guide+for+Windows+users&amp;kind=project+%C2%B7+guides">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/metantonio/hermes-wsl-ubuntu",
   "applicationCategory": "ReferenceApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Shell",
   "author": {
     "@type": "Organization",
     "name": "metantonio",
     "url": "https://github.com/metantonio"
   },
-  "dateModified": "2026-05-22T19:09:33.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">metantonio</span><span class="slash">/</span>hermes-wsl-ubuntu
   </h1>
-  <p class="project-desc">Instructions to use Hermes AI agents on WSL2 - Ubuntu</p>
+  <p class="project-desc">Step-by-step WSL2 Ubuntu setup guide for Windows users</p>
 
   <div class="meta-row">
     <span class="stars">★ 40</span>
-    <span><span class="meta-label">lang</span>Shell</span>
     
     
-    <span><span class="meta-label">updated</span>2026-05-22</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -796,7 +797,6 @@ chmod 755 /opt/llama.cpp/build/bin/llama-server
 <li>Qwen Models  <a href="https://huggingface.co/Qwen">https://huggingface.co/Qwen</a></li>
 </ul>
 <hr>
-
   </section>
 </details>
 

--- a/projects/mnemosyne-oss/mnemosyne.html
+++ b/projects/mnemosyne-oss/mnemosyne.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/mnemosyne-oss/mnemosyne">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=mnemosyne&amp;subtitle=Zero-cloud+AI+memory+that+works+everywhere.+SQLite-backed.+One+pure-Python+dependency.&amp;kind=project+%C2%B7+memory">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=mnemosyne&amp;subtitle=The+Zero-Dependency%2C+Sub-Millisecond+AI+Memory+System+for+Hermes+Agents&amp;kind=project+%C2%B7+memory">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="mnemosyne-oss/mnemosyne — Hermes Atlas">
 <meta name="twitter:description" content="Mnemosyne is a SQLite-backed memory layer designed for use with various agent frameworks. It provides a Python SDK and MCP server support for storing and…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=mnemosyne&amp;subtitle=Zero-cloud+AI+memory+that+works+everywhere.+SQLite-backed.+One+pure-Python+dependency.&amp;kind=project+%C2%B7+memory">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=mnemosyne&amp;subtitle=The+Zero-Dependency%2C+Sub-Millisecond+AI+Memory+System+for+Hermes+Agents&amp;kind=project+%C2%B7+memory">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/mnemosyne-oss/mnemosyne",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "mnemosyne-oss",
     "url": "https://github.com/mnemosyne-oss"
   },
-  "dateModified": "2026-08-20T12:37:41.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">mnemosyne-oss</span><span class="slash">/</span>mnemosyne
   </h1>
-  <p class="project-desc">Zero-cloud AI memory that works everywhere. SQLite-backed. One pure-Python dependency.</p>
+  <p class="project-desc">The Zero-Dependency, Sub-Millisecond AI Memory System for Hermes Agents</p>
 
   <div class="meta-row">
     <span class="stars">★ 2.7K</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-20</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/mnemosyne-oss/mnemosyne" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://mnemosyne.site" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -916,7 +916,6 @@ mnemosyne sync-status --remote https://my-vps:8765
 <p align="center">
   <em>"The faintest ink is more powerful than the strongest memory." -- Hermes Trismegistus</em>
 </p>
-
   </section>
 </details>
 

--- a/projects/mohitagw15856/pm-claude-skills.html
+++ b/projects/mohitagw15856/pm-claude-skills.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/mohitagw15856/pm-claude-skills">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=PM+Skills&amp;subtitle=1098+professional+Agent+Skills+for+Claude%2C+ChatGPT%2C+Gemini%2C+Cursor+%26+Codex+%E2%80%94+from+PRDs+and+postmortems+to+appealing+a+disability+benefit%2C+building+a+go-bag%2C+and+settling+into+a+new&amp;kind=project+%C2%B7+skills">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=PM+Skills&amp;subtitle=822+professional+agent+skills+that+run+natively+in+Hermes+Agent+and+Claude+Code%2C+with+ready-to-paste+exports+for+other+assistants.&amp;kind=project+%C2%B7+skills">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="mohitagw15856/PM Skills — Hermes Atlas">
 <meta name="twitter:description" content="PM Skills is an open-source library of 1,117 professional agent skills provided as plain markdown files. These files provide frameworks, output templates, and…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=PM+Skills&amp;subtitle=1098+professional+Agent+Skills+for+Claude%2C+ChatGPT%2C+Gemini%2C+Cursor+%26+Codex+%E2%80%94+from+PRDs+and+postmortems+to+appealing+a+disability+benefit%2C+building+a+go-bag%2C+and+settling+into+a+new&amp;kind=project+%C2%B7+skills">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=PM+Skills&amp;subtitle=822+professional+agent+skills+that+run+natively+in+Hermes+Agent+and+Claude+Code%2C+with+ready-to-paste+exports+for+other+assistants.&amp;kind=project+%C2%B7+skills">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/mohitagw15856/pm-claude-skills",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "HTML",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "mohitagw15856",
     "url": "https://github.com/mohitagw15856"
   },
-  "dateModified": "2026-08-21T07:29:47.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,30 @@
   <h1 class="project-name">
     <span class="org">mohitagw15856</span><span class="slash">/</span>pm-claude-skills
   </h1>
-  <p class="project-desc">1098 professional Agent Skills for Claude, ChatGPT, Gemini, Cursor &amp; Codex — from PRDs and postmortems to appealing a disability benefit, building a go-bag, and settling into a new country. Plain-markdown, MIT, in Anthropic's official plugin directory. Free in-browser or 'npx pm-claude-skills add'.</p>
+  <p class="project-desc">822 professional agent skills that run natively in Hermes Agent and Claude Code, with ready-to-paste exports for other assistants.</p>
 
   <div class="meta-row">
     <span class="stars">★ 1.3K</span>
-    <span><span class="meta-label">lang</span>HTML</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-21</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/mohitagw15856/pm-claude-skills" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://mohitagw15856.github.io/pm-claude-skills/" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
+<aside class="install-box" aria-label="How to install this skill">
+  <div class="ib-label">install<span class="ib-type">collection</span></div>
+  <code class="ib-cmd">npx pm-claude-skills add</code>
+  <p class="ib-compat">Claude Code plugin directory + Hermes Agent (plain markdown skills run natively); also exposes an MCP server.</p>
+  <p class="ib-verdict">1,000+ professional skills as plain markdown, the largest non-security collection here — organized into 120+ installable bundles instead of one all-or-nothing install.</p>
+  <a class="ib-more" href="/skills/">more picks → the skills hub</a>
+</aside>
 
 
 
@@ -712,7 +719,6 @@ Every skill passes a structural gate (SkillSpec L3) and a security scan in CI; 2
 <p>MIT — use them, fork them, ship them at work. Skills are judgment, and judgment wants to be free.</p>
 <hr>
 <p>*Built by <a href="https://github.com/mohitagw15856">Mohit</a> with Claude. 1117 skills · 121 bundles · 35 professions · every commit gated. The long version of this README — every feature, wave, and frontier bet — lives in the <strong><a href="https://github.com/mohitagw15856/pm-claude-skills/blob/main/docs/SHOWCASE.md">Showcase</a></strong>.*</p>
-
   </section>
 </details>
 

--- a/projects/mudrii/hermes-agent-docs.html
+++ b/projects/mudrii/hermes-agent-docs.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/mudrii/hermes-agent-docs">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-docs&amp;subtitle=Comprehensive+documentation+for+Hermes+Agent+by+NousResearch+%E2%80%94+the+self-improving+AI+agent+%28v0.2.0%29&amp;kind=project+%C2%B7+guides">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-docs&amp;subtitle=Community+documentation+covering+deployment+patterns+and+v0.2.0%2B+workflows&amp;kind=project+%C2%B7+guides">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="mudrii/hermes-agent-docs — Hermes Atlas">
 <meta name="twitter:description" content="Hermes Agent is an autonomous AI agent developed by Nous Research that features a built-in learning loop for skill creation and memory persistence. It supports…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-docs&amp;subtitle=Comprehensive+documentation+for+Hermes+Agent+by+NousResearch+%E2%80%94+the+self-improving+AI+agent+%28v0.2.0%29&amp;kind=project+%C2%B7+guides">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-docs&amp;subtitle=Community+documentation+covering+deployment+patterns+and+v0.2.0%2B+workflows&amp;kind=project+%C2%B7+guides">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/mudrii/hermes-agent-docs",
   "applicationCategory": "ReferenceApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "MDX",
   "author": {
     "@type": "Organization",
     "name": "mudrii",
     "url": "https://github.com/mudrii"
   },
-  "dateModified": "2026-05-18T09:37:47.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">mudrii</span><span class="slash">/</span>hermes-agent-docs
   </h1>
-  <p class="project-desc">Comprehensive documentation for Hermes Agent by NousResearch — the self-improving AI agent (v0.2.0)</p>
+  <p class="project-desc">Community documentation covering deployment patterns and v0.2.0+ workflows</p>
 
   <div class="meta-row">
     <span class="stars">★ 73</span>
-    <span><span class="meta-label">lang</span>MDX</span>
     
     
-    <span><span class="meta-label">updated</span>2026-05-18</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -980,7 +981,6 @@ hermes update       # Update to the latest version (with auto-restart for gatewa
 <h3>License</h3>
 <p>MIT -- see <a href="https://github.com/NousResearch/hermes-agent/blob/main/LICENSE">LICENSE</a>.</p>
 <p>Built by <a href="https://nousresearch.com">Nous Research</a>.</p>
-
   </section>
 </details>
 

--- a/projects/mukul975/Anthropic-Cybersecurity-Skills.html
+++ b/projects/mukul975/Anthropic-Cybersecurity-Skills.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/mukul975/Anthropic-Cybersecurity-Skills">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=Anthropic-Cybersecurity-Skills&amp;subtitle=817+structured+cybersecurity+skills+for+AI+agents+%C2%B7+Mapped+to+6+frameworks%3A+MITRE+ATT%26CK%2C+NIST+CSF+2.0%2C+MITRE+ATLAS%2C+D3FEND%2C+NIST+AI+RMF+%26+MITRE+F3+%28Fight+Fraud%29+%C2%B7+agentskills.io+s&amp;kind=project+%C2%B7+skills">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=Anthropic-Cybersecurity-Skills&amp;subtitle=754+structured+cybersecurity+skills+mapped+to+MITRE+ATT%26CK%2C+NIST+CSF+2.0%2C+ATLAS%2C+D3FEND+%26+NIST+AI+RMF&amp;kind=project+%C2%B7+skills">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="mukul975/Anthropic-Cybersecurity-Skills — Hermes Atlas">
 <meta name="twitter:description" content="This repository provides 817 structured cybersecurity skills across 29 security domains following the agentskills.io open standard. These skills map to six…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Anthropic-Cybersecurity-Skills&amp;subtitle=817+structured+cybersecurity+skills+for+AI+agents+%C2%B7+Mapped+to+6+frameworks%3A+MITRE+ATT%26CK%2C+NIST+CSF+2.0%2C+MITRE+ATLAS%2C+D3FEND%2C+NIST+AI+RMF+%26+MITRE+F3+%28Fight+Fraud%29+%C2%B7+agentskills.io+s&amp;kind=project+%C2%B7+skills">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Anthropic-Cybersecurity-Skills&amp;subtitle=754+structured+cybersecurity+skills+mapped+to+MITRE+ATT%26CK%2C+NIST+CSF+2.0%2C+ATLAS%2C+D3FEND+%26+NIST+AI+RMF&amp;kind=project+%C2%B7+skills">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/mukul975/Anthropic-Cybersecurity-Skills",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/Apache-2.0.html",
   "author": {
     "@type": "Organization",
     "name": "mukul975",
     "url": "https://github.com/mukul975"
   },
-  "dateModified": "2026-08-20T15:57:02.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,30 @@
   <h1 class="project-name">
     <span class="org">mukul975</span><span class="slash">/</span>Anthropic-Cybersecurity-Skills
   </h1>
-  <p class="project-desc">817 structured cybersecurity skills for AI agents · Mapped to 6 frameworks: MITRE ATT&amp;CK, NIST CSF 2.0, MITRE ATLAS, D3FEND, NIST AI RMF &amp; MITRE F3 (Fight Fraud) · agentskills.io standard · Works with Claude Code, GitHub Copilot, Codex CLI, Cursor, Gemini CLI &amp; 20+ platforms · 29 security domains · Apache 2.0</p>
+  <p class="project-desc">754 structured cybersecurity skills mapped to MITRE ATT&amp;CK, NIST CSF 2.0, ATLAS, D3FEND &amp; NIST AI RMF</p>
 
   <div class="meta-row">
     <span class="stars">★ 30.5K</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>Apache-2.0</span>
     
-    <span><span class="meta-label">updated</span>2026-08-20</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/mukul975/Anthropic-Cybersecurity-Skills" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://mahipal.engineer/Anthropic-Cybersecurity-Skills/" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
+<aside class="install-box" aria-label="How to install this skill">
+  <div class="ib-label">install<span class="ib-type">collection</span></div>
+  <code class="ib-cmd">npx skills add mukul975/Anthropic-Cybersecurity-Skills</code>
+  <p class="ib-compat">agentskills.io-compatible clients (Claude Code, Copilot, Codex); installable on Hermes via hermes skills tap add or npx skills add.</p>
+  <p class="ib-verdict">800+ skills across 29 security domains mapped to MITRE ATT&amp;CK, ATLAS, D3FEND, and NIST — the largest and most-starred security pack in the catalog. Start here before any narrower pentest skill.</p>
+  <a class="ib-more" href="/skills/">more picks → the skills hub</a>
+</aside>
 
 
 
@@ -916,7 +923,6 @@ LangChain · CrewAI · AutoGen · Semantic Kernel · Haystack · Vercel AI SDK �
 <p><a href="https://github.com/mukul975/Anthropic-Cybersecurity-Skills/stargazers">⭐ Star</a> · <a href="https://github.com/mukul975/Anthropic-Cybersecurity-Skills/fork">🍴 Fork</a> · <a href="https://github.com/mukul975/Anthropic-Cybersecurity-Skills/discussions">💬 Discuss</a> · <a href="https://github.com/mukul975/Anthropic-Cybersecurity-Skills/blob/main/CONTRIBUTING.md">📝 Contribute</a></p>
 <p>Community project by <a href="https://github.com/mukul975">@mukul975</a>. Not affiliated with Anthropic PBC.</p>
 </div>
-
   </section>
 </details>
 

--- a/projects/nativ3ai/hermes-agent-camel.html
+++ b/projects/nativ3ai/hermes-agent-camel.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/nativ3ai/hermes-agent-camel">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-camel&amp;subtitle=Hermes+Agent+fork+with+integrated+CaMeL+trust+boundaries&amp;kind=project+%C2%B7+forks">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-camel&amp;subtitle=Hermes+with+integrated+CaMeL+trust+boundaries+for+safer+autonomous+execution&amp;kind=project+%C2%B7+forks">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="nativ3ai/hermes-agent-camel — Hermes Atlas">
 <meta name="twitter:description" content="This project is a self-improving AI agent designed for autonomous execution with integrated safety boundaries. It utilizes a closed learning loop to create and…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-camel&amp;subtitle=Hermes+Agent+fork+with+integrated+CaMeL+trust+boundaries&amp;kind=project+%C2%B7+forks">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-camel&amp;subtitle=Hermes+with+integrated+CaMeL+trust+boundaries+for+safer+autonomous+execution&amp;kind=project+%C2%B7+forks">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/nativ3ai/hermes-agent-camel",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "nativ3ai",
     "url": "https://github.com/nativ3ai"
   },
-  "dateModified": "2026-05-07T20:30:11.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">nativ3ai</span><span class="slash">/</span>hermes-agent-camel
   </h1>
-  <p class="project-desc">Hermes Agent fork with integrated CaMeL trust boundaries</p>
+  <p class="project-desc">Hermes with integrated CaMeL trust boundaries for safer autonomous execution</p>
 
   <div class="meta-row">
     <span class="stars">★ 194</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-05-07</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -394,7 +394,6 @@ scripts/run_tests.sh
 <h3>License</h3>
 <p>MIT — see <a href="LICENSE">LICENSE</a>.</p>
 <p>Built by <a href="https://nousresearch.com">Nous Research</a>.</p>
-
   </section>
 </details>
 

--- a/projects/nativ3ai/hermes-payguard.html
+++ b/projects/nativ3ai/hermes-payguard.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/nativ3ai/hermes-payguard",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "nativ3ai",
     "url": "https://github.com/nativ3ai"
   },
-  "dateModified": "2026-03-20T15:43:30.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,10 +118,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 14</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-03-20</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -321,7 +321,6 @@ pytest -q
 <li>x402 over-limit flow with explicit operator approval</li>
 <li>Hermes plugin discovery and tool registration</li>
 </ul>
-
   </section>
 </details>
 

--- a/projects/nesquena/hermes-webui.html
+++ b/projects/nesquena/hermes-webui.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/nesquena/hermes-webui",
   "applicationCategory": "DesktopEnhancementApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "nesquena",
     "url": "https://github.com/nesquena"
   },
-  "dateModified": "2026-08-21T10:33:48.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,17 +118,19 @@
 
   <div class="meta-row">
     <span class="stars">★ 17.6K</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-21</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/nesquena/hermes-webui" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://get-hermes.ai/setup" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -1058,7 +1058,6 @@ Sidebar collapse via active-rail click (#2054, fuses #1884 + #1924), composer ch
 Original sprint of workspace fallback resolution, live reasoning cards (#366, #367, #394–#397), then a recent burst: manual "Refresh usage" button on the Provider quota card (#2150), cancelled-turn status classification (#2151), Firefox sidebar scroll stabilization (#2200), early provisional session titles (#2202), target-aware "What's new?" update-banner links (#2207), and MC</p>
 <hr>
 <p><em>README truncated. <a href="https://github.com/nesquena/hermes-webui#readme">Continue reading on GitHub</a></em></p>
-
   </section>
 </details>
 

--- a/projects/nexu-io/open-design.html
+++ b/projects/nexu-io/open-design.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/nexu-io/open-design">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=open-design&amp;subtitle=%F0%9F%8E%A8+Best+DeepSeek+Harness+Design+Plugin.+The+open-source+Claude+Design+alternative.+%F0%9F%96%A5%EF%B8%8F+Local-first+desktop+app.+%F0%9F%96%BC%EF%B8%8F+Your+coding+agent+becomes+the+design+engine%3A+prototypes%2C+landing&amp;kind=project+%C2%B7+skills">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=open-design&amp;subtitle=Local-first+open-source+design%2Fprototyping+system+with+coding-agent+CLI+support+including+Hermes+Agent&amp;kind=project+%C2%B7+skills">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="nexu-io/open-design — Hermes Atlas">
 <meta name="twitter:description" content="OpenDesign is an open-source, local-first design and prototyping system available as a native desktop application for macOS and Windows. It generates web,…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=open-design&amp;subtitle=%F0%9F%8E%A8+Best+DeepSeek+Harness+Design+Plugin.+The+open-source+Claude+Design+alternative.+%F0%9F%96%A5%EF%B8%8F+Local-first+desktop+app.+%F0%9F%96%BC%EF%B8%8F+Your+coding+agent+becomes+the+design+engine%3A+prototypes%2C+landing&amp;kind=project+%C2%B7+skills">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=open-design&amp;subtitle=Local-first+open-source+design%2Fprototyping+system+with+coding-agent+CLI+support+including+Hermes+Agent&amp;kind=project+%C2%B7+skills">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/nexu-io/open-design",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TypeScript",
-  "license": "https://spdx.org/licenses/Apache-2.0.html",
   "author": {
     "@type": "Organization",
     "name": "nexu-io",
     "url": "https://github.com/nexu-io"
   },
-  "dateModified": "2026-08-21T10:38:23.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,30 @@
   <h1 class="project-name">
     <span class="org">nexu-io</span><span class="slash">/</span>open-design
   </h1>
-  <p class="project-desc">🎨 Best DeepSeek Harness Design Plugin. The open-source Claude Design alternative. 🖥️ Local-first desktop app. 🖼️ Your coding agent becomes the design engine: prototypes, landing pages, dashboards, slides, images &amp; video — real files, HTML/PDF/PPTX/MP4 export. 🤖 Claude Code / Codex / Cursor / DeepSeek Harness / OpenCode &amp; 20+ CLIs via BYOK.</p>
+  <p class="project-desc">Local-first open-source design/prototyping system with coding-agent CLI support including Hermes Agent</p>
 
   <div class="meta-row">
     <span class="stars">★ 90.0K</span>
-    <span><span class="meta-label">lang</span>TypeScript</span>
-    <span><span class="meta-label">license</span>Apache-2.0</span>
     
-    <span><span class="meta-label">updated</span>2026-08-21</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/nexu-io/open-design" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://open-design.ai" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
+<aside class="install-box" aria-label="How to install this skill">
+  <div class="ib-label">install<span class="ib-type">plugin</span></div>
+  <code class="ib-cmd">curl -fsSL https://open-design.ai/install.sh | sh -s hermes (hosted); or self-host via docker compose from the repo's deploy/ directory.</code>
+  <p class="ib-compat">Native desktop app (macOS/Windows) plus a CLI; the README explicitly lists Hermes Agent among supported coding-agent CLIs for prototype generation.</p>
+  <p class="ib-verdict">By far the biggest project in the entire skills category — but it's a full local-first design platform, not a lightweight skill. Install it as prototyping infrastructure, not a five-minute skill add.</p>
+  <a class="ib-more" href="/skills/">more picks → the skills hub</a>
+</aside>
 
 
 
@@ -996,7 +1003,6 @@ pnpm guard &amp;&amp; pnpm --filter @open-design/plugin-runtime typecheck
 </tbody></table>
 <hr>
 <p><em>README truncated. <a href="https://github.com/nexu-io/open-design#readme">Continue reading on GitHub</a></em></p>
-
   </section>
 </details>
 

--- a/projects/nickvasilescu/hermes-desktop-os1.html
+++ b/projects/nickvasilescu/hermes-desktop-os1.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/nickvasilescu/hermes-desktop-os1">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-desktop-os1&amp;subtitle=Hermes+Desktop+-+OS1+Edition%3A+native+macOS+workspace+for+Hermes+Agent+on+Orgo+cloud+computers+and+SSH+hosts&amp;kind=project+%C2%B7+workspaces">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-desktop-os1&amp;subtitle=Native+macOS+workspace+for+Hermes+Agent+running+on+Orgo+cloud+computers+and+SSH+hosts&amp;kind=project+%C2%B7+workspaces">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="nickvasilescu/hermes-desktop-os1 — Hermes Atlas">
 <meta name="twitter:description" content="Hermes Desktop - OS1 Edition is a native macOS workspace designed to manage Hermes Agents running on Orgo cloud computers or SSH hosts. It provides a unified…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-desktop-os1&amp;subtitle=Hermes+Desktop+-+OS1+Edition%3A+native+macOS+workspace+for+Hermes+Agent+on+Orgo+cloud+computers+and+SSH+hosts&amp;kind=project+%C2%B7+workspaces">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-desktop-os1&amp;subtitle=Native+macOS+workspace+for+Hermes+Agent+running+on+Orgo+cloud+computers+and+SSH+hosts&amp;kind=project+%C2%B7+workspaces">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/nickvasilescu/hermes-desktop-os1",
   "applicationCategory": "DesktopEnhancementApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Swift",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "nickvasilescu",
     "url": "https://github.com/nickvasilescu"
   },
-  "dateModified": "2026-05-09T05:01:58.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">nickvasilescu</span><span class="slash">/</span>hermes-desktop-os1
   </h1>
-  <p class="project-desc">Hermes Desktop - OS1 Edition: native macOS workspace for Hermes Agent on Orgo cloud computers and SSH hosts</p>
+  <p class="project-desc">Native macOS workspace for Hermes Agent running on Orgo cloud computers and SSH hosts</p>
 
   <div class="meta-row">
     <span class="stars">★ 524</span>
-    <span><span class="meta-label">lang</span>Swift</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-05-09</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -322,7 +322,6 @@ for the canonical palette and motion vocabulary that this app borrows.</p>
 <p>This is an early build. Translation polish, GitHub Pages site, and
 signing/notarization are still in progress. Open issues in this repo
 for bugs and feature requests.</p>
-
   </section>
 </details>
 

--- a/projects/nujovich/hermes-telemetry.html
+++ b/projects/nujovich/hermes-telemetry.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/nujovich/hermes-telemetry",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "nujovich",
     "url": "https://github.com/nujovich"
   },
-  "dateModified": "2026-08-18T16:20:37.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,10 +118,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 30</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-18</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -1210,7 +1210,6 @@ on_estimated:
 <p>Some OpenRouter models have no fixed pricing (e.g. <code>auto</code> routing, experimental models). Thes</p>
 <hr>
 <p><em>README truncated. <a href="https://github.com/nujovich/hermes-telemetry#readme">Continue reading on GitHub</a></em></p>
-
   </section>
 </details>
 

--- a/projects/numtide/llm-agents.nix.html
+++ b/projects/numtide/llm-agents.nix.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/numtide/llm-agents.nix">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=llm-agents.nix&amp;subtitle=Nix+packages+for+AI+coding+agents+and+development+tools.+Automatically+updated+daily.&amp;kind=project+%C2%B7+deployment">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=llm-agents.nix&amp;subtitle=Nix+packages+for+AI+coding+agents+including+Hermes&amp;kind=project+%C2%B7+deployment">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="numtide/llm-agents.nix — Hermes Atlas">
 <meta name="twitter:description" content="This repository provides Nix packages for AI coding agents and development tools. The packages are automatically updated on a daily basis.">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=llm-agents.nix&amp;subtitle=Nix+packages+for+AI+coding+agents+and+development+tools.+Automatically+updated+daily.&amp;kind=project+%C2%B7+deployment">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=llm-agents.nix&amp;subtitle=Nix+packages+for+AI+coding+agents+including+Hermes&amp;kind=project+%C2%B7+deployment">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/numtide/llm-agents.nix",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Nix",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "numtide",
     "url": "https://github.com/numtide"
   },
-  "dateModified": "2026-08-21T04:32:19.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">numtide</span><span class="slash">/</span>llm-agents.nix
   </h1>
-  <p class="project-desc">Nix packages for AI coding agents and development tools. Automatically updated daily.</p>
+  <p class="project-desc">Nix packages for AI coding agents including Hermes</p>
 
   <div class="meta-row">
     <span class="stars">★ 1.8K</span>
-    <span><span class="meta-label">lang</span>Nix</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-21</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 

--- a/projects/obra/superpowers.html
+++ b/projects/obra/superpowers.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/obra/superpowers",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Shell",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "obra",
     "url": "https://github.com/obra"
   },
-  "dateModified": "2026-08-19T17:33:23.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,10 +118,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 275.3K</span>
-    <span><span class="meta-label">lang</span>Shell</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-19</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,15 @@
     
   </div>
 </section>
+
+
+<aside class="install-box" aria-label="How to install this skill">
+  <div class="ib-label">install<span class="ib-type">plugin</span></div>
+  <code class="ib-cmd">hermes plugins install obra/superpowers --enable</code>
+  <p class="ib-compat">Hermes Agent CLI (plugin); also ships as a Claude Code plugin via the official marketplace.</p>
+  <p class="ib-verdict">The most-starred agentic skills framework in the catalog by two orders of magnitude. If you install exactly one dev-workflow plugin, this is the default.</p>
+  <a class="ib-more" href="/skills/">more picks → the skills hub</a>
+</aside>
 
 
 
@@ -425,7 +432,6 @@ turn loses the bootstrap — start a fresh session if skills stop triggering.</p
 <p>MIT License - see LICENSE file for details</p>
 <h3>Visual companion telemetry</h3>
 <p>Because skills and plugins don't provide any feedback to creators, we have no idea how many of you are using Superpowers. By default, the Prime Radiant logo on brainstorming's optional visual companion feature is loaded from our website. It includes the version of Superpowers in use. It does not include any details about your project, prompt, or coding agent. We don't see your clicks or anything about what you're building. This helps us have a rough idea of how many folks are using Superpowers and which version of Superpowers they're using. It's 100% optional. To disable this, set the environment variable <code>SUPERPOWERS_DISABLE_TELEMETRY</code> to any true value. Superpowers also honors Claude Code's <code>DISABLE_TELEMETRY</code> and <code>CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC</code> opt-outs.</p>
-
   </section>
 </details>
 

--- a/projects/observeco/observeco.html
+++ b/projects/observeco/observeco.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/observeco/observeco",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "observeco",
     "url": "https://github.com/observeco"
   },
-  "dateModified": "2026-08-12T15:06:26.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,17 +118,19 @@
 
   <div class="meta-row">
     <span class="stars">★ 8</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-12</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/observeco/observeco" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://observeco.github.io/docs" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -757,7 +757,6 @@ Happened: 03:15 · Discovered: 07:00 · <strong>Gap: 3h 45m</strong></p>
 <strong>What a kill switch cannot do:</strong> Prevent the agent from restarting (auto-restart daemons will re-launch unless you also remove the agent config).
 <strong>What auto-heal does:</strong> Restart dead agents, reset tripped circuits, trim bloated memory. Configurable thresholds. Circuit breaker stops after 3 failures.
 <strong>What auto-heal does NOT do:</strong> Modify config files, delete agents, change system settings, or execute any action with irreversible side effects.</p>
-
   </section>
 </details>
 

--- a/projects/outsourc-e/hermes-workspace.html
+++ b/projects/outsourc-e/hermes-workspace.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/outsourc-e/hermes-workspace">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-workspace&amp;subtitle=Native+web+workspace+for+Hermes+Agent+%E2%80%94+chat%2C+terminal%2C+memory%2C+skills%2C+inspector.&amp;kind=project+%C2%B7+workspaces">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-workspace&amp;subtitle=Native+web+workspace+%E2%80%94+chat%2C+terminal%2C+memory+browser%2C+skills+manager%2C+and+inspector+panel&amp;kind=project+%C2%B7+workspaces">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="outsourc-e/hermes-workspace — Hermes Atlas">
 <meta name="twitter:description" content="Hermes Workspace is a comprehensive command center designed to orchestrate AI agents through a unified web interface. It integrates with the vanilla…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-workspace&amp;subtitle=Native+web+workspace+for+Hermes+Agent+%E2%80%94+chat%2C+terminal%2C+memory%2C+skills%2C+inspector.&amp;kind=project+%C2%B7+workspaces">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-workspace&amp;subtitle=Native+web+workspace+%E2%80%94+chat%2C+terminal%2C+memory+browser%2C+skills+manager%2C+and+inspector+panel&amp;kind=project+%C2%B7+workspaces">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/outsourc-e/hermes-workspace",
   "applicationCategory": "DesktopEnhancementApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "JavaScript",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "outsourc-e",
     "url": "https://github.com/outsourc-e"
   },
-  "dateModified": "2026-08-08T04:42:37.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">outsourc-e</span><span class="slash">/</span>hermes-workspace
   </h1>
-  <p class="project-desc">Native web workspace for Hermes Agent — chat, terminal, memory, skills, inspector.</p>
+  <p class="project-desc">Native web workspace — chat, terminal, memory browser, skills manager, and inspector panel</p>
 
   <div class="meta-row">
     <span class="stars">★ 6.5K</span>
-    <span><span class="meta-label">lang</span>JavaScript</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-08</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/outsourc-e/hermes-workspace" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://hermes-workspace.com" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -974,7 +974,6 @@ hermes dashboard      # dashboard plugin on :9119 (sessions/skills/jobs/config)
 <div align="center">
   <sub>Built with ⚡ by <a href="https://github.com/outsourc-e">@outsourc-e</a> and the Hermes Workspace community</sub>
 </div>
-
   </section>
 </details>
 

--- a/projects/penfieldlabs/hermes-penfield.html
+++ b/projects/penfieldlabs/hermes-penfield.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/penfieldlabs/hermes-penfield">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-penfield&amp;subtitle=%F0%9F%A7%A0+Penfield+memory+provider+for+Hermes+agent&amp;kind=project+%C2%B7+memory">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-penfield&amp;subtitle=%F0%9F%A7%A0+Penfield+memory+providers+for+Hermes+agent&amp;kind=project+%C2%B7+memory">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="penfieldlabs/hermes-penfield — Hermes Atlas">
 <meta name="twitter:description" content="hermes-penfield is a persistent memory provider that enables Hermes Agent to maintain memory across different sessions and agents. It connects the agent to the…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-penfield&amp;subtitle=%F0%9F%A7%A0+Penfield+memory+provider+for+Hermes+agent&amp;kind=project+%C2%B7+memory">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-penfield&amp;subtitle=%F0%9F%A7%A0+Penfield+memory+providers+for+Hermes+agent&amp;kind=project+%C2%B7+memory">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/penfieldlabs/hermes-penfield",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "penfieldlabs",
     "url": "https://github.com/penfieldlabs"
   },
-  "dateModified": "2026-07-01T19:08:04.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">penfieldlabs</span><span class="slash">/</span>hermes-penfield
   </h1>
-  <p class="project-desc">🧠 Penfield memory provider for Hermes agent</p>
+  <p class="project-desc">🧠 Penfield memory providers for Hermes agent</p>
 
   <div class="meta-row">
     <span class="stars">★ 3</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-07-01</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -277,7 +277,6 @@ pytest -m "not integration"
 </code></pre>
 <h3>License</h3>
 <p>MIT. Copyright (C) 2026 Penfield.</p>
-
   </section>
 </details>
 

--- a/projects/pengchengxia75-arch/hermes-agent-windows.html
+++ b/projects/pengchengxia75-arch/hermes-agent-windows.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/pengchengxia75-arch/hermes-agent-windows">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-windows&amp;subtitle=Hermes+Agent+with+native+Windows+support+and+one-line+PowerShell+installer&amp;kind=project+%C2%B7+forks">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-windows&amp;subtitle=Windows-native+Hermes+Agent+adaptation+with+one-line+PowerShell+installer+and+no+WSL+requirement&amp;kind=project+%C2%B7+forks">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="pengchengxia75-arch/hermes-agent-windows — Hermes Atlas">
 <meta name="twitter:description" content="This project is a Windows-native adaptation of the Hermes Agent that eliminates the need for WSL2 or Linux environments. It utilizes a PowerShell-based…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-windows&amp;subtitle=Hermes+Agent+with+native+Windows+support+and+one-line+PowerShell+installer&amp;kind=project+%C2%B7+forks">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-windows&amp;subtitle=Windows-native+Hermes+Agent+adaptation+with+one-line+PowerShell+installer+and+no+WSL+requirement&amp;kind=project+%C2%B7+forks">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/pengchengxia75-arch/hermes-agent-windows",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "pengchengxia75-arch",
     "url": "https://github.com/pengchengxia75-arch"
   },
-  "dateModified": "2026-04-18T12:54:38.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">pengchengxia75-arch</span><span class="slash">/</span>hermes-agent-windows
   </h1>
-  <p class="project-desc">Hermes Agent with native Windows support and one-line PowerShell installer</p>
+  <p class="project-desc">Windows-native Hermes Agent adaptation with one-line PowerShell installer and no WSL requirement</p>
 
   <div class="meta-row">
     <span class="stars">★ 39</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-04-18</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -245,7 +245,6 @@ hermes            # 启动命令行对话
 <hr>
 <h3>License</h3>
 <p>遵循上游 MIT 协议。</p>
-
   </section>
 </details>
 

--- a/projects/piprail/piprail.html
+++ b/projects/piprail/piprail.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/piprail/piprail",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TypeScript",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "piprail",
     "url": "https://github.com/piprail"
   },
-  "dateModified": "2026-07-14T18:07:59.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">piprail</span><span class="slash">/</span>piprail
   </h1>
-  <p class="project-desc">x402 (HTTP 402 Payment Required) SDK + MCP server: let any API charge for itself and any AI agent pay for itself, USDC &amp; stablecoins across EVM, Solana &amp; 8 more chain families, in a couple of lines. Backendless, no fee, self-custodial, paid straight to your wallet. TypeScript, MIT.</p>
+  <p class="project-desc">x402 (HTTP 402 Payment Required) SDK + MCP server: let any API charge for itself and any AI agent pay for itself, USDC &amp; stablecoins across EVM, Solana &amp; 8 more chain families, in a couple of lines. B</p>
 
   <div class="meta-row">
     <span class="stars">★ 7</span>
-    <span><span class="meta-label">lang</span>TypeScript</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-07-14</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/piprail/piprail" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://piprail.com" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -318,7 +318,6 @@ app.get('/report',
 
 <p><sub>Built for the agent economy · <a href="https://piprail.com">piprail.com</a></sub></p>
 </div>
-
   </section>
 </details>
 

--- a/projects/plastic-labs/honcho.html
+++ b/projects/plastic-labs/honcho.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/plastic-labs/honcho">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=honcho&amp;subtitle=+Memory+library+for+building+stateful+agents&amp;kind=project+%C2%B7+memory">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=honcho&amp;subtitle=Memory+library+for+building+stateful+agents+%E2%80%94+the+upstream+library+that+the+elkimek%2Fhoncho-self-hosted+Hermes+wrapper+builds+on.&amp;kind=project+%C2%B7+memory">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="plastic-labs/honcho — Hermes Atlas">
 <meta name="twitter:description" content="Honcho is memory infrastructure designed for building stateful agents by storing messages, events, and documents. It uses background reasoning to extract…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=honcho&amp;subtitle=+Memory+library+for+building+stateful+agents&amp;kind=project+%C2%B7+memory">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=honcho&amp;subtitle=Memory+library+for+building+stateful+agents+%E2%80%94+the+upstream+library+that+the+elkimek%2Fhoncho-self-hosted+Hermes+wrapper+builds+on.&amp;kind=project+%C2%B7+memory">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/plastic-labs/honcho",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/AGPL-3.0.html",
   "author": {
     "@type": "Organization",
     "name": "plastic-labs",
     "url": "https://github.com/plastic-labs"
   },
-  "dateModified": "2026-08-20T16:17:51.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">plastic-labs</span><span class="slash">/</span>honcho <span class="repo-flag">official</span>
   </h1>
-  <p class="project-desc"> Memory library for building stateful agents</p>
+  <p class="project-desc">Memory library for building stateful agents — the upstream library that the elkimek/honcho-self-hosted Hermes wrapper builds on.</p>
 
   <div class="meta-row">
     <span class="stars">★ 6.8K</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>AGPL-3.0</span>
+    
+    
     <span><span class="meta-label">maintainer</span>Nous Research</span>
-    <span><span class="meta-label">updated</span>2026-08-20</span>
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/plastic-labs/honcho" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://docs.honcho.dev" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -748,7 +748,6 @@ the results.</p>
 <p>We welcome contributions to Honcho! Please read our <a href="https://github.com/plastic-labs/honcho/blob/main/CONTRIBUTING.md">Contributing Guide</a> for details on our development process, coding conventions, and how to submit pull requests.</p>
 <h3>License</h3>
 <p>Honcho is licensed under the AGPL-3.0 License. Learn more at the <a href="./LICENSE">License file</a>.</p>
-
   </section>
 </details>
 

--- a/projects/plur-ai/plur.html
+++ b/projects/plur-ai/plur.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/plur-ai/plur">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=plur&amp;subtitle=Shared+memory+for+AI+agents&amp;kind=project+%C2%B7+memory">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=plur&amp;subtitle=Shared+memory+layer+with+open+engram+YAML+format+for+multi-agent+systems&amp;kind=project+%C2%B7+memory">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="plur-ai/plur — Hermes Atlas">
 <meta name="twitter:description" content="PLUR is a local-first shared memory layer for AI agents that stores information as plain-text YAML files called engrams. It allows agents across different…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=plur&amp;subtitle=Shared+memory+for+AI+agents&amp;kind=project+%C2%B7+memory">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=plur&amp;subtitle=Shared+memory+layer+with+open+engram+YAML+format+for+multi-agent+systems&amp;kind=project+%C2%B7+memory">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/plur-ai/plur",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TypeScript",
-  "license": "https://spdx.org/licenses/Apache-2.0.html",
   "author": {
     "@type": "Organization",
     "name": "plur-ai",
     "url": "https://github.com/plur-ai"
   },
-  "dateModified": "2026-08-20T09:49:41.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">plur-ai</span><span class="slash">/</span>plur
   </h1>
-  <p class="project-desc">Shared memory for AI agents</p>
+  <p class="project-desc">Shared memory layer with open engram YAML format for multi-agent systems</p>
 
   <div class="meta-row">
     <span class="stars">★ 241</span>
-    <span><span class="meta-label">lang</span>TypeScript</span>
-    <span><span class="meta-label">license</span>Apache-2.0</span>
     
-    <span><span class="meta-label">updated</span>2026-08-20</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/plur-ai/plur" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://plur.ai" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -725,7 +725,6 @@ pnpm install &amp;&amp; pnpm build &amp;&amp; pnpm test
 <p>Conventions: TypeScript, Zod validation, Vitest, no external APIs in core, YAML storage, zero-cost search by default.</p>
 <h3>License</h3>
 <p>Apache-2.0</p>
-
   </section>
 </details>
 

--- a/projects/pyrate-llama/hermes-ui.html
+++ b/projects/pyrate-llama/hermes-ui.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/pyrate-llama/hermes-ui">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-ui&amp;subtitle=The+command+center+for+Hermes+Agent+%E2%80%94+chat%2C+steer%2C+browse+files%2C+manage+skills%2C+and+monitor+everything+from+a+single+glassmorphic+HTML+app.&amp;kind=project+%C2%B7+workspaces">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-ui&amp;subtitle=Glassmorphic+web+interface+for+Hermes+Agent+%E2%80%94+your+self-hosted+AI+assistant&amp;kind=project+%C2%B7+workspaces">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="pyrate-llama/hermes-ui — Hermes Atlas">
 <meta name="twitter:description" content="Hermes UI serves as a centralized command center for managing and interacting with the Hermes Agent. It operates as a single-file HTML application powered by…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-ui&amp;subtitle=The+command+center+for+Hermes+Agent+%E2%80%94+chat%2C+steer%2C+browse+files%2C+manage+skills%2C+and+monitor+everything+from+a+single+glassmorphic+HTML+app.&amp;kind=project+%C2%B7+workspaces">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-ui&amp;subtitle=Glassmorphic+web+interface+for+Hermes+Agent+%E2%80%94+your+self-hosted+AI+assistant&amp;kind=project+%C2%B7+workspaces">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/pyrate-llama/hermes-ui",
   "applicationCategory": "DesktopEnhancementApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "HTML",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "pyrate-llama",
     "url": "https://github.com/pyrate-llama"
   },
-  "dateModified": "2026-06-30T09:54:59.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">pyrate-llama</span><span class="slash">/</span>hermes-ui
   </h1>
-  <p class="project-desc">The command center for Hermes Agent — chat, steer, browse files, manage skills, and monitor everything from a single glassmorphic HTML app.</p>
+  <p class="project-desc">Glassmorphic web interface for Hermes Agent — your self-hosted AI assistant</p>
 
   <div class="meta-row">
     <span class="stars">★ 196</span>
-    <span><span class="meta-label">lang</span>HTML</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-06-30</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -760,7 +760,6 @@ tailscale up
 <h3>Credits</h3>
 <p>Built by <a href="https://pyrate-llama.com">Pyrate Llama</a> with help from Claude (Anthropic).</p>
 <p>Powered by <a href="https://github.com/pyrate-llama/hermes-agent">Hermes Agent</a>.</p>
-
   </section>
 </details>
 

--- a/projects/raulvidis/hermes-android.html
+++ b/projects/raulvidis/hermes-android.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/raulvidis/hermes-android">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-android&amp;subtitle=Android+device+control+for+hermes-agent+%E2%80%94+bridge+app+%2B+Python+toolset&amp;kind=project+%C2%B7+integrations">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-android&amp;subtitle=Android+device+control+%E2%80%94+bridge+app+%2B+Python+toolset+for+mobile+automation&amp;kind=project+%C2%B7+integrations">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="raulvidis/hermes-android — Hermes Atlas">
 <meta name="twitter:description" content="This project provides remote Android device control for the hermes-agent. It consists of a Kotlin-based Android bridge app and a Python toolset that…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-android&amp;subtitle=Android+device+control+for+hermes-agent+%E2%80%94+bridge+app+%2B+Python+toolset&amp;kind=project+%C2%B7+integrations">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-android&amp;subtitle=Android+device+control+%E2%80%94+bridge+app+%2B+Python+toolset+for+mobile+automation&amp;kind=project+%C2%B7+integrations">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/raulvidis/hermes-android",
   "applicationCategory": "CommunicationApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "raulvidis",
     "url": "https://github.com/raulvidis"
   },
-  "dateModified": "2026-08-19T02:01:55.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">raulvidis</span><span class="slash">/</span>hermes-android
   </h1>
-  <p class="project-desc">Android device control for hermes-agent — bridge app + Python toolset</p>
+  <p class="project-desc">Android device control — bridge app + Python toolset for mobile automation</p>
 
   <div class="meta-row">
     <span class="stars">★ 470</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-19</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -603,7 +603,6 @@ cd hermes-android-bridge
 <ul>
 <li><strong>hermes-agent</strong>: <a href="https://github.com/NousResearch/hermes-agent">github.com/NousResearch/hermes-agent</a></li>
 </ul>
-
   </section>
 </details>
 

--- a/projects/raulvidis/hermes-cloudflare.html
+++ b/projects/raulvidis/hermes-cloudflare.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/raulvidis/hermes-cloudflare">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-cloudflare&amp;subtitle=Cloudflare+Browser+Rendering+plugin+for+hermes-agent+%E2%80%94+crawl%2C+scrape%2C+extract+content+from+web+pages&amp;kind=project+%C2%B7+plugins">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-cloudflare&amp;subtitle=Cloudflare+Browser+Rendering+plugin+%E2%80%94+crawl%2C+scrape%2C+extract+content+from+web+pages&amp;kind=project+%C2%B7+plugins">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="raulvidis/hermes-cloudflare — Hermes Atlas">
 <meta name="twitter:description" content="This plugin for hermes-agent uses Cloudflare's Browser Rendering API to crawl, scrape, and extract content from web pages. It provides tools for generating…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-cloudflare&amp;subtitle=Cloudflare+Browser+Rendering+plugin+for+hermes-agent+%E2%80%94+crawl%2C+scrape%2C+extract+content+from+web+pages&amp;kind=project+%C2%B7+plugins">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-cloudflare&amp;subtitle=Cloudflare+Browser+Rendering+plugin+%E2%80%94+crawl%2C+scrape%2C+extract+content+from+web+pages&amp;kind=project+%C2%B7+plugins">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/raulvidis/hermes-cloudflare",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "raulvidis",
     "url": "https://github.com/raulvidis"
   },
-  "dateModified": "2026-08-19T02:00:14.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">raulvidis</span><span class="slash">/</span>hermes-cloudflare
   </h1>
-  <p class="project-desc">Cloudflare Browser Rendering plugin for hermes-agent — crawl, scrape, extract content from web pages</p>
+  <p class="project-desc">Cloudflare Browser Rendering plugin — crawl, scrape, extract content from web pages</p>
 
   <div class="meta-row">
     <span class="stars">★ 50</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-19</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -293,7 +293,6 @@ export CLOUDFLARE_ACCOUNT_ID="your-account-id"
 </ul>
 <h3>License</h3>
 <p>MIT</p>
-
   </section>
 </details>
 

--- a/projects/robbyczgw-cla/hermes-web-search-plus.html
+++ b/projects/robbyczgw-cla/hermes-web-search-plus.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/robbyczgw-cla/hermes-web-search-plus">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-web-search-plus&amp;subtitle=Give+your+Hermes+agent+the+web+as+real+sources%2C+never+a+made-up+answer+%E2%80%94+multi-provider+search+and+extraction+with+an+optional+local%2C+key-free+DonSeTch+option.&amp;kind=project+%C2%B7+plugins">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-web-search-plus&amp;subtitle=Multi-provider+web+search+%28Serper%2C+Tavily%2C+Exa%2C+Querit%2C+Perplexity%29+with+auto-routing&amp;kind=project+%C2%B7+plugins">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="robbyczgw-cla/hermes-web-search-plus — Hermes Atlas">
 <meta name="twitter:description" content="Web Search Plus is a Hermes Agent plugin that provides tools for multi-provider web searching and page content extraction. It supports 15 search and 9…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-web-search-plus&amp;subtitle=Give+your+Hermes+agent+the+web+as+real+sources%2C+never+a+made-up+answer+%E2%80%94+multi-provider+search+and+extraction+with+an+optional+local%2C+key-free+DonSeTch+option.&amp;kind=project+%C2%B7+plugins">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-web-search-plus&amp;subtitle=Multi-provider+web+search+%28Serper%2C+Tavily%2C+Exa%2C+Querit%2C+Perplexity%29+with+auto-routing&amp;kind=project+%C2%B7+plugins">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/robbyczgw-cla/hermes-web-search-plus",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "robbyczgw-cla",
     "url": "https://github.com/robbyczgw-cla"
   },
-  "dateModified": "2026-08-17T16:53:20.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">robbyczgw-cla</span><span class="slash">/</span>hermes-web-search-plus
   </h1>
-  <p class="project-desc">Give your Hermes agent the web as real sources, never a made-up answer — multi-provider search and extraction with an optional local, key-free DonSeTch option.</p>
+  <p class="project-desc">Multi-provider web search (Serper, Tavily, Exa, Querit, Perplexity) with auto-routing</p>
 
   <div class="meta-row">
     <span class="stars">★ 384</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-17</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/robbyczgw-cla/hermes-web-search-plus" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://websearchplus.xyz" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -302,7 +302,6 @@ python3 -m compileall -q __init__.py search.py setup.py scripts tests
 <li><a href="https://github.com/NousResearch/hermes-agent">Hermes Agent</a> — the agent runtime this plugin extends</li>
 <li><a href="https://github.com/dondai44423/donsetch">DonSeTch</a> — independent AGPL-3.0-only local web-research MCP program; WSP integrates through a separate stdio process</li>
 </ul>
-
   </section>
 </details>
 

--- a/projects/rodmarkun/anihermes.html
+++ b/projects/rodmarkun/anihermes.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/rodmarkun/anihermes">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=anihermes&amp;subtitle=A+local+anime+server+%26+tracker+via+natural+language+for+Hermes+Agent+by+Nous+Research&amp;kind=project+%C2%B7+domain+applications">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=anihermes&amp;subtitle=Local+anime+server+and+tracker+via+natural+language+for+Hermes+Agent&amp;kind=project+%C2%B7+domain+applications">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="rodmarkun/anihermes — Hermes Atlas">
 <meta name="twitter:description" content="AniHermes is a natural language media server that simplifies the process of downloading and tracking anime. It leverages the Hermes Agent for LLM-driven tool…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=anihermes&amp;subtitle=A+local+anime+server+%26+tracker+via+natural+language+for+Hermes+Agent+by+Nous+Research&amp;kind=project+%C2%B7+domain+applications">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=anihermes&amp;subtitle=Local+anime+server+and+tracker+via+natural+language+for+Hermes+Agent&amp;kind=project+%C2%B7+domain+applications">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/rodmarkun/anihermes",
   "applicationCategory": "BusinessApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "rodmarkun",
     "url": "https://github.com/rodmarkun"
   },
-  "dateModified": "2026-03-15T14:29:26.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">rodmarkun</span><span class="slash">/</span>anihermes
   </h1>
-  <p class="project-desc">A local anime server &amp; tracker via natural language for Hermes Agent by Nous Research</p>
+  <p class="project-desc">Local anime server and tracker via natural language for Hermes Agent</p>
 
   <div class="meta-row">
     <span class="stars">★ 16</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-03-15</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -329,7 +329,6 @@ python3 ~/.hermes/scripts/anihermes_add_torrent.py --series "Frieren" --season "
 <p>This project references third-party services and APIs (SubsPlease, Nyaa.si, Anilist, MyAnimeList). These services are independently operated, and the developers of AniHermes have no affiliation with, endorsement from, or responsibility for those services or their content.</p>
 <h3>License</h3>
 <p>MIT</p>
-
   </section>
 </details>
 

--- a/projects/runta-dev/clawshell.html
+++ b/projects/runta-dev/clawshell.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/runta-dev/clawshell">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=clawshell&amp;subtitle=The+local+runtime+control+layer+for+OpenClaw%2FHermes-agent%2C+PII+%26+sensitive+credentials+protection.&amp;kind=project+%C2%B7+plugins">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=clawshell&amp;subtitle=The+Runtime+Security+Layer+for+OpenClaw%2FHermes-agent%2C+the+essential+safety+harness+for+PII+%26+sensitive+credentials+protection.&amp;kind=project+%C2%B7+plugins">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="runta-dev/clawshell — Hermes Atlas">
 <meta name="twitter:description" content="ClawShell is a security-privileged process that acts as a safety harness for the Hermes Agent ecosystem by protecting sensitive credentials and PII. It…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=clawshell&amp;subtitle=The+local+runtime+control+layer+for+OpenClaw%2FHermes-agent%2C+PII+%26+sensitive+credentials+protection.&amp;kind=project+%C2%B7+plugins">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=clawshell&amp;subtitle=The+Runtime+Security+Layer+for+OpenClaw%2FHermes-agent%2C+the+essential+safety+harness+for+PII+%26+sensitive+credentials+protection.&amp;kind=project+%C2%B7+plugins">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/runta-dev/clawshell",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Rust",
-  "license": "https://spdx.org/licenses/Apache-2.0.html",
   "author": {
     "@type": "Organization",
     "name": "runta-dev",
     "url": "https://github.com/runta-dev"
   },
-  "dateModified": "2026-07-13T18:45:51.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">runta-dev</span><span class="slash">/</span>clawshell
   </h1>
-  <p class="project-desc">The local runtime control layer for OpenClaw/Hermes-agent, PII &amp; sensitive credentials protection.</p>
+  <p class="project-desc">The Runtime Security Layer for OpenClaw/Hermes-agent, the essential safety harness for PII &amp; sensitive credentials protection.</p>
 
   <div class="meta-row">
     <span class="stars">★ 335</span>
-    <span><span class="meta-label">lang</span>Rust</span>
-    <span><span class="meta-label">license</span>Apache-2.0</span>
     
-    <span><span class="meta-label">updated</span>2026-07-13</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/runta-dev/clawshell" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://clawshell.org" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -464,7 +464,6 @@ hermes config set model.api_key  &lt;your-clawshell-virtual-key&gt;
 </code></pre>
 <h3>License</h3>
 <p>This project is licensed under the <a href="LICENSE">Apache License 2.0</a>.</p>
-
   </section>
 </details>
 

--- a/projects/runtimenoteslabs/gladiator.html
+++ b/projects/runtimenoteslabs/gladiator.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/runtimenoteslabs/gladiator">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=gladiator&amp;subtitle=Two+zero-human+AI+companies+battle+for+GitHub+stars+using+Hermes+Agent+%2B+Paperclip.+Nous+Research+Hackathon+2026.&amp;kind=project+%C2%B7+multi-agent">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=gladiator&amp;subtitle=Autonomous+AI+companies+competing+for+GitHub+stars+%E2%80%94+agent-vs-agent+arena&amp;kind=project+%C2%B7+multi-agent">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="runtimenoteslabs/gladiator — Hermes Atlas">
 <meta name="twitter:description" content="Gladiator is an autonomous agent arena that pits two AI companies against each other to compete for GitHub stars on identical repositories. The system uses…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=gladiator&amp;subtitle=Two+zero-human+AI+companies+battle+for+GitHub+stars+using+Hermes+Agent+%2B+Paperclip.+Nous+Research+Hackathon+2026.&amp;kind=project+%C2%B7+multi-agent">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=gladiator&amp;subtitle=Autonomous+AI+companies+competing+for+GitHub+stars+%E2%80%94+agent-vs-agent+arena&amp;kind=project+%C2%B7+multi-agent">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/runtimenoteslabs/gladiator",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "runtimenoteslabs",
     "url": "https://github.com/runtimenoteslabs"
   },
-  "dateModified": "2026-03-16T03:06:41.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">runtimenoteslabs</span><span class="slash">/</span>gladiator
   </h1>
-  <p class="project-desc">Two zero-human AI companies battle for GitHub stars using Hermes Agent + Paperclip. Nous Research Hackathon 2026.</p>
+  <p class="project-desc">Autonomous AI companies competing for GitHub stars — agent-vs-agent arena</p>
 
   <div class="meta-row">
     <span class="stars">★ 74</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-03-16</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -629,7 +629,6 @@ sudo service postgresql start
 </ul>
 <h3>License</h3>
 <p>This project is licensed under the <a href="LICENSE">MIT License</a>.</p>
-
   </section>
 </details>
 

--- a/projects/sanchomuzax/hermes-webui.html
+++ b/projects/sanchomuzax/hermes-webui.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/sanchomuzax/hermes-webui">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-webui&amp;subtitle=Process+monitoring+and+configuration+dashboard+for+Hermes+Agent&amp;kind=project+%C2%B7+workspaces">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-webui&amp;subtitle=Process+monitoring+and+configuration+dashboard+for+Hermes&amp;kind=project+%C2%B7+workspaces">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="sanchomuzax/hermes-webui — Hermes Atlas">
 <meta name="twitter:description" content="Hermes WebUI is a graphical dashboard designed to monitor and manage the Hermes Agent ecosystem. It utilizes a FastAPI backend and a React frontend to…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-webui&amp;subtitle=Process+monitoring+and+configuration+dashboard+for+Hermes+Agent&amp;kind=project+%C2%B7+workspaces">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-webui&amp;subtitle=Process+monitoring+and+configuration+dashboard+for+Hermes&amp;kind=project+%C2%B7+workspaces">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/sanchomuzax/hermes-webui",
   "applicationCategory": "DesktopEnhancementApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
   "author": {
     "@type": "Organization",
     "name": "sanchomuzax",
     "url": "https://github.com/sanchomuzax"
   },
-  "dateModified": "2026-03-24T21:52:07.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">sanchomuzax</span><span class="slash">/</span>hermes-webui
   </h1>
-  <p class="project-desc">Process monitoring and configuration dashboard for Hermes Agent</p>
+  <p class="project-desc">Process monitoring and configuration dashboard for Hermes</p>
 
   <div class="meta-row">
     <span class="stars">★ 113</span>
-    <span><span class="meta-label">lang</span>Python</span>
     
     
-    <span><span class="meta-label">updated</span>2026-03-24</span>
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/sanchomuzax/hermes-webui" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://github.com/NousResearch/hermes-agent" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -386,7 +387,6 @@ journalctl -u hermes-webui -f
 <p>This project was vibe-coded with <a href="https://claude.ai/claude-code">Claude Code</a> (Claude Opus 4.6).</p>
 <h3>License</h3>
 <p>MIT</p>
-
   </section>
 </details>
 

--- a/projects/scavio-ai/hermes-agent.html
+++ b/projects/scavio-ai/hermes-agent.html
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/scavio-ai/hermes-agent",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "scavio-ai",
     "url": "https://github.com/scavio-ai"
   },
-  "dateModified": "2026-08-19T08:14:26.000Z",
   "isPartOf": {
     "@id": "https://hermesatlas.com/#website"
   }
@@ -80,6 +78,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -113,9 +112,9 @@
   <div class="meta-row">
     <span class="stars">★ 0</span>
     
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-19</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -123,6 +122,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -282,7 +283,6 @@ credit total depends on which platforms those calls land on.</p>
 <li>Scavio API docs: <a href="https://scavio.dev/docs?utm_source=hermes">scavio.dev/docs</a></li>
 <li>Hermes Agent: <a href="https://hermes-agent.nousresearch.com/">hermes-agent.nousresearch.com</a></li>
 </ul>
-
   </section>
 </details>
 

--- a/projects/shannhk/hermes-agent-control-room.html
+++ b/projects/shannhk/hermes-agent-control-room.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/shannhk/hermes-agent-control-room">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-control-room&amp;subtitle=Control+Room-first+template+for+managing+Hermes+agents+from+one+VPS+agent+to+specialist+teams+and+orchestrated+workflows&amp;kind=project+%C2%B7+multi-agent">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-control-room&amp;subtitle=Control+Room-first+template+for+scaling+Hermes+Agent+from+one+VPS+agent+to+specialist+teams+and+automated+workflows&amp;kind=project+%C2%B7+multi-agent">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="shannhk/hermes-agent-control-room — Hermes Atlas">
 <meta name="twitter:description" content="Hermes Agent Control Room is a template-based framework designed to organize and govern Hermes agents across VPS environments. It functions as a sidecar…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-control-room&amp;subtitle=Control+Room-first+template+for+managing+Hermes+agents+from+one+VPS+agent+to+specialist+teams+and+orchestrated+workflows&amp;kind=project+%C2%B7+multi-agent">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-control-room&amp;subtitle=Control+Room-first+template+for+scaling+Hermes+Agent+from+one+VPS+agent+to+specialist+teams+and+automated+workflows&amp;kind=project+%C2%B7+multi-agent">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/shannhk/hermes-agent-control-room",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Shell",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "shannhk",
     "url": "https://github.com/shannhk"
   },
-  "dateModified": "2026-05-16T19:30:12.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">shannhk</span><span class="slash">/</span>hermes-agent-control-room
   </h1>
-  <p class="project-desc">Control Room-first template for managing Hermes agents from one VPS agent to specialist teams and orchestrated workflows</p>
+  <p class="project-desc">Control Room-first template for scaling Hermes Agent from one VPS agent to specialist teams and automated workflows</p>
 
   <div class="meta-row">
     <span class="stars">★ 696</span>
-    <span><span class="meta-label">lang</span>Shell</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-05-16</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -452,7 +452,6 @@ ls skills/
 </ul>
 <h3>License</h3>
 <p>MIT. See <code>LICENSE</code>.</p>
-
   </section>
 </details>
 

--- a/projects/sharbelxyz/hermes-agent-mission-control.html
+++ b/projects/sharbelxyz/hermes-agent-mission-control.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/sharbelxyz/hermes-agent-mission-control">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=Hermy+HQ&amp;subtitle=Hermy+HQ+%E2%80%94+a+self-hostable+mission-control+dashboard+template+that+pairs+with+your+own+local+Hermes+agent+over+a+Postgres+message+bus.+Send+it+to+your+Hermes+and+it+onboards+you+st&amp;kind=project+%C2%B7+workspaces">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=Hermy+HQ&amp;subtitle=Self-hostable+mission-control+dashboard+template+that+pairs+with+your+own+local+Hermes+agent+over+a+Postgres+message+bus.&amp;kind=project+%C2%B7+workspaces">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="sharbelxyz/Hermy HQ — Hermes Atlas">
 <meta name="twitter:description" content="Hermy HQ is a self-hostable dashboard template designed to manage a local Hermes AI agent through a shared Postgres database acting as a message bus. Users can…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Hermy+HQ&amp;subtitle=Hermy+HQ+%E2%80%94+a+self-hostable+mission-control+dashboard+template+that+pairs+with+your+own+local+Hermes+agent+over+a+Postgres+message+bus.+Send+it+to+your+Hermes+and+it+onboards+you+st&amp;kind=project+%C2%B7+workspaces">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Hermy+HQ&amp;subtitle=Self-hostable+mission-control+dashboard+template+that+pairs+with+your+own+local+Hermes+agent+over+a+Postgres+message+bus.&amp;kind=project+%C2%B7+workspaces">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/sharbelxyz/hermes-agent-mission-control",
   "applicationCategory": "DesktopEnhancementApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TypeScript",
   "author": {
     "@type": "Organization",
     "name": "sharbelxyz",
     "url": "https://github.com/sharbelxyz"
   },
-  "dateModified": "2026-07-26T09:13:29.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">sharbelxyz</span><span class="slash">/</span>hermes-agent-mission-control
   </h1>
-  <p class="project-desc">Hermy HQ — a self-hostable mission-control dashboard template that pairs with your own local Hermes agent over a Postgres message bus. Send it to your Hermes and it onboards you step by step.</p>
+  <p class="project-desc">Self-hostable mission-control dashboard template that pairs with your own local Hermes agent over a Postgres message bus.</p>
 
   <div class="meta-row">
     <span class="stars">★ 327</span>
-    <span><span class="meta-label">lang</span>TypeScript</span>
     
     
-    <span><span class="meta-label">updated</span>2026-07-26</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -355,7 +356,6 @@ approve.</li>
 <h3>License</h3>
 <p>Provided as a template for you to fork, self-host, and adapt. Add the license of
 your choice before publishing your own instance.</p>
-
   </section>
 </details>
 

--- a/projects/sheawinkler/hermes-agent-ultra.html
+++ b/projects/sheawinkler/hermes-agent-ultra.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/sheawinkler/hermes-agent-ultra">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-ultra&amp;subtitle=Hermes+Agent+Ultra+%28built+from+hermes-agent-rs+core+by+lumioresearch%2C+%40oxterrybit%29.+Hermes-agent+feature+parity+at+commit+level.+Rust+Performance&amp;kind=project+%C2%B7+forks">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-ultra&amp;subtitle=Rust-based+Hermes+Agent+Ultra+derivative+focused+on+performance+and+Hermes+Agent+feature+parity&amp;kind=project+%C2%B7+forks">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="sheawinkler/hermes-agent-ultra — Hermes Atlas">
 <meta name="twitter:description" content="Hermes Agent Ultra is a Rust-based autonomous agent runtime designed to provide feature parity with the original Hermes Agent while adding enhanced reliability…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-ultra&amp;subtitle=Hermes+Agent+Ultra+%28built+from+hermes-agent-rs+core+by+lumioresearch%2C+%40oxterrybit%29.+Hermes-agent+feature+parity+at+commit+level.+Rust+Performance&amp;kind=project+%C2%B7+forks">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-ultra&amp;subtitle=Rust-based+Hermes+Agent+Ultra+derivative+focused+on+performance+and+Hermes+Agent+feature+parity&amp;kind=project+%C2%B7+forks">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/sheawinkler/hermes-agent-ultra",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Rust",
   "author": {
     "@type": "Organization",
     "name": "sheawinkler",
     "url": "https://github.com/sheawinkler"
   },
-  "dateModified": "2026-07-26T12:35:25.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">sheawinkler</span><span class="slash">/</span>hermes-agent-ultra
   </h1>
-  <p class="project-desc">Hermes Agent Ultra (built from hermes-agent-rs core by lumioresearch, @oxterrybit). Hermes-agent feature parity at commit level. Rust Performance</p>
+  <p class="project-desc">Rust-based Hermes Agent Ultra derivative focused on performance and Hermes Agent feature parity</p>
 
   <div class="meta-row">
     <span class="stars">★ 84</span>
-    <span><span class="meta-label">lang</span>Rust</span>
     
     
-    <span><span class="meta-label">updated</span>2026-07-26</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -496,7 +497,6 @@ overrides.</p>
 </ul>
 <h3>License</h3>
 <p>Distributed under this repository's license and notices.<br>See <a href="./LICENSE">LICENSE</a>, <a href="./NOTICE">NOTICE</a>, and <a href="https://github.com/sheawinkler/hermes-agent-ultra/blob/main/UPSTREAM_ATTRIBUTION.md">UPSTREAM_ATTRIBUTION.md</a>.</p>
-
   </section>
 </details>
 

--- a/projects/skillseal/skillseal.html
+++ b/projects/skillseal/skillseal.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/skillseal/skillseal",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "skillseal",
     "url": "https://github.com/skillseal"
   },
-  "dateModified": "2026-08-11T16:38:50.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,17 +118,19 @@
 
   <div class="meta-row">
     <span class="stars">★ 1</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-11</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/skillseal/skillseal" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://skillseal.workloop.com.br" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -413,7 +413,6 @@ python3 certificates.py list
 </ul>
 <hr>
 <p>Built by <a href="https://workloop.com.br">Workloop</a> · <a href="https://skillseal.workloop.com.br">skillseal.workloop.com.br</a></p>
-
   </section>
 </details>
 

--- a/projects/smartcontractkit/chainlink-agent-skills.html
+++ b/projects/smartcontractkit/chainlink-agent-skills.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/smartcontractkit/chainlink-agent-skills">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=chainlink-agent-skills&amp;subtitle=%5BPUBLIC%5D+Repository+for+Chainlink+Skills+that+implement+https%3A%2F%2Fagentskills.io%2Fspecification&amp;kind=project+%C2%B7+skills">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=chainlink-agent-skills&amp;subtitle=Oracle+network+and+smart+contract+interaction+skills+%28agentskills.io+spec%29&amp;kind=project+%C2%B7+skills">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="smartcontractkit/chainlink-agent-skills — Hermes Atlas">
 <meta name="twitter:description" content="This repository provides a collection of official Chainlink coding skills designed for autonomous agents following the Agent Skills specification. These skills…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=chainlink-agent-skills&amp;subtitle=%5BPUBLIC%5D+Repository+for+Chainlink+Skills+that+implement+https%3A%2F%2Fagentskills.io%2Fspecification&amp;kind=project+%C2%B7+skills">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=chainlink-agent-skills&amp;subtitle=Oracle+network+and+smart+contract+interaction+skills+%28agentskills.io+spec%29&amp;kind=project+%C2%B7+skills">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/smartcontractkit/chainlink-agent-skills",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Solidity",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "smartcontractkit",
     "url": "https://github.com/smartcontractkit"
   },
-  "dateModified": "2026-08-19T18:28:03.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">smartcontractkit</span><span class="slash">/</span>chainlink-agent-skills
   </h1>
-  <p class="project-desc">[PUBLIC] Repository for Chainlink Skills that implement https://agentskills.io/specification</p>
+  <p class="project-desc">Oracle network and smart contract interaction skills (agentskills.io spec)</p>
 
   <div class="meta-row">
     <span class="stars">★ 125</span>
-    <span><span class="meta-label">lang</span>Solidity</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-19</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,15 @@
     
   </div>
 </section>
+
+
+<aside class="install-box" aria-label="How to install this skill">
+  <div class="ib-label">install<span class="ib-type">skill</span></div>
+  <code class="ib-cmd">npx skills add smartcontractkit/chainlink-agent-skills</code>
+  <p class="ib-compat">agentskills.io spec via the skills.sh CLI; project-level install is the default.</p>
+  <p class="ib-verdict">The official Chainlink team's own oracle-network skills (CCIP, VRF, Data Feeds) — the vendor-authoritative pick for cross-chain or oracle work, versus a community reimplementation.</p>
+  <a class="ib-more" href="/skills/">more picks → the skills hub</a>
+</aside>
 
 
 
@@ -219,7 +226,6 @@ how to monitor status of cross-chain transfers using the CCIP CLI.
 
 Any questions before you start?
 </code></pre>
-
   </section>
 </details>
 

--- a/projects/solomon2773/nora.html
+++ b/projects/solomon2773/nora.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/solomon2773/nora">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=nora&amp;subtitle=Open-source%2C+self-hosted+control+plane+for+OpenClaw+and+Hermes+AI-agent+fleets+on+Docker%2FKubernetes+%E2%80%94+REST%2C+CLI%2C+and+MCP.&amp;kind=project+%C2%B7+deployment">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=nora&amp;subtitle=Self-hosted+control+plane+to+deploy%2C+monitor%2C+and+operate+OpenClaw+and+Hermes+AI+agents+on+Docker%2FKubernetes+%E2%80%94+with+REST%2C+CLI%2C+and+MCP.&amp;kind=project+%C2%B7+deployment">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="solomon2773/nora — Hermes Atlas">
 <meta name="twitter:description" content="Nora is a self-hosted platform for deploying, monitoring, and operating OpenClaw and Hermes AI agent fleets. It supports agent lifecycle management on Docker…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=nora&amp;subtitle=Open-source%2C+self-hosted+control+plane+for+OpenClaw+and+Hermes+AI-agent+fleets+on+Docker%2FKubernetes+%E2%80%94+REST%2C+CLI%2C+and+MCP.&amp;kind=project+%C2%B7+deployment">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=nora&amp;subtitle=Self-hosted+control+plane+to+deploy%2C+monitor%2C+and+operate+OpenClaw+and+Hermes+AI+agents+on+Docker%2FKubernetes+%E2%80%94+with+REST%2C+CLI%2C+and+MCP.&amp;kind=project+%C2%B7+deployment">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/solomon2773/nora",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TypeScript",
-  "license": "https://spdx.org/licenses/Apache-2.0.html",
   "author": {
     "@type": "Organization",
     "name": "solomon2773",
     "url": "https://github.com/solomon2773"
   },
-  "dateModified": "2026-08-13T01:55:24.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">solomon2773</span><span class="slash">/</span>nora
   </h1>
-  <p class="project-desc">Open-source, self-hosted control plane for OpenClaw and Hermes AI-agent fleets on Docker/Kubernetes — REST, CLI, and MCP.</p>
+  <p class="project-desc">Self-hosted control plane to deploy, monitor, and operate OpenClaw and Hermes AI agents on Docker/Kubernetes — with REST, CLI, and MCP.</p>
 
   <div class="meta-row">
     <span class="stars">★ 32</span>
-    <span><span class="meta-label">lang</span>TypeScript</span>
-    <span><span class="meta-label">license</span>Apache-2.0</span>
     
-    <span><span class="meta-label">updated</span>2026-08-13</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/solomon2773/nora" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://nora.solomontsao.com" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -438,7 +438,6 @@ cd e2e &amp;&amp; npm test
 <p>If Nora is useful to you, a ⭐ on the repo helps other self-hosters find it.</p>
 <h3>License</h3>
 <p>This project is open source under the <a href="./LICENSE">Apache License 2.0</a>.</p>
-
   </section>
 </details>
 

--- a/projects/sourcevault-ai/sourcevault-code-tools.html
+++ b/projects/sourcevault-ai/sourcevault-code-tools.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/sourcevault-ai/sourcevault-code-tools",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "sourcevault-ai",
     "url": "https://github.com/sourcevault-ai"
   },
-  "dateModified": "2026-07-24T02:10:06.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,17 +118,19 @@
 
   <div class="meta-row">
     <span class="stars">★ 4</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-07-24</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/sourcevault-ai/sourcevault-code-tools" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://trysourcevault.com" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -348,7 +348,6 @@ again, or results will cite stale code.</li>
 <h3>License</h3>
 <p>MIT — see <a href="LICENSE">LICENSE</a>. The SourceVault server is a separate,
 commercially licensed product.</p>
-
   </section>
 </details>
 

--- a/projects/stainlu/hermes-labyrinth.html
+++ b/projects/stainlu/hermes-labyrinth.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/stainlu/hermes-labyrinth">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-labyrinth&amp;subtitle=Read-only+observability+plugin+for+Hermes+Agent%3A+journeys%2C+crossings%2C+guideposts%2C+and+reports.&amp;kind=project+%C2%B7+plugins">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-labyrinth&amp;subtitle=Read-only+observability+plugin+for+Hermes+Agent+with+journeys%2C+crossings%2C+guideposts%2C+and+reports&amp;kind=project+%C2%B7+plugins">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="stainlu/hermes-labyrinth — Hermes Atlas">
 <meta name="twitter:description" content="Hermes Labyrinth is a read-only observability plugin for Hermes Agent that visualizes autonomous workflows as a structured map of events. It functions as a…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-labyrinth&amp;subtitle=Read-only+observability+plugin+for+Hermes+Agent%3A+journeys%2C+crossings%2C+guideposts%2C+and+reports.&amp;kind=project+%C2%B7+plugins">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-labyrinth&amp;subtitle=Read-only+observability+plugin+for+Hermes+Agent+with+journeys%2C+crossings%2C+guideposts%2C+and+reports&amp;kind=project+%C2%B7+plugins">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/stainlu/hermes-labyrinth",
   "applicationCategory": "BrowserApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "HTML",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "stainlu",
     "url": "https://github.com/stainlu"
   },
-  "dateModified": "2026-05-04T12:45:24.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">stainlu</span><span class="slash">/</span>hermes-labyrinth
   </h1>
-  <p class="project-desc">Read-only observability plugin for Hermes Agent: journeys, crossings, guideposts, and reports.</p>
+  <p class="project-desc">Read-only observability plugin for Hermes Agent with journeys, crossings, guideposts, and reports</p>
 
   <div class="meta-row">
     <span class="stars">★ 304</span>
-    <span><span class="meta-label">lang</span>HTML</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-05-04</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/stainlu/hermes-labyrinth" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://stainlu.github.io/hermes-labyrinth/" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -335,7 +335,6 @@ browser smoke tests; full Hermes dashboard integration tests are still on the
 roadmap.</p>
 <p>See <a href="https://github.com/stainlu/hermes-labyrinth/blob/main/KNOWN_LIMITATIONS.md">Known Limitations</a>, <a href="https://github.com/stainlu/hermes-labyrinth/blob/main/ROADMAP.md">Roadmap</a>, and
 <a href="https://github.com/stainlu/hermes-labyrinth/blob/main/CHANGELOG.md">Changelog</a>.</p>
-
   </section>
 </details>
 

--- a/projects/stepanov1975/hermes-local-knowledge.html
+++ b/projects/stepanov1975/hermes-local-knowledge.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/stepanov1975/hermes-local-knowledge">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-local-knowledge&amp;subtitle=Hermes+Agent+plugin+for+local+knowledge+search+and+artifact+routing%E2%80%94find+the+right+skill%2C+script%2C+runbook%2C+cron+job%2C+MCP+server%2C+or+document.&amp;kind=project+%C2%B7+memory">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-local-knowledge&amp;subtitle=Reusable+Hermes+Agent+plugin+for+local+capability+indexing+and+routing&amp;kind=project+%C2%B7+memory">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="stepanov1975/hermes-local-knowledge — Hermes Atlas">
 <meta name="twitter:description" content="Hermes Local Knowledge is a reusable plugin for Hermes Agents that functions as an artifact router for local indexing and discovery. It provides tools to…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-local-knowledge&amp;subtitle=Hermes+Agent+plugin+for+local+knowledge+search+and+artifact+routing%E2%80%94find+the+right+skill%2C+script%2C+runbook%2C+cron+job%2C+MCP+server%2C+or+document.&amp;kind=project+%C2%B7+memory">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-local-knowledge&amp;subtitle=Reusable+Hermes+Agent+plugin+for+local+capability+indexing+and+routing&amp;kind=project+%C2%B7+memory">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/stepanov1975/hermes-local-knowledge",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "stepanov1975",
     "url": "https://github.com/stepanov1975"
   },
-  "dateModified": "2026-08-17T17:59:27.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">stepanov1975</span><span class="slash">/</span>hermes-local-knowledge
   </h1>
-  <p class="project-desc">Hermes Agent plugin for local knowledge search and artifact routing—find the right skill, script, runbook, cron job, MCP server, or document.</p>
+  <p class="project-desc">Reusable Hermes Agent plugin for local capability indexing and routing</p>
 
   <div class="meta-row">
     <span class="stars">★ 6</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-17</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -502,7 +502,6 @@ git diff --check
 <li><code>indexer.py</code> — thin compatibility facade exporting exactly <code>Artifact</code>, <code>Edge</code>, <code>IndexSettings</code>, <code>build_index</code>, <code>search_index</code>, <code>get_artifact</code>, <code>get_neighbors</code>, and <code>main</code>.</li>
 <li><code>__init__.py</code> — package version.</li>
 </ul>
-
   </section>
 </details>
 

--- a/projects/stephenschoettler/hermes-lcm.html
+++ b/projects/stephenschoettler/hermes-lcm.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/stephenschoettler/hermes-lcm",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "stephenschoettler",
     "url": "https://github.com/stephenschoettler"
   },
-  "dateModified": "2026-08-13T01:47:30.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,10 +118,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 1.0K</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-13</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -1132,7 +1132,6 @@ for changelogs.</p>
    <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=stephenschoettler/hermes-lcm&amp;type=timeline&amp;legend=top-left">
  </picture>
 </a>
-
   </section>
 </details>
 

--- a/projects/supermemoryai/supermemory.html
+++ b/projects/supermemoryai/supermemory.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/supermemoryai/supermemory">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=supermemory&amp;subtitle=Memory+and+context+engine+%2B+app+that+is+extremely+fast%2C+scalable%2C+and+can+be+run+fully+locally.+The+Memory+API+for+the+AI+era.&amp;kind=project+%C2%B7+memory">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=supermemory&amp;subtitle=Memory+engine+and+API+%E2%80%94+official+Hermes+Agent+memory+provider+with+sub-300ms+recall+sustained+at+100B%2B+tokens%2Fmonth%2C+custom+vector+graph+engine%2C+context+fencing%2C+and+byte-level+ded&amp;kind=project+%C2%B7+memory">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="supermemoryai/supermemory — Hermes Atlas">
 <meta name="twitter:description" content="Supermemory is a memory and context engine for AI that manages user profiles, knowledge updates, and conversation history. It provides a single API for memory,…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=supermemory&amp;subtitle=Memory+and+context+engine+%2B+app+that+is+extremely+fast%2C+scalable%2C+and+can+be+run+fully+locally.+The+Memory+API+for+the+AI+era.&amp;kind=project+%C2%B7+memory">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=supermemory&amp;subtitle=Memory+engine+and+API+%E2%80%94+official+Hermes+Agent+memory+provider+with+sub-300ms+recall+sustained+at+100B%2B+tokens%2Fmonth%2C+custom+vector+graph+engine%2C+context+fencing%2C+and+byte-level+ded&amp;kind=project+%C2%B7+memory">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/supermemoryai/supermemory",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TypeScript",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "supermemoryai",
     "url": "https://github.com/supermemoryai"
   },
-  "dateModified": "2026-08-20T23:00:59.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">supermemoryai</span><span class="slash">/</span>supermemory
   </h1>
-  <p class="project-desc">Memory and context engine + app that is extremely fast, scalable, and can be run fully locally. The Memory API for the AI era.</p>
+  <p class="project-desc">Memory engine and API — official Hermes Agent memory provider with sub-300ms recall sustained at 100B+ tokens/month, custom vector graph engine, context fencing, and byte-level dedupe with 100% prompt-cache discount.</p>
 
   <div class="meta-row">
     <span class="stars">★ 29.0K</span>
-    <span><span class="meta-label">lang</span>TypeScript</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-20</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/supermemoryai/supermemory" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://supermemory.ai/docs" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -542,7 +542,6 @@ npx supermemory local
 <p align="center">
   <strong>Give your AI a memory. It's about time..</strong>
 </p>
-
   </section>
 </details>
 

--- a/projects/supernovae-st/nika.html
+++ b/projects/supernovae-st/nika.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/supernovae-st/nika",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Rust",
-  "license": "https://spdx.org/licenses/AGPL-3.0.html",
   "author": {
     "@type": "Organization",
     "name": "supernovae-st",
     "url": "https://github.com/supernovae-st"
   },
-  "dateModified": "2026-08-21T10:17:44.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,17 +118,19 @@
 
   <div class="meta-row">
     <span class="stars">★ 54</span>
-    <span><span class="meta-label">lang</span>Rust</span>
-    <span><span class="meta-label">license</span>AGPL-3.0</span>
     
-    <span><span class="meta-label">updated</span>2026-08-21</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/supernovae-st/nika" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://nika.sh" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -775,7 +775,6 @@ reports: <code>security@supernovae.studio</code>.</p>
 <hr>
 <p>© 2024–2026 <a href="https://supernovae.studio">SuperNovae Studio</a> · 🦋 Nika, the
 butterfly on the SuperNovae flag. <em>Prompt once. Run forever.</em></p>
-
   </section>
 </details>
 

--- a/projects/swarmclawai/swarmclaw.html
+++ b/projects/swarmclawai/swarmclaw.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/swarmclawai/swarmclaw">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=swarmclaw&amp;subtitle=Open-source+self-hosted+AI+agent+runtime+and+multi-agent+framework+for+autonomous+agent+swarms.+Agent+memory%2C+MCP+tools%2C+schedules%2C+delegation%2C+and+23%2B+LLM+providers+%28Claude%2C+GPT%2C+&amp;kind=project+%C2%B7+multi-agent">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=swarmclaw&amp;subtitle=Build+autonomous+AI+agent+swarms+with+orchestration%2C+skills%2C+and+multiple+model+providers&amp;kind=project+%C2%B7+multi-agent">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="swarmclawai/swarmclaw — Hermes Atlas">
 <meta name="twitter:description" content="SwarmClaw is a self-hosted runtime and framework designed for managing autonomous AI agent swarms and orchestrators. It utilizes a multi-agent architecture…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=swarmclaw&amp;subtitle=Open-source+self-hosted+AI+agent+runtime+and+multi-agent+framework+for+autonomous+agent+swarms.+Agent+memory%2C+MCP+tools%2C+schedules%2C+delegation%2C+and+23%2B+LLM+providers+%28Claude%2C+GPT%2C+&amp;kind=project+%C2%B7+multi-agent">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=swarmclaw&amp;subtitle=Build+autonomous+AI+agent+swarms+with+orchestration%2C+skills%2C+and+multiple+model+providers&amp;kind=project+%C2%B7+multi-agent">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/swarmclawai/swarmclaw",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TypeScript",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "swarmclawai",
     "url": "https://github.com/swarmclawai"
   },
-  "dateModified": "2026-06-30T20:58:13.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">swarmclawai</span><span class="slash">/</span>swarmclaw
   </h1>
-  <p class="project-desc">Open-source self-hosted AI agent runtime and multi-agent framework for autonomous agent swarms. Agent memory, MCP tools, schedules, delegation, and 23+ LLM providers (Claude, GPT, Gemini, OpenRouter, Ollama). A practical Claude Code and LangChain alternative.</p>
+  <p class="project-desc">Build autonomous AI agent swarms with orchestration, skills, and multiple model providers</p>
 
   <div class="meta-row">
     <span class="stars">★ 649</span>
-    <span><span class="meta-label">lang</span>TypeScript</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-06-30</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/swarmclawai/swarmclaw" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://www.swarmclaw.ai" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -792,7 +792,6 @@ OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer your-token
 <p>Agent configuration </p>
 <hr>
 <p><em>README truncated. <a href="https://github.com/swarmclawai/swarmclaw#readme">Continue reading on GitHub</a></em></p>
-
   </section>
 </details>
 

--- a/projects/teixeirazeus/fablize-for-hermes.html
+++ b/projects/teixeirazeus/fablize-for-hermes.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/teixeirazeus/fablize-for-hermes">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=fablize-for-hermes&amp;subtitle=+This+project+adapts+fablize%27s+verified+procedures+%E2%80%94+verification+grounding%2C+multi-story+evidence+gating%2C+investigation+protocol%2C+and+early-stop+prevention.&amp;kind=project+%C2%B7+skills">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=fablize-for-hermes&amp;subtitle=This+project+adapts+fablize%27s+verified+procedures+%E2%80%94+verification+grounding%2C+multi-story+evidence+gating%2C+investigation+protocol%2C+and+early-stop+prevention.&amp;kind=project+%C2%B7+skills">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="teixeirazeus/fablize-for-hermes — Hermes Atlas">
 <meta name="twitter:description" content="fablize-for-hermes is a port of the fablize procedure system designed to improve task completion and verification within the Hermes Agent ecosystem. It…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=fablize-for-hermes&amp;subtitle=+This+project+adapts+fablize%27s+verified+procedures+%E2%80%94+verification+grounding%2C+multi-story+evidence+gating%2C+investigation+protocol%2C+and+early-stop+prevention.&amp;kind=project+%C2%B7+skills">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=fablize-for-hermes&amp;subtitle=This+project+adapts+fablize%27s+verified+procedures+%E2%80%94+verification+grounding%2C+multi-story+evidence+gating%2C+investigation+protocol%2C+and+early-stop+prevention.&amp;kind=project+%C2%B7+skills">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/teixeirazeus/fablize-for-hermes",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "teixeirazeus",
     "url": "https://github.com/teixeirazeus"
   },
-  "dateModified": "2026-06-17T12:02:17.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">teixeirazeus</span><span class="slash">/</span>fablize-for-hermes
   </h1>
-  <p class="project-desc"> This project adapts fablize's verified procedures — verification grounding, multi-story evidence gating, investigation protocol, and early-stop prevention.</p>
+  <p class="project-desc">This project adapts fablize's verified procedures — verification grounding, multi-story evidence gating, investigation protocol, and early-stop prevention.</p>
 
   <div class="meta-row">
     <span class="stars">★ 15</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-06-17</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -337,7 +337,6 @@ It is a guideline, not a guard.</li>
 <h3>License</h3>
 <p>MIT — same as the original fablize. The upstream fablize by fivetaku is MIT licensed.
 This port adapts the design and procedures to the Hermes Agent ecosystem.</p>
-
   </section>
 </details>
 

--- a/projects/teknium1/hermes-miniverse.html
+++ b/projects/teknium1/hermes-miniverse.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/teknium1/hermes-miniverse">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-miniverse&amp;subtitle=Bridge+connecting+Hermes+Agent+to+Miniverse+pixel+worlds&amp;kind=project+%C2%B7+integrations">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-miniverse&amp;subtitle=Bridge+Hermes+to+Miniverse+pixel+worlds+%E2%80%94+agent+embodiment+in+virtual+environments&amp;kind=project+%C2%B7+integrations">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="teknium1/hermes-miniverse — Hermes Atlas">
 <meta name="twitter:description" content="Hermes-miniverse is a bridge that enables Hermes Agents to inhabit and interact within Miniverse pixel worlds. It functions through a three-part architecture…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-miniverse&amp;subtitle=Bridge+connecting+Hermes+Agent+to+Miniverse+pixel+worlds&amp;kind=project+%C2%B7+integrations">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-miniverse&amp;subtitle=Bridge+Hermes+to+Miniverse+pixel+worlds+%E2%80%94+agent+embodiment+in+virtual+environments&amp;kind=project+%C2%B7+integrations">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/teknium1/hermes-miniverse",
   "applicationCategory": "CommunicationApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
   "author": {
     "@type": "Organization",
     "name": "teknium1",
     "url": "https://github.com/teknium1"
   },
-  "dateModified": "2026-03-13T11:44:21.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">teknium1</span><span class="slash">/</span>hermes-miniverse
   </h1>
-  <p class="project-desc">Bridge connecting Hermes Agent to Miniverse pixel worlds</p>
+  <p class="project-desc">Bridge Hermes to Miniverse pixel worlds — agent embodiment in virtual environments</p>
 
   <div class="meta-row">
     <span class="stars">★ 55</span>
-    <span><span class="meta-label">lang</span>Python</span>
     
     
-    <span><span class="meta-label">updated</span>2026-03-13</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -258,7 +259,6 @@ python bridge.py --agent hermes-researcher --name "Hermes (Research)" --color "#
 <p>Each connects to a separate Hermes session.</p>
 <h3>License</h3>
 <p>MIT</p>
-
   </section>
 </details>
 

--- a/projects/tiann/execplan-skill.html
+++ b/projects/tiann/execplan-skill.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/tiann/execplan-skill">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=execplan-skill&amp;subtitle=An+%5BAgent+Skill%5D%28https%3A%2F%2Fagentskills.io%29+that+enables+AI+coding+agents+to+tackle+complex%2C+long-running+implementation+tasks+autonomously.&amp;kind=project+%C2%B7+skills">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=execplan-skill&amp;subtitle=Complex+multi-step+task+execution+with+checkpoints+and+recovery&amp;kind=project+%C2%B7+skills">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="tiann/execplan-skill — Hermes Atlas">
 <meta name="twitter:description" content="ExecPlan is an Agent Skill designed to help AI coding agents autonomously manage complex, long-running implementation tasks. It utilizes a structured execution…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=execplan-skill&amp;subtitle=An+%5BAgent+Skill%5D%28https%3A%2F%2Fagentskills.io%29+that+enables+AI+coding+agents+to+tackle+complex%2C+long-running+implementation+tasks+autonomously.&amp;kind=project+%C2%B7+skills">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=execplan-skill&amp;subtitle=Complex+multi-step+task+execution+with+checkpoints+and+recovery&amp;kind=project+%C2%B7+skills">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -45,7 +45,6 @@
     "name": "tiann",
     "url": "https://github.com/tiann"
   },
-  "dateModified": "2025-12-20T02:41:28.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -86,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -114,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">tiann</span><span class="slash">/</span>execplan-skill
   </h1>
-  <p class="project-desc">An [Agent Skill](https://agentskills.io) that enables AI coding agents to tackle complex, long-running implementation tasks autonomously.</p>
+  <p class="project-desc">Complex multi-step task execution with checkpoints and recovery</p>
 
   <div class="meta-row">
     <span class="stars">★ 67</span>
     
     
     
-    <span><span class="meta-label">updated</span>2025-12-20</span>
+    
   </div>
 
   <div class="actions">
@@ -129,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -174,7 +176,6 @@
 <p>Works with: Claude Code, Cursor, OpenCode, Amp, Goose, VS Code, and other Agent Skills-compatible tools.</p>
 <h3>License</h3>
 <p>MIT</p>
-
   </section>
 </details>
 

--- a/projects/tinyhumansai/tiny.place.html
+++ b/projects/tinyhumansai/tiny.place.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/tinyhumansai/tiny.place",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TypeScript",
-  "license": "https://spdx.org/licenses/GPL-3.0.html",
   "author": {
     "@type": "Organization",
     "name": "tinyhumansai",
     "url": "https://github.com/tinyhumansai"
   },
-  "dateModified": "2026-08-08T16:09:07.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,17 +118,19 @@
 
   <div class="meta-row">
     <span class="stars">★ 127</span>
-    <span><span class="meta-label">lang</span>TypeScript</span>
-    <span><span class="meta-label">license</span>GPL-3.0</span>
     
-    <span><span class="meta-label">updated</span>2026-08-08</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/tinyhumansai/tiny.place" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://tiny.place/" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -324,7 +324,6 @@ pnpm test                 # run all tests
 
 <h3>License</h3>
 <p>GNU General Public License v3.0, see <a href="LICENSE">LICENSE</a>.</p>
-
   </section>
 </details>
 

--- a/projects/tlehman/litprog-skill.html
+++ b/projects/tlehman/litprog-skill.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/tlehman/litprog-skill">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=litprog-skill&amp;subtitle=Literate+programming+skill+for+agent+harnesses+like+Claude+Code%2C+OpenCode+and+Hermes+Agent&amp;kind=project+%C2%B7+skills">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=litprog-skill&amp;subtitle=Literate+programming+skill+%E2%80%94+weave+code+and+documentation+across+agents&amp;kind=project+%C2%B7+skills">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="tlehman/litprog-skill — Hermes Atlas">
 <meta name="twitter:description" content="The litprog-skill is a Claude Code extension that implements Donald Knuth's literate programming paradigm by transforming codebases into human-readable…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=litprog-skill&amp;subtitle=Literate+programming+skill+for+agent+harnesses+like+Claude+Code%2C+OpenCode+and+Hermes+Agent&amp;kind=project+%C2%B7+skills">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=litprog-skill&amp;subtitle=Literate+programming+skill+%E2%80%94+weave+code+and+documentation+across+agents&amp;kind=project+%C2%B7+skills">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/tlehman/litprog-skill",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TypeScript",
   "author": {
     "@type": "Organization",
     "name": "tlehman",
     "url": "https://github.com/tlehman"
   },
-  "dateModified": "2026-04-10T02:24:09.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">tlehman</span><span class="slash">/</span>litprog-skill
   </h1>
-  <p class="project-desc">Literate programming skill for agent harnesses like Claude Code, OpenCode and Hermes Agent</p>
+  <p class="project-desc">Literate programming skill — weave code and documentation across agents</p>
 
   <div class="meta-row">
     <span class="stars">★ 251</span>
-    <span><span class="meta-label">lang</span>TypeScript</span>
     
     
-    <span><span class="meta-label">updated</span>2026-04-10</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -210,7 +211,6 @@ cp litprog-skill/SKILL.md your-project/.claude/skills/literate-programming.md
 <li><strong>Architectural clarity</strong>: Reveals architectural decisions that comments and READMEs miss. The narrative structure shows how pieces fit together.</li>
 <li><strong>Knowledge transfer</strong>: Useful for onboarding, code reviews, and preserving institutional knowledge. A new team member can read the literate program start to finish and understand the system.</li>
 </ul>
-
   </section>
 </details>
 

--- a/projects/topoteretes/cognee-integrations.html
+++ b/projects/topoteretes/cognee-integrations.html
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/topoteretes/cognee-integrations",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
   "author": {
     "@type": "Organization",
     "name": "topoteretes",
     "url": "https://github.com/topoteretes"
   },
-  "dateModified": "2026-08-21T10:07:01.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -119,10 +118,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 82</span>
-    <span><span class="meta-label">lang</span>Python</span>
     
     
-    <span><span class="meta-label">updated</span>2026-08-21</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -491,7 +492,6 @@ git tag openclaw-v2026.2.4 &amp;&amp; git push --tags
 </ul>
 <h3>Inventory</h3>
 <p><code>integrations/inventory.yml</code> tracks all known integrations with ownership, migration status, package names, and version info. Update it when adding or migrating integrations.</p>
-
   </section>
 </details>
 

--- a/projects/topoteretes/cognee.html
+++ b/projects/topoteretes/cognee.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/topoteretes/cognee",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/Apache-2.0.html",
   "author": {
     "@type": "Organization",
     "name": "topoteretes",
     "url": "https://github.com/topoteretes"
   },
-  "dateModified": "2026-08-21T10:33:23.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,17 +118,19 @@
 
   <div class="meta-row">
     <span class="stars">★ 30.2K</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>Apache-2.0</span>
     
-    <span><span class="meta-label">updated</span>2026-08-21</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/topoteretes/cognee" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://www.cognee.ai" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -613,7 +613,6 @@ single-tenant with <code>ENABLE_BACKEND_ACCESS_CONTROL=false</code>.</p>
       url={https://arxiv.org/abs/2505.24478},
 }
 </code></pre>
-
   </section>
 </details>
 

--- a/projects/ucsandman/DashClaw.html
+++ b/projects/ucsandman/DashClaw.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/ucsandman/DashClaw">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=DashClaw&amp;subtitle=%F0%9F%9B%A1%EF%B8%8F+The+approval+and+policy+layer+for+AI+agents.+Intercept+risky+actions+before+they+run%2C+block+them%2C+or+approve+them+remotely.&amp;kind=project+%C2%B7+domain+applications">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=DashClaw&amp;subtitle=Decision+infrastructure+with+guard+policies+and+risk+assessment+for+agents&amp;kind=project+%C2%B7+domain+applications">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="ucsandman/DashClaw — Hermes Atlas">
 <meta name="twitter:description" content="DashClaw is a fail-closed decision infrastructure that intercepts and evaluates AI agent tool calls before execution. It provides a remote approval system for…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=DashClaw&amp;subtitle=%F0%9F%9B%A1%EF%B8%8F+The+approval+and+policy+layer+for+AI+agents.+Intercept+risky+actions+before+they+run%2C+block+them%2C+or+approve+them+remotely.&amp;kind=project+%C2%B7+domain+applications">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=DashClaw&amp;subtitle=Decision+infrastructure+with+guard+policies+and+risk+assessment+for+agents&amp;kind=project+%C2%B7+domain+applications">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/ucsandman/DashClaw",
   "applicationCategory": "BusinessApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TypeScript",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "ucsandman",
     "url": "https://github.com/ucsandman"
   },
-  "dateModified": "2026-08-21T04:24:21.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">ucsandman</span><span class="slash">/</span>DashClaw
   </h1>
-  <p class="project-desc">🛡️ The approval and policy layer for AI agents. Intercept risky actions before they run, block them, or approve them remotely.</p>
+  <p class="project-desc">Decision infrastructure with guard policies and risk assessment for agents</p>
 
   <div class="meta-row">
     <span class="stars">★ 295</span>
-    <span><span class="meta-label">lang</span>TypeScript</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-21</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/ucsandman/DashClaw" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://www.dashclaw.io/" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -534,7 +534,6 @@ bash scripts/install-hermes-plugin.sh            # macOS / Linux (.ps1 on Window
 <p>If my tools save you time, you can support my work here:</p>
 <p><a href="https://github.com/sponsors/ucsandman"><img src="https://img.shields.io/badge/GitHub%20Sponsors-%E2%9D%A4-db61a2?logo=githubsponsors&amp;logoColor=white" alt="Sponsor on GitHub" loading="lazy" decoding="async"></a>
 <a href="https://buymeacoffee.com/wes_sander"><img src="https://img.shields.io/badge/Buy%20Me%20a%20Coffee-%E2%98%95-ffdd00?logo=buymeacoffee&amp;logoColor=black" alt="Buy Me a Coffee" loading="lazy" decoding="async"></a></p>
-
   </section>
 </details>
 

--- a/projects/ultraworkers/hermes-agent-helm-chart.html
+++ b/projects/ultraworkers/hermes-agent-helm-chart.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/ultraworkers/hermes-agent-helm-chart">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-helm-chart&amp;subtitle=The+community-driven+unofficial+chart+packages+Hermes+Agent+for+Kubernetes+with+cloud-native+defaults%2C+explicit+state-safety+guardrails%2C+and+flexible+composition+points+for+platfor&amp;kind=project+%C2%B7+deployment">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-helm-chart&amp;subtitle=Unofficial+community+Helm+chart+for+deploying+Hermes+Agent+on+Kubernetes+with+cloud-native+state-safety+guardrails&amp;kind=project+%C2%B7+deployment">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="ultraworkers/hermes-agent-helm-chart — Hermes Atlas">
 <meta name="twitter:description" content="This unofficial community Helm chart facilitates the deployment of Nous Research's Hermes Agent on Kubernetes clusters. It provides a structured configuration…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-helm-chart&amp;subtitle=The+community-driven+unofficial+chart+packages+Hermes+Agent+for+Kubernetes+with+cloud-native+defaults%2C+explicit+state-safety+guardrails%2C+and+flexible+composition+points+for+platfor&amp;kind=project+%C2%B7+deployment">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-helm-chart&amp;subtitle=Unofficial+community+Helm+chart+for+deploying+Hermes+Agent+on+Kubernetes+with+cloud-native+state-safety+guardrails&amp;kind=project+%C2%B7+deployment">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/ultraworkers/hermes-agent-helm-chart",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Shell",
   "author": {
     "@type": "Organization",
     "name": "ultraworkers",
     "url": "https://github.com/ultraworkers"
   },
-  "dateModified": "2026-04-12T06:58:49.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">ultraworkers</span><span class="slash">/</span>hermes-agent-helm-chart
   </h1>
-  <p class="project-desc">The community-driven unofficial chart packages Hermes Agent for Kubernetes with cloud-native defaults, explicit state-safety guardrails, and flexible composition points for platform teams.</p>
+  <p class="project-desc">Unofficial community Helm chart for deploying Hermes Agent on Kubernetes with cloud-native state-safety guardrails</p>
 
   <div class="meta-row">
     <span class="stars">★ 134</span>
-    <span><span class="meta-label">lang</span>Shell</span>
     
     
-    <span><span class="meta-label">updated</span>2026-04-12</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -449,7 +450,6 @@ helm template hermes . -f ci/tenant-isolation-values.yaml
 helm template hermes . --include-crds -f ci/operator-values.yaml
 bash ci/verify.sh
 </code></pre>
-
   </section>
 </details>
 

--- a/projects/unmodeled-tyler/vessel-browser.html
+++ b/projects/unmodeled-tyler/vessel-browser.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/unmodeled-tyler/vessel-browser">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=vessel-browser&amp;subtitle=Built+from+the+ground-up+for+agents%2C+Vessel+Browser+is+an+open+source+AI+browser+for+Linux%2FMac%2FWindows+that+provides+a+durable+state%2C+MCP+control%2C+and+BYOK+with+full+autonomous+bro&amp;kind=project+%C2%B7+developer+tools">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=vessel-browser&amp;subtitle=AI-native+browser+built+for+autonomous+agent+control+via+MCP&amp;kind=project+%C2%B7+developer+tools">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="unmodeled-tyler/vessel-browser — Hermes Atlas">
 <meta name="twitter:description" content="Vessel is a Chromium-based web browser with a built-in AI assistant designed for research, navigation, and form filling. It provides a visible interface for AI…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=vessel-browser&amp;subtitle=Built+from+the+ground-up+for+agents%2C+Vessel+Browser+is+an+open+source+AI+browser+for+Linux%2FMac%2FWindows+that+provides+a+durable+state%2C+MCP+control%2C+and+BYOK+with+full+autonomous+bro&amp;kind=project+%C2%B7+developer+tools">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=vessel-browser&amp;subtitle=AI-native+browser+built+for+autonomous+agent+control+via+MCP&amp;kind=project+%C2%B7+developer+tools">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/unmodeled-tyler/vessel-browser",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TypeScript",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "unmodeled-tyler",
     "url": "https://github.com/unmodeled-tyler"
   },
-  "dateModified": "2026-08-18T18:34:26.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">unmodeled-tyler</span><span class="slash">/</span>vessel-browser
   </h1>
-  <p class="project-desc">Built from the ground-up for agents, Vessel Browser is an open source AI browser for Linux/Mac/Windows that provides a durable state, MCP control, and BYOK with full autonomous browsing. Use with Hermes Agent, OpenClaw, or connect to your favorite API provider.</p>
+  <p class="project-desc">AI-native browser built for autonomous agent control via MCP</p>
 
   <div class="meta-row">
     <span class="stars">★ 127</span>
-    <span><span class="meta-label">lang</span>TypeScript</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-18</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/unmodeled-tyler/vessel-browser" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://quantaintellect.com" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -745,7 +745,6 @@ vessel-browser-launch --dry-run
 <h3>License</h3>
 <p>MIT</p>
 <p><em>Developed by Tyler Williams in Portland, Oregon (2026)</em></p>
-
   </section>
 </details>
 

--- a/projects/uzairansaruzi/hermex.html
+++ b/projects/uzairansaruzi/hermex.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/uzairansaruzi/hermex">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=Hermex&amp;subtitle=Native+iPhone+app+for+your+Hermes+agent&amp;kind=project+%C2%B7+workspaces">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=Hermex&amp;subtitle=Native+SwiftUI+iPhone+app+for+driving+a+self-hosted+Hermes+agent+from+your+phone%2C+pairing+with+a+hermes-webui+server.&amp;kind=project+%C2%B7+workspaces">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="uzairansaruzi/Hermex — Hermes Atlas">
 <meta name="twitter:description" content="Hermex is a native SwiftUI iPhone app designed to control a self-hosted hermes-webui server. It functions as a mobile control plane for an AI agent, allowing…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Hermex&amp;subtitle=Native+iPhone+app+for+your+Hermes+agent&amp;kind=project+%C2%B7+workspaces">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Hermex&amp;subtitle=Native+SwiftUI+iPhone+app+for+driving+a+self-hosted+Hermes+agent+from+your+phone%2C+pairing+with+a+hermes-webui+server.&amp;kind=project+%C2%B7+workspaces">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/uzairansaruzi/hermex",
   "applicationCategory": "DesktopEnhancementApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Swift",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "uzairansaruzi",
     "url": "https://github.com/uzairansaruzi"
   },
-  "dateModified": "2026-08-21T06:03:00.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">uzairansaruzi</span><span class="slash">/</span>hermex
   </h1>
-  <p class="project-desc">Native iPhone app for your Hermes agent</p>
+  <p class="project-desc">Native SwiftUI iPhone app for driving a self-hosted Hermes agent from your phone, pairing with a hermes-webui server.</p>
 
   <div class="meta-row">
     <span class="stars">★ 1.1K</span>
-    <span><span class="meta-label">lang</span>Swift</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-21</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/uzairansaruzi/hermex" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://hermexapp.com/" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -267,7 +267,6 @@
 <h3>License</h3>
 <p>MIT — see <a href="LICENSE">LICENSE</a>.</p>
 <p>Hermex is an independent client and is not affiliated with the upstream <a href="https://github.com/nesquena/hermes-webui">hermes-webui</a> project. Apple, the Apple logo, and App Store are trademarks of Apple Inc.</p>
-
   </section>
 </details>
 

--- a/projects/vectorize-io/hindsight.html
+++ b/projects/vectorize-io/hindsight.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/vectorize-io/hindsight">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hindsight&amp;subtitle=Hindsight%3A+Agent+Memory+That++Learns&amp;kind=project+%C2%B7+memory">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hindsight&amp;subtitle=Agent+memory+that+learns+%E2%80%94+long-term+retain%2Frecall%2Freflect+workflows&amp;kind=project+%C2%B7+memory">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="vectorize-io/hindsight — Hermes Atlas">
 <meta name="twitter:description" content="Hindsight is an agent memory system designed for long-term learning through retain, pseudonym, and reflect workflows. It supports various deployment methods…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hindsight&amp;subtitle=Hindsight%3A+Agent+Memory+That++Learns&amp;kind=project+%C2%B7+memory">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hindsight&amp;subtitle=Agent+memory+that+learns+%E2%80%94+long-term+retain%2Frecall%2Freflect+workflows&amp;kind=project+%C2%B7+memory">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/vectorize-io/hindsight",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "vectorize-io",
     "url": "https://github.com/vectorize-io"
   },
-  "dateModified": "2026-08-21T10:37:39.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">vectorize-io</span><span class="slash">/</span>hindsight <span class="repo-flag">official</span>
   </h1>
-  <p class="project-desc">Hindsight: Agent Memory That  Learns</p>
+  <p class="project-desc">Agent memory that learns — long-term retain/recall/reflect workflows</p>
 
   <div class="meta-row">
     <span class="stars">★ 20.8K</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
+    
+    
     <span><span class="meta-label">maintainer</span>Nous Research</span>
-    <span><span class="meta-label">updated</span>2026-08-21</span>
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/vectorize-io/hindsight" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://hindsight.vectorize.io/" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 <aside class="handbook-mention" aria-label="Mentioned in the Hermes Handbook">
@@ -535,7 +535,6 @@ client.recall(bank_id="my-bank", query="What happened in June?")   # temporal
 <hr>
 <p>Built by <a href="https://vectorize.io">Vectorize.io</a></p>
 <img src="https://umami-pixel.chris-latimer.workers.dev/?id=a8b043e6-6964-454d-80df-69b69d3f0d50&amp;host=github.com&amp;url=/vectorize-io/hindsight" width="1" height="1" alt="">
-
   </section>
 </details>
 

--- a/projects/vectrocomputers/Hermes-Agent-Action-Plan.html
+++ b/projects/vectrocomputers/Hermes-Agent-Action-Plan.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/vectrocomputers/Hermes-Agent-Action-Plan">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=Hermes-Agent-Action-Plan&amp;subtitle=Practical+guidance+for+operating+Hermes+Agent+effectively+without+sacrificing+security+or+privacy.+&amp;kind=project+%C2%B7+guides">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=Hermes-Agent-Action-Plan&amp;subtitle=Privacy-first+practical+guidance+for+configuring+and+operating+Hermes+Agent+effectively&amp;kind=project+%C2%B7+guides">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="vectrocomputers/Hermes-Agent-Action-Plan — Hermes Atlas">
 <meta name="twitter:description" content="The Hermes Agent Action Plan is a configuration framework and operational guide designed to optimize Hermes Agent deployments on Ubuntu 24. It provides a…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Hermes-Agent-Action-Plan&amp;subtitle=Practical+guidance+for+operating+Hermes+Agent+effectively+without+sacrificing+security+or+privacy.+&amp;kind=project+%C2%B7+guides">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Hermes-Agent-Action-Plan&amp;subtitle=Privacy-first+practical+guidance+for+configuring+and+operating+Hermes+Agent+effectively&amp;kind=project+%C2%B7+guides">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/vectrocomputers/Hermes-Agent-Action-Plan",
   "applicationCategory": "ReferenceApplication",
   "operatingSystem": "Cross-platform",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "vectrocomputers",
     "url": "https://github.com/vectrocomputers"
   },
-  "dateModified": "2026-02-28T23:26:44.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">vectrocomputers</span><span class="slash">/</span>Hermes-Agent-Action-Plan
   </h1>
-  <p class="project-desc">Practical guidance for operating Hermes Agent effectively without sacrificing security or privacy. </p>
+  <p class="project-desc">Privacy-first practical guidance for configuring and operating Hermes Agent effectively</p>
 
   <div class="meta-row">
     <span class="stars">★ 23</span>
     
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-02-28</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -332,7 +333,6 @@
 <li>Auditable, recoverable, secure</li>
 </ul>
 <p><strong>Result:</strong> An assistant that actually assists, remembers what matters, respects your privacy, and grows in capability over time.</p>
-
   </section>
 </details>
 

--- a/projects/visorcraft/MongrelDB-Hermes.html
+++ b/projects/visorcraft/MongrelDB-Hermes.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/visorcraft/MongrelDB-Hermes",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/Apache-2.0.html",
   "author": {
     "@type": "Organization",
     "name": "visorcraft",
     "url": "https://github.com/visorcraft"
   },
-  "dateModified": "2026-08-11T22:03:24.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">visorcraft</span><span class="slash">/</span>MongrelDB-Hermes
   </h1>
-  <p class="project-desc">AI-native long-term memory for Hermes Agent with AES-256-GCM encryption at rest, dense HNSW ANN, sparse and exact-text recall, metadata/range filters, and MinHash dedup, backed by an embedded or multi-client server columnar SQL database with 35 language bindings.</p>
+  <p class="project-desc">AI-native long-term memory for Hermes Agent with AES-256-GCM encryption at rest, dense HNSW ANN, sparse and exact-text recall, metadata/range filters, and MinHash dedup, backed by an embedded or multi</p>
 
   <div class="meta-row">
     <span class="stars">★ 5</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>Apache-2.0</span>
     
-    <span><span class="meta-label">updated</span>2026-08-11</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/visorcraft/MongrelDB-Hermes" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://www.mongreldb.com" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -516,7 +516,6 @@ export MONGRELDB_DB_PASSWORD='choose-a-strong-password'
 </ul>
 <h3>License</h3>
 <p>MIT OR Apache-2.0</p>
-
   </section>
 </details>
 

--- a/projects/volcengine/OpenViking.html
+++ b/projects/volcengine/OpenViking.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/volcengine/OpenViking">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=OpenViking&amp;subtitle=Self-evolving+Context+Database+for+AI+Agents.+Unify+Agent+Memory%2C+Knowledge+RAG+and+Skills.&amp;kind=project+%C2%B7+memory">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=OpenViking&amp;subtitle=Open-source+context+database+for+AI+agents+%E2%80%94+official+Hermes+Agent+memory+provider+using+viking%3A%2F%2F+URIs+and+tiered+L0%2FL1%2FL2+loading%3B+91%25+token+reduction+and+43-49%25+task-completion+&amp;kind=project+%C2%B7+memory">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="volcengine/OpenViking — Hermes Atlas">
 <meta name="twitter:description" content="OpenViking is an open-source context database that organizes AI agent memories, resources, and skills into a virtual filesystem using the viking:// protocol.…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=OpenViking&amp;subtitle=Self-evolving+Context+Database+for+AI+Agents.+Unify+Agent+Memory%2C+Knowledge+RAG+and+Skills.&amp;kind=project+%C2%B7+memory">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=OpenViking&amp;subtitle=Open-source+context+database+for+AI+agents+%E2%80%94+official+Hermes+Agent+memory+provider+using+viking%3A%2F%2F+URIs+and+tiered+L0%2FL1%2FL2+loading%3B+91%25+token+reduction+and+43-49%25+task-completion+&amp;kind=project+%C2%B7+memory">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/volcengine/OpenViking",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/AGPL-3.0.html",
   "author": {
     "@type": "Organization",
     "name": "volcengine",
     "url": "https://github.com/volcengine"
   },
-  "dateModified": "2026-08-21T09:55:26.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">volcengine</span><span class="slash">/</span>OpenViking
   </h1>
-  <p class="project-desc">Self-evolving Context Database for AI Agents. Unify Agent Memory, Knowledge RAG and Skills.</p>
+  <p class="project-desc">Open-source context database for AI agents — official Hermes Agent memory provider using viking:// URIs and tiered L0/L1/L2 loading; 91% token reduction and 43-49% task-completion gain over baseline on LoCoMo10. AGPL-3.0.</p>
 
   <div class="meta-row">
     <span class="stars">★ 31.4K</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>AGPL-3.0</span>
     
-    <span><span class="meta-label">updated</span>2026-08-21</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/volcengine/OpenViking" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://openviking.ai/" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -376,7 +376,6 @@ For vulnerability reporting and supported versions, see <a href="https://github.
 <li><strong>examples</strong>: Apache 2.0 - see the <a href="./examples/LICENSE">LICENSE</a> for details</li>
 <li><strong>third_party</strong>: Respective original licenses of third-party projects</li>
 </ul>
-
   </section>
 </details>
 

--- a/projects/webmilmind1/hermes-bounty-board.html
+++ b/projects/webmilmind1/hermes-bounty-board.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/webmilmind1/hermes-bounty-board",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "webmilmind1",
     "url": "https://github.com/webmilmind1"
   },
-  "dateModified": "2026-08-18T12:29:24.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">webmilmind1</span><span class="slash">/</span>hermes-bounty-board
   </h1>
-  <p class="project-desc">Hermes Agent plugin: earn USDC answering real support bounties, or run your own bounty board, over x402. No account, no API key. A human approves the winning answer and the wallet is paid 85% automatically.</p>
+  <p class="project-desc">Hermes Agent plugin: earn USDC answering real support bounties, or run your own bounty board, over x402. No account, no API key. A human approves the winning answer and the wallet is paid 85% automati</p>
 
   <div class="meta-row">
     <span class="stars">★ 1</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-18</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/webmilmind1/hermes-bounty-board" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://deskcrew.io/bounties" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -229,7 +229,6 @@ server co-signs fees) use the JS packages:
 <a href="https://www.npmjs.com/package/@deskcrew/board-runner">@deskcrew/board-runner</a>.</p>
 <p>Works against any board exposing the same endpoints: set <code>DESKCREW_BOARD_URL</code>.</p>
 <p>MIT licensed. Issues and pull requests welcome.</p>
-
   </section>
 </details>
 

--- a/projects/willingning-coder/eagle-eye.html
+++ b/projects/willingning-coder/eagle-eye.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/willingning-coder/eagle-eye">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=eagle-eye&amp;subtitle=%F0%9F%A6%85+5-Layer+Intelligent+Skill+Retrieval+for+Hermes+Agent+%E2%80%94+hard+triggers%2C+FTS5%2C+synonym+dictionary%2C+dense+embedding%2C+RRF+fusion.+Zero+core+modification.&amp;kind=project+%C2%B7+skills">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=eagle-eye&amp;subtitle=5-layer+intelligent+skill+retrieval+for+Hermes+Agent+with+hard+triggers%2C+FTS5%2C+synonyms%2C+dense+embeddings%2C+and+RRF+fusion.&amp;kind=project+%C2%B7+skills">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="willingning-coder/eagle-eye — Hermes Atlas">
 <meta name="twitter:description" content="Eagle Eye is a plugin for Hermes Agent designed to optimize skill selection by filtering large skill libraries into a small set of relevant candidates. It…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=eagle-eye&amp;subtitle=%F0%9F%A6%85+5-Layer+Intelligent+Skill+Retrieval+for+Hermes+Agent+%E2%80%94+hard+triggers%2C+FTS5%2C+synonym+dictionary%2C+dense+embedding%2C+RRF+fusion.+Zero+core+modification.&amp;kind=project+%C2%B7+skills">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=eagle-eye&amp;subtitle=5-layer+intelligent+skill+retrieval+for+Hermes+Agent+with+hard+triggers%2C+FTS5%2C+synonyms%2C+dense+embeddings%2C+and+RRF+fusion.&amp;kind=project+%C2%B7+skills">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/willingning-coder/eagle-eye",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "willingning-coder",
     "url": "https://github.com/willingning-coder"
   },
-  "dateModified": "2026-06-01T06:40:48.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">willingning-coder</span><span class="slash">/</span>eagle-eye
   </h1>
-  <p class="project-desc">🦅 5-Layer Intelligent Skill Retrieval for Hermes Agent — hard triggers, FTS5, synonym dictionary, dense embedding, RRF fusion. Zero core modification.</p>
+  <p class="project-desc">5-layer intelligent skill retrieval for Hermes Agent with hard triggers, FTS5, synonyms, dense embeddings, and RRF fusion.</p>
 
   <div class="meta-row">
     <span class="stars">★ 33</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-06-01</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,15 @@
     
   </div>
 </section>
+
+
+<aside class="install-box" aria-label="How to install this skill">
+  <div class="ib-label">install<span class="ib-type">plugin</span></div>
+  <code class="ib-cmd">git clone https://github.com/willingning-coder/eagle-eye.git, then run python scripts/generate_config.py.</code>
+  <p class="ib-compat">Hermes Agent plugin; optional dense-embedding dependencies for the retrieval layers.</p>
+  <p class="ib-verdict">Five-layer retrieval (hard triggers, FTS5, synonyms, dense embeddings, RRF fusion) built to solve Hermes' own skill-selection problem once your skills directory gets large — the most Hermes-native entry in this group.</p>
+  <a class="ib-more" href="/skills/">more picks → the skills hub</a>
+</aside>
 
 
 
@@ -368,7 +375,6 @@ python scripts/generate_config.py --scan-only
 </ul>
 <h3>License</h3>
 <p><a href="LICENSE">MIT</a></p>
-
   </section>
 </details>
 

--- a/projects/wondelai/skills.html
+++ b/projects/wondelai/skills.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/wondelai/skills">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=wondelai%2Fskills&amp;subtitle=Wondel.ai+Agent+Skills+%E2%80%94+Business%2C+Marketing%2C+UX+%26+Coding+Frameworks+from+Bestselling+Books.+50+skills+%2B+12+guided+journeys+for+Claude+Code%2C+Codex%2C+Cursor+%26+other+agentskills.io+ag&amp;kind=project+%C2%B7+skills">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=wondelai%2Fskills&amp;subtitle=Cross-platform+skills+library+for+Claude+Code+and+agentskills.io-compatible+agents&amp;kind=project+%C2%B7+skills">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="wondelai/skills — Hermes Atlas">
 <meta name="twitter:description" content="Wondel.ai Agent Skills provides 62 agent skills based on 50 frameworks from bestselling books. The library includes 12 metaskills that function as guided…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=wondelai%2Fskills&amp;subtitle=Wondel.ai+Agent+Skills+%E2%80%94+Business%2C+Marketing%2C+UX+%26+Coding+Frameworks+from+Bestselling+Books.+50+skills+%2B+12+guided+journeys+for+Claude+Code%2C+Codex%2C+Cursor+%26+other+agentskills.io+ag&amp;kind=project+%C2%B7+skills">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=wondelai%2Fskills&amp;subtitle=Cross-platform+skills+library+for+Claude+Code+and+agentskills.io-compatible+agents&amp;kind=project+%C2%B7+skills">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/wondelai/skills",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Shell",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "wondelai",
     "url": "https://github.com/wondelai"
   },
-  "dateModified": "2026-08-10T11:47:12.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,30 @@
   <h1 class="project-name">
     <span class="org">wondelai</span><span class="slash">/</span>skills
   </h1>
-  <p class="project-desc">Wondel.ai Agent Skills — Business, Marketing, UX &amp; Coding Frameworks from Bestselling Books. 50 skills + 12 guided journeys for Claude Code, Codex, Cursor &amp; other agentskills.io agents.</p>
+  <p class="project-desc">Cross-platform skills library for Claude Code and agentskills.io-compatible agents</p>
 
   <div class="meta-row">
     <span class="stars">★ 2.0K</span>
-    <span><span class="meta-label">lang</span>Shell</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-10</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/wondelai/skills" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://skills.wondel.ai" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
+<aside class="install-box" aria-label="How to install this skill">
+  <div class="ib-label">install<span class="ib-type">collection</span></div>
+  <code class="ib-cmd">npx skills add wondelai/skills --all --global (or pick individual skills, e.g. npx skills add wondelai/skills/jobs-to-be-done --global).</code>
+  <p class="ib-compat">skills.sh / agentskills.io-compatible clients including Claude Code and Hermes; also ships Claude Code plugin collections.</p>
+  <p class="ib-verdict">62 skills built from 50 named business and design frameworks (Jobs-to-be-Done, the Mom Test, Refactoring UI) rather than generic prompts — a business-strategy layer to sit alongside a coding skill set.</p>
+  <a class="ib-more" href="/skills/">more picks → the skills hub</a>
+</aside>
 
 
 
@@ -857,7 +864,6 @@ npx skills add wondelai/skills/design-code-architecture --global
 <p>Persuasion</p>
 <hr>
 <p><em>README truncated. <a href="https://github.com/wondelai/skills#readme">Continue reading on GitHub</a></em></p>
-
   </section>
 </details>
 

--- a/projects/xaspx/hermes-control-interface.html
+++ b/projects/xaspx/hermes-control-interface.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/xaspx/hermes-control-interface",
   "applicationCategory": "DesktopEnhancementApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "JavaScript",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "xaspx",
     "url": "https://github.com/xaspx"
   },
-  "dateModified": "2026-06-28T06:40:10.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">xaspx</span><span class="slash">/</span>hermes-control-interface
   </h1>
-  <p class="project-desc">A self-hosted web dashboard for the Hermes AI agent stack. Provides a browser-based terminal, file explorer, session overview, cron management, system metrics, and an agent status panel — all behind a single password gate.</p>
+  <p class="project-desc">A self-hosted web dashboard for the Hermes AI agent stack. Provides a browser-based terminal, file explorer, session overview, cron management, system metrics, and an agent status panel — all behind a</p>
 
   <div class="meta-row">
     <span class="stars">★ 881</span>
-    <span><span class="meta-label">lang</span>JavaScript</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-06-28</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -823,7 +823,6 @@ systemctl restart hci-staging
 <h4>License</h4>
 <p><strong>Q: Is Hermes Control Interface free and open source?</strong></p>
 <p>Yes! <strong>MIT License</strong> - see <a href="LICENSE">LICENSE</a>. Self-host for free, manage your Hermes agent stack with a beautiful web UI.</p>
-
   </section>
 </details>
 

--- a/projects/xiaonancs/hermes-agent-study.html
+++ b/projects/xiaonancs/hermes-agent-study.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/xiaonancs/hermes-agent-study">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-study&amp;subtitle=Hermes+Agent+%E6%B7%B1%E5%BA%A6%E7%A0%94%E7%A9%B6%EF%BC%9A%E4%BB%8E%E6%9C%BA%E5%88%B6%E6%9C%AC%E8%B4%A8%E5%88%B0%E4%BB%A3%E7%A0%81%E5%AE%9E%E7%8E%B0%EF%BC%8C%E4%BB%8E+OpenClaw+%E6%B8%8A%E6%BA%90%E5%88%B0+EvoMap+%E4%BA%89%E8%AE%AE&amp;kind=project+%C2%B7+guides">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-study&amp;subtitle=Chinese+deep+research+series+on+Hermes+Agent+internals%2C+OpenClaw+lineage%2C+self-evolution%2C+and+source-code+architecture&amp;kind=project+%C2%B7+guides">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="xiaonancs/hermes-agent-study — Hermes Atlas">
 <meta name="twitter:description" content="This project provides a comprehensive technical analysis and documentation series focused on the internal architecture of the Hermes Agent by Nous Research. It…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-study&amp;subtitle=Hermes+Agent+%E6%B7%B1%E5%BA%A6%E7%A0%94%E7%A9%B6%EF%BC%9A%E4%BB%8E%E6%9C%BA%E5%88%B6%E6%9C%AC%E8%B4%A8%E5%88%B0%E4%BB%A3%E7%A0%81%E5%AE%9E%E7%8E%B0%EF%BC%8C%E4%BB%8E+OpenClaw+%E6%B8%8A%E6%BA%90%E5%88%B0+EvoMap+%E4%BA%89%E8%AE%AE&amp;kind=project+%C2%B7+guides">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-study&amp;subtitle=Chinese+deep+research+series+on+Hermes+Agent+internals%2C+OpenClaw+lineage%2C+self-evolution%2C+and+source-code+architecture&amp;kind=project+%C2%B7+guides">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/xiaonancs/hermes-agent-study",
   "applicationCategory": "ReferenceApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "JavaScript",
   "author": {
     "@type": "Organization",
     "name": "xiaonancs",
     "url": "https://github.com/xiaonancs"
   },
-  "dateModified": "2026-05-27T16:03:32.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">xiaonancs</span><span class="slash">/</span>hermes-agent-study
   </h1>
-  <p class="project-desc">Hermes Agent 深度研究：从机制本质到代码实现，从 OpenClaw 渊源到 EvoMap 争议</p>
+  <p class="project-desc">Chinese deep research series on Hermes Agent internals, OpenClaw lineage, self-evolution, and source-code architecture</p>
 
   <div class="meta-row">
     <span class="stars">★ 35</span>
-    <span><span class="meta-label">lang</span>JavaScript</span>
     
     
-    <span><span class="meta-label">updated</span>2026-05-27</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -472,7 +473,6 @@
 </ul>
 <h3>许可</h3>
 <p>本研究内容采用 <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a> 许可证。所分析的源码版权归原项目所有者所有。</p>
-
   </section>
 </details>
 

--- a/projects/xintaofei/codeg.html
+++ b/projects/xintaofei/codeg.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/xintaofei/codeg">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=Codeg&amp;subtitle=Collaborative+multi-agent+AI+coding+workspace%3A+aggregate+sessions+from+Claude+Code%2C+Codex%2C+OpenCode%2C+Pi%2C+Grok+Build%2C+etc.+Desktop+app%2C+self-hosted+server%2C+or+Docker.&amp;kind=project+%C2%B7+workspaces">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=Codeg&amp;subtitle=Collaborative+multi-agent+coding+workspace+that+aggregates+sessions+from+Hermes%2C+Claude+Code%2C+Codex%2C+OpenCode%2C+and+others+as+a+desktop+or+self-hosted+app.&amp;kind=project+%C2%B7+workspaces">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="xintaofei/Codeg — Hermes Atlas">
 <meta name="twitter:description" content="Codeg is a multi-agent coding workspace that aggregates sessions from various AI coding agents into a single searchable interface. It supports task delegation…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Codeg&amp;subtitle=Collaborative+multi-agent+AI+coding+workspace%3A+aggregate+sessions+from+Claude+Code%2C+Codex%2C+OpenCode%2C+Pi%2C+Grok+Build%2C+etc.+Desktop+app%2C+self-hosted+server%2C+or+Docker.&amp;kind=project+%C2%B7+workspaces">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Codeg&amp;subtitle=Collaborative+multi-agent+coding+workspace+that+aggregates+sessions+from+Hermes%2C+Claude+Code%2C+Codex%2C+OpenCode%2C+and+others+as+a+desktop+or+self-hosted+app.&amp;kind=project+%C2%B7+workspaces">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/xintaofei/codeg",
   "applicationCategory": "DesktopEnhancementApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Rust",
-  "license": "https://spdx.org/licenses/Apache-2.0.html",
   "author": {
     "@type": "Organization",
     "name": "xintaofei",
     "url": "https://github.com/xintaofei"
   },
-  "dateModified": "2026-08-21T01:37:03.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">xintaofei</span><span class="slash">/</span>codeg
   </h1>
-  <p class="project-desc">Collaborative multi-agent AI coding workspace: aggregate sessions from Claude Code, Codex, OpenCode, Pi, Grok Build, etc. Desktop app, self-hosted server, or Docker.</p>
+  <p class="project-desc">Collaborative multi-agent coding workspace that aggregates sessions from Hermes, Claude Code, Codex, OpenCode, and others as a desktop or self-hosted app.</p>
 
   <div class="meta-row">
     <span class="stars">★ 2.9K</span>
-    <span><span class="meta-label">lang</span>Rust</span>
-    <span><span class="meta-label">license</span>Apache-2.0</span>
     
-    <span><span class="meta-label">updated</span>2026-08-21</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/xintaofei/codeg" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://docs.codeg.app" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -312,7 +312,6 @@ $env:CODEG_STATIC_DIR="$env:LOCALAPPDATA\codeg\web"; codeg-server
 </ul>
 <h3>📜 License</h3>
 <p>Apache-2.0. See <a href="./LICENSE">LICENSE</a>.</p>
-
   </section>
 </details>
 

--- a/projects/xmbshwll/hermes-agent-docker.html
+++ b/projects/xmbshwll/hermes-agent-docker.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/xmbshwll/hermes-agent-docker">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-docker&amp;subtitle=Simple+docker+sandbox+image+for+Hermes+Agent&amp;kind=project+%C2%B7+deployment">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=hermes-agent-docker&amp;subtitle=Simple+Docker+sandbox+image+for+Hermes+Agent&amp;kind=project+%C2%B7+deployment">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="xmbshwll/hermes-agent-docker — Hermes Atlas">
 <meta name="twitter:description" content="This project provides a minimal Docker sandbox image designed to package and deploy Hermes Agent. It utilizes the official upstream installation script to set…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-docker&amp;subtitle=Simple+docker+sandbox+image+for+Hermes+Agent&amp;kind=project+%C2%B7+deployment">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=hermes-agent-docker&amp;subtitle=Simple+Docker+sandbox+image+for+Hermes+Agent&amp;kind=project+%C2%B7+deployment">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/xmbshwll/hermes-agent-docker",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Dockerfile",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "xmbshwll",
     "url": "https://github.com/xmbshwll"
   },
-  "dateModified": "2026-08-14T20:05:44.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">xmbshwll</span><span class="slash">/</span>hermes-agent-docker
   </h1>
-  <p class="project-desc">Simple docker sandbox image for Hermes Agent</p>
+  <p class="project-desc">Simple Docker sandbox image for Hermes Agent</p>
 
   <div class="meta-row">
     <span class="stars">★ 48</span>
-    <span><span class="meta-label">lang</span>Dockerfile</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-14</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -195,7 +195,6 @@
 <p>If you do not mount <code>/home/agent/.hermes</code>, Hermes will still start, but its state will be lost when the container exits.</p>
 <h3>Environment and setup</h3>
 <p>Run <code>hermes setup</code> inside the container and persist <code>/home/agent/.hermes</code>, or place the expected config files inside that mounted directory.</p>
-
   </section>
 </details>
 

--- a/projects/yantrikos/yantrikdb-hermes-plugin.html
+++ b/projects/yantrikos/yantrikdb-hermes-plugin.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/yantrikos/yantrikdb-hermes-plugin">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=yantrikdb-hermes-plugin&amp;subtitle=YantrikDB+memory+provider+for+NousResearch%2Fhermes-agent+%E2%80%94+self-maintaining+memory+with+benchmarked+recall%2C+self-tuning+ranking%2C+contradiction+tracking%2C+proactive+hygiene%2C+and+expla&amp;kind=project+%C2%B7+memory">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=yantrikdb-hermes-plugin&amp;subtitle=Self-maintaining+Hermes+memory+plugin+with+explainable+retrieval+%E2%80%94+every+recall+comes+back+with+a+why_retrieved+tag%2C+plus+canonicalization%2C+contradiction+tracking%2C+and+recency+rank&amp;kind=project+%C2%B7+memory">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="yantrikos/yantrikdb-hermes-plugin — Hermes Atlas">
 <meta name="twitter:description" content="This is a standalone plugin that serves as a memory provider for the Hermes Agent. It provides features such as canonicalization of duplicates, contradiction…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=yantrikdb-hermes-plugin&amp;subtitle=YantrikDB+memory+provider+for+NousResearch%2Fhermes-agent+%E2%80%94+self-maintaining+memory+with+benchmarked+recall%2C+self-tuning+ranking%2C+contradiction+tracking%2C+proactive+hygiene%2C+and+expla&amp;kind=project+%C2%B7+memory">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=yantrikdb-hermes-plugin&amp;subtitle=Self-maintaining+Hermes+memory+plugin+with+explainable+retrieval+%E2%80%94+every+recall+comes+back+with+a+why_retrieved+tag%2C+plus+canonicalization%2C+contradiction+tracking%2C+and+recency+rank&amp;kind=project+%C2%B7+memory">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/yantrikos/yantrikdb-hermes-plugin",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "yantrikos",
     "url": "https://github.com/yantrikos"
   },
-  "dateModified": "2026-08-19T21:39:27.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">yantrikos</span><span class="slash">/</span>yantrikdb-hermes-plugin
   </h1>
-  <p class="project-desc">YantrikDB memory provider for NousResearch/hermes-agent — self-maintaining memory with benchmarked recall, self-tuning ranking, contradiction tracking, proactive hygiene, and explainable recall.</p>
+  <p class="project-desc">Self-maintaining Hermes memory plugin with explainable retrieval — every recall comes back with a why_retrieved tag, plus canonicalization, contradiction tracking, and recency ranking. Embedded by default.</p>
 
   <div class="meta-row">
     <span class="stars">★ 81</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-19</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/yantrikos/yantrikdb-hermes-plugin" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://yantrikdb.com" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -833,7 +833,6 @@ YANTRIKDB_INTEGRATION_TOKEN=ydb_... \
 <li><strong>YantrikDB server</strong>: <a href="https://github.com/yantrikos/yantrikdb-server">https://github.com/yantrikos/yantrikdb-server</a></li>
 <li><strong>YantrikDB docs</strong>: <a href="https://yantrikdb.com">https://yantrikdb.com</a></li>
 </ul>
-
   </section>
 </details>
 

--- a/projects/yepyhun/Brainstack.html
+++ b/projects/yepyhun/Brainstack.html
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/yepyhun/Brainstack",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
   "author": {
     "@type": "Organization",
     "name": "yepyhun",
     "url": "https://github.com/yepyhun"
   },
-  "dateModified": "2026-07-07T16:52:35.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -119,10 +118,10 @@
 
   <div class="meta-row">
     <span class="stars">★ 46</span>
-    <span><span class="meta-label">lang</span>Python</span>
     
     
-    <span><span class="meta-label">updated</span>2026-07-07</span>
+    
+    
   </div>
 
   <div class="actions">
@@ -130,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -577,7 +578,6 @@ target Hermes config to accept upstream or installer defaults for those blocks.<
 </ul>
 <h3>Legal Terms</h3>
 <p>Brainstack is proprietary source-available software: only personal, non-commercial, local use is permitted by default; all commercial, company/internal, hosted, redistribution, integration, derivative-product, model-training, and sublicensing use requires prior written permission. See <a href="https://github.com/yepyhun/Brainstack/blob/main/LEGAL.md">LEGAL.md</a>.</p>
-
   </section>
 </details>
 

--- a/projects/yoloshii/ClawMem.html
+++ b/projects/yoloshii/ClawMem.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/yoloshii/ClawMem">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=ClawMem&amp;subtitle=On-device+memory+layer+for+AI+agents.+Claude+Code%2C+Hermes+and+OpenClaw.+Hooks+%2B+MCP+server+%2B+hybrid+RAG+search.&amp;kind=project+%C2%B7+memory">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=ClawMem&amp;subtitle=On-device+memory+and+context+engine+for+agents+%E2%80%94+local-first%2C+no+cloud+dependencies&amp;kind=project+%C2%B7+memory">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="yoloshii/ClawMem — Hermes Atlas">
 <meta name="twitter:description" content="ClawMem is an on-device memory layer designed for Claude Code, OpenClaw, Hermes, and other AI agents. It uses a local SQLite vault to store and retrieve…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=ClawMem&amp;subtitle=On-device+memory+layer+for+AI+agents.+Claude+Code%2C+Hermes+and+OpenClaw.+Hooks+%2B+MCP+server+%2B+hybrid+RAG+search.&amp;kind=project+%C2%B7+memory">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=ClawMem&amp;subtitle=On-device+memory+and+context+engine+for+agents+%E2%80%94+local-first%2C+no+cloud+dependencies&amp;kind=project+%C2%B7+memory">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/yoloshii/ClawMem",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "TypeScript",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "yoloshii",
     "url": "https://github.com/yoloshii"
   },
-  "dateModified": "2026-08-18T19:28:18.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -116,14 +114,14 @@
   <h1 class="project-name">
     <span class="org">yoloshii</span><span class="slash">/</span>ClawMem
   </h1>
-  <p class="project-desc">On-device memory layer for AI agents. Claude Code, Hermes and OpenClaw. Hooks + MCP server + hybrid RAG search.</p>
+  <p class="project-desc">On-device memory and context engine for agents — local-first, no cloud dependencies</p>
 
   <div class="meta-row">
     <span class="stars">★ 199</span>
-    <span><span class="meta-label">lang</span>TypeScript</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-08-18</span>
+    
+    
+    
   </div>
 
   <div class="actions">
@@ -131,6 +129,8 @@
     
   </div>
 </section>
+
+
 
 
 
@@ -1103,7 +1103,6 @@ clawmem status                                  Quick index status
 </tbody></table>
 <hr>
 <p><em>README truncated. <a href="https://github.com/yoloshii/ClawMem#readme">Continue reading on GitHub</a></em></p>
-
   </section>
 </details>
 

--- a/projects/yonro/hermes-xmemo-plugin.html
+++ b/projects/yonro/hermes-xmemo-plugin.html
@@ -40,14 +40,11 @@
   "codeRepository": "https://github.com/yonro/hermes-xmemo-plugin",
   "applicationCategory": "UtilitiesApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
-  "license": "https://spdx.org/licenses/MIT.html",
   "author": {
     "@type": "Organization",
     "name": "yonro",
     "url": "https://github.com/yonro"
   },
-  "dateModified": "2026-07-28T20:25:02.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -88,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -120,17 +118,19 @@
 
   <div class="meta-row">
     <span class="stars">★ 7</span>
-    <span><span class="meta-label">lang</span>Python</span>
-    <span><span class="meta-label">license</span>MIT</span>
     
-    <span><span class="meta-label">updated</span>2026-07-28</span>
+    
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/yonro/hermes-xmemo-plugin" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="https://xmemo.dev" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -698,7 +698,6 @@ README whenever installation or configuration behavior changes.</p>
 </ul>
 <h3>License</h3>
 <p><a href="LICENSE">MIT</a> © XMemo contributors.</p>
-
   </section>
 </details>
 

--- a/projects/zcweah1981/awesome-hermes-agent-zh.html
+++ b/projects/zcweah1981/awesome-hermes-agent-zh.html
@@ -11,13 +11,13 @@
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/projects/zcweah1981/awesome-hermes-agent-zh">
 <meta property="og:site_name" content="Hermes Atlas">
-<meta property="og:image" content="https://hermesatlas.com/api/og?title=Hermes+Agent+%E4%B8%AD%E6%96%87%E7%AB%99&amp;subtitle=Hermes+Agent%E4%B8%AD%E6%96%87%E7%AB%99-+%E4%B8%AD%E6%96%87%E5%AE%9E%E6%88%98%E5%85%A5%E5%8F%A3%EF%BC%9A%E4%B8%8A%E6%89%8B%E8%B7%AF%E5%BE%84%E3%80%81%E5%9B%BD%E5%86%85%E8%90%BD%E5%9C%B0%E3%80%81OpenClaw+%E5%85%B1%E5%AD%98%E8%BF%81%E7%A7%BB%E3%80%81%E6%8E%92%E9%9A%9C%E5%8F%82%E8%80%83%E4%B8%8E%E5%8F%AF%E4%B8%8B%E8%BD%BD%E6%96%B9%E6%A1%88%E5%8C%85%E3%80%82&amp;kind=project+%C2%B7+guides">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=Hermes+Agent+%E4%B8%AD%E6%96%87%E7%AB%99&amp;subtitle=Chinese-language+Hermes+Agent+hub%3A+onboarding+paths%2C+local+deployment+guidance%2C+OpenClaw+migration+notes%2C+and+troubleshooting+references.&amp;kind=project+%C2%B7+guides">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="zcweah1981/Hermes Agent 中文站 — Hermes Atlas">
 <meta name="twitter:description" content="Hermes Agent 中文站 is a Chinese-language documentation hub providing practical implementation paths for the Hermes Agent project. It covers initial setup, local…">
-<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Hermes+Agent+%E4%B8%AD%E6%96%87%E7%AB%99&amp;subtitle=Hermes+Agent%E4%B8%AD%E6%96%87%E7%AB%99-+%E4%B8%AD%E6%96%87%E5%AE%9E%E6%88%98%E5%85%A5%E5%8F%A3%EF%BC%9A%E4%B8%8A%E6%89%8B%E8%B7%AF%E5%BE%84%E3%80%81%E5%9B%BD%E5%86%85%E8%90%BD%E5%9C%B0%E3%80%81OpenClaw+%E5%85%B1%E5%AD%98%E8%BF%81%E7%A7%BB%E3%80%81%E6%8E%92%E9%9A%9C%E5%8F%82%E8%80%83%E4%B8%8E%E5%8F%AF%E4%B8%8B%E8%BD%BD%E6%96%B9%E6%A1%88%E5%8C%85%E3%80%82&amp;kind=project+%C2%B7+guides">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Hermes+Agent+%E4%B8%AD%E6%96%87%E7%AB%99&amp;subtitle=Chinese-language+Hermes+Agent+hub%3A+onboarding+paths%2C+local+deployment+guidance%2C+OpenClaw+migration+notes%2C+and+troubleshooting+references.&amp;kind=project+%C2%B7+guides">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -40,13 +40,11 @@
   "codeRepository": "https://github.com/zcweah1981/awesome-hermes-agent-zh",
   "applicationCategory": "ReferenceApplication",
   "operatingSystem": "Cross-platform",
-  "programmingLanguage": "Python",
   "author": {
     "@type": "Organization",
     "name": "zcweah1981",
     "url": "https://github.com/zcweah1981"
   },
-  "dateModified": "2026-08-13T15:32:14.000Z",
   "interactionStatistic": {
     "@type": "InteractionCounter",
     "interactionType": {
@@ -87,6 +85,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/" class="active">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>
@@ -115,21 +114,23 @@
   <h1 class="project-name">
     <span class="org">zcweah1981</span><span class="slash">/</span>awesome-hermes-agent-zh
   </h1>
-  <p class="project-desc">Hermes Agent中文站- 中文实战入口：上手路径、国内落地、OpenClaw 共存迁移、排障参考与可下载方案包。</p>
+  <p class="project-desc">Chinese-language Hermes Agent hub: onboarding paths, local deployment guidance, OpenClaw migration notes, and troubleshooting references.</p>
 
   <div class="meta-row">
     <span class="stars">★ 45</span>
-    <span><span class="meta-label">lang</span>Python</span>
     
     
-    <span><span class="meta-label">updated</span>2026-08-13</span>
+    
+    
   </div>
 
   <div class="actions">
     <a href="https://github.com/zcweah1981/awesome-hermes-agent-zh" target="_blank" rel="noopener" class="btn-primary">view on github →</a>
-    <a href="http://www.hermes-zh.com" target="_blank" rel="noopener" class="btn-secondary">homepage</a>
+    
   </div>
 </section>
+
+
 
 
 
@@ -398,7 +399,6 @@
 </ul>
 <hr>
 <p>如果你现在还没决定先点哪一个，默认从 <a href="https://github.com/zcweah1981/awesome-hermes-agent-zh/blob/main/docs/01-%E4%BB%8E%E8%BF%99%E5%BC%80%E5%A7%8B/%E6%80%BB%E8%A7%88.md">01-从这开始</a> 进入。</p>
-
   </section>
 </details>
 

--- a/reports/index.html
+++ b/reports/index.html
@@ -102,6 +102,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/reports/state-of-hermes-april-2026.html
+++ b/reports/state-of-hermes-april-2026.html
@@ -132,6 +132,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/reports/state-of-hermes-july-2026.html
+++ b/reports/state-of-hermes-july-2026.html
@@ -94,6 +94,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/reports/state-of-hermes-may-2026.html
+++ b/reports/state-of-hermes-may-2026.html
@@ -132,6 +132,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/rss.xml
+++ b/rss.xml
@@ -6,7 +6,7 @@
     <atom:link href="https://hermesatlas.com/rss.xml" rel="self" type="application/rss+xml" />
     <description>Newly added community-built tools, skills, plugins, and integrations for Nous Research's Hermes Agent. Updated daily.</description>
     <language>en</language>
-    <lastBuildDate>Fri, 21 Aug 2026 10:41:09 GMT</lastBuildDate>
+    <lastBuildDate>Fri, 21 Aug 2026 11:14:19 GMT</lastBuildDate>
     <generator>hermesatlas.com/scripts/build-pages.js</generator>
     <item>
       <title>hermes-appearance-hub (Plugins &amp; Extensions)</title>

--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -19,7 +19,7 @@ import { JSDOM } from "jsdom";
 import createDOMPurify from "dompurify";
 import { githubHeaders, fetchReadme, fetchAllMetadata } from "../lib/github.js";
 import { REFRESHED_CONTENT_PATHS } from "../lib/build-artifacts.js";
-import { validateSkills } from "./validate-skills-json.js";
+import { validateSkills, SKILLS_CATEGORY } from "./validate-skills-json.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..");
@@ -239,6 +239,11 @@ if (fs.existsSync(reportsPath)) {
   reports.sort((a, b) => (b.date || "").localeCompare(a.date || ""));
 }
 
+// Skills Hub curation (data/skills.json). Loaded and validated inside main()
+// so a malformed hand-edit fails the build with the other data gates rather
+// than at import time; held here so the render pass can reach it.
+let skillsData = null;
+
 let latestHermesVersion = "v0.15.2";
 const latestReleasePath = path.join(ROOT, "data", "latest-release.json");
 if (fs.existsSync(latestReleasePath)) {
@@ -296,6 +301,7 @@ function renderMasthead(activeNav) {
   const nav = [
     { href: "/", label: "map", id: "map" },
     { href: "/lists/", label: "lists", id: "lists" },
+    { href: "/skills/", label: "skills", id: "skills" },
     { href: "/use-cases/", label: "use cases", id: "use-cases" },
     { href: "/guide/", label: "handbook", id: "handbook" },
     { href: "/masterclass/", label: "masterclass", id: "masterclass" },
@@ -669,7 +675,12 @@ ${topProjects.map((r) => `- [${r.owner}/${r.repo}](${SITE_URL}/projects/${r.owne
 
 ## Curated Lists
 ${lists.map((l) => `- [${l.title}](${SITE_URL}/lists/${l.slug}): ${l.description.slice(0, 180)}`).join("\n")}
-
+${skillsData ? `
+## Skills
+The decision layer over the ${SKILLS_CATEGORY} category: hand-picked groups, one top pick each, install command read from the project's own README, and a verdict per entry. ${skillsData.skills.length} curated entries across ${skillsData.useCases.length} use cases. Updated ${skillsData.updatedAt}, tested against Hermes ${skillsData.testedAgainst}.
+- [Hermes Skills Hub](${SITE_URL}/skills/): Every curated pick, the top pick per use case, and the full ${repos.filter((r) => r.category === SKILLS_CATEGORY).length}-project skills catalog.
+${skillsData.useCases.map((g) => `- [${g.title}](${SITE_URL}/skills/for-${g.slug}): ${g.intent}`).join("\n")}
+` : ""}
 ## Use Cases
 Cross-category repo bundles for a specific buildable outcome ("I want to build X"), each with a rationale and links to real community posts that prove people ship it.
 - [Use cases index](${SITE_URL}/use-cases/): All ${useCases.length} use-case bundles.
@@ -743,6 +754,26 @@ This file is the companion to ${SITE_URL}/llms.txt (the concise index).`);
     if (stripped) sections.push(`# State of Hermes — April 2026\n\nCanonical URL: ${SITE_URL}/reports/state-of-hermes-april-2026\n\n${stripped}`);
   } catch {}
 
+  if (skillsData) {
+    const skillLines = skillsData.useCases.map((group) => {
+      const members = skillsData.skills.filter((s) => s.useCases.includes(group.slug));
+      const body = members
+        .map((s) => [
+          `- ${s.owner}/${s.repo} (${s.type})${s.topPick ? " — TOP PICK" : ""}: ${s.verdict}`,
+          s.install ? `  Install: ${s.install}` : null,
+          s.compatibility ? `  Compatibility: ${s.compatibility}` : null,
+          `  URL: ${SITE_URL}/projects/${s.owner}/${s.repo}`,
+        ].filter(Boolean).join("\n"))
+        .join("\n");
+      return `## ${group.title}\n\nCanonical URL: ${SITE_URL}/skills/for-${group.slug}\n\n${group.intent}\n\n${group.description}\n\n${body}`;
+    });
+    sections.push(
+      `# Skills Hub (/skills/)\n\nCanonical URL: ${SITE_URL}/skills/\n\n` +
+      `Hand-curated judgment layer over the ${SKILLS_CATEGORY} category. Updated ${skillsData.updatedAt}, tested against Hermes ${skillsData.testedAgainst}.\n\n` +
+      skillLines.join("\n\n")
+    );
+  }
+
   sections.push(`# Project Catalog (${repos.length} projects)`);
   for (const repo of sorted) {
     const key = `${repo.owner}/${repo.repo}`;
@@ -780,7 +811,7 @@ This file is the companion to ${SITE_URL}/llms.txt (the concise index).`);
 }
 
 // ── Project page template ──
-function renderProjectPage(repo, meta, readmeHtml, relatedRepos, summary, handbookMention) {
+function renderProjectPage(repo, meta, readmeHtml, relatedRepos, summary, handbookMention, skillEntry) {
   // Owner-qualified title: several catalog entries share a bare repo name
   // (hermes-desktop, hermes-webui, ...) — without the owner the pairs emit
   // byte-identical <title> tags on different URLs, a duplicate-content signal.
@@ -880,6 +911,15 @@ ${renderMasthead("map")}
     ${safeExternalUrl(meta.homepage) ? `<a href="${escapeHtml(safeExternalUrl(meta.homepage))}" target="_blank" rel="noopener" class="btn-secondary">homepage</a>` : ""}
   </div>
 </section>
+
+${skillEntry ? `
+<aside class="install-box" aria-label="How to install this skill">
+  <div class="ib-label">install<span class="ib-type">${escapeHtml(skillEntry.type)}</span></div>
+  ${skillEntry.install ? `<code class="ib-cmd">${escapeHtml(skillEntry.install)}</code>` : ""}
+  ${skillEntry.compatibility ? `<p class="ib-compat">${escapeHtml(skillEntry.compatibility)}</p>` : ""}
+  <p class="ib-verdict">${escapeHtml(skillEntry.verdict)}</p>
+  <a class="ib-more" href="/skills/">more picks → the skills hub</a>
+</aside>` : ""}
 
 ${handbookMention ? `
 <aside class="handbook-mention" aria-label="Mentioned in the Hermes Handbook">
@@ -1033,6 +1073,7 @@ ${renderMasthead("lists")}
   <h1 class="list-title">${escapeHtml(list.title)}</h1>
   <p class="list-intro">${escapeHtml(list.description)}</p>
   ${list.slug === "best-memory-providers" ? '<p class="list-intro">For the architecture behind these tools, read <a href="/guide/memory/">The Hermes Agent Memory Guidebook</a>.</p>' : ""}
+  ${list.slug === "top-skills" ? '<p class="list-intro">This page ranks the whole category by stars. For picks by what you\'re trying to do — with install commands, compatibility notes, and a verdict per skill — see the <a href="/skills/">Hermes Skills Hub</a>.</p>' : ""}
 </section>
 
 <div class="list-table" aria-label="Ranked list">
@@ -1175,6 +1216,478 @@ ${renderMasthead("lists")}
 </div>
 
 <div class="back-link"><a href="/">← back to the map</a></div>
+
+</main>
+
+${PAGE_FOOTER}
+
+<script src="/assets/js/theme-toggle.js" defer></script>
+<script src="/assets/js/masthead-fetch.js" defer></script>
+<!-- Cloudflare Web Analytics -->
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js"
+        data-cf-beacon='{"token": "fe0d4d79280b4386b6b0cd99b2d94dbc"}'></script>
+<!-- End Cloudflare Web Analytics -->
+</body>
+</html>`;
+}
+
+// ── Skills Hub (/skills/) ──
+// /lists/top-skills ranks the "Skills & Skill Registries" category by stars.
+// This hub is the layer above it: hand-picked groups, one top pick each, the
+// install command verified against the repo's README, and a verdict saying why
+// you'd pick it. Nous Research's own Skills Hub is the registry; this is the
+// judgment. Stars are always read live from the catalog (never from
+// data/skills.json) so the curated file only ever claims what was re-verified
+// by hand — see skillsFreshness().
+
+const SKILL_TYPE_LABELS = {
+  skill: "skill",
+  plugin: "plugin",
+  registry: "registry",
+  collection: "collection",
+};
+
+function skillTypeLabel(type) {
+  return SKILL_TYPE_LABELS[type] || "skill";
+}
+
+// The topic a group is "for" — "Best Hermes Skills for Coding" → "Coding".
+// Used in FAQ questions, which target the "best hermes skill for X" queries.
+function skillsGroupTopic(group) {
+  const m = group.title.match(/\bfor\s+(.+)$/i);
+  return m ? m[1] : group.title;
+}
+
+// Honest freshness: {updatedAt, testedAgainst} come straight from the curated
+// file and are only bumped by a real re-verification pass. When the catalog's
+// latest Hermes release has moved past testedAgainst, say so rather than let
+// the stamp imply the picks were checked against it.
+function skillsFreshness(data) {
+  const base = `Updated ${data.updatedAt} · tested against Hermes ${data.testedAgainst}`;
+  const stale = data.testedAgainst !== latestHermesVersion
+    ? `Hermes ${latestHermesVersion} is out — re-verification pending`
+    : null;
+  return {
+    text: stale ? `${base} · ${stale}` : base,
+    html: `<p class="sk-freshness">${escapeHtml(base)}${stale ? ` · <span class="sk-stale">${escapeHtml(stale)}</span>` : ""}</p>`,
+  };
+}
+
+// Join the curated entries to the live catalog once; every skills surface
+// renders off this model so stars, ordering, and group membership can't drift
+// between the hub and the per-group pages.
+function buildSkillsModel(data, allRepos, metadata) {
+  const repoIndex = new Map(allRepos.map((r) => [`${r.owner}/${r.repo}`, r]));
+  const entries = data.skills.map((skill) => {
+    const key = `${skill.owner}/${skill.repo}`;
+    // NB: `repo` on a skill entry is the repo *name* string — the joined
+    // catalog record goes on `catalogRepo` so it can't clobber it.
+    const catalogRepo = repoIndex.get(key) || null;
+    return {
+      ...skill,
+      key,
+      catalogRepo,
+      stars: metadata?.[key]?.stars ?? catalogRepo?.stars ?? 0,
+    };
+  });
+
+  const byStars = (a, b) =>
+    Number(b.topPick === true) - Number(a.topPick === true) || b.stars - a.stars;
+
+  const groups = data.useCases.map((group) => {
+    const members = entries.filter((e) => e.useCases.includes(group.slug)).sort(byStars);
+    return {
+      ...group,
+      entries: members,
+      topPick: members.find((e) => e.topPick === true) || members[0] || null,
+    };
+  });
+
+  const catalog = allRepos
+    .filter((r) => r.category === SKILLS_CATEGORY)
+    .map((r) => ({ ...r, stars: metadata?.[`${r.owner}/${r.repo}`]?.stars ?? r.stars ?? 0 }))
+    .sort((a, b) => (b.stars || 0) - (a.stars || 0));
+
+  return { entries, groups, catalog, byKey: new Map(entries.map((e) => [e.key, e])) };
+}
+
+function renderSkillInstallBlock(entry) {
+  if (!entry.install) return "";
+  return `<div class="sk-install-label">install</div>
+      <code class="sk-install">${escapeHtml(entry.install)}</code>`;
+}
+
+// Shared row for a skill inside a group section on the hub.
+function renderSkillRow(entry, i) {
+  const rank = String(i + 1).padStart(2, "0");
+  return `<a class="list-row" href="/projects/${entry.owner}/${entry.repo}">
+    <div class="list-rank">${rank}</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">${escapeHtml(entry.owner)} /</span> ${escapeHtml(entry.repo)}<span class="sk-type">${escapeHtml(skillTypeLabel(entry.type))}</span>${entry.topPick ? ' <span class="sk-pick-flag">top pick</span>' : ""}</div>
+      <div class="list-cell-desc">${escapeHtml(truncate(entry.verdict, 180))}</div>
+    </div>
+    <div class="list-cell-stars">★ ${formatStars(entry.stars)}</div>
+  </a>`;
+}
+
+function renderSkillsHub(data, model) {
+  const title = "Best Hermes Agent Skills — the Skills Hub decision layer | Hermes Atlas";
+  const desc =
+    "The best Hermes Agent skills, picked by use case — coding, cybersecurity, writing, crypto, design, and skill management. Install command, compatibility, and a verdict for every pick.";
+  const canonicalUrl = `${SITE_URL}/skills/`;
+  const ogTitle = "Hermes Skills Hub — Hermes Atlas";
+  const ogSubtitle = "The best Hermes Agent skills by use case, with install commands and verdicts.";
+  const fresh = skillsFreshness(data);
+
+  const topPicks = model.groups
+    .map((g) => ({ group: g, entry: g.topPick }))
+    .filter((x) => x.entry);
+
+  const topPickCards = topPicks
+    .map(({ group, entry }) => `<article class="sk-card">
+      <div class="sk-card-group">${escapeHtml(skillsGroupTopic(group))}</div>
+      <div class="sk-card-head">
+        <div class="sk-card-name"><span class="org">${escapeHtml(entry.owner)} /</span> ${escapeHtml(entry.repo)}</div>
+        <div class="sk-card-stars">★ ${formatStars(entry.stars)}</div>
+      </div>
+      <p class="sk-verdict">${escapeHtml(entry.verdict)}</p>
+      ${renderSkillInstallBlock(entry)}
+      <a class="sk-card-link" href="/projects/${entry.owner}/${entry.repo}">${escapeHtml(entry.repo)} details →</a>
+    </article>`)
+    .join("\n    ");
+
+  const groupSections = model.groups
+    .map((group) => {
+      const shown = group.entries.slice(0, 4);
+      return `
+<section class="uc-section" aria-label="${escapeHtml(group.title)}">
+  <div class="section-label">${escapeHtml(group.title)}</div>
+  <p class="uc-section-note">${escapeHtml(group.description)}</p>
+  <div class="list-table">
+    ${shown.map(renderSkillRow).join("\n    ")}
+  </div>
+  <p class="list-link"><a href="/skills/for-${escapeHtml(group.slug)}">see all ${group.entries.length} picks for ${escapeHtml(skillsGroupTopic(group).toLowerCase())} →</a></p>
+</section>`;
+    })
+    .join("");
+
+  const registries = model.entries
+    .filter((e) => e.type === "registry" || e.type === "collection")
+    .slice()
+    .sort((a, b) => b.stars - a.stars);
+
+  const registriesHtml = registries.length
+    ? `
+<section class="uc-section" aria-label="Registries and collections">
+  <div class="section-label">registries &amp; collections</div>
+  <p class="uc-section-note">Nous Research's own Skills Hub is the registry — the place skills are published and installed from. Atlas is the judgment layer on top of it: which of them are worth installing, and why. These ${registries.length} entries are the other side of that split — search surfaces, taps, and bulk collections that hand you many skills at once rather than solving one problem well.</p>
+  <div class="list-table">
+    ${registries.map(renderSkillRow).join("\n    ")}
+  </div>
+</section>`
+    : "";
+
+  const catalogRows = model.catalog
+    .map((r, i) => {
+      const rank = String(i + 1).padStart(2, "0");
+      return `<a class="list-row" href="/projects/${r.owner}/${r.repo}">
+    <div class="list-rank">${rank}</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">${escapeHtml(r.owner)} /</span> ${escapeHtml(r.repo)}${r.official ? ' <span class="repo-flag">official</span>' : ""}</div>
+      <div class="list-cell-desc">${escapeHtml((r.description || "").slice(0, 140))}</div>
+    </div>
+    <div class="list-cell-stars">★ ${formatStars(r.stars)}</div>
+  </a>`;
+    })
+    .join("\n    ");
+
+  const collectionLD = {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "@id": canonicalUrl,
+    name: "Hermes Skills Hub — the best Hermes Agent skills by use case",
+    description: desc,
+    url: canonicalUrl,
+    isPartOf: { "@id": "https://hermesatlas.com/#website" },
+    dateModified: data.updatedAt,
+    mainEntity: {
+      "@type": "ItemList",
+      numberOfItems: topPicks.length,
+      itemListElement: topPicks.map(({ group, entry }, i) => ({
+        "@type": "ListItem",
+        position: i + 1,
+        url: `${SITE_URL}/projects/${entry.owner}/${entry.repo}`,
+        name: `${entry.owner}/${entry.repo}`,
+        description: `Top pick — ${group.title}`,
+      })),
+    },
+  };
+
+  const breadcrumbLD = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "map", item: "https://hermesatlas.com/" },
+      { "@type": "ListItem", position: 2, name: "skills" },
+    ],
+  };
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>${escapeHtml(title)}</title>
+<meta name="description" content="${escapeHtml(desc)}">
+<link rel="canonical" href="${canonicalUrl}">
+<meta property="og:title" content="${escapeHtml(ogTitle)}">
+<meta property="og:description" content="${escapeHtml(desc)}">
+<meta property="og:type" content="website">
+<meta property="og:url" content="${canonicalUrl}">
+<meta property="og:site_name" content="Hermes Atlas">
+<meta property="og:image" content="${escapeHtml(ogImageUrl({ title: ogTitle, subtitle: ogSubtitle, kind: "skills" }))}">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="${escapeHtml(ogTitle)}">
+<meta name="twitter:image" content="${escapeHtml(ogImageUrl({ title: ogTitle, subtitle: ogSubtitle, kind: "skills" }))}">
+${ldJson(breadcrumbLD)}
+${ldJson(collectionLD)}
+<link rel="alternate" type="application/rss+xml" title="Hermes Atlas — new projects" href="/rss.xml">
+${FAVICON}
+<script src="/assets/js/theme-init.js"></script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap">
+<link rel="stylesheet" href="/assets/css/tokens.css">
+<link rel="stylesheet" href="/assets/css/base.css">
+<link rel="stylesheet" href="/assets/css/page.css">
+<link rel="stylesheet" href="/assets/css/use-cases.css">
+<link rel="stylesheet" href="/assets/css/skills.css">
+</head>
+<body>
+
+<a class="skip-link" href="#main">Skip to content</a>
+
+${renderMasthead("skills")}
+
+<div class="breadcrumb" aria-label="Breadcrumb">
+  <a href="/">map</a><span class="sep">/</span>skills
+</div>
+
+<main id="main">
+
+<section class="list-page">
+  <h1 class="list-title">Hermes Agent skills</h1>
+  <p class="list-intro">A registry tells you what exists. This is the decision layer: ${model.entries.length} hand-checked skills, plugins, registries, and collections across ${model.groups.length} use cases — each with the install command taken from its README, what it's compatible with, and a one-line verdict on why you'd pick it over the alternatives.</p>
+  <p class="list-intro sk-lede">Want the whole category ranked by stars instead? That's <a href="/lists/top-skills">the ranked list — top Hermes skills</a>, all ${model.catalog.length} of them.</p>
+  ${fresh.html}
+</section>
+
+<section class="uc-section" aria-label="Top picks">
+  <div class="section-label">top picks — one per use case</div>
+  <p class="uc-section-note">If you only install one thing per category, install these.</p>
+  <div class="sk-card-grid">
+    ${topPickCards}
+  </div>
+</section>
+${groupSections}${registriesHtml}
+
+<section class="uc-section" aria-label="Full skills catalog">
+  <div class="section-label">the full catalog — ${model.catalog.length} projects</div>
+  <p class="uc-section-note">Everything in the Atlas categorized as ${escapeHtml(SKILLS_CATEGORY)}, ranked by live GitHub stars. Entries without a verdict above haven't been through a curation pass yet.</p>
+  <div class="list-table" aria-label="All skills repos">
+    <div class="list-table-head">
+      <div>#</div>
+      <div>project</div>
+      <div class="text-right">stars</div>
+    </div>
+    ${catalogRows}
+  </div>
+</section>
+
+<div class="back-link"><a href="/lists/top-skills">← top skills, ranked by stars</a></div>
+
+</main>
+
+${PAGE_FOOTER}
+
+<script src="/assets/js/theme-toggle.js" defer></script>
+<script src="/assets/js/masthead-fetch.js" defer></script>
+<!-- Cloudflare Web Analytics -->
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js"
+        data-cf-beacon='{"token": "fe0d4d79280b4386b6b0cd99b2d94dbc"}'></script>
+<!-- End Cloudflare Web Analytics -->
+</body>
+</html>`;
+}
+
+function renderSkillsUseCasePage(data, group, otherGroups) {
+  const title = `${group.title} | Hermes Atlas`;
+  const desc = escapeHtml(truncate(group.description, 160));
+  const canonicalUrl = `${SITE_URL}/skills/for-${group.slug}`;
+  const fresh = skillsFreshness(data);
+  const topic = skillsGroupTopic(group);
+  const pick = group.topPick;
+
+  const entriesHtml = group.entries
+    .map((entry) => `<article class="sk-entry">
+      <div class="sk-entry-head">
+        <h2 class="sk-entry-name"><a href="/projects/${entry.owner}/${entry.repo}"><span class="org">${escapeHtml(entry.owner)} /</span> ${escapeHtml(entry.repo)}</a><span class="sk-type">${escapeHtml(skillTypeLabel(entry.type))}</span>${entry.topPick ? ' <span class="sk-pick-flag">top pick</span>' : ""}</h2>
+        <div class="sk-card-stars">★ ${formatStars(entry.stars)}</div>
+      </div>
+      <div class="sk-entry-body">
+        <p class="sk-verdict">${escapeHtml(entry.verdict)}</p>
+        ${renderSkillInstallBlock(entry)}
+        ${entry.compatibility ? `<p class="sk-compat"><span class="sk-compat-label">works with</span>${escapeHtml(entry.compatibility)}</p>` : ""}
+      </div>
+    </article>`)
+    .join("\n    ");
+
+  // Answers are plain text: they go into FAQPage JSON-LD verbatim and are
+  // escaped once on the way into the visible markup.
+  const faqs = [
+    {
+      q: `What is the best Hermes Agent skill for ${topic.toLowerCase()}?`,
+      a: pick
+        ? `${pick.owner}/${pick.repo}. ${pick.verdict}${pick.install ? ` Install it with: ${pick.install}` : ""}`
+        : `Hermes Atlas tracks ${group.entries.length} options for ${topic.toLowerCase()}; see the ranked picks on this page.`,
+    },
+    {
+      q: "How do I install Hermes skills?",
+      a: "From the Hermes CLI. Running hermes skills install owner/repo/skills/name installs a single skill; hermes skills tap add owner/repo registers a whole repository as a tap, so every skill inside it becomes available. Plugins use hermes plugins install owner/repo --enable. Skills that follow the agentskills.io spec but aren't published to the Skills Hub can be added with npx skills add owner/repo, or cloned straight into your skills directory. Every entry on this page carries the exact command from its own README.",
+    },
+    {
+      q: "How current are these picks?",
+      a: `${fresh.text}. The picks are curated by hand — install commands are read out of each project's README rather than generated, and star counts are refreshed from the GitHub API on every build.`,
+    },
+  ];
+
+  const faqHtml = faqs
+    .map((f) => `<div class="sk-faq-item">
+      <div class="sk-faq-q">${escapeHtml(f.q)}</div>
+      <p class="sk-faq-a">${escapeHtml(f.a)}</p>
+    </div>`)
+    .join("\n    ");
+
+  const collectionLD = {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "@id": canonicalUrl,
+    name: group.title,
+    description: group.description,
+    url: canonicalUrl,
+    isPartOf: { "@id": "https://hermesatlas.com/#website" },
+    dateModified: data.updatedAt,
+    mainEntity: {
+      "@type": "ItemList",
+      numberOfItems: group.entries.length,
+      itemListOrder: "https://schema.org/ItemListOrderDescending",
+      itemListElement: group.entries.map((entry, i) => ({
+        "@type": "ListItem",
+        position: i + 1,
+        url: `${SITE_URL}/projects/${entry.owner}/${entry.repo}`,
+        name: `${entry.owner}/${entry.repo}`,
+      })),
+    },
+  };
+
+  const breadcrumbLD = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "map", item: "https://hermesatlas.com/" },
+      { "@type": "ListItem", position: 2, name: "skills", item: "https://hermesatlas.com/skills/" },
+      { "@type": "ListItem", position: 3, name: group.slug },
+    ],
+  };
+
+  const relatedHtml = otherGroups.length
+    ? `
+<section class="uc-section" aria-label="Other skill use cases">
+  <div class="section-label">other use cases</div>
+  <div class="uc-related">
+    ${otherGroups
+      .map((g) => `<a class="uc-related-link" href="/skills/for-${escapeHtml(g.slug)}">${escapeHtml(g.title)}</a>`)
+      .join("\n    ")}
+  </div>
+</section>`
+    : "";
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>${escapeHtml(title)}</title>
+<meta name="description" content="${desc}">
+<link rel="canonical" href="${canonicalUrl}">
+<meta property="og:title" content="${escapeHtml(group.title)}">
+<meta property="og:description" content="${desc}">
+<meta property="og:type" content="article">
+<meta property="og:url" content="${canonicalUrl}">
+<meta property="og:site_name" content="Hermes Atlas">
+<meta property="og:image" content="${escapeHtml(ogImageUrl({ title: group.title, subtitle: group.intent, kind: "skills" }))}">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="${escapeHtml(group.title)}">
+<meta name="twitter:image" content="${escapeHtml(ogImageUrl({ title: group.title, subtitle: group.intent, kind: "skills" }))}">
+${ldJson(breadcrumbLD)}
+${ldJson(collectionLD)}
+${renderFAQPageLD(faqs)}
+<link rel="alternate" type="application/rss+xml" title="Hermes Atlas — new projects" href="/rss.xml">
+${FAVICON}
+<script src="/assets/js/theme-init.js"></script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap">
+<link rel="stylesheet" href="/assets/css/tokens.css">
+<link rel="stylesheet" href="/assets/css/base.css">
+<link rel="stylesheet" href="/assets/css/page.css">
+<link rel="stylesheet" href="/assets/css/use-cases.css">
+<link rel="stylesheet" href="/assets/css/skills.css">
+</head>
+<body>
+
+<a class="skip-link" href="#main">Skip to content</a>
+
+${renderMasthead("skills")}
+
+<div class="breadcrumb" aria-label="Breadcrumb">
+  <a href="/">map</a><span class="sep">/</span><a href="/skills/">skills</a><span class="sep">/</span>${escapeHtml(group.slug)}
+</div>
+
+<main id="main">
+
+<section class="list-page">
+  <h1 class="list-title">${escapeHtml(group.title)}</h1>
+  <p class="uc-intent">“${escapeHtml(group.intent)}”</p>
+  <p class="list-intro sk-lede">${escapeHtml(group.description)}</p>
+  ${fresh.html}
+</section>
+
+<section class="uc-section" aria-label="Ranked picks">
+  <div class="section-label">the picks — ${group.entries.length}</div>
+  <div class="sk-entries">
+    ${entriesHtml}
+  </div>
+</section>
+
+<section class="uc-section" aria-label="How we picked">
+  <div class="section-label">how we picked</div>
+  <p class="sk-method">These are curated by hand, not scraped or ranked by an algorithm. Every entry is a project already accepted into the Atlas catalog; the install command is copied out of that project's own README (not inferred), the compatibility line reflects what the README actually claims to support, and the verdict says what this pick does that its neighbours don't. Star counts come live from the GitHub API on each build. ${escapeHtml(fresh.text)}.</p>
+</section>
+
+<section class="uc-section" aria-label="Frequently asked questions">
+  <div class="section-label">faq</div>
+  <div class="sk-faq">
+    ${faqHtml}
+  </div>
+</section>
+${relatedHtml}
+
+<div class="back-link"><a href="/skills/">← all skills</a></div>
 
 </main>
 
@@ -1685,7 +2198,7 @@ ${PAGE_FOOTER}
 // without touching this function), and <lastmod> is the file's real last
 // change: today if this build rewrote it, otherwise its last git commit date.
 // Stamping everything "today" trains crawlers to ignore the signal entirely.
-function generateSitemap(projectPages, listPages, reportPages = [], useCasePages = []) {
+function generateSitemap(projectPages, listPages, reportPages = [], useCasePages = [], skillGroups = []) {
   const entry = (urlPath, relFile, changefreq, priority) =>
     `  <url><loc>${SITE_URL}${urlPath}</loc><changefreq>${changefreq}</changefreq><priority>${priority}</priority><lastmod>${lastmodFor(relFile)}</lastmod></url>\n`;
 
@@ -1729,6 +2242,14 @@ function generateSitemap(projectPages, listPages, reportPages = [], useCasePages
   urls += entry("/use-cases/", "use-cases/index.html", "weekly", "0.8");
   for (const uc of useCasePages) {
     urls += entry(`/use-cases/${uc.slug}`, `use-cases/${uc.slug}.html`, "weekly", "0.7");
+  }
+
+  // The Skills Hub outranks every other section by search demand, hence 0.9.
+  if (skillGroups.length > 0) {
+    urls += entry("/skills/", "skills/index.html", "weekly", "0.9");
+    for (const group of skillGroups) {
+      urls += entry(`/skills/for-${group.slug}`, `skills/for-${group.slug}.html`, "weekly", "0.8");
+    }
   }
 
   return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${urls}</urlset>\n`;
@@ -2107,12 +2628,16 @@ async function main() {
   // it's added; gate it here the same way validate-skills-json.js gates CI
   // so a bad hand-edit fails the build instead of shipping silently broken.
   const skillsPath = path.join(ROOT, "data", "skills.json");
+  let skillsModel = null;
   if (fs.existsSync(skillsPath)) {
-    const skillsData = JSON.parse(fs.readFileSync(skillsPath, "utf-8"));
+    skillsData = JSON.parse(fs.readFileSync(skillsPath, "utf-8"));
     const skillsErrors = validateSkills(skillsData, repos, useCases);
     if (skillsErrors.length > 0) {
       throw new Error(`data/skills.json validation failed:\n- ${skillsErrors.join("\n- ")}`);
     }
+    // Built here, before project pages render: the per-project install box
+    // reads the same joined model the hub does.
+    skillsModel = buildSkillsModel(skillsData, repos, metadata);
     console.log(`  Loaded data/skills.json (${skillsData.skills.length} skills)`);
   } else {
     console.log("  data/skills.json not present; skills hub skipped");
@@ -2187,7 +2712,8 @@ async function main() {
       readmeHtml,
       relatedRepos,
       summaries[key] || null,
-      handbookMentions[key] || null
+      handbookMentions[key] || null,
+      skillsModel?.byKey.get(key) || null
     );
 
     // Write file
@@ -2324,6 +2850,37 @@ async function main() {
     console.log("\nNo data/use-cases.json found — skipping use-case pages");
   }
 
+  // Generate the Skills Hub (/skills/ + /skills/for-*)
+  if (skillsModel) {
+    console.log("\nGenerating skills hub...");
+    const skillsDir = path.join(ROOT, "skills");
+    fs.mkdirSync(skillsDir, { recursive: true });
+
+    writePage(path.join(skillsDir, "index.html"), renderSkillsHub(skillsData, skillsModel));
+    console.log(`  index (${skillsModel.entries.length} curated, ${skillsModel.catalog.length} in catalog)`);
+
+    for (const group of skillsModel.groups) {
+      const others = skillsModel.groups.filter((g) => g.slug !== group.slug);
+      const html = renderSkillsUseCasePage(skillsData, group, others);
+      writePage(path.join(skillsDir, `for-${group.slug}.html`), html);
+      console.log(`  for-${group.slug} (${group.entries.length} picks)`);
+    }
+
+    // Orphan cleanup — a group removed from data/skills.json must not keep
+    // serving a stale page (same failure mode as PR #148 on project pages).
+    const canonicalSkills = new Set([
+      "index.html",
+      ...skillsModel.groups.map((g) => `for-${g.slug}.html`),
+    ]);
+    for (const file of fs.readdirSync(skillsDir)) {
+      if (!file.endsWith(".html") || canonicalSkills.has(file)) continue;
+      fs.unlinkSync(path.join(skillsDir, file));
+      console.log(`  Removed orphan: skills/${file}`);
+    }
+  } else {
+    console.log("\nNo data/skills.json found — skipping skills hub");
+  }
+
   // Generate reports index page
   if (reports.length > 0) {
     console.log("\nGenerating reports index...");
@@ -2335,7 +2892,7 @@ async function main() {
 
   // Generate sitemap
   console.log("\nGenerating sitemap.xml...");
-  const sitemap = generateSitemap(repos, lists, reports, useCases);
+  const sitemap = generateSitemap(repos, lists, reports, useCases, skillsModel?.groups || []);
   fs.writeFileSync(path.join(ROOT, "sitemap.xml"), sitemap, "utf-8");
   console.log(`  ${(sitemap.match(/<url>/g) || []).length} URLs (${changedPages.size} pages changed this build)`);
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -3,25 +3,25 @@
   <url><loc>https://hermesatlas.com/</loc><changefreq>daily</changefreq><priority>1.0</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/guide/</loc><changefreq>monthly</changefreq><priority>0.9</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/guide/install/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
-  <url><loc>https://hermesatlas.com/guide/memory/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
+  <url><loc>https://hermesatlas.com/guide/memory/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/guide/vs-claude-code/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
-  <url><loc>https://hermesatlas.com/masterclass/</loc><changefreq>monthly</changefreq><priority>0.9</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/dev/</loc><changefreq>monthly</changefreq><priority>0.9</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/dev/agent-loop</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/dev/building-on-hermes</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/dev/codebase-map</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/dev/glossary</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/dev/mcp-gateway-cron</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/dev/memory</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/dev/skill-template</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/dev/skills</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/dev/tools-and-toolsets</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/dev/what-is-hermes-agent</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/reports/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/reports/state-of-hermes-july-2026</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/reports/state-of-hermes-may-2026</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/reports/state-of-hermes-april-2026</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/privacy</loc><changefreq>yearly</changefreq><priority>0.3</priority><lastmod>2026-08-20</lastmod></url>
+  <url><loc>https://hermesatlas.com/masterclass/</loc><changefreq>monthly</changefreq><priority>0.9</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/dev/</loc><changefreq>monthly</changefreq><priority>0.9</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/dev/agent-loop</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/dev/building-on-hermes</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/dev/codebase-map</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/dev/glossary</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/dev/mcp-gateway-cron</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/dev/memory</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/dev/skill-template</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/dev/skills</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/dev/tools-and-toolsets</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/dev/what-is-hermes-agent</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/reports/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/reports/state-of-hermes-july-2026</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/reports/state-of-hermes-may-2026</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/reports/state-of-hermes-april-2026</loc><changefreq>monthly</changefreq><priority>0.7</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/privacy</loc><changefreq>yearly</changefreq><priority>0.3</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/NousResearch/hermes-agent</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/NousResearch/Hermes-Function-Calling</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/NousResearch/atropos</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
@@ -30,8 +30,8 @@
   <url><loc>https://hermesatlas.com/projects/NousResearch/autonovel</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/outsourc-e/hermes-workspace</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/fathah/hermes-desktop</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/sanchomuzax/hermes-webui</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/Euraika-Labs/pan-ui</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/sanchomuzax/hermes-webui</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/Euraika-Labs/pan-ui</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/abundantbeing/hermes-browser-extension</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/mukul975/Anthropic-Cybersecurity-Skills</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/conorbronsdon/avoid-ai-writing</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
@@ -75,35 +75,35 @@
   <url><loc>https://hermesatlas.com/projects/agent37-platform/minions</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/CryptoDmitry/hermes-agent-control-room</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/colbymchenry/codegraph</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/Felix-Forever/hermes-agent-desktop</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/Felix-Forever/hermes-agent-desktop</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/AkoliteZA/hermes-agent-idea-workflow</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/shannhk/hermes-agent-control-room</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/Salomondiei08/oh-my-hermes</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/liaohch3/claude-tap</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/jazzyalex/agent-sessions</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/vectrocomputers/Hermes-Agent-Action-Plan</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/xiaonancs/hermes-agent-study</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/carterwayneskhizeine/hermes-agent-windows-R</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/sheawinkler/hermes-agent-ultra</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/AbuZar-Ansarii/Hermes-Agent-On-Android</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/jefferyjob/awesome-hermes-agent-zh</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/anneheartrecord/hermes-agent-anatomy</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/nickvasilescu/hermes-desktop-os1</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/jazzyalex/agent-sessions</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/vectrocomputers/Hermes-Agent-Action-Plan</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/xiaonancs/hermes-agent-study</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/carterwayneskhizeine/hermes-agent-windows-R</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/sheawinkler/hermes-agent-ultra</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/AbuZar-Ansarii/Hermes-Agent-On-Android</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/jefferyjob/awesome-hermes-agent-zh</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/anneheartrecord/hermes-agent-anatomy</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/nickvasilescu/hermes-desktop-os1</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/adityahimaone/hermes-agent-rtk-caveman</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/pengchengxia75-arch/hermes-agent-windows</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/ultraworkers/hermes-agent-helm-chart</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/pengchengxia75-arch/hermes-agent-windows</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/ultraworkers/hermes-agent-helm-chart</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/ZeroPointRepo/youtube-skills</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/stainlu/hermes-labyrinth</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/marshallrichards/ClawPhone</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/marshallrichards/ClawPhone</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/agent-of-empires/agent-of-empires</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/nexu-io/open-design</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/farion1231/cc-switch</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/iOfficeAI/AionUi</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/numtide/llm-agents.nix</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/TheAiSingularity/hermesclaw</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/TheAiSingularity/hermesclaw</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/0xrsydn/nix-hermes-agent</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/xmbshwll/hermes-agent-docker</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/JackTheGit/hermes-autonomous-server</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/xmbshwll/hermes-agent-docker</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/JackTheGit/hermes-autonomous-server</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/raulvidis/hermes-android</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/teknium1/hermes-miniverse</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/Ridwannurudeen/hermes-council</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
@@ -126,37 +126,37 @@
   <url><loc>https://hermesatlas.com/projects/bryercowan/hermes-embodied</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/0xNyk/awesome-hermes-agent</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/alchaincyf/hermes-agent-orange-book</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/OnlyTerp/hermes-optimization-guide</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/metantonio/hermes-wsl-ubuntu</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/mudrii/hermes-agent-docs</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/martymcenroe/HermesWiki</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/nativ3ai/hermes-agent-camel</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/kaminocorp/hermes-alpha</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/beardthelion/hermes-skill-distillation</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/xaspx/hermes-control-interface</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/OnlyTerp/hermes-optimization-guide</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/metantonio/hermes-wsl-ubuntu</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/mudrii/hermes-agent-docs</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/martymcenroe/HermesWiki</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/nativ3ai/hermes-agent-camel</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/kaminocorp/hermes-alpha</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/beardthelion/hermes-skill-distillation</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/xaspx/hermes-control-interface</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/ksimback/hermes-ecosystem</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/dodo-reach/hermes-desktop</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/runta-dev/clawshell</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/nesquena/hermes-webui</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/garrytan/gbrain</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/pyrate-llama/hermes-ui</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/pyrate-llama/hermes-ui</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/kevinmarmstrong/hermes-claude-code-rc</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/AaronWong1999/hermesclaw</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/stephenschoettler/hermes-lcm</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/Codename-11/hermes-relay</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/clawvader-tech/hermes-telegram-miniapp</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/clawvader-tech/hermes-telegram-miniapp</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/briancaffey/hermes-otel</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/EKKOLearnAI/hermes-studio</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/generalbusiness-ai/keep</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/mnemosyne-oss/mnemosyne</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/AMAP-ML/SkillClaw</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/aivrar/portable-hermes-agent</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/aivrar/portable-hermes-agent</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/Cranot/super-hermes</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/EfficientContext/ContextPilot</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/335234131/agent-browser-mcp</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/jwangkun/hermes-agent-guide</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/longyunfeigu/learn-hermes-agent</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/jpalmae/hermeshq</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/longyunfeigu/learn-hermes-agent</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/jpalmae/hermeshq</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/plastic-labs/honcho</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/adnw-vinc/hermes-nextcloud</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/Xquik-dev/hermes-tweet</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
@@ -174,7 +174,7 @@
   <url><loc>https://hermesatlas.com/projects/BORT-AGENTS/hermes-bort</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/futurebrowser/hermes-exabase-plugin</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/willingning-coder/eagle-eye</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/liftaris/herm</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/liftaris/herm</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/basilisk-labs/agentplane-hermes-plugin</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/8bit64k/cronalytics</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/Sahil-SS9/hermes-multichannel-prompt-optimizer</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
@@ -205,7 +205,7 @@
   <url><loc>https://hermesatlas.com/projects/internet-court/internet-court-skill</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/Sibyl-Labs/Sibyl-Memory</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/supernovae-st/nika</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/solomon2773/nora</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/solomon2773/nora</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/longsizhuo/openInvest</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/obra/superpowers</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/indranilbanerjee/contentforge</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
@@ -227,11 +227,11 @@
   <url><loc>https://hermesatlas.com/projects/ClaudioDrews/memory-os</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/uzairansaruzi/hermex</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/sharbelxyz/hermes-agent-mission-control</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/amirghm/hermes-agent-mobile</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/bookunt3d/hermes-agent-fa</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/amirghm/hermes-agent-mobile</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/bookunt3d/hermes-agent-fa</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/InfiniteWhispers/HermesAgent-MultiModel</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/0xarkstar/awesome-hermes-agent</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/zcweah1981/awesome-hermes-agent-zh</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/0xarkstar/awesome-hermes-agent</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/zcweah1981/awesome-hermes-agent-zh</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/xintaofei/codeg</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/mohitagw15856/pm-claude-skills</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/Javis603/token-monitor</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
@@ -240,7 +240,7 @@
   <url><loc>https://hermesatlas.com/projects/topoteretes/cognee</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/topoteretes/cognee-integrations</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/Hermes-brasil/hermes-brasil</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
-  <url><loc>https://hermesatlas.com/projects/freehul/progressive-skill</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
+  <url><loc>https://hermesatlas.com/projects/freehul/progressive-skill</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/handnewb/hermes-voice</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/MilkyWay008/Hermes-OTG</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/jiawood2006/hermes-skills</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
@@ -253,26 +253,34 @@
   <url><loc>https://hermesatlas.com/projects/webmilmind1/hermes-bounty-board</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/scavio-ai/hermes-agent</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/projects/Heybinshao/hermes-appearance-hub</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
-  <url><loc>https://hermesatlas.com/lists/</loc><changefreq>weekly</changefreq><priority>0.7</priority><lastmod>2026-08-20</lastmod></url>
+  <url><loc>https://hermesatlas.com/lists/</loc><changefreq>weekly</changefreq><priority>0.7</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/lists/best-memory-providers</loc><changefreq>weekly</changefreq><priority>0.6</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/lists/top-skills</loc><changefreq>weekly</changefreq><priority>0.6</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/lists/deployment-options</loc><changefreq>weekly</changefreq><priority>0.6</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/lists/multi-agent-frameworks</loc><changefreq>weekly</changefreq><priority>0.6</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/lists/developer-tools</loc><changefreq>weekly</changefreq><priority>0.6</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/lists/workspaces-and-guis</loc><changefreq>weekly</changefreq><priority>0.6</priority><lastmod>2026-08-21</lastmod></url>
-  <url><loc>https://hermesatlas.com/use-cases/</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-20</lastmod></url>
-  <url><loc>https://hermesatlas.com/use-cases/always-on-personal-ops-agent</loc><changefreq>weekly</changefreq><priority>0.7</priority><lastmod>2026-08-20</lastmod></url>
+  <url><loc>https://hermesatlas.com/use-cases/</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/use-cases/always-on-personal-ops-agent</loc><changefreq>weekly</changefreq><priority>0.7</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/use-cases/hermes-in-your-pocket</loc><changefreq>weekly</changefreq><priority>0.7</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/use-cases/codebase-aware-coding-agent</loc><changefreq>weekly</changefreq><priority>0.7</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/use-cases/cut-your-token-bill</loc><changefreq>weekly</changefreq><priority>0.7</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/use-cases/multi-agent-build-pipeline</loc><changefreq>weekly</changefreq><priority>0.7</priority><lastmod>2026-08-21</lastmod></url>
-  <url><loc>https://hermesatlas.com/use-cases/fully-self-hosted-private-stack</loc><changefreq>weekly</changefreq><priority>0.7</priority><lastmod>2026-08-20</lastmod></url>
+  <url><loc>https://hermesatlas.com/use-cases/fully-self-hosted-private-stack</loc><changefreq>weekly</changefreq><priority>0.7</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/use-cases/obsidian-second-brain</loc><changefreq>weekly</changefreq><priority>0.7</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/use-cases/content-engine-in-your-voice</loc><changefreq>weekly</changefreq><priority>0.7</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/use-cases/generative-media-studio</loc><changefreq>weekly</changefreq><priority>0.7</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/use-cases/daily-research-briefing</loc><changefreq>weekly</changefreq><priority>0.7</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/use-cases/agent-that-browses-the-web</loc><changefreq>weekly</changefreq><priority>0.7</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/use-cases/run-hermes-for-your-team</loc><changefreq>weekly</changefreq><priority>0.7</priority><lastmod>2026-08-21</lastmod></url>
-  <url><loc>https://hermesatlas.com/use-cases/guardrails-before-it-touches-prod</loc><changefreq>weekly</changefreq><priority>0.7</priority><lastmod>2026-08-20</lastmod></url>
+  <url><loc>https://hermesatlas.com/use-cases/guardrails-before-it-touches-prod</loc><changefreq>weekly</changefreq><priority>0.7</priority><lastmod>2026-08-21</lastmod></url>
   <url><loc>https://hermesatlas.com/use-cases/see-what-your-agent-is-doing</loc><changefreq>weekly</changefreq><priority>0.7</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/skills/</loc><changefreq>weekly</changefreq><priority>0.9</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/skills/for-coding</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/skills/for-cybersecurity</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/skills/for-skill-management</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/skills/for-design-and-diagrams</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/skills/for-writing-and-content</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/skills/for-crypto-and-payments</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
+  <url><loc>https://hermesatlas.com/skills/for-personal-ops</loc><changefreq>weekly</changefreq><priority>0.8</priority><lastmod>2026-08-21</lastmod></url>
 </urlset>

--- a/skills/for-coding.html
+++ b/skills/for-coding.html
@@ -1,0 +1,307 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Best Hermes Skills for Coding | Hermes Atlas</title>
+<meta name="description" content="Structured methodologies and subagent swarms that turn ad-hoc coding sessions into repeatable, checkpointed workflows — spec-first planning, adversarial code…">
+<link rel="canonical" href="https://hermesatlas.com/skills/for-coding">
+<meta property="og:title" content="Best Hermes Skills for Coding">
+<meta property="og:description" content="Structured methodologies and subagent swarms that turn ad-hoc coding sessions into repeatable, checkpointed workflows — spec-first planning, adversarial code…">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://hermesatlas.com/skills/for-coding">
+<meta property="og:site_name" content="Hermes Atlas">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=Best+Hermes+Skills+for+Coding&amp;subtitle=Developers+looking+for+skills+or+plugins+that+plan%2C+review%2C+harden%2C+or+simplify+code+changes+inside+Hermes+Agent+or+Claude+Code.&amp;kind=skills">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Best Hermes Skills for Coding">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Best+Hermes+Skills+for+Coding&amp;subtitle=Developers+looking+for+skills+or+plugins+that+plan%2C+review%2C+harden%2C+or+simplify+code+changes+inside+Hermes+Agent+or+Claude+Code.&amp;kind=skills">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "map",
+      "item": "https://hermesatlas.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "skills",
+      "item": "https://hermesatlas.com/skills/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "coding"
+    }
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "@id": "https://hermesatlas.com/skills/for-coding",
+  "name": "Best Hermes Skills for Coding",
+  "description": "Structured methodologies and subagent swarms that turn ad-hoc coding sessions into repeatable, checkpointed workflows — spec-first planning, adversarial code review, and multi-agent simplification passes.",
+  "url": "https://hermesatlas.com/skills/for-coding",
+  "isPartOf": {
+    "@id": "https://hermesatlas.com/#website"
+  },
+  "dateModified": "2026-08-20",
+  "mainEntity": {
+    "@type": "ItemList",
+    "numberOfItems": 5,
+    "itemListOrder": "https://schema.org/ItemListOrderDescending",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "url": "https://hermesatlas.com/projects/obra/superpowers",
+        "name": "obra/superpowers"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "url": "https://hermesatlas.com/projects/Cranot/super-hermes",
+        "name": "Cranot/super-hermes"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "url": "https://hermesatlas.com/projects/armelhbobdad/bmad-module-skill-forge",
+        "name": "armelhbobdad/bmad-module-skill-forge"
+      },
+      {
+        "@type": "ListItem",
+        "position": 4,
+        "url": "https://hermesatlas.com/projects/Sahil-SS9/hermaguard",
+        "name": "Sahil-SS9/hermaguard"
+      },
+      {
+        "@type": "ListItem",
+        "position": 5,
+        "url": "https://hermesatlas.com/projects/Sahil-SS9/hermes-simplify-swarm",
+        "name": "Sahil-SS9/hermes-simplify-swarm"
+      }
+    ]
+  }
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is the best Hermes Agent skill for coding?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "obra/superpowers. The most-starred agentic skills framework in the catalog by two orders of magnitude. If you install exactly one dev-workflow plugin, this is the default. Install it with: hermes plugins install obra/superpowers --enable"
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How do I install Hermes skills?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "From the Hermes CLI. Running hermes skills install owner/repo/skills/name installs a single skill; hermes skills tap add owner/repo registers a whole repository as a tap, so every skill inside it becomes available. Plugins use hermes plugins install owner/repo --enable. Skills that follow the agentskills.io spec but aren't published to the Skills Hub can be added with npx skills add owner/repo, or cloned straight into your skills directory. Every entry on this page carries the exact command from its own README."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How current are these picks?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Updated 2026-08-20 · tested against Hermes v0.20.4. The picks are curated by hand — install commands are read out of each project's README rather than generated, and star counts are refreshed from the GitHub API on every build."
+      }
+    }
+  ]
+}
+</script>
+<link rel="alternate" type="application/rss+xml" title="Hermes Atlas — new projects" href="/rss.xml">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+<link rel="apple-touch-icon" href="/apple-touch-icon.png">
+<link rel="manifest" href="/site.webmanifest">
+<script src="/assets/js/theme-init.js"></script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap">
+<link rel="stylesheet" href="/assets/css/tokens.css">
+<link rel="stylesheet" href="/assets/css/base.css">
+<link rel="stylesheet" href="/assets/css/page.css">
+<link rel="stylesheet" href="/assets/css/use-cases.css">
+<link rel="stylesheet" href="/assets/css/skills.css">
+</head>
+<body>
+
+<a class="skip-link" href="#main">Skip to content</a>
+
+<header class="masthead">
+  <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
+  <div class="mast-meta" aria-label="Site metadata">
+    <span id="meta-count">231·repos</span>
+    <span id="meta-version">hermes·v0.20.4</span>
+    <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
+  </div>
+  <nav class="mast-nav" aria-label="Primary">
+    <a href="/">map</a>
+    <a href="/lists/">lists</a>
+    <a href="/skills/" class="active">skills</a>
+    <a href="/use-cases/">use cases</a>
+    <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
+    <a href="/dev/">dev</a>
+    <a href="/reports/">reports</a>
+    <a href="/#newsletter">newsletter</a>
+    <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
+  </nav>
+  <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
+  </button>
+</header>
+
+<div class="breadcrumb" aria-label="Breadcrumb">
+  <a href="/">map</a><span class="sep">/</span><a href="/skills/">skills</a><span class="sep">/</span>coding
+</div>
+
+<main id="main">
+
+<section class="list-page">
+  <h1 class="list-title">Best Hermes Skills for Coding</h1>
+  <p class="uc-intent">“Developers looking for skills or plugins that plan, review, harden, or simplify code changes inside Hermes Agent or Claude Code.”</p>
+  <p class="list-intro sk-lede">Structured methodologies and subagent swarms that turn ad-hoc coding sessions into repeatable, checkpointed workflows — spec-first planning, adversarial code review, and multi-agent simplification passes.</p>
+  <p class="sk-freshness">Updated 2026-08-20 · tested against Hermes v0.20.4</p>
+</section>
+
+<section class="uc-section" aria-label="Ranked picks">
+  <div class="section-label">the picks — 5</div>
+  <div class="sk-entries">
+    <article class="sk-entry">
+      <div class="sk-entry-head">
+        <h2 class="sk-entry-name"><a href="/projects/obra/superpowers"><span class="org">obra /</span> superpowers</a><span class="sk-type">plugin</span> <span class="sk-pick-flag">top pick</span></h2>
+        <div class="sk-card-stars">★ 275.3K</div>
+      </div>
+      <div class="sk-entry-body">
+        <p class="sk-verdict">The most-starred agentic skills framework in the catalog by two orders of magnitude. If you install exactly one dev-workflow plugin, this is the default.</p>
+        <div class="sk-install-label">install</div>
+      <code class="sk-install">hermes plugins install obra/superpowers --enable</code>
+        <p class="sk-compat"><span class="sk-compat-label">works with</span>Hermes Agent CLI (plugin); also ships as a Claude Code plugin via the official marketplace.</p>
+      </div>
+    </article>
+    <article class="sk-entry">
+      <div class="sk-entry-head">
+        <h2 class="sk-entry-name"><a href="/projects/Cranot/super-hermes"><span class="org">Cranot /</span> super-hermes</a><span class="sk-type">skill</span></h2>
+        <div class="sk-card-stars">★ 382</div>
+      </div>
+      <div class="sk-entry-body">
+        <p class="sk-verdict">Built specifically for Hermes' own Skills Hub syntax rather than ported from Claude Code — teaches the agent to write its own analytical prompts via prism-scan plus seven proven analytical lenses.</p>
+        <div class="sk-install-label">install</div>
+      <code class="sk-install">hermes skills tap add Cranot/super-hermes</code>
+        <p class="sk-compat"><span class="sk-compat-label">works with</span>Hermes Agent native (Skills Hub tap); manual git-clone install also documented for other harnesses.</p>
+      </div>
+    </article>
+    <article class="sk-entry">
+      <div class="sk-entry-head">
+        <h2 class="sk-entry-name"><a href="/projects/armelhbobdad/bmad-module-skill-forge"><span class="org">armelhbobdad /</span> bmad-module-skill-forge</a><span class="sk-type">skill</span></h2>
+        <div class="sk-card-stars">★ 93</div>
+      </div>
+      <div class="sk-entry-body">
+        <p class="sk-verdict">Turns your own repo, docs, and developer discourse into agentskills.io-compliant skills with file/line provenance citations — for teams standardizing internal skills, not consuming someone else's.</p>
+        <div class="sk-install-label">install</div>
+      <code class="sk-install">npx bmad-module-skill-forge install</code>
+        <p class="sk-compat"><span class="sk-compat-label">works with</span>Node.js &gt;= 22, Python &gt;= 3.10, uv required; IDE-agnostic scaffolding tool, not Hermes-specific.</p>
+      </div>
+    </article>
+    <article class="sk-entry">
+      <div class="sk-entry-head">
+        <h2 class="sk-entry-name"><a href="/projects/Sahil-SS9/hermaguard"><span class="org">Sahil-SS9 /</span> hermaguard</a><span class="sk-type">skill</span></h2>
+        <div class="sk-card-stars">★ 25</div>
+      </div>
+      <div class="sk-entry-body">
+        <p class="sk-verdict">Three parallel subagents attack code from different angles, then verify findings via sandboxed proof-of-concept execution before reporting VERIFIED or REFUTED — the most rigorous read-only code-review skill in this list.</p>
+        <div class="sk-install-label">install</div>
+      <code class="sk-install">Clone the repo and copy it into your harness's skill directory (pip install . provides its 9 console scripts); no Skills Hub listing yet.</code>
+        <p class="sk-compat"><span class="sk-compat-label">works with</span>Harness-agnostic Agent Skill, Python-backed; works with Hermes, Claude Code, and any agentskills.io-compatible client.</p>
+      </div>
+    </article>
+    <article class="sk-entry">
+      <div class="sk-entry-head">
+        <h2 class="sk-entry-name"><a href="/projects/Sahil-SS9/hermes-simplify-swarm"><span class="org">Sahil-SS9 /</span> hermes-simplify-swarm</a><span class="sk-type">skill</span></h2>
+        <div class="sk-card-stars">★ 13</div>
+      </div>
+      <div class="sk-entry-body">
+        <p class="sk-verdict">Three read-only subagents (Hygiene, Clarity, Correctness) with a SAFE/CAREFUL/RISKY tiered approval gate before anything is applied — a safer default than a single autonomous simplification pass.</p>
+        <div class="sk-install-label">install</div>
+      <code class="sk-install">git clone https://github.com/Sahil-SS9/hermes-simplify-swarm.git, then copy SKILL.md and references/ into your harness's skill directory as simplify-swarm/.</code>
+        <p class="sk-compat"><span class="sk-compat-label">works with</span>Harness-agnostic (copy-in SKILL.md); explicitly built for Hermes Agent, also works in Claude Code.</p>
+      </div>
+    </article>
+  </div>
+</section>
+
+<section class="uc-section" aria-label="How we picked">
+  <div class="section-label">how we picked</div>
+  <p class="sk-method">These are curated by hand, not scraped or ranked by an algorithm. Every entry is a project already accepted into the Atlas catalog; the install command is copied out of that project's own README (not inferred), the compatibility line reflects what the README actually claims to support, and the verdict says what this pick does that its neighbours don't. Star counts come live from the GitHub API on each build. Updated 2026-08-20 · tested against Hermes v0.20.4.</p>
+</section>
+
+<section class="uc-section" aria-label="Frequently asked questions">
+  <div class="section-label">faq</div>
+  <div class="sk-faq">
+    <div class="sk-faq-item">
+      <div class="sk-faq-q">What is the best Hermes Agent skill for coding?</div>
+      <p class="sk-faq-a">obra/superpowers. The most-starred agentic skills framework in the catalog by two orders of magnitude. If you install exactly one dev-workflow plugin, this is the default. Install it with: hermes plugins install obra/superpowers --enable</p>
+    </div>
+    <div class="sk-faq-item">
+      <div class="sk-faq-q">How do I install Hermes skills?</div>
+      <p class="sk-faq-a">From the Hermes CLI. Running hermes skills install owner/repo/skills/name installs a single skill; hermes skills tap add owner/repo registers a whole repository as a tap, so every skill inside it becomes available. Plugins use hermes plugins install owner/repo --enable. Skills that follow the agentskills.io spec but aren't published to the Skills Hub can be added with npx skills add owner/repo, or cloned straight into your skills directory. Every entry on this page carries the exact command from its own README.</p>
+    </div>
+    <div class="sk-faq-item">
+      <div class="sk-faq-q">How current are these picks?</div>
+      <p class="sk-faq-a">Updated 2026-08-20 · tested against Hermes v0.20.4. The picks are curated by hand — install commands are read out of each project's README rather than generated, and star counts are refreshed from the GitHub API on every build.</p>
+    </div>
+  </div>
+</section>
+
+<section class="uc-section" aria-label="Other skill use cases">
+  <div class="section-label">other use cases</div>
+  <div class="uc-related">
+    <a class="uc-related-link" href="/skills/for-cybersecurity">Best Hermes Skills for Cybersecurity</a>
+    <a class="uc-related-link" href="/skills/for-skill-management">Best Tools for Discovering &amp; Managing Hermes Skills</a>
+    <a class="uc-related-link" href="/skills/for-design-and-diagrams">Best Hermes Skills for Design &amp; Diagrams</a>
+    <a class="uc-related-link" href="/skills/for-writing-and-content">Best Hermes Skills for Writing &amp; Content</a>
+    <a class="uc-related-link" href="/skills/for-crypto-and-payments">Best Hermes Skills for Crypto &amp; Agent Payments</a>
+    <a class="uc-related-link" href="/skills/for-personal-ops">Best Hermes Skills for Personal Ops</a>
+  </div>
+</section>
+
+<div class="back-link"><a href="/skills/">← all skills</a></div>
+
+</main>
+
+<footer class="page-footer">
+  <div class="fn-left">hermes atlas · curated by <a href="https://github.com/ksimback">ksimback</a> · <a href="https://github.com/ksimback/hermes-ecosystem/issues">suggest a repo</a> · <a href="/privacy">privacy</a></div>
+  <div>v2 · 2026.04</div>
+</footer>
+
+<script src="/assets/js/theme-toggle.js" defer></script>
+<script src="/assets/js/masthead-fetch.js" defer></script>
+<!-- Cloudflare Web Analytics -->
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js"
+        data-cf-beacon='{"token": "fe0d4d79280b4386b6b0cd99b2d94dbc"}'></script>
+<!-- End Cloudflare Web Analytics -->
+</body>
+</html>

--- a/skills/for-crypto-and-payments.html
+++ b/skills/for-crypto-and-payments.html
@@ -1,0 +1,253 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Best Hermes Skills for Crypto &amp; Agent Payments | Hermes Atlas</title>
+<meta name="description" content="Skills for interacting with smart-contract oracle networks and for structuring agent-to-agent commerce, escrow, delegated permissions, and micropayments.">
+<link rel="canonical" href="https://hermesatlas.com/skills/for-crypto-and-payments">
+<meta property="og:title" content="Best Hermes Skills for Crypto &amp; Agent Payments">
+<meta property="og:description" content="Skills for interacting with smart-contract oracle networks and for structuring agent-to-agent commerce, escrow, delegated permissions, and micropayments.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://hermesatlas.com/skills/for-crypto-and-payments">
+<meta property="og:site_name" content="Hermes Atlas">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=Best+Hermes+Skills+for+Crypto+%26+Agent+Payments&amp;subtitle=Builders+wiring+agents+into+on-chain+protocols+or+agent-to-agent+payment+and+dispute-resolution+rails.&amp;kind=skills">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Best Hermes Skills for Crypto &amp; Agent Payments">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Best+Hermes+Skills+for+Crypto+%26+Agent+Payments&amp;subtitle=Builders+wiring+agents+into+on-chain+protocols+or+agent-to-agent+payment+and+dispute-resolution+rails.&amp;kind=skills">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "map",
+      "item": "https://hermesatlas.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "skills",
+      "item": "https://hermesatlas.com/skills/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "crypto-and-payments"
+    }
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "@id": "https://hermesatlas.com/skills/for-crypto-and-payments",
+  "name": "Best Hermes Skills for Crypto & Agent Payments",
+  "description": "Skills for interacting with smart-contract oracle networks and for structuring agent-to-agent commerce, escrow, delegated permissions, and micropayments.",
+  "url": "https://hermesatlas.com/skills/for-crypto-and-payments",
+  "isPartOf": {
+    "@id": "https://hermesatlas.com/#website"
+  },
+  "dateModified": "2026-08-20",
+  "mainEntity": {
+    "@type": "ItemList",
+    "numberOfItems": 2,
+    "itemListOrder": "https://schema.org/ItemListOrderDescending",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "url": "https://hermesatlas.com/projects/internet-court/internet-court-skill",
+        "name": "internet-court/internet-court-skill"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "url": "https://hermesatlas.com/projects/smartcontractkit/chainlink-agent-skills",
+        "name": "smartcontractkit/chainlink-agent-skills"
+      }
+    ]
+  }
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is the best Hermes Agent skill for crypto & agent payments?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "internet-court/internet-court-skill. A genuinely new primitive — a master router plus vendored official protocol skills covering ERC-7710 delegated permissions, x402 payments, and escrow/dispute resolution as one catch-all agent-commerce skill. Install it with: hermes skills tap add internet-court/internet-court-skill (the README prefers the tap over a direct URL install, which misses bundled reference files)."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How do I install Hermes skills?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "From the Hermes CLI. Running hermes skills install owner/repo/skills/name installs a single skill; hermes skills tap add owner/repo registers a whole repository as a tap, so every skill inside it becomes available. Plugins use hermes plugins install owner/repo --enable. Skills that follow the agentskills.io spec but aren't published to the Skills Hub can be added with npx skills add owner/repo, or cloned straight into your skills directory. Every entry on this page carries the exact command from its own README."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How current are these picks?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Updated 2026-08-20 · tested against Hermes v0.20.4. The picks are curated by hand — install commands are read out of each project's README rather than generated, and star counts are refreshed from the GitHub API on every build."
+      }
+    }
+  ]
+}
+</script>
+<link rel="alternate" type="application/rss+xml" title="Hermes Atlas — new projects" href="/rss.xml">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+<link rel="apple-touch-icon" href="/apple-touch-icon.png">
+<link rel="manifest" href="/site.webmanifest">
+<script src="/assets/js/theme-init.js"></script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap">
+<link rel="stylesheet" href="/assets/css/tokens.css">
+<link rel="stylesheet" href="/assets/css/base.css">
+<link rel="stylesheet" href="/assets/css/page.css">
+<link rel="stylesheet" href="/assets/css/use-cases.css">
+<link rel="stylesheet" href="/assets/css/skills.css">
+</head>
+<body>
+
+<a class="skip-link" href="#main">Skip to content</a>
+
+<header class="masthead">
+  <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
+  <div class="mast-meta" aria-label="Site metadata">
+    <span id="meta-count">231·repos</span>
+    <span id="meta-version">hermes·v0.20.4</span>
+    <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
+  </div>
+  <nav class="mast-nav" aria-label="Primary">
+    <a href="/">map</a>
+    <a href="/lists/">lists</a>
+    <a href="/skills/" class="active">skills</a>
+    <a href="/use-cases/">use cases</a>
+    <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
+    <a href="/dev/">dev</a>
+    <a href="/reports/">reports</a>
+    <a href="/#newsletter">newsletter</a>
+    <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
+  </nav>
+  <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
+  </button>
+</header>
+
+<div class="breadcrumb" aria-label="Breadcrumb">
+  <a href="/">map</a><span class="sep">/</span><a href="/skills/">skills</a><span class="sep">/</span>crypto-and-payments
+</div>
+
+<main id="main">
+
+<section class="list-page">
+  <h1 class="list-title">Best Hermes Skills for Crypto &amp; Agent Payments</h1>
+  <p class="uc-intent">“Builders wiring agents into on-chain protocols or agent-to-agent payment and dispute-resolution rails.”</p>
+  <p class="list-intro sk-lede">Skills for interacting with smart-contract oracle networks and for structuring agent-to-agent commerce, escrow, delegated permissions, and micropayments.</p>
+  <p class="sk-freshness">Updated 2026-08-20 · tested against Hermes v0.20.4</p>
+</section>
+
+<section class="uc-section" aria-label="Ranked picks">
+  <div class="section-label">the picks — 2</div>
+  <div class="sk-entries">
+    <article class="sk-entry">
+      <div class="sk-entry-head">
+        <h2 class="sk-entry-name"><a href="/projects/internet-court/internet-court-skill"><span class="org">internet-court /</span> internet-court-skill</a><span class="sk-type">collection</span> <span class="sk-pick-flag">top pick</span></h2>
+        <div class="sk-card-stars">★ 4.3K</div>
+      </div>
+      <div class="sk-entry-body">
+        <p class="sk-verdict">A genuinely new primitive — a master router plus vendored official protocol skills covering ERC-7710 delegated permissions, x402 payments, and escrow/dispute resolution as one catch-all agent-commerce skill.</p>
+        <div class="sk-install-label">install</div>
+      <code class="sk-install">hermes skills tap add internet-court/internet-court-skill (the README prefers the tap over a direct URL install, which misses bundled reference files).</code>
+        <p class="sk-compat"><span class="sk-compat-label">works with</span>Hermes Agent (tap), Claude Code (plugin marketplace or manual clone), OpenClaw, and Codex.</p>
+      </div>
+    </article>
+    <article class="sk-entry">
+      <div class="sk-entry-head">
+        <h2 class="sk-entry-name"><a href="/projects/smartcontractkit/chainlink-agent-skills"><span class="org">smartcontractkit /</span> chainlink-agent-skills</a><span class="sk-type">skill</span></h2>
+        <div class="sk-card-stars">★ 125</div>
+      </div>
+      <div class="sk-entry-body">
+        <p class="sk-verdict">The official Chainlink team's own oracle-network skills (CCIP, VRF, Data Feeds) — the vendor-authoritative pick for cross-chain or oracle work, versus a community reimplementation.</p>
+        <div class="sk-install-label">install</div>
+      <code class="sk-install">npx skills add smartcontractkit/chainlink-agent-skills</code>
+        <p class="sk-compat"><span class="sk-compat-label">works with</span>agentskills.io spec via the skills.sh CLI; project-level install is the default.</p>
+      </div>
+    </article>
+  </div>
+</section>
+
+<section class="uc-section" aria-label="How we picked">
+  <div class="section-label">how we picked</div>
+  <p class="sk-method">These are curated by hand, not scraped or ranked by an algorithm. Every entry is a project already accepted into the Atlas catalog; the install command is copied out of that project's own README (not inferred), the compatibility line reflects what the README actually claims to support, and the verdict says what this pick does that its neighbours don't. Star counts come live from the GitHub API on each build. Updated 2026-08-20 · tested against Hermes v0.20.4.</p>
+</section>
+
+<section class="uc-section" aria-label="Frequently asked questions">
+  <div class="section-label">faq</div>
+  <div class="sk-faq">
+    <div class="sk-faq-item">
+      <div class="sk-faq-q">What is the best Hermes Agent skill for crypto &amp; agent payments?</div>
+      <p class="sk-faq-a">internet-court/internet-court-skill. A genuinely new primitive — a master router plus vendored official protocol skills covering ERC-7710 delegated permissions, x402 payments, and escrow/dispute resolution as one catch-all agent-commerce skill. Install it with: hermes skills tap add internet-court/internet-court-skill (the README prefers the tap over a direct URL install, which misses bundled reference files).</p>
+    </div>
+    <div class="sk-faq-item">
+      <div class="sk-faq-q">How do I install Hermes skills?</div>
+      <p class="sk-faq-a">From the Hermes CLI. Running hermes skills install owner/repo/skills/name installs a single skill; hermes skills tap add owner/repo registers a whole repository as a tap, so every skill inside it becomes available. Plugins use hermes plugins install owner/repo --enable. Skills that follow the agentskills.io spec but aren't published to the Skills Hub can be added with npx skills add owner/repo, or cloned straight into your skills directory. Every entry on this page carries the exact command from its own README.</p>
+    </div>
+    <div class="sk-faq-item">
+      <div class="sk-faq-q">How current are these picks?</div>
+      <p class="sk-faq-a">Updated 2026-08-20 · tested against Hermes v0.20.4. The picks are curated by hand — install commands are read out of each project's README rather than generated, and star counts are refreshed from the GitHub API on every build.</p>
+    </div>
+  </div>
+</section>
+
+<section class="uc-section" aria-label="Other skill use cases">
+  <div class="section-label">other use cases</div>
+  <div class="uc-related">
+    <a class="uc-related-link" href="/skills/for-coding">Best Hermes Skills for Coding</a>
+    <a class="uc-related-link" href="/skills/for-cybersecurity">Best Hermes Skills for Cybersecurity</a>
+    <a class="uc-related-link" href="/skills/for-skill-management">Best Tools for Discovering &amp; Managing Hermes Skills</a>
+    <a class="uc-related-link" href="/skills/for-design-and-diagrams">Best Hermes Skills for Design &amp; Diagrams</a>
+    <a class="uc-related-link" href="/skills/for-writing-and-content">Best Hermes Skills for Writing &amp; Content</a>
+    <a class="uc-related-link" href="/skills/for-personal-ops">Best Hermes Skills for Personal Ops</a>
+  </div>
+</section>
+
+<div class="back-link"><a href="/skills/">← all skills</a></div>
+
+</main>
+
+<footer class="page-footer">
+  <div class="fn-left">hermes atlas · curated by <a href="https://github.com/ksimback">ksimback</a> · <a href="https://github.com/ksimback/hermes-ecosystem/issues">suggest a repo</a> · <a href="/privacy">privacy</a></div>
+  <div>v2 · 2026.04</div>
+</footer>
+
+<script src="/assets/js/theme-toggle.js" defer></script>
+<script src="/assets/js/masthead-fetch.js" defer></script>
+<!-- Cloudflare Web Analytics -->
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js"
+        data-cf-beacon='{"token": "fe0d4d79280b4386b6b0cd99b2d94dbc"}'></script>
+<!-- End Cloudflare Web Analytics -->
+</body>
+</html>

--- a/skills/for-cybersecurity.html
+++ b/skills/for-cybersecurity.html
@@ -1,0 +1,253 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Best Hermes Skills for Cybersecurity | Hermes Atlas</title>
+<meta name="description" content="Structured skill packs mapping MITRE ATT&amp;CK, NIST, and CVE data into agent-usable procedures for pentesting, forensics, and threat modeling.">
+<link rel="canonical" href="https://hermesatlas.com/skills/for-cybersecurity">
+<meta property="og:title" content="Best Hermes Skills for Cybersecurity">
+<meta property="og:description" content="Structured skill packs mapping MITRE ATT&amp;CK, NIST, and CVE data into agent-usable procedures for pentesting, forensics, and threat modeling.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://hermesatlas.com/skills/for-cybersecurity">
+<meta property="og:site_name" content="Hermes Atlas">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=Best+Hermes+Skills+for+Cybersecurity&amp;subtitle=Security+engineers+and+red-teamers+looking+for+large%2C+framework-mapped+skill+packs+covering+offense%2C+defense%2C+and+compliance.&amp;kind=skills">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Best Hermes Skills for Cybersecurity">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Best+Hermes+Skills+for+Cybersecurity&amp;subtitle=Security+engineers+and+red-teamers+looking+for+large%2C+framework-mapped+skill+packs+covering+offense%2C+defense%2C+and+compliance.&amp;kind=skills">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "map",
+      "item": "https://hermesatlas.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "skills",
+      "item": "https://hermesatlas.com/skills/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "cybersecurity"
+    }
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "@id": "https://hermesatlas.com/skills/for-cybersecurity",
+  "name": "Best Hermes Skills for Cybersecurity",
+  "description": "Structured skill packs mapping MITRE ATT&CK, NIST, and CVE data into agent-usable procedures for pentesting, forensics, and threat modeling.",
+  "url": "https://hermesatlas.com/skills/for-cybersecurity",
+  "isPartOf": {
+    "@id": "https://hermesatlas.com/#website"
+  },
+  "dateModified": "2026-08-20",
+  "mainEntity": {
+    "@type": "ItemList",
+    "numberOfItems": 2,
+    "itemListOrder": "https://schema.org/ItemListOrderDescending",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "url": "https://hermesatlas.com/projects/mukul975/Anthropic-Cybersecurity-Skills",
+        "name": "mukul975/Anthropic-Cybersecurity-Skills"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "url": "https://hermesatlas.com/projects/handnewb/hermes-cybersec-lab",
+        "name": "handnewb/hermes-cybersec-lab"
+      }
+    ]
+  }
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is the best Hermes Agent skill for cybersecurity?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "mukul975/Anthropic-Cybersecurity-Skills. 800+ skills across 29 security domains mapped to MITRE ATT&CK, ATLAS, D3FEND, and NIST — the largest and most-starred security pack in the catalog. Start here before any narrower pentest skill. Install it with: npx skills add mukul975/Anthropic-Cybersecurity-Skills"
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How do I install Hermes skills?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "From the Hermes CLI. Running hermes skills install owner/repo/skills/name installs a single skill; hermes skills tap add owner/repo registers a whole repository as a tap, so every skill inside it becomes available. Plugins use hermes plugins install owner/repo --enable. Skills that follow the agentskills.io spec but aren't published to the Skills Hub can be added with npx skills add owner/repo, or cloned straight into your skills directory. Every entry on this page carries the exact command from its own README."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How current are these picks?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Updated 2026-08-20 · tested against Hermes v0.20.4. The picks are curated by hand — install commands are read out of each project's README rather than generated, and star counts are refreshed from the GitHub API on every build."
+      }
+    }
+  ]
+}
+</script>
+<link rel="alternate" type="application/rss+xml" title="Hermes Atlas — new projects" href="/rss.xml">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+<link rel="apple-touch-icon" href="/apple-touch-icon.png">
+<link rel="manifest" href="/site.webmanifest">
+<script src="/assets/js/theme-init.js"></script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap">
+<link rel="stylesheet" href="/assets/css/tokens.css">
+<link rel="stylesheet" href="/assets/css/base.css">
+<link rel="stylesheet" href="/assets/css/page.css">
+<link rel="stylesheet" href="/assets/css/use-cases.css">
+<link rel="stylesheet" href="/assets/css/skills.css">
+</head>
+<body>
+
+<a class="skip-link" href="#main">Skip to content</a>
+
+<header class="masthead">
+  <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
+  <div class="mast-meta" aria-label="Site metadata">
+    <span id="meta-count">231·repos</span>
+    <span id="meta-version">hermes·v0.20.4</span>
+    <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
+  </div>
+  <nav class="mast-nav" aria-label="Primary">
+    <a href="/">map</a>
+    <a href="/lists/">lists</a>
+    <a href="/skills/" class="active">skills</a>
+    <a href="/use-cases/">use cases</a>
+    <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
+    <a href="/dev/">dev</a>
+    <a href="/reports/">reports</a>
+    <a href="/#newsletter">newsletter</a>
+    <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
+  </nav>
+  <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
+  </button>
+</header>
+
+<div class="breadcrumb" aria-label="Breadcrumb">
+  <a href="/">map</a><span class="sep">/</span><a href="/skills/">skills</a><span class="sep">/</span>cybersecurity
+</div>
+
+<main id="main">
+
+<section class="list-page">
+  <h1 class="list-title">Best Hermes Skills for Cybersecurity</h1>
+  <p class="uc-intent">“Security engineers and red-teamers looking for large, framework-mapped skill packs covering offense, defense, and compliance.”</p>
+  <p class="list-intro sk-lede">Structured skill packs mapping MITRE ATT&amp;CK, NIST, and CVE data into agent-usable procedures for pentesting, forensics, and threat modeling.</p>
+  <p class="sk-freshness">Updated 2026-08-20 · tested against Hermes v0.20.4</p>
+</section>
+
+<section class="uc-section" aria-label="Ranked picks">
+  <div class="section-label">the picks — 2</div>
+  <div class="sk-entries">
+    <article class="sk-entry">
+      <div class="sk-entry-head">
+        <h2 class="sk-entry-name"><a href="/projects/mukul975/Anthropic-Cybersecurity-Skills"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</a><span class="sk-type">collection</span> <span class="sk-pick-flag">top pick</span></h2>
+        <div class="sk-card-stars">★ 30.5K</div>
+      </div>
+      <div class="sk-entry-body">
+        <p class="sk-verdict">800+ skills across 29 security domains mapped to MITRE ATT&amp;CK, ATLAS, D3FEND, and NIST — the largest and most-starred security pack in the catalog. Start here before any narrower pentest skill.</p>
+        <div class="sk-install-label">install</div>
+      <code class="sk-install">npx skills add mukul975/Anthropic-Cybersecurity-Skills</code>
+        <p class="sk-compat"><span class="sk-compat-label">works with</span>agentskills.io-compatible clients (Claude Code, Copilot, Codex); installable on Hermes via hermes skills tap add or npx skills add.</p>
+      </div>
+    </article>
+    <article class="sk-entry">
+      <div class="sk-entry-head">
+        <h2 class="sk-entry-name"><a href="/projects/handnewb/hermes-cybersec-lab"><span class="org">handnewb /</span> hermes-cybersec-lab</a><span class="sk-type">collection</span></h2>
+        <div class="sk-card-stars">★ 8</div>
+      </div>
+      <div class="sk-entry-body">
+        <p class="sk-verdict">2,000+ skills stitched from 7 external repos plus 130+ installable tools (Sigma, YARA, MISP). A deeper turnkey lab than the Anthropic-Cybersecurity-Skills pack, but a heavier multi-repo clone — pick it for a dedicated security profile, not a quick add.</p>
+        <div class="sk-install-label">install</div>
+      <code class="sk-install">git clone https://github.com/handnewb/hermes-cybersec-lab.git, run scripts/clone-all.sh, then copy into ~/.hermes/profiles/&lt;profile&gt;/skills/cybersecurity-lab/.</code>
+        <p class="sk-compat"><span class="sk-compat-label">works with</span>Hermes Agent native — the README targets ~/.hermes/profiles/&lt;profile&gt;/skills/ explicitly.</p>
+      </div>
+    </article>
+  </div>
+</section>
+
+<section class="uc-section" aria-label="How we picked">
+  <div class="section-label">how we picked</div>
+  <p class="sk-method">These are curated by hand, not scraped or ranked by an algorithm. Every entry is a project already accepted into the Atlas catalog; the install command is copied out of that project's own README (not inferred), the compatibility line reflects what the README actually claims to support, and the verdict says what this pick does that its neighbours don't. Star counts come live from the GitHub API on each build. Updated 2026-08-20 · tested against Hermes v0.20.4.</p>
+</section>
+
+<section class="uc-section" aria-label="Frequently asked questions">
+  <div class="section-label">faq</div>
+  <div class="sk-faq">
+    <div class="sk-faq-item">
+      <div class="sk-faq-q">What is the best Hermes Agent skill for cybersecurity?</div>
+      <p class="sk-faq-a">mukul975/Anthropic-Cybersecurity-Skills. 800+ skills across 29 security domains mapped to MITRE ATT&amp;CK, ATLAS, D3FEND, and NIST — the largest and most-starred security pack in the catalog. Start here before any narrower pentest skill. Install it with: npx skills add mukul975/Anthropic-Cybersecurity-Skills</p>
+    </div>
+    <div class="sk-faq-item">
+      <div class="sk-faq-q">How do I install Hermes skills?</div>
+      <p class="sk-faq-a">From the Hermes CLI. Running hermes skills install owner/repo/skills/name installs a single skill; hermes skills tap add owner/repo registers a whole repository as a tap, so every skill inside it becomes available. Plugins use hermes plugins install owner/repo --enable. Skills that follow the agentskills.io spec but aren't published to the Skills Hub can be added with npx skills add owner/repo, or cloned straight into your skills directory. Every entry on this page carries the exact command from its own README.</p>
+    </div>
+    <div class="sk-faq-item">
+      <div class="sk-faq-q">How current are these picks?</div>
+      <p class="sk-faq-a">Updated 2026-08-20 · tested against Hermes v0.20.4. The picks are curated by hand — install commands are read out of each project's README rather than generated, and star counts are refreshed from the GitHub API on every build.</p>
+    </div>
+  </div>
+</section>
+
+<section class="uc-section" aria-label="Other skill use cases">
+  <div class="section-label">other use cases</div>
+  <div class="uc-related">
+    <a class="uc-related-link" href="/skills/for-coding">Best Hermes Skills for Coding</a>
+    <a class="uc-related-link" href="/skills/for-skill-management">Best Tools for Discovering &amp; Managing Hermes Skills</a>
+    <a class="uc-related-link" href="/skills/for-design-and-diagrams">Best Hermes Skills for Design &amp; Diagrams</a>
+    <a class="uc-related-link" href="/skills/for-writing-and-content">Best Hermes Skills for Writing &amp; Content</a>
+    <a class="uc-related-link" href="/skills/for-crypto-and-payments">Best Hermes Skills for Crypto &amp; Agent Payments</a>
+    <a class="uc-related-link" href="/skills/for-personal-ops">Best Hermes Skills for Personal Ops</a>
+  </div>
+</section>
+
+<div class="back-link"><a href="/skills/">← all skills</a></div>
+
+</main>
+
+<footer class="page-footer">
+  <div class="fn-left">hermes atlas · curated by <a href="https://github.com/ksimback">ksimback</a> · <a href="https://github.com/ksimback/hermes-ecosystem/issues">suggest a repo</a> · <a href="/privacy">privacy</a></div>
+  <div>v2 · 2026.04</div>
+</footer>
+
+<script src="/assets/js/theme-toggle.js" defer></script>
+<script src="/assets/js/masthead-fetch.js" defer></script>
+<!-- Cloudflare Web Analytics -->
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js"
+        data-cf-beacon='{"token": "fe0d4d79280b4386b6b0cd99b2d94dbc"}'></script>
+<!-- End Cloudflare Web Analytics -->
+</body>
+</html>

--- a/skills/for-design-and-diagrams.html
+++ b/skills/for-design-and-diagrams.html
@@ -1,0 +1,271 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Best Hermes Skills for Design &amp; Diagrams | Hermes Atlas</title>
+<meta name="description" content="Skills and tools that turn natural-language descriptions into draw.io diagrams, FLUX-generated images, or full local-first design prototypes.">
+<link rel="canonical" href="https://hermesatlas.com/skills/for-design-and-diagrams">
+<meta property="og:title" content="Best Hermes Skills for Design &amp; Diagrams">
+<meta property="og:description" content="Skills and tools that turn natural-language descriptions into draw.io diagrams, FLUX-generated images, or full local-first design prototypes.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://hermesatlas.com/skills/for-design-and-diagrams">
+<meta property="og:site_name" content="Hermes Atlas">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=Best+Hermes+Skills+for+Design+%26+Diagrams&amp;subtitle=Users+generating+diagrams%2C+design+prototypes%2C+or+image+output+through+agent+skills.&amp;kind=skills">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Best Hermes Skills for Design &amp; Diagrams">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Best+Hermes+Skills+for+Design+%26+Diagrams&amp;subtitle=Users+generating+diagrams%2C+design+prototypes%2C+or+image+output+through+agent+skills.&amp;kind=skills">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "map",
+      "item": "https://hermesatlas.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "skills",
+      "item": "https://hermesatlas.com/skills/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "design-and-diagrams"
+    }
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "@id": "https://hermesatlas.com/skills/for-design-and-diagrams",
+  "name": "Best Hermes Skills for Design & Diagrams",
+  "description": "Skills and tools that turn natural-language descriptions into draw.io diagrams, FLUX-generated images, or full local-first design prototypes.",
+  "url": "https://hermesatlas.com/skills/for-design-and-diagrams",
+  "isPartOf": {
+    "@id": "https://hermesatlas.com/#website"
+  },
+  "dateModified": "2026-08-20",
+  "mainEntity": {
+    "@type": "ItemList",
+    "numberOfItems": 3,
+    "itemListOrder": "https://schema.org/ItemListOrderDescending",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "url": "https://hermesatlas.com/projects/Agents365-ai/drawio-skill",
+        "name": "Agents365-ai/drawio-skill"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "url": "https://hermesatlas.com/projects/nexu-io/open-design",
+        "name": "nexu-io/open-design"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "url": "https://hermesatlas.com/projects/black-forest-labs/skills",
+        "name": "black-forest-labs/skills"
+      }
+    ]
+  }
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is the best Hermes Agent skill for design & diagrams?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Agents365-ai/drawio-skill. Eleven diagram-type presets plus Mermaid-to-drawio conversion, and the most-starred diagram skill in the catalog — the clear default over hand-rolling diagram prompts. Install it with: npx skills add Agents365-ai/365-skills -g (or git clone into your skills directory)."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How do I install Hermes skills?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "From the Hermes CLI. Running hermes skills install owner/repo/skills/name installs a single skill; hermes skills tap add owner/repo registers a whole repository as a tap, so every skill inside it becomes available. Plugins use hermes plugins install owner/repo --enable. Skills that follow the agentskills.io spec but aren't published to the Skills Hub can be added with npx skills add owner/repo, or cloned straight into your skills directory. Every entry on this page carries the exact command from its own README."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How current are these picks?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Updated 2026-08-20 · tested against Hermes v0.20.4. The picks are curated by hand — install commands are read out of each project's README rather than generated, and star counts are refreshed from the GitHub API on every build."
+      }
+    }
+  ]
+}
+</script>
+<link rel="alternate" type="application/rss+xml" title="Hermes Atlas — new projects" href="/rss.xml">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+<link rel="apple-touch-icon" href="/apple-touch-icon.png">
+<link rel="manifest" href="/site.webmanifest">
+<script src="/assets/js/theme-init.js"></script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap">
+<link rel="stylesheet" href="/assets/css/tokens.css">
+<link rel="stylesheet" href="/assets/css/base.css">
+<link rel="stylesheet" href="/assets/css/page.css">
+<link rel="stylesheet" href="/assets/css/use-cases.css">
+<link rel="stylesheet" href="/assets/css/skills.css">
+</head>
+<body>
+
+<a class="skip-link" href="#main">Skip to content</a>
+
+<header class="masthead">
+  <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
+  <div class="mast-meta" aria-label="Site metadata">
+    <span id="meta-count">231·repos</span>
+    <span id="meta-version">hermes·v0.20.4</span>
+    <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
+  </div>
+  <nav class="mast-nav" aria-label="Primary">
+    <a href="/">map</a>
+    <a href="/lists/">lists</a>
+    <a href="/skills/" class="active">skills</a>
+    <a href="/use-cases/">use cases</a>
+    <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
+    <a href="/dev/">dev</a>
+    <a href="/reports/">reports</a>
+    <a href="/#newsletter">newsletter</a>
+    <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
+  </nav>
+  <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
+  </button>
+</header>
+
+<div class="breadcrumb" aria-label="Breadcrumb">
+  <a href="/">map</a><span class="sep">/</span><a href="/skills/">skills</a><span class="sep">/</span>design-and-diagrams
+</div>
+
+<main id="main">
+
+<section class="list-page">
+  <h1 class="list-title">Best Hermes Skills for Design &amp; Diagrams</h1>
+  <p class="uc-intent">“Users generating diagrams, design prototypes, or image output through agent skills.”</p>
+  <p class="list-intro sk-lede">Skills and tools that turn natural-language descriptions into draw.io diagrams, FLUX-generated images, or full local-first design prototypes.</p>
+  <p class="sk-freshness">Updated 2026-08-20 · tested against Hermes v0.20.4</p>
+</section>
+
+<section class="uc-section" aria-label="Ranked picks">
+  <div class="section-label">the picks — 3</div>
+  <div class="sk-entries">
+    <article class="sk-entry">
+      <div class="sk-entry-head">
+        <h2 class="sk-entry-name"><a href="/projects/Agents365-ai/drawio-skill"><span class="org">Agents365-ai /</span> drawio-skill</a><span class="sk-type">skill</span> <span class="sk-pick-flag">top pick</span></h2>
+        <div class="sk-card-stars">★ 7.9K</div>
+      </div>
+      <div class="sk-entry-body">
+        <p class="sk-verdict">Eleven diagram-type presets plus Mermaid-to-drawio conversion, and the most-starred diagram skill in the catalog — the clear default over hand-rolling diagram prompts.</p>
+        <div class="sk-install-label">install</div>
+      <code class="sk-install">npx skills add Agents365-ai/365-skills -g (or git clone into your skills directory).</code>
+        <p class="sk-compat"><span class="sk-compat-label">works with</span>Runs from a single SKILL.md, no MCP server or daemon (needs the draw.io desktop CLI for rendering); works anywhere agentskills.io skills load, including Hermes.</p>
+      </div>
+    </article>
+    <article class="sk-entry">
+      <div class="sk-entry-head">
+        <h2 class="sk-entry-name"><a href="/projects/nexu-io/open-design"><span class="org">nexu-io /</span> open-design</a><span class="sk-type">plugin</span></h2>
+        <div class="sk-card-stars">★ 90.0K</div>
+      </div>
+      <div class="sk-entry-body">
+        <p class="sk-verdict">By far the biggest project in the entire skills category — but it's a full local-first design platform, not a lightweight skill. Install it as prototyping infrastructure, not a five-minute skill add.</p>
+        <div class="sk-install-label">install</div>
+      <code class="sk-install">curl -fsSL https://open-design.ai/install.sh | sh -s hermes (hosted); or self-host via docker compose from the repo's deploy/ directory.</code>
+        <p class="sk-compat"><span class="sk-compat-label">works with</span>Native desktop app (macOS/Windows) plus a CLI; the README explicitly lists Hermes Agent among supported coding-agent CLIs for prototype generation.</p>
+      </div>
+    </article>
+    <article class="sk-entry">
+      <div class="sk-entry-head">
+        <h2 class="sk-entry-name"><a href="/projects/black-forest-labs/skills"><span class="org">black-forest-labs /</span> skills</a><span class="sk-type">skill</span></h2>
+        <div class="sk-card-stars">★ 103</div>
+      </div>
+      <div class="sk-entry-body">
+        <p class="sk-verdict">The one official-vendor entry in this bucket — Black Forest Labs' own FLUX prompting guidelines and API integration patterns, not a third-party reverse-engineering of their docs.</p>
+        <div class="sk-install-label">install</div>
+      <code class="sk-install">npx skills add black-forest-labs/skills (or target one: npx skills add black-forest-labs/skills --skill flux-image-best-practices).</code>
+        <p class="sk-compat"><span class="sk-compat-label">works with</span>agentskills.io spec; also a Claude Code plugin.</p>
+      </div>
+    </article>
+  </div>
+</section>
+
+<section class="uc-section" aria-label="How we picked">
+  <div class="section-label">how we picked</div>
+  <p class="sk-method">These are curated by hand, not scraped or ranked by an algorithm. Every entry is a project already accepted into the Atlas catalog; the install command is copied out of that project's own README (not inferred), the compatibility line reflects what the README actually claims to support, and the verdict says what this pick does that its neighbours don't. Star counts come live from the GitHub API on each build. Updated 2026-08-20 · tested against Hermes v0.20.4.</p>
+</section>
+
+<section class="uc-section" aria-label="Frequently asked questions">
+  <div class="section-label">faq</div>
+  <div class="sk-faq">
+    <div class="sk-faq-item">
+      <div class="sk-faq-q">What is the best Hermes Agent skill for design &amp; diagrams?</div>
+      <p class="sk-faq-a">Agents365-ai/drawio-skill. Eleven diagram-type presets plus Mermaid-to-drawio conversion, and the most-starred diagram skill in the catalog — the clear default over hand-rolling diagram prompts. Install it with: npx skills add Agents365-ai/365-skills -g (or git clone into your skills directory).</p>
+    </div>
+    <div class="sk-faq-item">
+      <div class="sk-faq-q">How do I install Hermes skills?</div>
+      <p class="sk-faq-a">From the Hermes CLI. Running hermes skills install owner/repo/skills/name installs a single skill; hermes skills tap add owner/repo registers a whole repository as a tap, so every skill inside it becomes available. Plugins use hermes plugins install owner/repo --enable. Skills that follow the agentskills.io spec but aren't published to the Skills Hub can be added with npx skills add owner/repo, or cloned straight into your skills directory. Every entry on this page carries the exact command from its own README.</p>
+    </div>
+    <div class="sk-faq-item">
+      <div class="sk-faq-q">How current are these picks?</div>
+      <p class="sk-faq-a">Updated 2026-08-20 · tested against Hermes v0.20.4. The picks are curated by hand — install commands are read out of each project's README rather than generated, and star counts are refreshed from the GitHub API on every build.</p>
+    </div>
+  </div>
+</section>
+
+<section class="uc-section" aria-label="Other skill use cases">
+  <div class="section-label">other use cases</div>
+  <div class="uc-related">
+    <a class="uc-related-link" href="/skills/for-coding">Best Hermes Skills for Coding</a>
+    <a class="uc-related-link" href="/skills/for-cybersecurity">Best Hermes Skills for Cybersecurity</a>
+    <a class="uc-related-link" href="/skills/for-skill-management">Best Tools for Discovering &amp; Managing Hermes Skills</a>
+    <a class="uc-related-link" href="/skills/for-writing-and-content">Best Hermes Skills for Writing &amp; Content</a>
+    <a class="uc-related-link" href="/skills/for-crypto-and-payments">Best Hermes Skills for Crypto &amp; Agent Payments</a>
+    <a class="uc-related-link" href="/skills/for-personal-ops">Best Hermes Skills for Personal Ops</a>
+  </div>
+</section>
+
+<div class="back-link"><a href="/skills/">← all skills</a></div>
+
+</main>
+
+<footer class="page-footer">
+  <div class="fn-left">hermes atlas · curated by <a href="https://github.com/ksimback">ksimback</a> · <a href="https://github.com/ksimback/hermes-ecosystem/issues">suggest a repo</a> · <a href="/privacy">privacy</a></div>
+  <div>v2 · 2026.04</div>
+</footer>
+
+<script src="/assets/js/theme-toggle.js" defer></script>
+<script src="/assets/js/masthead-fetch.js" defer></script>
+<!-- Cloudflare Web Analytics -->
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js"
+        data-cf-beacon='{"token": "fe0d4d79280b4386b6b0cd99b2d94dbc"}'></script>
+<!-- End Cloudflare Web Analytics -->
+</body>
+</html>

--- a/skills/for-personal-ops.html
+++ b/skills/for-personal-ops.html
@@ -1,0 +1,253 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Best Hermes Skills for Personal Ops | Hermes Atlas</title>
+<meta name="description" content="Skills that connect Hermes to personal infrastructure like self-hosted Nextcloud and that smooth over Windows/WSL/Git Bash path and runtime quirks.">
+<link rel="canonical" href="https://hermesatlas.com/skills/for-personal-ops">
+<meta property="og:title" content="Best Hermes Skills for Personal Ops">
+<meta property="og:description" content="Skills that connect Hermes to personal infrastructure like self-hosted Nextcloud and that smooth over Windows/WSL/Git Bash path and runtime quirks.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://hermesatlas.com/skills/for-personal-ops">
+<meta property="og:site_name" content="Hermes Atlas">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=Best+Hermes+Skills+for+Personal+Ops&amp;subtitle=Users+who+want+Hermes+to+manage+personal+infrastructure+%E2%80%94+self-hosted+services+and+cross-platform+runtime+friction.&amp;kind=skills">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Best Hermes Skills for Personal Ops">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Best+Hermes+Skills+for+Personal+Ops&amp;subtitle=Users+who+want+Hermes+to+manage+personal+infrastructure+%E2%80%94+self-hosted+services+and+cross-platform+runtime+friction.&amp;kind=skills">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "map",
+      "item": "https://hermesatlas.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "skills",
+      "item": "https://hermesatlas.com/skills/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "personal-ops"
+    }
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "@id": "https://hermesatlas.com/skills/for-personal-ops",
+  "name": "Best Hermes Skills for Personal Ops",
+  "description": "Skills that connect Hermes to personal infrastructure like self-hosted Nextcloud and that smooth over Windows/WSL/Git Bash path and runtime quirks.",
+  "url": "https://hermesatlas.com/skills/for-personal-ops",
+  "isPartOf": {
+    "@id": "https://hermesatlas.com/#website"
+  },
+  "dateModified": "2026-08-20",
+  "mainEntity": {
+    "@type": "ItemList",
+    "numberOfItems": 2,
+    "itemListOrder": "https://schema.org/ItemListOrderDescending",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "url": "https://hermesatlas.com/projects/adnw-vinc/hermes-nextcloud",
+        "name": "adnw-vinc/hermes-nextcloud"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "url": "https://hermesatlas.com/projects/CorsenAI/hermes-windows-runtime-skills",
+        "name": "CorsenAI/hermes-windows-runtime-skills"
+      }
+    ]
+  }
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is the best Hermes Agent skill for personal ops?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "adnw-vinc/hermes-nextcloud. The only skill in the catalog wiring Hermes directly into a self-hosted Nextcloud over WebDAV/CalDAV/CardDAV — no browser, no third-party sync service, credentials kept in a restricted local .env. Install it with: git clone https://github.com/adnw-vinc/hermes-nextcloud.git into ~/.hermes/skills/productivity/nextcloud, then run its guided setup script."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How do I install Hermes skills?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "From the Hermes CLI. Running hermes skills install owner/repo/skills/name installs a single skill; hermes skills tap add owner/repo registers a whole repository as a tap, so every skill inside it becomes available. Plugins use hermes plugins install owner/repo --enable. Skills that follow the agentskills.io spec but aren't published to the Skills Hub can be added with npx skills add owner/repo, or cloned straight into your skills directory. Every entry on this page carries the exact command from its own README."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How current are these picks?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Updated 2026-08-20 · tested against Hermes v0.20.4. The picks are curated by hand — install commands are read out of each project's README rather than generated, and star counts are refreshed from the GitHub API on every build."
+      }
+    }
+  ]
+}
+</script>
+<link rel="alternate" type="application/rss+xml" title="Hermes Atlas — new projects" href="/rss.xml">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+<link rel="apple-touch-icon" href="/apple-touch-icon.png">
+<link rel="manifest" href="/site.webmanifest">
+<script src="/assets/js/theme-init.js"></script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap">
+<link rel="stylesheet" href="/assets/css/tokens.css">
+<link rel="stylesheet" href="/assets/css/base.css">
+<link rel="stylesheet" href="/assets/css/page.css">
+<link rel="stylesheet" href="/assets/css/use-cases.css">
+<link rel="stylesheet" href="/assets/css/skills.css">
+</head>
+<body>
+
+<a class="skip-link" href="#main">Skip to content</a>
+
+<header class="masthead">
+  <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
+  <div class="mast-meta" aria-label="Site metadata">
+    <span id="meta-count">231·repos</span>
+    <span id="meta-version">hermes·v0.20.4</span>
+    <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
+  </div>
+  <nav class="mast-nav" aria-label="Primary">
+    <a href="/">map</a>
+    <a href="/lists/">lists</a>
+    <a href="/skills/" class="active">skills</a>
+    <a href="/use-cases/">use cases</a>
+    <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
+    <a href="/dev/">dev</a>
+    <a href="/reports/">reports</a>
+    <a href="/#newsletter">newsletter</a>
+    <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
+  </nav>
+  <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
+  </button>
+</header>
+
+<div class="breadcrumb" aria-label="Breadcrumb">
+  <a href="/">map</a><span class="sep">/</span><a href="/skills/">skills</a><span class="sep">/</span>personal-ops
+</div>
+
+<main id="main">
+
+<section class="list-page">
+  <h1 class="list-title">Best Hermes Skills for Personal Ops</h1>
+  <p class="uc-intent">“Users who want Hermes to manage personal infrastructure — self-hosted services and cross-platform runtime friction.”</p>
+  <p class="list-intro sk-lede">Skills that connect Hermes to personal infrastructure like self-hosted Nextcloud and that smooth over Windows/WSL/Git Bash path and runtime quirks.</p>
+  <p class="sk-freshness">Updated 2026-08-20 · tested against Hermes v0.20.4</p>
+</section>
+
+<section class="uc-section" aria-label="Ranked picks">
+  <div class="section-label">the picks — 2</div>
+  <div class="sk-entries">
+    <article class="sk-entry">
+      <div class="sk-entry-head">
+        <h2 class="sk-entry-name"><a href="/projects/adnw-vinc/hermes-nextcloud"><span class="org">adnw-vinc /</span> hermes-nextcloud</a><span class="sk-type">skill</span> <span class="sk-pick-flag">top pick</span></h2>
+        <div class="sk-card-stars">★ 44</div>
+      </div>
+      <div class="sk-entry-body">
+        <p class="sk-verdict">The only skill in the catalog wiring Hermes directly into a self-hosted Nextcloud over WebDAV/CalDAV/CardDAV — no browser, no third-party sync service, credentials kept in a restricted local .env.</p>
+        <div class="sk-install-label">install</div>
+      <code class="sk-install">git clone https://github.com/adnw-vinc/hermes-nextcloud.git into ~/.hermes/skills/productivity/nextcloud, then run its guided setup script.</code>
+        <p class="sk-compat"><span class="sk-compat-label">works with</span>Hermes Agent native — targets ~/.hermes/skills/ explicitly, with App Password validation for Nextcloud.</p>
+      </div>
+    </article>
+    <article class="sk-entry">
+      <div class="sk-entry-head">
+        <h2 class="sk-entry-name"><a href="/projects/CorsenAI/hermes-windows-runtime-skills"><span class="org">CorsenAI /</span> hermes-windows-runtime-skills</a><span class="sk-type">collection</span></h2>
+        <div class="sk-card-stars">★ 1</div>
+      </div>
+      <div class="sk-entry-body">
+        <p class="sk-verdict">Solves a real, narrow Hermes pain point — deterministic path routing and non-destructive Python runtime selection across Windows, Git Bash, and WSL — with exact hermes skills install commands in the README.</p>
+        <div class="sk-install-label">install</div>
+      <code class="sk-install">hermes skills tap add CorsenAI/hermes-windows-runtime-skills (or install each skill directly, e.g. hermes skills install CorsenAI/hermes-windows-runtime-skills/skills/windows-wsl-file-navigation).</code>
+        <p class="sk-compat"><span class="sk-compat-label">works with</span>Hermes Agent native, specifically for native Windows, Git Bash/MSYS, and WSL environments.</p>
+      </div>
+    </article>
+  </div>
+</section>
+
+<section class="uc-section" aria-label="How we picked">
+  <div class="section-label">how we picked</div>
+  <p class="sk-method">These are curated by hand, not scraped or ranked by an algorithm. Every entry is a project already accepted into the Atlas catalog; the install command is copied out of that project's own README (not inferred), the compatibility line reflects what the README actually claims to support, and the verdict says what this pick does that its neighbours don't. Star counts come live from the GitHub API on each build. Updated 2026-08-20 · tested against Hermes v0.20.4.</p>
+</section>
+
+<section class="uc-section" aria-label="Frequently asked questions">
+  <div class="section-label">faq</div>
+  <div class="sk-faq">
+    <div class="sk-faq-item">
+      <div class="sk-faq-q">What is the best Hermes Agent skill for personal ops?</div>
+      <p class="sk-faq-a">adnw-vinc/hermes-nextcloud. The only skill in the catalog wiring Hermes directly into a self-hosted Nextcloud over WebDAV/CalDAV/CardDAV — no browser, no third-party sync service, credentials kept in a restricted local .env. Install it with: git clone https://github.com/adnw-vinc/hermes-nextcloud.git into ~/.hermes/skills/productivity/nextcloud, then run its guided setup script.</p>
+    </div>
+    <div class="sk-faq-item">
+      <div class="sk-faq-q">How do I install Hermes skills?</div>
+      <p class="sk-faq-a">From the Hermes CLI. Running hermes skills install owner/repo/skills/name installs a single skill; hermes skills tap add owner/repo registers a whole repository as a tap, so every skill inside it becomes available. Plugins use hermes plugins install owner/repo --enable. Skills that follow the agentskills.io spec but aren't published to the Skills Hub can be added with npx skills add owner/repo, or cloned straight into your skills directory. Every entry on this page carries the exact command from its own README.</p>
+    </div>
+    <div class="sk-faq-item">
+      <div class="sk-faq-q">How current are these picks?</div>
+      <p class="sk-faq-a">Updated 2026-08-20 · tested against Hermes v0.20.4. The picks are curated by hand — install commands are read out of each project's README rather than generated, and star counts are refreshed from the GitHub API on every build.</p>
+    </div>
+  </div>
+</section>
+
+<section class="uc-section" aria-label="Other skill use cases">
+  <div class="section-label">other use cases</div>
+  <div class="uc-related">
+    <a class="uc-related-link" href="/skills/for-coding">Best Hermes Skills for Coding</a>
+    <a class="uc-related-link" href="/skills/for-cybersecurity">Best Hermes Skills for Cybersecurity</a>
+    <a class="uc-related-link" href="/skills/for-skill-management">Best Tools for Discovering &amp; Managing Hermes Skills</a>
+    <a class="uc-related-link" href="/skills/for-design-and-diagrams">Best Hermes Skills for Design &amp; Diagrams</a>
+    <a class="uc-related-link" href="/skills/for-writing-and-content">Best Hermes Skills for Writing &amp; Content</a>
+    <a class="uc-related-link" href="/skills/for-crypto-and-payments">Best Hermes Skills for Crypto &amp; Agent Payments</a>
+  </div>
+</section>
+
+<div class="back-link"><a href="/skills/">← all skills</a></div>
+
+</main>
+
+<footer class="page-footer">
+  <div class="fn-left">hermes atlas · curated by <a href="https://github.com/ksimback">ksimback</a> · <a href="https://github.com/ksimback/hermes-ecosystem/issues">suggest a repo</a> · <a href="/privacy">privacy</a></div>
+  <div>v2 · 2026.04</div>
+</footer>
+
+<script src="/assets/js/theme-toggle.js" defer></script>
+<script src="/assets/js/masthead-fetch.js" defer></script>
+<!-- Cloudflare Web Analytics -->
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js"
+        data-cf-beacon='{"token": "fe0d4d79280b4386b6b0cd99b2d94dbc"}'></script>
+<!-- End Cloudflare Web Analytics -->
+</body>
+</html>

--- a/skills/for-skill-management.html
+++ b/skills/for-skill-management.html
@@ -1,0 +1,325 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Best Tools for Discovering &amp; Managing Hermes Skills | Hermes Atlas</title>
+<meta name="description" content="Meta-tools that sit above individual skills — registries, retrieval layers, evolution engines, and large curated skill collections spanning many professions.">
+<link rel="canonical" href="https://hermesatlas.com/skills/for-skill-management">
+<meta property="og:title" content="Best Tools for Discovering &amp; Managing Hermes Skills">
+<meta property="og:description" content="Meta-tools that sit above individual skills — registries, retrieval layers, evolution engines, and large curated skill collections spanning many professions.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://hermesatlas.com/skills/for-skill-management">
+<meta property="og:site_name" content="Hermes Atlas">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=Best+Tools+for+Discovering+%26+Managing+Hermes+Skills&amp;subtitle=Users+who+want+to+browse%2C+retrieve%2C+evolve%2C+or+bulk-install+skills+at+scale+rather+than+add+a+single-purpose+skill.&amp;kind=skills">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Best Tools for Discovering &amp; Managing Hermes Skills">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Best+Tools+for+Discovering+%26+Managing+Hermes+Skills&amp;subtitle=Users+who+want+to+browse%2C+retrieve%2C+evolve%2C+or+bulk-install+skills+at+scale+rather+than+add+a+single-purpose+skill.&amp;kind=skills">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "map",
+      "item": "https://hermesatlas.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "skills",
+      "item": "https://hermesatlas.com/skills/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "skill-management"
+    }
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "@id": "https://hermesatlas.com/skills/for-skill-management",
+  "name": "Best Tools for Discovering & Managing Hermes Skills",
+  "description": "Meta-tools that sit above individual skills — registries, retrieval layers, evolution engines, and large curated skill collections spanning many professions.",
+  "url": "https://hermesatlas.com/skills/for-skill-management",
+  "isPartOf": {
+    "@id": "https://hermesatlas.com/#website"
+  },
+  "dateModified": "2026-08-20",
+  "mainEntity": {
+    "@type": "ItemList",
+    "numberOfItems": 6,
+    "itemListOrder": "https://schema.org/ItemListOrderDescending",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "url": "https://hermesatlas.com/projects/AMAP-ML/SkillClaw",
+        "name": "AMAP-ML/SkillClaw"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "url": "https://hermesatlas.com/projects/wondelai/skills",
+        "name": "wondelai/skills"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "url": "https://hermesatlas.com/projects/mohitagw15856/pm-claude-skills",
+        "name": "mohitagw15856/pm-claude-skills"
+      },
+      {
+        "@type": "ListItem",
+        "position": 4,
+        "url": "https://hermesatlas.com/projects/armelhbobdad/bmad-module-skill-forge",
+        "name": "armelhbobdad/bmad-module-skill-forge"
+      },
+      {
+        "@type": "ListItem",
+        "position": 5,
+        "url": "https://hermesatlas.com/projects/willingning-coder/eagle-eye",
+        "name": "willingning-coder/eagle-eye"
+      },
+      {
+        "@type": "ListItem",
+        "position": 6,
+        "url": "https://hermesatlas.com/projects/aidevelopers2/remoteopenclaw-mcp",
+        "name": "aidevelopers2/remoteopenclaw-mcp"
+      }
+    ]
+  }
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is the best Hermes Agent skill for discovering & managing hermes skills?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "AMAP-ML/SkillClaw. A genuinely different mechanism: runs in the background, deduplicates, and cross-pollinates your skill library across agents, devices, and users instead of just hosting a list. Install it with: git clone https://github.com/AMAP-ML/SkillClaw.git, run scripts/install_skillclaw.sh, activate the venv, then run skillclaw setup."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How do I install Hermes skills?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "From the Hermes CLI. Running hermes skills install owner/repo/skills/name installs a single skill; hermes skills tap add owner/repo registers a whole repository as a tap, so every skill inside it becomes available. Plugins use hermes plugins install owner/repo --enable. Skills that follow the agentskills.io spec but aren't published to the Skills Hub can be added with npx skills add owner/repo, or cloned straight into your skills directory. Every entry on this page carries the exact command from its own README."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How current are these picks?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Updated 2026-08-20 · tested against Hermes v0.20.4. The picks are curated by hand — install commands are read out of each project's README rather than generated, and star counts are refreshed from the GitHub API on every build."
+      }
+    }
+  ]
+}
+</script>
+<link rel="alternate" type="application/rss+xml" title="Hermes Atlas — new projects" href="/rss.xml">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+<link rel="apple-touch-icon" href="/apple-touch-icon.png">
+<link rel="manifest" href="/site.webmanifest">
+<script src="/assets/js/theme-init.js"></script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap">
+<link rel="stylesheet" href="/assets/css/tokens.css">
+<link rel="stylesheet" href="/assets/css/base.css">
+<link rel="stylesheet" href="/assets/css/page.css">
+<link rel="stylesheet" href="/assets/css/use-cases.css">
+<link rel="stylesheet" href="/assets/css/skills.css">
+</head>
+<body>
+
+<a class="skip-link" href="#main">Skip to content</a>
+
+<header class="masthead">
+  <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
+  <div class="mast-meta" aria-label="Site metadata">
+    <span id="meta-count">231·repos</span>
+    <span id="meta-version">hermes·v0.20.4</span>
+    <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
+  </div>
+  <nav class="mast-nav" aria-label="Primary">
+    <a href="/">map</a>
+    <a href="/lists/">lists</a>
+    <a href="/skills/" class="active">skills</a>
+    <a href="/use-cases/">use cases</a>
+    <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
+    <a href="/dev/">dev</a>
+    <a href="/reports/">reports</a>
+    <a href="/#newsletter">newsletter</a>
+    <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
+  </nav>
+  <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
+  </button>
+</header>
+
+<div class="breadcrumb" aria-label="Breadcrumb">
+  <a href="/">map</a><span class="sep">/</span><a href="/skills/">skills</a><span class="sep">/</span>skill-management
+</div>
+
+<main id="main">
+
+<section class="list-page">
+  <h1 class="list-title">Best Tools for Discovering &amp; Managing Hermes Skills</h1>
+  <p class="uc-intent">“Users who want to browse, retrieve, evolve, or bulk-install skills at scale rather than add a single-purpose skill.”</p>
+  <p class="list-intro sk-lede">Meta-tools that sit above individual skills — registries, retrieval layers, evolution engines, and large curated skill collections spanning many professions.</p>
+  <p class="sk-freshness">Updated 2026-08-20 · tested against Hermes v0.20.4</p>
+</section>
+
+<section class="uc-section" aria-label="Ranked picks">
+  <div class="section-label">the picks — 6</div>
+  <div class="sk-entries">
+    <article class="sk-entry">
+      <div class="sk-entry-head">
+        <h2 class="sk-entry-name"><a href="/projects/AMAP-ML/SkillClaw"><span class="org">AMAP-ML /</span> SkillClaw</a><span class="sk-type">registry</span> <span class="sk-pick-flag">top pick</span></h2>
+        <div class="sk-card-stars">★ 2.5K</div>
+      </div>
+      <div class="sk-entry-body">
+        <p class="sk-verdict">A genuinely different mechanism: runs in the background, deduplicates, and cross-pollinates your skill library across agents, devices, and users instead of just hosting a list.</p>
+        <div class="sk-install-label">install</div>
+      <code class="sk-install">git clone https://github.com/AMAP-ML/SkillClaw.git, run scripts/install_skillclaw.sh, activate the venv, then run skillclaw setup.</code>
+        <p class="sk-compat"><span class="sk-compat-label">works with</span>Standalone Python CLI/daemon; integrates with Hermes, Codex, Claude Code, and OpenAI-compatible APIs — not a drop-in SKILL.md.</p>
+      </div>
+    </article>
+    <article class="sk-entry">
+      <div class="sk-entry-head">
+        <h2 class="sk-entry-name"><a href="/projects/wondelai/skills"><span class="org">wondelai /</span> skills</a><span class="sk-type">collection</span></h2>
+        <div class="sk-card-stars">★ 2.0K</div>
+      </div>
+      <div class="sk-entry-body">
+        <p class="sk-verdict">62 skills built from 50 named business and design frameworks (Jobs-to-be-Done, the Mom Test, Refactoring UI) rather than generic prompts — a business-strategy layer to sit alongside a coding skill set.</p>
+        <div class="sk-install-label">install</div>
+      <code class="sk-install">npx skills add wondelai/skills --all --global (or pick individual skills, e.g. npx skills add wondelai/skills/jobs-to-be-done --global).</code>
+        <p class="sk-compat"><span class="sk-compat-label">works with</span>skills.sh / agentskills.io-compatible clients including Claude Code and Hermes; also ships Claude Code plugin collections.</p>
+      </div>
+    </article>
+    <article class="sk-entry">
+      <div class="sk-entry-head">
+        <h2 class="sk-entry-name"><a href="/projects/mohitagw15856/pm-claude-skills"><span class="org">mohitagw15856 /</span> pm-claude-skills</a><span class="sk-type">collection</span></h2>
+        <div class="sk-card-stars">★ 1.3K</div>
+      </div>
+      <div class="sk-entry-body">
+        <p class="sk-verdict">1,000+ professional skills as plain markdown, the largest non-security collection here — organized into 120+ installable bundles instead of one all-or-nothing install.</p>
+        <div class="sk-install-label">install</div>
+      <code class="sk-install">npx pm-claude-skills add</code>
+        <p class="sk-compat"><span class="sk-compat-label">works with</span>Claude Code plugin directory + Hermes Agent (plain markdown skills run natively); also exposes an MCP server.</p>
+      </div>
+    </article>
+    <article class="sk-entry">
+      <div class="sk-entry-head">
+        <h2 class="sk-entry-name"><a href="/projects/armelhbobdad/bmad-module-skill-forge"><span class="org">armelhbobdad /</span> bmad-module-skill-forge</a><span class="sk-type">skill</span></h2>
+        <div class="sk-card-stars">★ 93</div>
+      </div>
+      <div class="sk-entry-body">
+        <p class="sk-verdict">Turns your own repo, docs, and developer discourse into agentskills.io-compliant skills with file/line provenance citations — for teams standardizing internal skills, not consuming someone else's.</p>
+        <div class="sk-install-label">install</div>
+      <code class="sk-install">npx bmad-module-skill-forge install</code>
+        <p class="sk-compat"><span class="sk-compat-label">works with</span>Node.js &gt;= 22, Python &gt;= 3.10, uv required; IDE-agnostic scaffolding tool, not Hermes-specific.</p>
+      </div>
+    </article>
+    <article class="sk-entry">
+      <div class="sk-entry-head">
+        <h2 class="sk-entry-name"><a href="/projects/willingning-coder/eagle-eye"><span class="org">willingning-coder /</span> eagle-eye</a><span class="sk-type">plugin</span></h2>
+        <div class="sk-card-stars">★ 33</div>
+      </div>
+      <div class="sk-entry-body">
+        <p class="sk-verdict">Five-layer retrieval (hard triggers, FTS5, synonyms, dense embeddings, RRF fusion) built to solve Hermes' own skill-selection problem once your skills directory gets large — the most Hermes-native entry in this group.</p>
+        <div class="sk-install-label">install</div>
+      <code class="sk-install">git clone https://github.com/willingning-coder/eagle-eye.git, then run python scripts/generate_config.py.</code>
+        <p class="sk-compat"><span class="sk-compat-label">works with</span>Hermes Agent plugin; optional dense-embedding dependencies for the retrieval layers.</p>
+      </div>
+    </article>
+    <article class="sk-entry">
+      <div class="sk-entry-head">
+        <h2 class="sk-entry-name"><a href="/projects/aidevelopers2/remoteopenclaw-mcp"><span class="org">aidevelopers2 /</span> remoteopenclaw-mcp</a><span class="sk-type">registry</span></h2>
+        <div class="sk-card-stars">★ 3</div>
+      </div>
+      <div class="sk-entry-body">
+        <p class="sk-verdict">Searches 13,000+ MCP servers and 4,000+ agent skills from the terminal with no API key — the widest single search surface in this category, though it's discovery-only, not an installer.</p>
+        <div class="sk-install-label">install</div>
+      <code class="sk-install">Add remoteopenclaw (npx -y remoteopenclaw) under mcp_servers in Hermes' config; for Claude Code: claude mcp add remoteopenclaw -- npx -y remoteopenclaw.</code>
+        <p class="sk-compat"><span class="sk-compat-label">works with</span>MCP server — any MCP client (Hermes, Cursor, Windsurf, Claude Code) via mcp_servers config.</p>
+      </div>
+    </article>
+  </div>
+</section>
+
+<section class="uc-section" aria-label="How we picked">
+  <div class="section-label">how we picked</div>
+  <p class="sk-method">These are curated by hand, not scraped or ranked by an algorithm. Every entry is a project already accepted into the Atlas catalog; the install command is copied out of that project's own README (not inferred), the compatibility line reflects what the README actually claims to support, and the verdict says what this pick does that its neighbours don't. Star counts come live from the GitHub API on each build. Updated 2026-08-20 · tested against Hermes v0.20.4.</p>
+</section>
+
+<section class="uc-section" aria-label="Frequently asked questions">
+  <div class="section-label">faq</div>
+  <div class="sk-faq">
+    <div class="sk-faq-item">
+      <div class="sk-faq-q">What is the best Hermes Agent skill for discovering &amp; managing hermes skills?</div>
+      <p class="sk-faq-a">AMAP-ML/SkillClaw. A genuinely different mechanism: runs in the background, deduplicates, and cross-pollinates your skill library across agents, devices, and users instead of just hosting a list. Install it with: git clone https://github.com/AMAP-ML/SkillClaw.git, run scripts/install_skillclaw.sh, activate the venv, then run skillclaw setup.</p>
+    </div>
+    <div class="sk-faq-item">
+      <div class="sk-faq-q">How do I install Hermes skills?</div>
+      <p class="sk-faq-a">From the Hermes CLI. Running hermes skills install owner/repo/skills/name installs a single skill; hermes skills tap add owner/repo registers a whole repository as a tap, so every skill inside it becomes available. Plugins use hermes plugins install owner/repo --enable. Skills that follow the agentskills.io spec but aren't published to the Skills Hub can be added with npx skills add owner/repo, or cloned straight into your skills directory. Every entry on this page carries the exact command from its own README.</p>
+    </div>
+    <div class="sk-faq-item">
+      <div class="sk-faq-q">How current are these picks?</div>
+      <p class="sk-faq-a">Updated 2026-08-20 · tested against Hermes v0.20.4. The picks are curated by hand — install commands are read out of each project's README rather than generated, and star counts are refreshed from the GitHub API on every build.</p>
+    </div>
+  </div>
+</section>
+
+<section class="uc-section" aria-label="Other skill use cases">
+  <div class="section-label">other use cases</div>
+  <div class="uc-related">
+    <a class="uc-related-link" href="/skills/for-coding">Best Hermes Skills for Coding</a>
+    <a class="uc-related-link" href="/skills/for-cybersecurity">Best Hermes Skills for Cybersecurity</a>
+    <a class="uc-related-link" href="/skills/for-design-and-diagrams">Best Hermes Skills for Design &amp; Diagrams</a>
+    <a class="uc-related-link" href="/skills/for-writing-and-content">Best Hermes Skills for Writing &amp; Content</a>
+    <a class="uc-related-link" href="/skills/for-crypto-and-payments">Best Hermes Skills for Crypto &amp; Agent Payments</a>
+    <a class="uc-related-link" href="/skills/for-personal-ops">Best Hermes Skills for Personal Ops</a>
+  </div>
+</section>
+
+<div class="back-link"><a href="/skills/">← all skills</a></div>
+
+</main>
+
+<footer class="page-footer">
+  <div class="fn-left">hermes atlas · curated by <a href="https://github.com/ksimback">ksimback</a> · <a href="https://github.com/ksimback/hermes-ecosystem/issues">suggest a repo</a> · <a href="/privacy">privacy</a></div>
+  <div>v2 · 2026.04</div>
+</footer>
+
+<script src="/assets/js/theme-toggle.js" defer></script>
+<script src="/assets/js/masthead-fetch.js" defer></script>
+<!-- Cloudflare Web Analytics -->
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js"
+        data-cf-beacon='{"token": "fe0d4d79280b4386b6b0cd99b2d94dbc"}'></script>
+<!-- End Cloudflare Web Analytics -->
+</body>
+</html>

--- a/skills/for-writing-and-content.html
+++ b/skills/for-writing-and-content.html
@@ -1,0 +1,271 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Best Hermes Skills for Writing &amp; Content | Hermes Atlas</title>
+<meta name="description" content="Skills for auditing AI-sounding prose, extracting structured YouTube data, and generating marketing or e-commerce material.">
+<link rel="canonical" href="https://hermesatlas.com/skills/for-writing-and-content">
+<meta property="og:title" content="Best Hermes Skills for Writing &amp; Content">
+<meta property="og:description" content="Skills for auditing AI-sounding prose, extracting structured YouTube data, and generating marketing or e-commerce material.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://hermesatlas.com/skills/for-writing-and-content">
+<meta property="og:site_name" content="Hermes Atlas">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=Best+Hermes+Skills+for+Writing+%26+Content&amp;subtitle=Content+creators+and+marketers+who+want+to+de-AI-ify+prose%2C+pull+structured+video%2Fplatform+data%2C+or+automate+content+production.&amp;kind=skills">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Best Hermes Skills for Writing &amp; Content">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Best+Hermes+Skills+for+Writing+%26+Content&amp;subtitle=Content+creators+and+marketers+who+want+to+de-AI-ify+prose%2C+pull+structured+video%2Fplatform+data%2C+or+automate+content+production.&amp;kind=skills">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "map",
+      "item": "https://hermesatlas.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "skills",
+      "item": "https://hermesatlas.com/skills/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "writing-and-content"
+    }
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "@id": "https://hermesatlas.com/skills/for-writing-and-content",
+  "name": "Best Hermes Skills for Writing & Content",
+  "description": "Skills for auditing AI-sounding prose, extracting structured YouTube data, and generating marketing or e-commerce material.",
+  "url": "https://hermesatlas.com/skills/for-writing-and-content",
+  "isPartOf": {
+    "@id": "https://hermesatlas.com/#website"
+  },
+  "dateModified": "2026-08-20",
+  "mainEntity": {
+    "@type": "ItemList",
+    "numberOfItems": 3,
+    "itemListOrder": "https://schema.org/ItemListOrderDescending",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "url": "https://hermesatlas.com/projects/conorbronsdon/avoid-ai-writing",
+        "name": "conorbronsdon/avoid-ai-writing"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "url": "https://hermesatlas.com/projects/ZeroPointRepo/youtube-skills",
+        "name": "ZeroPointRepo/youtube-skills"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "url": "https://hermesatlas.com/projects/jiawood2006/hermes-skills",
+        "name": "jiawood2006/hermes-skills"
+      }
+    ]
+  }
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is the best Hermes Agent skill for writing & content?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "conorbronsdon/avoid-ai-writing. Three modes (Rewrite, Detect, Edit) and a 100+ entry tiered word-replacement table — the most mechanically detailed de-AI-ify skill in the category, not a vague 'sound more human' prompt. Install it with: git clone https://github.com/conorbronsdon/avoid-ai-writing into your skills directory (or install the plugin from its marketplace)."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How do I install Hermes skills?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "From the Hermes CLI. Running hermes skills install owner/repo/skills/name installs a single skill; hermes skills tap add owner/repo registers a whole repository as a tap, so every skill inside it becomes available. Plugins use hermes plugins install owner/repo --enable. Skills that follow the agentskills.io spec but aren't published to the Skills Hub can be added with npx skills add owner/repo, or cloned straight into your skills directory. Every entry on this page carries the exact command from its own README."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How current are these picks?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Updated 2026-08-20 · tested against Hermes v0.20.4. The picks are curated by hand — install commands are read out of each project's README rather than generated, and star counts are refreshed from the GitHub API on every build."
+      }
+    }
+  ]
+}
+</script>
+<link rel="alternate" type="application/rss+xml" title="Hermes Atlas — new projects" href="/rss.xml">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+<link rel="apple-touch-icon" href="/apple-touch-icon.png">
+<link rel="manifest" href="/site.webmanifest">
+<script src="/assets/js/theme-init.js"></script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap">
+<link rel="stylesheet" href="/assets/css/tokens.css">
+<link rel="stylesheet" href="/assets/css/base.css">
+<link rel="stylesheet" href="/assets/css/page.css">
+<link rel="stylesheet" href="/assets/css/use-cases.css">
+<link rel="stylesheet" href="/assets/css/skills.css">
+</head>
+<body>
+
+<a class="skip-link" href="#main">Skip to content</a>
+
+<header class="masthead">
+  <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
+  <div class="mast-meta" aria-label="Site metadata">
+    <span id="meta-count">231·repos</span>
+    <span id="meta-version">hermes·v0.20.4</span>
+    <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
+  </div>
+  <nav class="mast-nav" aria-label="Primary">
+    <a href="/">map</a>
+    <a href="/lists/">lists</a>
+    <a href="/skills/" class="active">skills</a>
+    <a href="/use-cases/">use cases</a>
+    <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
+    <a href="/dev/">dev</a>
+    <a href="/reports/">reports</a>
+    <a href="/#newsletter">newsletter</a>
+    <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
+  </nav>
+  <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
+  </button>
+</header>
+
+<div class="breadcrumb" aria-label="Breadcrumb">
+  <a href="/">map</a><span class="sep">/</span><a href="/skills/">skills</a><span class="sep">/</span>writing-and-content
+</div>
+
+<main id="main">
+
+<section class="list-page">
+  <h1 class="list-title">Best Hermes Skills for Writing &amp; Content</h1>
+  <p class="uc-intent">“Content creators and marketers who want to de-AI-ify prose, pull structured video/platform data, or automate content production.”</p>
+  <p class="list-intro sk-lede">Skills for auditing AI-sounding prose, extracting structured YouTube data, and generating marketing or e-commerce material.</p>
+  <p class="sk-freshness">Updated 2026-08-20 · tested against Hermes v0.20.4</p>
+</section>
+
+<section class="uc-section" aria-label="Ranked picks">
+  <div class="section-label">the picks — 3</div>
+  <div class="sk-entries">
+    <article class="sk-entry">
+      <div class="sk-entry-head">
+        <h2 class="sk-entry-name"><a href="/projects/conorbronsdon/avoid-ai-writing"><span class="org">conorbronsdon /</span> avoid-ai-writing</a><span class="sk-type">skill</span> <span class="sk-pick-flag">top pick</span></h2>
+        <div class="sk-card-stars">★ 3.2K</div>
+      </div>
+      <div class="sk-entry-body">
+        <p class="sk-verdict">Three modes (Rewrite, Detect, Edit) and a 100+ entry tiered word-replacement table — the most mechanically detailed de-AI-ify skill in the category, not a vague 'sound more human' prompt.</p>
+        <div class="sk-install-label">install</div>
+      <code class="sk-install">git clone https://github.com/conorbronsdon/avoid-ai-writing into your skills directory (or install the plugin from its marketplace).</code>
+        <p class="sk-compat"><span class="sk-compat-label">works with</span>README states explicit compatibility with Claude Code, OpenClaw, Hermes, and Cursor.</p>
+      </div>
+    </article>
+    <article class="sk-entry">
+      <div class="sk-entry-head">
+        <h2 class="sk-entry-name"><a href="/projects/ZeroPointRepo/youtube-skills"><span class="org">ZeroPointRepo /</span> youtube-skills</a><span class="sk-type">skill</span></h2>
+        <div class="sk-card-stars">★ 544</div>
+      </div>
+      <div class="sk-entry-body">
+        <p class="sk-verdict">An explicit, working Hermes install line via the skills.sh hub source — covers YouTube transcript, search, channel, and playlist data in one skill.</p>
+        <div class="sk-install-label">install</div>
+      <code class="sk-install">hermes skills install skills-sh/ZeroPointRepo/youtube-skills/skills/youtube-full</code>
+        <p class="sk-compat"><span class="sk-compat-label">works with</span>Hermes Agent (skills.sh source), OpenClaw, Claude Code, Cursor, and Codex via npx skills add.</p>
+      </div>
+    </article>
+    <article class="sk-entry">
+      <div class="sk-entry-head">
+        <h2 class="sk-entry-name"><a href="/projects/jiawood2006/hermes-skills"><span class="org">jiawood2006 /</span> hermes-skills</a><span class="sk-type">collection</span></h2>
+        <div class="sk-card-stars">★ 0</div>
+      </div>
+      <div class="sk-entry-body">
+        <p class="sk-verdict">Four narrow, concrete skills — video transcription, AI-text de-humanizer, local OCR, e-commerce material generation — with correct Hermes-native install commands out of the box. Early-stage, but useful for e-commerce and Chinese-language workflows.</p>
+        <div class="sk-install-label">install</div>
+      <code class="sk-install">hermes skills install jiawood2006/hermes-skills/skills/video-to-text (repeat per skill: de-ai-writer, doc-ocr, ecommerce-material-studio).</code>
+        <p class="sk-compat"><span class="sk-compat-label">works with</span>Hermes Agent native install commands documented directly in the README; portable to other agentskills.io clients via manual copy.</p>
+      </div>
+    </article>
+  </div>
+</section>
+
+<section class="uc-section" aria-label="How we picked">
+  <div class="section-label">how we picked</div>
+  <p class="sk-method">These are curated by hand, not scraped or ranked by an algorithm. Every entry is a project already accepted into the Atlas catalog; the install command is copied out of that project's own README (not inferred), the compatibility line reflects what the README actually claims to support, and the verdict says what this pick does that its neighbours don't. Star counts come live from the GitHub API on each build. Updated 2026-08-20 · tested against Hermes v0.20.4.</p>
+</section>
+
+<section class="uc-section" aria-label="Frequently asked questions">
+  <div class="section-label">faq</div>
+  <div class="sk-faq">
+    <div class="sk-faq-item">
+      <div class="sk-faq-q">What is the best Hermes Agent skill for writing &amp; content?</div>
+      <p class="sk-faq-a">conorbronsdon/avoid-ai-writing. Three modes (Rewrite, Detect, Edit) and a 100+ entry tiered word-replacement table — the most mechanically detailed de-AI-ify skill in the category, not a vague 'sound more human' prompt. Install it with: git clone https://github.com/conorbronsdon/avoid-ai-writing into your skills directory (or install the plugin from its marketplace).</p>
+    </div>
+    <div class="sk-faq-item">
+      <div class="sk-faq-q">How do I install Hermes skills?</div>
+      <p class="sk-faq-a">From the Hermes CLI. Running hermes skills install owner/repo/skills/name installs a single skill; hermes skills tap add owner/repo registers a whole repository as a tap, so every skill inside it becomes available. Plugins use hermes plugins install owner/repo --enable. Skills that follow the agentskills.io spec but aren't published to the Skills Hub can be added with npx skills add owner/repo, or cloned straight into your skills directory. Every entry on this page carries the exact command from its own README.</p>
+    </div>
+    <div class="sk-faq-item">
+      <div class="sk-faq-q">How current are these picks?</div>
+      <p class="sk-faq-a">Updated 2026-08-20 · tested against Hermes v0.20.4. The picks are curated by hand — install commands are read out of each project's README rather than generated, and star counts are refreshed from the GitHub API on every build.</p>
+    </div>
+  </div>
+</section>
+
+<section class="uc-section" aria-label="Other skill use cases">
+  <div class="section-label">other use cases</div>
+  <div class="uc-related">
+    <a class="uc-related-link" href="/skills/for-coding">Best Hermes Skills for Coding</a>
+    <a class="uc-related-link" href="/skills/for-cybersecurity">Best Hermes Skills for Cybersecurity</a>
+    <a class="uc-related-link" href="/skills/for-skill-management">Best Tools for Discovering &amp; Managing Hermes Skills</a>
+    <a class="uc-related-link" href="/skills/for-design-and-diagrams">Best Hermes Skills for Design &amp; Diagrams</a>
+    <a class="uc-related-link" href="/skills/for-crypto-and-payments">Best Hermes Skills for Crypto &amp; Agent Payments</a>
+    <a class="uc-related-link" href="/skills/for-personal-ops">Best Hermes Skills for Personal Ops</a>
+  </div>
+</section>
+
+<div class="back-link"><a href="/skills/">← all skills</a></div>
+
+</main>
+
+<footer class="page-footer">
+  <div class="fn-left">hermes atlas · curated by <a href="https://github.com/ksimback">ksimback</a> · <a href="https://github.com/ksimback/hermes-ecosystem/issues">suggest a repo</a> · <a href="/privacy">privacy</a></div>
+  <div>v2 · 2026.04</div>
+</footer>
+
+<script src="/assets/js/theme-toggle.js" defer></script>
+<script src="/assets/js/masthead-fetch.js" defer></script>
+<!-- Cloudflare Web Analytics -->
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js"
+        data-cf-beacon='{"token": "fe0d4d79280b4386b6b0cd99b2d94dbc"}'></script>
+<!-- End Cloudflare Web Analytics -->
+</body>
+</html>

--- a/skills/index.html
+++ b/skills/index.html
@@ -1,0 +1,922 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Best Hermes Agent Skills — the Skills Hub decision layer | Hermes Atlas</title>
+<meta name="description" content="The best Hermes Agent skills, picked by use case — coding, cybersecurity, writing, crypto, design, and skill management. Install command, compatibility, and a verdict for every pick.">
+<link rel="canonical" href="https://hermesatlas.com/skills/">
+<meta property="og:title" content="Hermes Skills Hub — Hermes Atlas">
+<meta property="og:description" content="The best Hermes Agent skills, picked by use case — coding, cybersecurity, writing, crypto, design, and skill management. Install command, compatibility, and a verdict for every pick.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://hermesatlas.com/skills/">
+<meta property="og:site_name" content="Hermes Atlas">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=Hermes+Skills+Hub+%E2%80%94+Hermes+Atlas&amp;subtitle=The+best+Hermes+Agent+skills+by+use+case%2C+with+install+commands+and+verdicts.&amp;kind=skills">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Hermes Skills Hub — Hermes Atlas">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Hermes+Skills+Hub+%E2%80%94+Hermes+Atlas&amp;subtitle=The+best+Hermes+Agent+skills+by+use+case%2C+with+install+commands+and+verdicts.&amp;kind=skills">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "map",
+      "item": "https://hermesatlas.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "skills"
+    }
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "@id": "https://hermesatlas.com/skills/",
+  "name": "Hermes Skills Hub — the best Hermes Agent skills by use case",
+  "description": "The best Hermes Agent skills, picked by use case — coding, cybersecurity, writing, crypto, design, and skill management. Install command, compatibility, and a verdict for every pick.",
+  "url": "https://hermesatlas.com/skills/",
+  "isPartOf": {
+    "@id": "https://hermesatlas.com/#website"
+  },
+  "dateModified": "2026-08-20",
+  "mainEntity": {
+    "@type": "ItemList",
+    "numberOfItems": 7,
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "url": "https://hermesatlas.com/projects/obra/superpowers",
+        "name": "obra/superpowers",
+        "description": "Top pick — Best Hermes Skills for Coding"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "url": "https://hermesatlas.com/projects/mukul975/Anthropic-Cybersecurity-Skills",
+        "name": "mukul975/Anthropic-Cybersecurity-Skills",
+        "description": "Top pick — Best Hermes Skills for Cybersecurity"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "url": "https://hermesatlas.com/projects/AMAP-ML/SkillClaw",
+        "name": "AMAP-ML/SkillClaw",
+        "description": "Top pick — Best Tools for Discovering & Managing Hermes Skills"
+      },
+      {
+        "@type": "ListItem",
+        "position": 4,
+        "url": "https://hermesatlas.com/projects/Agents365-ai/drawio-skill",
+        "name": "Agents365-ai/drawio-skill",
+        "description": "Top pick — Best Hermes Skills for Design & Diagrams"
+      },
+      {
+        "@type": "ListItem",
+        "position": 5,
+        "url": "https://hermesatlas.com/projects/conorbronsdon/avoid-ai-writing",
+        "name": "conorbronsdon/avoid-ai-writing",
+        "description": "Top pick — Best Hermes Skills for Writing & Content"
+      },
+      {
+        "@type": "ListItem",
+        "position": 6,
+        "url": "https://hermesatlas.com/projects/internet-court/internet-court-skill",
+        "name": "internet-court/internet-court-skill",
+        "description": "Top pick — Best Hermes Skills for Crypto & Agent Payments"
+      },
+      {
+        "@type": "ListItem",
+        "position": 7,
+        "url": "https://hermesatlas.com/projects/adnw-vinc/hermes-nextcloud",
+        "name": "adnw-vinc/hermes-nextcloud",
+        "description": "Top pick — Best Hermes Skills for Personal Ops"
+      }
+    ]
+  }
+}
+</script>
+<link rel="alternate" type="application/rss+xml" title="Hermes Atlas — new projects" href="/rss.xml">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+<link rel="apple-touch-icon" href="/apple-touch-icon.png">
+<link rel="manifest" href="/site.webmanifest">
+<script src="/assets/js/theme-init.js"></script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap">
+<link rel="stylesheet" href="/assets/css/tokens.css">
+<link rel="stylesheet" href="/assets/css/base.css">
+<link rel="stylesheet" href="/assets/css/page.css">
+<link rel="stylesheet" href="/assets/css/use-cases.css">
+<link rel="stylesheet" href="/assets/css/skills.css">
+</head>
+<body>
+
+<a class="skip-link" href="#main">Skip to content</a>
+
+<header class="masthead">
+  <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
+  <div class="mast-meta" aria-label="Site metadata">
+    <span id="meta-count">231·repos</span>
+    <span id="meta-version">hermes·v0.20.4</span>
+    <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
+  </div>
+  <nav class="mast-nav" aria-label="Primary">
+    <a href="/">map</a>
+    <a href="/lists/">lists</a>
+    <a href="/skills/" class="active">skills</a>
+    <a href="/use-cases/">use cases</a>
+    <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
+    <a href="/dev/">dev</a>
+    <a href="/reports/">reports</a>
+    <a href="/#newsletter">newsletter</a>
+    <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
+  </nav>
+  <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
+  </button>
+</header>
+
+<div class="breadcrumb" aria-label="Breadcrumb">
+  <a href="/">map</a><span class="sep">/</span>skills
+</div>
+
+<main id="main">
+
+<section class="list-page">
+  <h1 class="list-title">Hermes Agent skills</h1>
+  <p class="list-intro">A registry tells you what exists. This is the decision layer: 22 hand-checked skills, plugins, registries, and collections across 7 use cases — each with the install command taken from its README, what it's compatible with, and a one-line verdict on why you'd pick it over the alternatives.</p>
+  <p class="list-intro sk-lede">Want the whole category ranked by stars instead? That's <a href="/lists/top-skills">the ranked list — top Hermes skills</a>, all 44 of them.</p>
+  <p class="sk-freshness">Updated 2026-08-20 · tested against Hermes v0.20.4</p>
+</section>
+
+<section class="uc-section" aria-label="Top picks">
+  <div class="section-label">top picks — one per use case</div>
+  <p class="uc-section-note">If you only install one thing per category, install these.</p>
+  <div class="sk-card-grid">
+    <article class="sk-card">
+      <div class="sk-card-group">Coding</div>
+      <div class="sk-card-head">
+        <div class="sk-card-name"><span class="org">obra /</span> superpowers</div>
+        <div class="sk-card-stars">★ 275.3K</div>
+      </div>
+      <p class="sk-verdict">The most-starred agentic skills framework in the catalog by two orders of magnitude. If you install exactly one dev-workflow plugin, this is the default.</p>
+      <div class="sk-install-label">install</div>
+      <code class="sk-install">hermes plugins install obra/superpowers --enable</code>
+      <a class="sk-card-link" href="/projects/obra/superpowers">superpowers details →</a>
+    </article>
+    <article class="sk-card">
+      <div class="sk-card-group">Cybersecurity</div>
+      <div class="sk-card-head">
+        <div class="sk-card-name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</div>
+        <div class="sk-card-stars">★ 30.5K</div>
+      </div>
+      <p class="sk-verdict">800+ skills across 29 security domains mapped to MITRE ATT&amp;CK, ATLAS, D3FEND, and NIST — the largest and most-starred security pack in the catalog. Start here before any narrower pentest skill.</p>
+      <div class="sk-install-label">install</div>
+      <code class="sk-install">npx skills add mukul975/Anthropic-Cybersecurity-Skills</code>
+      <a class="sk-card-link" href="/projects/mukul975/Anthropic-Cybersecurity-Skills">Anthropic-Cybersecurity-Skills details →</a>
+    </article>
+    <article class="sk-card">
+      <div class="sk-card-group">Discovering &amp; Managing Hermes Skills</div>
+      <div class="sk-card-head">
+        <div class="sk-card-name"><span class="org">AMAP-ML /</span> SkillClaw</div>
+        <div class="sk-card-stars">★ 2.5K</div>
+      </div>
+      <p class="sk-verdict">A genuinely different mechanism: runs in the background, deduplicates, and cross-pollinates your skill library across agents, devices, and users instead of just hosting a list.</p>
+      <div class="sk-install-label">install</div>
+      <code class="sk-install">git clone https://github.com/AMAP-ML/SkillClaw.git, run scripts/install_skillclaw.sh, activate the venv, then run skillclaw setup.</code>
+      <a class="sk-card-link" href="/projects/AMAP-ML/SkillClaw">SkillClaw details →</a>
+    </article>
+    <article class="sk-card">
+      <div class="sk-card-group">Design &amp; Diagrams</div>
+      <div class="sk-card-head">
+        <div class="sk-card-name"><span class="org">Agents365-ai /</span> drawio-skill</div>
+        <div class="sk-card-stars">★ 7.9K</div>
+      </div>
+      <p class="sk-verdict">Eleven diagram-type presets plus Mermaid-to-drawio conversion, and the most-starred diagram skill in the catalog — the clear default over hand-rolling diagram prompts.</p>
+      <div class="sk-install-label">install</div>
+      <code class="sk-install">npx skills add Agents365-ai/365-skills -g (or git clone into your skills directory).</code>
+      <a class="sk-card-link" href="/projects/Agents365-ai/drawio-skill">drawio-skill details →</a>
+    </article>
+    <article class="sk-card">
+      <div class="sk-card-group">Writing &amp; Content</div>
+      <div class="sk-card-head">
+        <div class="sk-card-name"><span class="org">conorbronsdon /</span> avoid-ai-writing</div>
+        <div class="sk-card-stars">★ 3.2K</div>
+      </div>
+      <p class="sk-verdict">Three modes (Rewrite, Detect, Edit) and a 100+ entry tiered word-replacement table — the most mechanically detailed de-AI-ify skill in the category, not a vague 'sound more human' prompt.</p>
+      <div class="sk-install-label">install</div>
+      <code class="sk-install">git clone https://github.com/conorbronsdon/avoid-ai-writing into your skills directory (or install the plugin from its marketplace).</code>
+      <a class="sk-card-link" href="/projects/conorbronsdon/avoid-ai-writing">avoid-ai-writing details →</a>
+    </article>
+    <article class="sk-card">
+      <div class="sk-card-group">Crypto &amp; Agent Payments</div>
+      <div class="sk-card-head">
+        <div class="sk-card-name"><span class="org">internet-court /</span> internet-court-skill</div>
+        <div class="sk-card-stars">★ 4.3K</div>
+      </div>
+      <p class="sk-verdict">A genuinely new primitive — a master router plus vendored official protocol skills covering ERC-7710 delegated permissions, x402 payments, and escrow/dispute resolution as one catch-all agent-commerce skill.</p>
+      <div class="sk-install-label">install</div>
+      <code class="sk-install">hermes skills tap add internet-court/internet-court-skill (the README prefers the tap over a direct URL install, which misses bundled reference files).</code>
+      <a class="sk-card-link" href="/projects/internet-court/internet-court-skill">internet-court-skill details →</a>
+    </article>
+    <article class="sk-card">
+      <div class="sk-card-group">Personal Ops</div>
+      <div class="sk-card-head">
+        <div class="sk-card-name"><span class="org">adnw-vinc /</span> hermes-nextcloud</div>
+        <div class="sk-card-stars">★ 44</div>
+      </div>
+      <p class="sk-verdict">The only skill in the catalog wiring Hermes directly into a self-hosted Nextcloud over WebDAV/CalDAV/CardDAV — no browser, no third-party sync service, credentials kept in a restricted local .env.</p>
+      <div class="sk-install-label">install</div>
+      <code class="sk-install">git clone https://github.com/adnw-vinc/hermes-nextcloud.git into ~/.hermes/skills/productivity/nextcloud, then run its guided setup script.</code>
+      <a class="sk-card-link" href="/projects/adnw-vinc/hermes-nextcloud">hermes-nextcloud details →</a>
+    </article>
+  </div>
+</section>
+
+<section class="uc-section" aria-label="Best Hermes Skills for Coding">
+  <div class="section-label">Best Hermes Skills for Coding</div>
+  <p class="uc-section-note">Structured methodologies and subagent swarms that turn ad-hoc coding sessions into repeatable, checkpointed workflows — spec-first planning, adversarial code review, and multi-agent simplification passes.</p>
+  <div class="list-table">
+    <a class="list-row" href="/projects/obra/superpowers">
+    <div class="list-rank">01</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">obra /</span> superpowers<span class="sk-type">plugin</span> <span class="sk-pick-flag">top pick</span></div>
+      <div class="list-cell-desc">The most-starred agentic skills framework in the catalog by two orders of magnitude. If you install exactly one dev-workflow plugin, this is the default.</div>
+    </div>
+    <div class="list-cell-stars">★ 275.3K</div>
+  </a>
+    <a class="list-row" href="/projects/Cranot/super-hermes">
+    <div class="list-rank">02</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">Cranot /</span> super-hermes<span class="sk-type">skill</span></div>
+      <div class="list-cell-desc">Built specifically for Hermes' own Skills Hub syntax rather than ported from Claude Code — teaches the agent to write its own analytical prompts via prism-scan plus seven proven…</div>
+    </div>
+    <div class="list-cell-stars">★ 382</div>
+  </a>
+    <a class="list-row" href="/projects/armelhbobdad/bmad-module-skill-forge">
+    <div class="list-rank">03</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">armelhbobdad /</span> bmad-module-skill-forge<span class="sk-type">skill</span></div>
+      <div class="list-cell-desc">Turns your own repo, docs, and developer discourse into agentskills.io-compliant skills with file/line provenance citations — for teams standardizing internal skills, not…</div>
+    </div>
+    <div class="list-cell-stars">★ 93</div>
+  </a>
+    <a class="list-row" href="/projects/Sahil-SS9/hermaguard">
+    <div class="list-rank">04</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">Sahil-SS9 /</span> hermaguard<span class="sk-type">skill</span></div>
+      <div class="list-cell-desc">Three parallel subagents attack code from different angles, then verify findings via sandboxed proof-of-concept execution before reporting VERIFIED or REFUTED — the most rigorous…</div>
+    </div>
+    <div class="list-cell-stars">★ 25</div>
+  </a>
+  </div>
+  <p class="list-link"><a href="/skills/for-coding">see all 5 picks for coding →</a></p>
+</section>
+<section class="uc-section" aria-label="Best Hermes Skills for Cybersecurity">
+  <div class="section-label">Best Hermes Skills for Cybersecurity</div>
+  <p class="uc-section-note">Structured skill packs mapping MITRE ATT&amp;CK, NIST, and CVE data into agent-usable procedures for pentesting, forensics, and threat modeling.</p>
+  <div class="list-table">
+    <a class="list-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills">
+    <div class="list-rank">01</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills<span class="sk-type">collection</span> <span class="sk-pick-flag">top pick</span></div>
+      <div class="list-cell-desc">800+ skills across 29 security domains mapped to MITRE ATT&amp;CK, ATLAS, D3FEND, and NIST — the largest and most-starred security pack in the catalog. Start here before any narrower…</div>
+    </div>
+    <div class="list-cell-stars">★ 30.5K</div>
+  </a>
+    <a class="list-row" href="/projects/handnewb/hermes-cybersec-lab">
+    <div class="list-rank">02</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">handnewb /</span> hermes-cybersec-lab<span class="sk-type">collection</span></div>
+      <div class="list-cell-desc">2,000+ skills stitched from 7 external repos plus 130+ installable tools (Sigma, YARA, MISP). A deeper turnkey lab than the Anthropic-Cybersecurity-Skills pack, but a heavier…</div>
+    </div>
+    <div class="list-cell-stars">★ 8</div>
+  </a>
+  </div>
+  <p class="list-link"><a href="/skills/for-cybersecurity">see all 2 picks for cybersecurity →</a></p>
+</section>
+<section class="uc-section" aria-label="Best Tools for Discovering &amp; Managing Hermes Skills">
+  <div class="section-label">Best Tools for Discovering &amp; Managing Hermes Skills</div>
+  <p class="uc-section-note">Meta-tools that sit above individual skills — registries, retrieval layers, evolution engines, and large curated skill collections spanning many professions.</p>
+  <div class="list-table">
+    <a class="list-row" href="/projects/AMAP-ML/SkillClaw">
+    <div class="list-rank">01</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">AMAP-ML /</span> SkillClaw<span class="sk-type">registry</span> <span class="sk-pick-flag">top pick</span></div>
+      <div class="list-cell-desc">A genuinely different mechanism: runs in the background, deduplicates, and cross-pollinates your skill library across agents, devices, and users instead of just hosting a list.</div>
+    </div>
+    <div class="list-cell-stars">★ 2.5K</div>
+  </a>
+    <a class="list-row" href="/projects/wondelai/skills">
+    <div class="list-rank">02</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">wondelai /</span> skills<span class="sk-type">collection</span></div>
+      <div class="list-cell-desc">62 skills built from 50 named business and design frameworks (Jobs-to-be-Done, the Mom Test, Refactoring UI) rather than generic prompts — a business-strategy layer to sit…</div>
+    </div>
+    <div class="list-cell-stars">★ 2.0K</div>
+  </a>
+    <a class="list-row" href="/projects/mohitagw15856/pm-claude-skills">
+    <div class="list-rank">03</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">mohitagw15856 /</span> pm-claude-skills<span class="sk-type">collection</span></div>
+      <div class="list-cell-desc">1,000+ professional skills as plain markdown, the largest non-security collection here — organized into 120+ installable bundles instead of one all-or-nothing install.</div>
+    </div>
+    <div class="list-cell-stars">★ 1.3K</div>
+  </a>
+    <a class="list-row" href="/projects/armelhbobdad/bmad-module-skill-forge">
+    <div class="list-rank">04</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">armelhbobdad /</span> bmad-module-skill-forge<span class="sk-type">skill</span></div>
+      <div class="list-cell-desc">Turns your own repo, docs, and developer discourse into agentskills.io-compliant skills with file/line provenance citations — for teams standardizing internal skills, not…</div>
+    </div>
+    <div class="list-cell-stars">★ 93</div>
+  </a>
+  </div>
+  <p class="list-link"><a href="/skills/for-skill-management">see all 6 picks for discovering &amp; managing hermes skills →</a></p>
+</section>
+<section class="uc-section" aria-label="Best Hermes Skills for Design &amp; Diagrams">
+  <div class="section-label">Best Hermes Skills for Design &amp; Diagrams</div>
+  <p class="uc-section-note">Skills and tools that turn natural-language descriptions into draw.io diagrams, FLUX-generated images, or full local-first design prototypes.</p>
+  <div class="list-table">
+    <a class="list-row" href="/projects/Agents365-ai/drawio-skill">
+    <div class="list-rank">01</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">Agents365-ai /</span> drawio-skill<span class="sk-type">skill</span> <span class="sk-pick-flag">top pick</span></div>
+      <div class="list-cell-desc">Eleven diagram-type presets plus Mermaid-to-drawio conversion, and the most-starred diagram skill in the catalog — the clear default over hand-rolling diagram prompts.</div>
+    </div>
+    <div class="list-cell-stars">★ 7.9K</div>
+  </a>
+    <a class="list-row" href="/projects/nexu-io/open-design">
+    <div class="list-rank">02</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">nexu-io /</span> open-design<span class="sk-type">plugin</span></div>
+      <div class="list-cell-desc">By far the biggest project in the entire skills category — but it's a full local-first design platform, not a lightweight skill. Install it as prototyping infrastructure, not a…</div>
+    </div>
+    <div class="list-cell-stars">★ 90.0K</div>
+  </a>
+    <a class="list-row" href="/projects/black-forest-labs/skills">
+    <div class="list-rank">03</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">black-forest-labs /</span> skills<span class="sk-type">skill</span></div>
+      <div class="list-cell-desc">The one official-vendor entry in this bucket — Black Forest Labs' own FLUX prompting guidelines and API integration patterns, not a third-party reverse-engineering of their docs.</div>
+    </div>
+    <div class="list-cell-stars">★ 103</div>
+  </a>
+  </div>
+  <p class="list-link"><a href="/skills/for-design-and-diagrams">see all 3 picks for design &amp; diagrams →</a></p>
+</section>
+<section class="uc-section" aria-label="Best Hermes Skills for Writing &amp; Content">
+  <div class="section-label">Best Hermes Skills for Writing &amp; Content</div>
+  <p class="uc-section-note">Skills for auditing AI-sounding prose, extracting structured YouTube data, and generating marketing or e-commerce material.</p>
+  <div class="list-table">
+    <a class="list-row" href="/projects/conorbronsdon/avoid-ai-writing">
+    <div class="list-rank">01</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">conorbronsdon /</span> avoid-ai-writing<span class="sk-type">skill</span> <span class="sk-pick-flag">top pick</span></div>
+      <div class="list-cell-desc">Three modes (Rewrite, Detect, Edit) and a 100+ entry tiered word-replacement table — the most mechanically detailed de-AI-ify skill in the category, not a vague 'sound more human'…</div>
+    </div>
+    <div class="list-cell-stars">★ 3.2K</div>
+  </a>
+    <a class="list-row" href="/projects/ZeroPointRepo/youtube-skills">
+    <div class="list-rank">02</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">ZeroPointRepo /</span> youtube-skills<span class="sk-type">skill</span></div>
+      <div class="list-cell-desc">An explicit, working Hermes install line via the skills.sh hub source — covers YouTube transcript, search, channel, and playlist data in one skill.</div>
+    </div>
+    <div class="list-cell-stars">★ 544</div>
+  </a>
+    <a class="list-row" href="/projects/jiawood2006/hermes-skills">
+    <div class="list-rank">03</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">jiawood2006 /</span> hermes-skills<span class="sk-type">collection</span></div>
+      <div class="list-cell-desc">Four narrow, concrete skills — video transcription, AI-text de-humanizer, local OCR, e-commerce material generation — with correct Hermes-native install commands out of the box.…</div>
+    </div>
+    <div class="list-cell-stars">★ 0</div>
+  </a>
+  </div>
+  <p class="list-link"><a href="/skills/for-writing-and-content">see all 3 picks for writing &amp; content →</a></p>
+</section>
+<section class="uc-section" aria-label="Best Hermes Skills for Crypto &amp; Agent Payments">
+  <div class="section-label">Best Hermes Skills for Crypto &amp; Agent Payments</div>
+  <p class="uc-section-note">Skills for interacting with smart-contract oracle networks and for structuring agent-to-agent commerce, escrow, delegated permissions, and micropayments.</p>
+  <div class="list-table">
+    <a class="list-row" href="/projects/internet-court/internet-court-skill">
+    <div class="list-rank">01</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">internet-court /</span> internet-court-skill<span class="sk-type">collection</span> <span class="sk-pick-flag">top pick</span></div>
+      <div class="list-cell-desc">A genuinely new primitive — a master router plus vendored official protocol skills covering ERC-7710 delegated permissions, x402 payments, and escrow/dispute resolution as one…</div>
+    </div>
+    <div class="list-cell-stars">★ 4.3K</div>
+  </a>
+    <a class="list-row" href="/projects/smartcontractkit/chainlink-agent-skills">
+    <div class="list-rank">02</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">smartcontractkit /</span> chainlink-agent-skills<span class="sk-type">skill</span></div>
+      <div class="list-cell-desc">The official Chainlink team's own oracle-network skills (CCIP, VRF, Data Feeds) — the vendor-authoritative pick for cross-chain or oracle work, versus a community reimplementation.</div>
+    </div>
+    <div class="list-cell-stars">★ 125</div>
+  </a>
+  </div>
+  <p class="list-link"><a href="/skills/for-crypto-and-payments">see all 2 picks for crypto &amp; agent payments →</a></p>
+</section>
+<section class="uc-section" aria-label="Best Hermes Skills for Personal Ops">
+  <div class="section-label">Best Hermes Skills for Personal Ops</div>
+  <p class="uc-section-note">Skills that connect Hermes to personal infrastructure like self-hosted Nextcloud and that smooth over Windows/WSL/Git Bash path and runtime quirks.</p>
+  <div class="list-table">
+    <a class="list-row" href="/projects/adnw-vinc/hermes-nextcloud">
+    <div class="list-rank">01</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">adnw-vinc /</span> hermes-nextcloud<span class="sk-type">skill</span> <span class="sk-pick-flag">top pick</span></div>
+      <div class="list-cell-desc">The only skill in the catalog wiring Hermes directly into a self-hosted Nextcloud over WebDAV/CalDAV/CardDAV — no browser, no third-party sync service, credentials kept in a…</div>
+    </div>
+    <div class="list-cell-stars">★ 44</div>
+  </a>
+    <a class="list-row" href="/projects/CorsenAI/hermes-windows-runtime-skills">
+    <div class="list-rank">02</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">CorsenAI /</span> hermes-windows-runtime-skills<span class="sk-type">collection</span></div>
+      <div class="list-cell-desc">Solves a real, narrow Hermes pain point — deterministic path routing and non-destructive Python runtime selection across Windows, Git Bash, and WSL — with exact hermes skills…</div>
+    </div>
+    <div class="list-cell-stars">★ 1</div>
+  </a>
+  </div>
+  <p class="list-link"><a href="/skills/for-personal-ops">see all 2 picks for personal ops →</a></p>
+</section>
+<section class="uc-section" aria-label="Registries and collections">
+  <div class="section-label">registries &amp; collections</div>
+  <p class="uc-section-note">Nous Research's own Skills Hub is the registry — the place skills are published and installed from. Atlas is the judgment layer on top of it: which of them are worth installing, and why. These 9 entries are the other side of that split — search surfaces, taps, and bulk collections that hand you many skills at once rather than solving one problem well.</p>
+  <div class="list-table">
+    <a class="list-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills">
+    <div class="list-rank">01</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills<span class="sk-type">collection</span> <span class="sk-pick-flag">top pick</span></div>
+      <div class="list-cell-desc">800+ skills across 29 security domains mapped to MITRE ATT&amp;CK, ATLAS, D3FEND, and NIST — the largest and most-starred security pack in the catalog. Start here before any narrower…</div>
+    </div>
+    <div class="list-cell-stars">★ 30.5K</div>
+  </a>
+    <a class="list-row" href="/projects/internet-court/internet-court-skill">
+    <div class="list-rank">02</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">internet-court /</span> internet-court-skill<span class="sk-type">collection</span> <span class="sk-pick-flag">top pick</span></div>
+      <div class="list-cell-desc">A genuinely new primitive — a master router plus vendored official protocol skills covering ERC-7710 delegated permissions, x402 payments, and escrow/dispute resolution as one…</div>
+    </div>
+    <div class="list-cell-stars">★ 4.3K</div>
+  </a>
+    <a class="list-row" href="/projects/AMAP-ML/SkillClaw">
+    <div class="list-rank">03</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">AMAP-ML /</span> SkillClaw<span class="sk-type">registry</span> <span class="sk-pick-flag">top pick</span></div>
+      <div class="list-cell-desc">A genuinely different mechanism: runs in the background, deduplicates, and cross-pollinates your skill library across agents, devices, and users instead of just hosting a list.</div>
+    </div>
+    <div class="list-cell-stars">★ 2.5K</div>
+  </a>
+    <a class="list-row" href="/projects/wondelai/skills">
+    <div class="list-rank">04</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">wondelai /</span> skills<span class="sk-type">collection</span></div>
+      <div class="list-cell-desc">62 skills built from 50 named business and design frameworks (Jobs-to-be-Done, the Mom Test, Refactoring UI) rather than generic prompts — a business-strategy layer to sit…</div>
+    </div>
+    <div class="list-cell-stars">★ 2.0K</div>
+  </a>
+    <a class="list-row" href="/projects/mohitagw15856/pm-claude-skills">
+    <div class="list-rank">05</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">mohitagw15856 /</span> pm-claude-skills<span class="sk-type">collection</span></div>
+      <div class="list-cell-desc">1,000+ professional skills as plain markdown, the largest non-security collection here — organized into 120+ installable bundles instead of one all-or-nothing install.</div>
+    </div>
+    <div class="list-cell-stars">★ 1.3K</div>
+  </a>
+    <a class="list-row" href="/projects/handnewb/hermes-cybersec-lab">
+    <div class="list-rank">06</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">handnewb /</span> hermes-cybersec-lab<span class="sk-type">collection</span></div>
+      <div class="list-cell-desc">2,000+ skills stitched from 7 external repos plus 130+ installable tools (Sigma, YARA, MISP). A deeper turnkey lab than the Anthropic-Cybersecurity-Skills pack, but a heavier…</div>
+    </div>
+    <div class="list-cell-stars">★ 8</div>
+  </a>
+    <a class="list-row" href="/projects/aidevelopers2/remoteopenclaw-mcp">
+    <div class="list-rank">07</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">aidevelopers2 /</span> remoteopenclaw-mcp<span class="sk-type">registry</span></div>
+      <div class="list-cell-desc">Searches 13,000+ MCP servers and 4,000+ agent skills from the terminal with no API key — the widest single search surface in this category, though it's discovery-only, not an…</div>
+    </div>
+    <div class="list-cell-stars">★ 3</div>
+  </a>
+    <a class="list-row" href="/projects/CorsenAI/hermes-windows-runtime-skills">
+    <div class="list-rank">08</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">CorsenAI /</span> hermes-windows-runtime-skills<span class="sk-type">collection</span></div>
+      <div class="list-cell-desc">Solves a real, narrow Hermes pain point — deterministic path routing and non-destructive Python runtime selection across Windows, Git Bash, and WSL — with exact hermes skills…</div>
+    </div>
+    <div class="list-cell-stars">★ 1</div>
+  </a>
+    <a class="list-row" href="/projects/jiawood2006/hermes-skills">
+    <div class="list-rank">09</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">jiawood2006 /</span> hermes-skills<span class="sk-type">collection</span></div>
+      <div class="list-cell-desc">Four narrow, concrete skills — video transcription, AI-text de-humanizer, local OCR, e-commerce material generation — with correct Hermes-native install commands out of the box.…</div>
+    </div>
+    <div class="list-cell-stars">★ 0</div>
+  </a>
+  </div>
+</section>
+
+<section class="uc-section" aria-label="Full skills catalog">
+  <div class="section-label">the full catalog — 44 projects</div>
+  <p class="uc-section-note">Everything in the Atlas categorized as Skills &amp; Skill Registries, ranked by live GitHub stars. Entries without a verdict above haven't been through a curation pass yet.</p>
+  <div class="list-table" aria-label="All skills repos">
+    <div class="list-table-head">
+      <div>#</div>
+      <div>project</div>
+      <div class="text-right">stars</div>
+    </div>
+    <a class="list-row" href="/projects/obra/superpowers">
+    <div class="list-rank">01</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">obra /</span> superpowers</div>
+      <div class="list-cell-desc">An agentic skills framework &amp; software development methodology that works.</div>
+    </div>
+    <div class="list-cell-stars">★ 275.3K</div>
+  </a>
+    <a class="list-row" href="/projects/nexu-io/open-design">
+    <div class="list-rank">02</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">nexu-io /</span> open-design</div>
+      <div class="list-cell-desc">Local-first open-source design/prototyping system with coding-agent CLI support including Hermes Agent</div>
+    </div>
+    <div class="list-cell-stars">★ 90.0K</div>
+  </a>
+    <a class="list-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills">
+    <div class="list-rank">03</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</div>
+      <div class="list-cell-desc">754 structured cybersecurity skills mapped to MITRE ATT&amp;CK, NIST CSF 2.0, ATLAS, D3FEND &amp; NIST AI RMF</div>
+    </div>
+    <div class="list-cell-stars">★ 30.5K</div>
+  </a>
+    <a class="list-row" href="/projects/topoteretes/cognee">
+    <div class="list-rank">04</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">topoteretes /</span> cognee</div>
+      <div class="list-cell-desc">Cognee is the open-source AI memory platform for agents. Give your AI agents persistent long-term memory across sessions with a self-hosted </div>
+    </div>
+    <div class="list-cell-stars">★ 30.2K</div>
+  </a>
+    <a class="list-row" href="/projects/Agents365-ai/drawio-skill">
+    <div class="list-rank">05</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">Agents365-ai /</span> drawio-skill</div>
+      <div class="list-cell-desc">Generate draw.io diagrams from natural language descriptions</div>
+    </div>
+    <div class="list-cell-stars">★ 7.9K</div>
+  </a>
+    <a class="list-row" href="/projects/internet-court/internet-court-skill">
+    <div class="list-rank">06</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">internet-court /</span> internet-court-skill</div>
+      <div class="list-cell-desc">The trust layer for agent-to-agent commerce — natural-language mandates, ERC-7710 delegated permissions, x402 payments, escrow, and dispute </div>
+    </div>
+    <div class="list-cell-stars">★ 4.3K</div>
+  </a>
+    <a class="list-row" href="/projects/conorbronsdon/avoid-ai-writing">
+    <div class="list-rank">07</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">conorbronsdon /</span> avoid-ai-writing</div>
+      <div class="list-cell-desc">Audits and rewrites content to eliminate detectable AI writing patterns</div>
+    </div>
+    <div class="list-cell-stars">★ 3.2K</div>
+  </a>
+    <a class="list-row" href="/projects/AMAP-ML/SkillClaw">
+    <div class="list-rank">08</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">AMAP-ML /</span> SkillClaw</div>
+      <div class="list-cell-desc">Let Skills Evolve Collectively with Agentic Evolver</div>
+    </div>
+    <div class="list-cell-stars">★ 2.5K</div>
+  </a>
+    <a class="list-row" href="/projects/wondelai/skills">
+    <div class="list-rank">09</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">wondelai /</span> skills</div>
+      <div class="list-cell-desc">Cross-platform skills library for Claude Code and agentskills.io-compatible agents</div>
+    </div>
+    <div class="list-cell-stars">★ 2.0K</div>
+  </a>
+    <a class="list-row" href="/projects/mohitagw15856/pm-claude-skills">
+    <div class="list-rank">10</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">mohitagw15856 /</span> pm-claude-skills</div>
+      <div class="list-cell-desc">822 professional agent skills that run natively in Hermes Agent and Claude Code, with ready-to-paste exports for other assistants.</div>
+    </div>
+    <div class="list-cell-stars">★ 1.3K</div>
+  </a>
+    <a class="list-row" href="/projects/ZeroPointRepo/youtube-skills">
+    <div class="list-rank">11</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">ZeroPointRepo /</span> youtube-skills</div>
+      <div class="list-cell-desc">YouTube transcript, search, channel, and playlist skills for Hermes Agent, OpenClaw, Claude Code, Cursor, and Windsurf</div>
+    </div>
+    <div class="list-cell-stars">★ 544</div>
+  </a>
+    <a class="list-row" href="/projects/Romanescu11/hermes-skill-factory">
+    <div class="list-rank">12</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">Romanescu11 /</span> hermes-skill-factory</div>
+      <div class="list-cell-desc">Meta-skill plugin that watches workflows and auto-generates reusable skills</div>
+    </div>
+    <div class="list-cell-stars">★ 527</div>
+  </a>
+    <a class="list-row" href="/projects/Cranot/super-hermes">
+    <div class="list-rank">13</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">Cranot /</span> super-hermes</div>
+      <div class="list-cell-desc">Skills that teach Hermes Agent to write its own analytical prompts</div>
+    </div>
+    <div class="list-cell-stars">★ 382</div>
+  </a>
+    <a class="list-row" href="/projects/DougTrajano/pydantic-ai-skills">
+    <div class="list-rank">14</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">DougTrajano /</span> pydantic-ai-skills</div>
+      <div class="list-cell-desc">Type-safe agentskills.io support with progressive disclosure for Pydantic AI</div>
+    </div>
+    <div class="list-cell-stars">★ 360</div>
+  </a>
+    <a class="list-row" href="/projects/AkoliteZA/hermes-agent-idea-workflow">
+    <div class="list-rank">15</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">AkoliteZA /</span> hermes-agent-idea-workflow</div>
+      <div class="list-cell-desc">Pre-build idea-to-spec workflow skills for Hermes Agent that turn rough ideas into design docs and implementation handoffs</div>
+    </div>
+    <div class="list-cell-stars">★ 261</div>
+  </a>
+    <a class="list-row" href="/projects/tlehman/litprog-skill">
+    <div class="list-rank">16</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">tlehman /</span> litprog-skill</div>
+      <div class="list-cell-desc">Literate programming skill — weave code and documentation across agents</div>
+    </div>
+    <div class="list-cell-stars">★ 251</div>
+  </a>
+    <a class="list-row" href="/projects/ReinaMacCredy/maestro">
+    <div class="list-rank">17</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">ReinaMacCredy /</span> maestro</div>
+      <div class="list-cell-desc">Harness for long-running AI agents — structured memory, cross-feature learning, plan-approve-execute</div>
+    </div>
+    <div class="list-cell-stars">★ 227</div>
+  </a>
+    <a class="list-row" href="/projects/esaradev/icarus-plugin">
+    <div class="list-rank">18</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">esaradev /</span> icarus-plugin</div>
+      <div class="list-cell-desc">Self-memory and replacement models — remember your work, train your replacement</div>
+    </div>
+    <div class="list-cell-stars">★ 142</div>
+  </a>
+    <a class="list-row" href="/projects/smartcontractkit/chainlink-agent-skills">
+    <div class="list-rank">19</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
+      <div class="list-cell-desc">Oracle network and smart contract interaction skills (agentskills.io spec)</div>
+    </div>
+    <div class="list-cell-stars">★ 125</div>
+  </a>
+    <a class="list-row" href="/projects/Hermes-brasil/hermes-brasil">
+    <div class="list-rank">20</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">Hermes-brasil /</span> hermes-brasil</div>
+      <div class="list-cell-desc">Comunidade brasileira de Hermes Agent (Nous Research) — skills, guias e integrações em português.</div>
+    </div>
+    <div class="list-cell-stars">★ 116</div>
+  </a>
+    <a class="list-row" href="/projects/black-forest-labs/skills">
+    <div class="list-rank">21</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">black-forest-labs /</span> skills</div>
+      <div class="list-cell-desc">Official FLUX image generation skills — prompting guidelines and API integration</div>
+    </div>
+    <div class="list-cell-stars">★ 103</div>
+  </a>
+    <a class="list-row" href="/projects/armelhbobdad/bmad-module-skill-forge">
+    <div class="list-rank">22</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">armelhbobdad /</span> bmad-module-skill-forge</div>
+      <div class="list-cell-desc">Converts repos, docs, and developer discourse into agentskills.io-compliant skills</div>
+    </div>
+    <div class="list-cell-stars">★ 93</div>
+  </a>
+    <a class="list-row" href="/projects/chigwell/skilldock.io">
+    <div class="list-rank">23</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">chigwell /</span> skilldock.io</div>
+      <div class="list-cell-desc">Registry of reusable AI skills based on AgentSkills specification</div>
+    </div>
+    <div class="list-cell-stars">★ 86</div>
+  </a>
+    <a class="list-row" href="/projects/tiann/execplan-skill">
+    <div class="list-rank">24</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">tiann /</span> execplan-skill</div>
+      <div class="list-cell-desc">Complex multi-step task execution with checkpoints and recovery</div>
+    </div>
+    <div class="list-cell-stars">★ 67</div>
+  </a>
+    <a class="list-row" href="/projects/supernovae-st/nika">
+    <div class="list-rank">25</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">supernovae-st /</span> nika</div>
+      <div class="list-cell-desc">Intent as Code | the workflow language for AI. One file, 4 verbs, one Rust binary. Local-first, any model, AGPL-3.0. 🦋</div>
+    </div>
+    <div class="list-cell-stars">★ 54</div>
+  </a>
+    <a class="list-row" href="/projects/adnw-vinc/hermes-nextcloud">
+    <div class="list-rank">26</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">adnw-vinc /</span> hermes-nextcloud</div>
+      <div class="list-cell-desc">Hermes Agent skill for Nextcloud — manage files, notes, calendar, tasks, and contacts via WebDAV and CalDAV.</div>
+    </div>
+    <div class="list-cell-stars">★ 44</div>
+  </a>
+    <a class="list-row" href="/projects/cablate/Agentic-MCP-Skill">
+    <div class="list-rank">27</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">cablate /</span> Agentic-MCP-Skill</div>
+      <div class="list-cell-desc">Progressive MCP client with three-layer lazy loading — validates agentskills.io pattern</div>
+    </div>
+    <div class="list-cell-stars">★ 39</div>
+  </a>
+    <a class="list-row" href="/projects/willingning-coder/eagle-eye">
+    <div class="list-rank">28</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">willingning-coder /</span> eagle-eye</div>
+      <div class="list-cell-desc">5-layer intelligent skill retrieval for Hermes Agent with hard triggers, FTS5, synonyms, dense embeddings, and RRF fusion.</div>
+    </div>
+    <div class="list-cell-stars">★ 33</div>
+  </a>
+    <a class="list-row" href="/projects/Sahil-SS9/hermaguard">
+    <div class="list-rank">29</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">Sahil-SS9 /</span> hermaguard</div>
+      <div class="list-cell-desc">Adversarial bug-hunting code review for AI agents. 3 parallel subagents attack code from different angles, then a consolidator merges and tr</div>
+    </div>
+    <div class="list-cell-stars">★ 25</div>
+  </a>
+    <a class="list-row" href="/projects/amanning3390/hermeshub">
+    <div class="list-rank">30</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">amanning3390 /</span> hermeshub</div>
+      <div class="list-cell-desc">Community skill browsing, search, and one-click installation hub</div>
+    </div>
+    <div class="list-cell-stars">★ 23</div>
+  </a>
+    <a class="list-row" href="/projects/EntangledQuantum/Life_OS">
+    <div class="list-rank">31</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">EntangledQuantum /</span> Life_OS</div>
+      <div class="list-cell-desc">ADHD-friendly personal execution OS: habits, study blocks, agent control (Hermes/MCP), local SQLite</div>
+    </div>
+    <div class="list-cell-stars">★ 23</div>
+  </a>
+    <a class="list-row" href="/projects/Sahil-SS9/hermes-multichannel-prompt-optimizer">
+    <div class="list-rank">32</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">Sahil-SS9 /</span> hermes-multichannel-prompt-optimizer</div>
+      <div class="list-cell-desc">Hermes Agent plugin that rewrites and scores prompts across CLI, TUI, Discord, Telegram, and other surfaces.</div>
+    </div>
+    <div class="list-cell-stars">★ 20</div>
+  </a>
+    <a class="list-row" href="/projects/teixeirazeus/fablize-for-hermes">
+    <div class="list-rank">33</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">teixeirazeus /</span> fablize-for-hermes</div>
+      <div class="list-cell-desc">This project adapts fablize's verified procedures — verification grounding, multi-story evidence gating, investigation protocol, and early-s</div>
+    </div>
+    <div class="list-cell-stars">★ 15</div>
+  </a>
+    <a class="list-row" href="/projects/Sahil-SS9/hermes-simplify-swarm">
+    <div class="list-rank">34</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">Sahil-SS9 /</span> hermes-simplify-swarm</div>
+      <div class="list-cell-desc">Multi-agent code simplification skill for Hermes Agent. 3 parallel sub-agents (Hygiene, Clarity, Correctness) with risk-tiered application. </div>
+    </div>
+    <div class="list-cell-stars">★ 13</div>
+  </a>
+    <a class="list-row" href="/projects/PederHP/skillsdotnet">
+    <div class="list-rank">35</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">PederHP /</span> skillsdotnet</div>
+      <div class="list-cell-desc">C# / .NET implementation of agentskills.io with MCP integration</div>
+    </div>
+    <div class="list-cell-stars">★ 12</div>
+  </a>
+    <a class="list-row" href="/projects/handnewb/hermes-cybersec-lab">
+    <div class="list-rank">36</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">handnewb /</span> hermes-cybersec-lab</div>
+      <div class="list-cell-desc">🛡️ Turnkey cybersecurity lab for Hermes Agent — 397 CVE-driven skills, 152 tools, 28 frameworks (MITRE ATT&amp;CK, MISP, CVSS, EPSS, OWASP, NIS</div>
+    </div>
+    <div class="list-cell-stars">★ 8</div>
+  </a>
+    <a class="list-row" href="/projects/aidevelopers2/remoteopenclaw-mcp">
+    <div class="list-rank">37</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">aidevelopers2 /</span> remoteopenclaw-mcp</div>
+      <div class="list-cell-desc">Search 13,870+ MCP servers, 4,384+ agent skills, and plugins from your terminal or AI agent. CLI + MCP server for remoteopenclaw.com</div>
+    </div>
+    <div class="list-cell-stars">★ 3</div>
+  </a>
+    <a class="list-row" href="/projects/mag3nt-com/openclaw-skill">
+    <div class="list-rank">38</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">mag3nt-com /</span> openclaw-skill</div>
+      <div class="list-cell-desc">Openclaw Skills</div>
+    </div>
+    <div class="list-cell-stars">★ 1</div>
+  </a>
+    <a class="list-row" href="/projects/skillseal/skillseal">
+    <div class="list-rank">39</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">skillseal /</span> skillseal</div>
+      <div class="list-cell-desc">Functional quality seal for AI agent skills. Tests every skill in an isolated Docker environment - structure, functionality and security - a</div>
+    </div>
+    <div class="list-cell-stars">★ 1</div>
+  </a>
+    <a class="list-row" href="/projects/CorsenAI/hermes-windows-runtime-skills">
+    <div class="list-rank">40</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">CorsenAI /</span> hermes-windows-runtime-skills</div>
+      <div class="list-cell-desc">Hermes Agent skills for deterministic path routing and non-installing Python runtime selection across Windows, Git Bash/MSYS, and WSL.</div>
+    </div>
+    <div class="list-cell-stars">★ 1</div>
+  </a>
+    <a class="list-row" href="/projects/webmilmind1/hermes-bounty-board">
+    <div class="list-rank">41</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">webmilmind1 /</span> hermes-bounty-board</div>
+      <div class="list-cell-desc">Hermes Agent plugin: earn USDC answering real support bounties, or run your own bounty board, over x402. No account, no API key. A human app</div>
+    </div>
+    <div class="list-cell-stars">★ 1</div>
+  </a>
+    <a class="list-row" href="/projects/Shine8592/china-briefing">
+    <div class="list-rank">42</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">Shine8592 /</span> china-briefing</div>
+      <div class="list-cell-desc">多尺度中文资讯简报技能 - Multi-scale Chinese news briefing generator for Hermes Agent. From global to street level, with quality gates and AI analysis.</div>
+    </div>
+    <div class="list-cell-stars">★ 0</div>
+  </a>
+    <a class="list-row" href="/projects/jiawood2006/hermes-skills">
+    <div class="list-rank">43</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">jiawood2006 /</span> hermes-skills</div>
+      <div class="list-cell-desc">Hermes Skills: 视频转文字 / AI文案去味 / 文档OCR / 电商素材工坊 (Video-to-text, AI text de-humanizer, OCR, E-commerce Material Studio)</div>
+    </div>
+    <div class="list-cell-stars">★ 0</div>
+  </a>
+    <a class="list-row" href="/projects/scavio-ai/hermes-agent">
+    <div class="list-rank">44</div>
+    <div class="list-cell-body">
+      <div class="list-cell-name"><span class="org">scavio-ai /</span> hermes-agent</div>
+      <div class="list-cell-desc">Scavio for Hermes Agent - structured web data across 31 platforms via the hosted MCP server, plus 5 ready-to-use workflow skills.</div>
+    </div>
+    <div class="list-cell-stars">★ 0</div>
+  </a>
+  </div>
+</section>
+
+<div class="back-link"><a href="/lists/top-skills">← top skills, ranked by stars</a></div>
+
+</main>
+
+<footer class="page-footer">
+  <div class="fn-left">hermes atlas · curated by <a href="https://github.com/ksimback">ksimback</a> · <a href="https://github.com/ksimback/hermes-ecosystem/issues">suggest a repo</a> · <a href="/privacy">privacy</a></div>
+  <div>v2 · 2026.04</div>
+</footer>
+
+<script src="/assets/js/theme-toggle.js" defer></script>
+<script src="/assets/js/masthead-fetch.js" defer></script>
+<!-- Cloudflare Web Analytics -->
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js"
+        data-cf-beacon='{"token": "fe0d4d79280b4386b6b0cd99b2d94dbc"}'></script>
+<!-- End Cloudflare Web Analytics -->
+</body>
+</html>

--- a/tests/build-artifacts.test.js
+++ b/tests/build-artifacts.test.js
@@ -19,6 +19,7 @@ test("generated artifact manifest covers current build outputs", () => {
     "projects/",
     "lists/",
     "use-cases/",
+    "skills/",
     "reports/",
     "sitemap.xml",
     "robots.txt",

--- a/tests/skills-pages.test.js
+++ b/tests/skills-pages.test.js
@@ -1,0 +1,198 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Generated-output assertions, in the style of tests/seo-pages.test.js: the
+// Skills Hub is templated inside build-pages.js, so the committed HTML on disk
+// is the artifact worth guarding. These fail if a rebuild drops the freshness
+// stamp, loses catalog coverage, or breaks /lists/top-skills — the crown-jewel
+// URL the hub is built to defend rather than replace.
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel), "utf-8");
+const readJson = (rel) => JSON.parse(read(rel));
+
+const repos = readJson("data/repos.json");
+const skills = readJson("data/skills.json");
+const latestRelease = readJson("data/latest-release.json");
+
+const SKILLS_CATEGORY = "Skills & Skill Registries";
+const catalog = repos.filter((r) => r.category === SKILLS_CATEGORY);
+const enrichedKeys = new Set(skills.skills.map((s) => `${s.owner}/${s.repo}`));
+
+test("skills hub is canonical, templated, and carries the honest freshness stamp", () => {
+  const html = read("skills/index.html");
+
+  assert.ok(
+    html.includes('<link rel="canonical" href="https://hermesatlas.com/skills/">'),
+    "hub declares its canonical URL"
+  );
+  assert.ok(html.includes('class="masthead"'), "hub uses the shared masthead");
+  assert.ok(html.includes("application/ld+json"), "hub has JSON-LD");
+
+  const stamp = html.match(/<p class="sk-freshness">([\s\S]*?)<\/p>/);
+  assert.ok(stamp, "hub renders a freshness stamp");
+  assert.ok(
+    stamp[1].includes(`Updated ${skills.updatedAt}`),
+    "stamp shows data/skills.json updatedAt, not build day"
+  );
+  assert.ok(
+    stamp[1].includes(`tested against Hermes ${skills.testedAgainst}`),
+    "stamp shows the version the picks were verified against"
+  );
+
+  // The stale warning is the whole point of the stamp: it must appear exactly
+  // when the catalog's Hermes release has moved past the last curation pass.
+  const isStale = skills.testedAgainst !== latestRelease.version;
+  assert.equal(
+    stamp[1].includes("re-verification pending"),
+    isStale,
+    isStale
+      ? `stamp must flag that Hermes ${latestRelease.version} is out`
+      : "stamp must not claim re-verification is pending when it isn't"
+  );
+});
+
+test("skills hub lists every repo in the skills catalog, enriched or not", () => {
+  const html = read("skills/index.html");
+  assert.ok(catalog.length > 0, "catalog category is non-empty");
+  for (const r of catalog) {
+    assert.ok(
+      html.includes(`href="/projects/${r.owner}/${r.repo}"`),
+      `hub links /projects/${r.owner}/${r.repo}`
+    );
+  }
+  assert.ok(
+    html.includes(`the full catalog — ${catalog.length} projects`),
+    "hub states the live catalog size"
+  );
+});
+
+test("skills hub links the ranked list and every per-use-case page", () => {
+  const html = read("skills/index.html");
+  assert.ok(html.includes('href="/lists/top-skills"'), "hub links the ranked list");
+  for (const group of skills.useCases) {
+    assert.ok(
+      html.includes(`href="/skills/for-${group.slug}"`),
+      `hub links /skills/for-${group.slug}`
+    );
+  }
+});
+
+test("each /skills/for-* page is canonical, ranked, and carries FAQ JSON-LD", () => {
+  for (const group of skills.useCases) {
+    const rel = `skills/for-${group.slug}.html`;
+    const html = read(rel);
+
+    assert.ok(
+      html.includes(`<link rel="canonical" href="https://hermesatlas.com/skills/for-${group.slug}">`),
+      `${rel} has a canonical URL`
+    );
+    assert.ok(html.includes(group.title), `${rel} uses the group title as its h1`);
+
+    const ldBlocks = [...html.matchAll(/<script type="application\/ld\+json">\s*([\s\S]*?)\s*<\/script>/g)]
+      .map((m) => JSON.parse(m[1]));
+    const faq = ldBlocks.find((node) => node["@type"] === "FAQPage");
+    assert.ok(faq, `${rel} emits FAQPage JSON-LD`);
+    assert.ok(faq.mainEntity.length >= 2, `${rel} FAQ has at least 2 questions`);
+    assert.ok(
+      faq.mainEntity.some((q) => /how do i install/i.test(q.name)),
+      `${rel} answers the install question`
+    );
+    for (const q of faq.mainEntity) {
+      assert.ok(q.acceptedAnswer?.text?.length > 0, `${rel} FAQ answers are non-empty`);
+    }
+
+    // Every curated entry in the group must be present with its install command.
+    const members = skills.skills.filter((s) => s.useCases.includes(group.slug));
+    assert.ok(members.length >= 2, `${group.slug} has at least 2 picks`);
+    for (const s of members) {
+      assert.ok(
+        html.includes(`href="/projects/${s.owner}/${s.repo}"`),
+        `${rel} links /projects/${s.owner}/${s.repo}`
+      );
+    }
+    assert.ok(html.includes("how we picked"), `${rel} discloses the curation method`);
+  }
+});
+
+test("install box appears on curated project pages and nowhere else", () => {
+  const enriched = skills.skills[0];
+  const enrichedHtml = read(`projects/${enriched.owner}/${enriched.repo}.html`);
+  assert.ok(
+    enrichedHtml.includes('class="install-box"'),
+    `${enriched.owner}/${enriched.repo} renders the install box`
+  );
+  assert.ok(enrichedHtml.includes('class="ib-cmd"'), "install box shows the command");
+  assert.ok(enrichedHtml.includes('href="/skills/"'), "install box links back to the hub");
+
+  const plain = repos.find((r) => !enrichedKeys.has(`${r.owner}/${r.repo}`));
+  assert.ok(plain, "at least one repo has no curated skills entry");
+  assert.ok(
+    !read(`projects/${plain.owner}/${plain.repo}.html`).includes('class="install-box"'),
+    `${plain.owner}/${plain.repo} must not render an install box`
+  );
+});
+
+test("/lists/top-skills keeps its full ranked table and gains only a hub link", () => {
+  const html = read("lists/top-skills.html");
+
+  assert.ok(
+    html.includes('<link rel="canonical" href="https://hermesatlas.com/lists/top-skills">'),
+    "top-skills canonical unchanged"
+  );
+  assert.ok(html.includes('class="list-table"'), "ranked table still present");
+  const rows = html.match(/<a class="list-row" href="\/projects\//g) || [];
+  assert.equal(rows.length, catalog.length, "every skills repo still ranked on top-skills");
+  assert.ok(html.includes('href="/skills/"'), "top-skills links into the hub");
+});
+
+test("sitemap and llms.txt advertise the skills hub", () => {
+  const sitemap = read("sitemap.xml");
+  assert.ok(sitemap.includes("<loc>https://hermesatlas.com/skills/</loc>"), "/skills/ in sitemap");
+  for (const group of skills.useCases) {
+    assert.ok(
+      sitemap.includes(`<loc>https://hermesatlas.com/skills/for-${group.slug}</loc>`),
+      `sitemap has /skills/for-${group.slug}`
+    );
+  }
+
+  const llms = read("llms.txt");
+  assert.ok(llms.includes("## Skills"), "llms.txt has a Skills section");
+  assert.ok(llms.includes("https://hermesatlas.com/skills/"), "llms.txt links the hub");
+  for (const group of skills.useCases) {
+    assert.ok(
+      llms.includes(`https://hermesatlas.com/skills/for-${group.slug}`),
+      `llms.txt lists /skills/for-${group.slug}`
+    );
+  }
+  assert.ok(
+    Buffer.byteLength(read("llms-full.txt"), "utf-8") < 1_000_000,
+    "llms-full.txt stays under the 1 MB ingestion cap"
+  );
+});
+
+test("the skills nav item is on generated and hand-authored pages alike", () => {
+  for (const rel of [
+    "skills/index.html",
+    "lists/index.html",
+    "use-cases/index.html",
+    `projects/${repos[0].owner}/${repos[0].repo}.html`,
+    "index.html",
+    "guide/index.html",
+  ]) {
+    assert.match(
+      read(rel),
+      /<nav class="mast-nav"[\s\S]*?<a href="\/skills\/"[\s\S]*?<\/nav>/,
+      `${rel} masthead links /skills/`
+    );
+  }
+  assert.match(
+    read("skills/index.html"),
+    /<a href="\/skills\/" class="active">skills<\/a>/,
+    "hub marks the skills nav item active"
+  );
+});

--- a/use-cases/agent-that-browses-the-web.html
+++ b/use-cases/agent-that-browses-the-web.html
@@ -128,6 +128,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/" class="active">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/use-cases/always-on-personal-ops-agent.html
+++ b/use-cases/always-on-personal-ops-agent.html
@@ -121,6 +121,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/" class="active">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/use-cases/codebase-aware-coding-agent.html
+++ b/use-cases/codebase-aware-coding-agent.html
@@ -121,6 +121,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/" class="active">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/use-cases/content-engine-in-your-voice.html
+++ b/use-cases/content-engine-in-your-voice.html
@@ -121,6 +121,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/" class="active">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/use-cases/cut-your-token-bill.html
+++ b/use-cases/cut-your-token-bill.html
@@ -121,6 +121,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/" class="active">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/use-cases/daily-research-briefing.html
+++ b/use-cases/daily-research-briefing.html
@@ -121,6 +121,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/" class="active">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/use-cases/fully-self-hosted-private-stack.html
+++ b/use-cases/fully-self-hosted-private-stack.html
@@ -121,6 +121,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/" class="active">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/use-cases/generative-media-studio.html
+++ b/use-cases/generative-media-studio.html
@@ -121,6 +121,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/" class="active">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/use-cases/guardrails-before-it-touches-prod.html
+++ b/use-cases/guardrails-before-it-touches-prod.html
@@ -121,6 +121,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/" class="active">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/use-cases/hermes-in-your-pocket.html
+++ b/use-cases/hermes-in-your-pocket.html
@@ -121,6 +121,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/" class="active">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/use-cases/index.html
+++ b/use-cases/index.html
@@ -168,6 +168,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/" class="active">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/use-cases/multi-agent-build-pipeline.html
+++ b/use-cases/multi-agent-build-pipeline.html
@@ -121,6 +121,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/" class="active">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/use-cases/obsidian-second-brain.html
+++ b/use-cases/obsidian-second-brain.html
@@ -114,6 +114,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/" class="active">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/use-cases/run-hermes-for-your-team.html
+++ b/use-cases/run-hermes-for-your-team.html
@@ -121,6 +121,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/" class="active">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>

--- a/use-cases/see-what-your-agent-is-doing.html
+++ b/use-cases/see-what-your-agent-is-doing.html
@@ -121,6 +121,7 @@
   <nav class="mast-nav" aria-label="Primary">
     <a href="/">map</a>
     <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
     <a href="/use-cases/" class="active">use cases</a>
     <a href="/guide/">handbook</a>
     <a href="/masterclass/">masterclass</a>


### PR DESCRIPTION
## What

Second half of the **/skills/ hub** — the pages and SEO wiring, rendering from `data/skills.json` (PR #860). **Stacked on #860** (base branch `skills-hub-data`); merge that first.

- **`/skills/`** — the flagship decision-layer page: top pick per group, by-use-case sections, a "registries & collections" section (framing: Nous's Skills Hub is the registry, Atlas is the judgment layer), the full 44-repo skills catalog, and a prominent cross-link to `/lists/top-skills`. CollectionPage + BreadcrumbList JSON-LD, canonical, OG image.
- **`/skills/for-{slug}` × 7** — "best hermes skills for X" landers: ranked entries with verdict, install command, compatibility, live stars; "how we picked" note; FAQPage JSON-LD (3 questions each).
- **Honest freshness stamp** — `Updated 2026-08-20 · tested against Hermes v0.20.4`; if `testedAgainst` lags `latest-release.json` the build appends "Hermes vX is out — re-verification pending" (tested both ways).
- **Project pages** — compact install box (command, type badge, compatibility, verdict, link to /skills/) on the 22 curated repos only.
- **Wiring** — "skills" nav item site-wide (10th item — eyeball mobile wrap on the preview); sitemap (`/skills/` 0.9, group pages 0.8, weekly); `## Skills` sections in llms.txt + llms-full (357KB total, cap 1MB); one additive intro paragraph on `/lists/top-skills` linking to the hub — **all existing top-skills content intact** (test-asserted: all 44 ranked rows still present); homepage CTA above the curated-lists section; `skills/` added to `GENERATED_ARTIFACT_PATHS`; `data/skills.json` added to build-pages.yml triggers.

## Notes for review

- The big file count is regenerated pages (231 project pages pick up the nav item; 22 also gain install boxes). Source changes are: `scripts/build-pages.js`, `assets/css/skills.css` (new), `assets/css/page.css`, `lib/build-artifacts.js` (+test), `build-pages.yml`, `index.html` (5-line diff, per-region EOLs preserved).
- Stars on skills pages render live from `repos.json`/metadata, never from `skills.json` — verdicts carry no bakeable star counts.
- Install commands render as selectable `<code>` blocks (no copy button — several are multi-step prose; a JS copy button would need a new script file, deferred).

## Verification

- Offline `node scripts/build-pages.js`: hub + 7 group pages generated, 283 sitemap URLs, no crash, no unstaged-artifact drift.
- `npm test`: **298/298** (8 new jsdom tests: canonical + conditional freshness banner, 44-repo coverage, FAQ JSON-LD per group page, install box present/absent correctly, top-skills integrity + hub link, sitemap/llms coverage, nav propagation).

## Post-merge follow-ups

1. Extend post-deploy smoke route list to `/skills/`.
2. GSC: request indexing for `/skills/` + group pages.
3. QA the 10-item masthead wrap on mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018rNWuEGEjuDprjNEseLpsf
