### PR TITLE
Add thomasbek3/hermes-computer-viewer (Workspaces & GUIs)

### DIFF
--- a/data/repos.json
+++ b/data/repos.json
@@ -2378,5 +2378,15 @@
     "url": "https://github.com/conorbronsdon/agent-skills",
     "official": false,
     "category": "Skills & Skill Registries"
+  },
+  {
+    "owner": "thomasbek3",
+    "repo": "hermes-computer-viewer",
+    "name": "hermes-computer-viewer",
+    "description": "KVM-switch-style live remote-desktop pane for Hermes Desktop. Dockable thumbnail + fullscreen noVNC viewer for cloud boxes (Orgo) and LAN Macs/Windows/Linux machines, with optional H.264 HD streaming and an agent-side plugin that gives bots shell/GUI tools on their pinned computer.",
+    "stars": 0,
+    "url": "https://github.com/thomasbek3/hermes-computer-viewer",
+    "official": false,
+    "category": "Workspaces & GUIs"
   }
 ]


### PR DESCRIPTION
## What

Adds [hermes-computer-viewer](https://github.com/thomasbek3/hermes-computer-viewer) to **Workspaces & GUIs**.

A Hermes Desktop plugin that docks a live remote-desktop pane (noVNC thumbnail, click-to-expand fullscreen) for:

- Orgo cloud computers (session API with per-session credential fetching)
- LAN machines: macOS, Windows, Linux via one-paste bridge installers
- Optional H.264 HD overlay (VideoToolbox / NVENC / VAAPI)

Includes an agent-side companion plugin (`orgo_computer_bash`, `orgo_computer_run`) so bots can actually drive the machine they're pinned to — shell + delegated GUI tasks.

## Checklist (per README criteria)

- [x] Built specifically for Hermes Agent (desktop plugin via public contribution points + agent plugin)
- [x] Created after July 22, 2025
- [x] Not a personal pet project — solves computer-viewing for the agent fleet use case
- [x] Adds ecosystem value: first open-source computer-viewer pane for Hermes Desktop
- [x] Should pass security review: VNC loopback-only bindings, secrets stored 0600 local-only, no telemetry; full history scrubbed and audited
- [x] MIT licensed

10-line addition to `data/repos.json`, no other files touched.