### PR TITLE
Add generated /ecosystem/ catalog page (homepage redesign, PR 1 of 2)

### DIFF
--- a/assets/css/ecosystem.css
+++ b/assets/css/ecosystem.css
@@ -1,0 +1,230 @@
+/* ═══════════════════════════════════════════════════════════════
+   ecosystem.css — /ecosystem/ full catalog page
+   Catalog rules extracted from index.css (category sections, repo
+   rows, search/sort controls, tooltip). Loaded on top of page.css.
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ─── Category section ─────────────────────────────────────── */
+.cat {
+  padding: 40px 40px 48px;
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: 40px;
+  border-bottom: 1px solid var(--rule);
+}
+.cat:last-of-type { border-bottom-color: var(--rule-strong); }
+.cat-meta {
+  position: sticky;
+  top: 40px;
+  align-self: start;
+}
+.cat-num {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--ink-mute);
+  letter-spacing: 0.1em;
+  margin-bottom: 4px;
+}
+.cat-title {
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+  margin-bottom: 10px;
+  color: var(--ink);
+  text-wrap: balance;
+}
+.cat-desc {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--ink-soft);
+  line-height: 1.6;
+}
+.cat-count {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--accent);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px solid var(--rule-strong);
+}
+.cat-count-n { font-variant-numeric: tabular-nums; }
+
+/* ─── Repo row ─────────────────────────────────────────────── */
+.cat-list {
+  display: flex;
+  flex-direction: column;
+}
+.repo-row {
+  display: grid;
+  grid-template-columns: 80px 1fr auto;
+  gap: 24px;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--rule);
+  align-items: baseline;
+  transition: padding 0.12s ease-out, border-bottom-color 0.12s ease-out;
+  color: var(--ink);
+}
+.repo-row:last-child { border-bottom: none; }
+.repo-row:hover {
+  padding-left: 12px;
+  border-bottom-color: var(--rule-strong);
+}
+.repo-stars {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--accent);
+  letter-spacing: -0.01em;
+}
+.repo-body { min-width: 0; }
+.repo-name {
+  font-family: var(--font-display);
+  font-size: 16px;
+  font-weight: 500;
+  letter-spacing: -0.015em;
+  color: var(--ink);
+}
+.repo-name .org {
+  color: var(--ink-mute);
+  font-weight: 400;
+}
+.repo-desc {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--ink-dim);
+  line-height: 1.55;
+  margin-top: 4px;
+}
+.repo-delta {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--positive);
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+.repo-delta.negative { color: var(--negative); }
+.repo-delta.zero { color: var(--ink-mute); }
+.repo-delta .hot {
+  color: var(--accent);
+  margin-left: 6px;
+}
+.repo-flag {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: var(--bg);
+  background: var(--accent);
+  padding: 2px 6px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  margin-left: 8px;
+  font-weight: 600;
+  display: inline-block;
+  vertical-align: 2px;
+}
+
+/* ─── Catalog search + sort (progressive enhancement) ─────────── */
+.catalog-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 14px;
+  padding: 36px 40px 4px;
+}
+.catalog-search {
+  flex: 1 1 320px;
+  min-width: 0;
+  font-family: var(--font-mono);
+  font-size: 15px;
+  color: var(--ink);
+  background: var(--bg-elev);
+  border: 1px solid var(--rule-strong);
+  padding: 12px 14px;
+}
+.catalog-search::placeholder { color: var(--ink-mute); }
+.catalog-search:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.catalog-sort-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--ink-mute);
+}
+.catalog-sort {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  color: var(--ink);
+  background: var(--bg-elev);
+  border: 1px solid var(--rule-strong);
+  padding: 11px 12px;
+  cursor: pointer;
+}
+.catalog-sort:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.catalog-result-count {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--ink-mute);
+  white-space: nowrap;
+}
+
+/* ─── Tooltip ──────────────────────────────────────────────── */
+.tooltip {
+  display: none;
+  position: fixed;
+  background: var(--bg-elev);
+  border: 1px solid var(--rule-strong);
+  padding: 12px 14px;
+  max-width: 340px;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  line-height: 1.55;
+  color: var(--ink-dim);
+  z-index: 1000;
+  pointer-events: none;
+}
+.tt-name {
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 13px;
+  color: var(--ink);
+  margin-bottom: 4px;
+  letter-spacing: -0.01em;
+}
+.tt-desc {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--ink-dim);
+  line-height: 1.55;
+}
+.tt-link {
+  color: var(--accent);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  margin-top: 8px;
+}
+
+/* ─── Responsive ───────────────────────────────────────────── */
+@media (max-width: 1100px) {
+  .cat {
+    grid-template-columns: 1fr;
+    padding: 32px 20px;
+    gap: 20px;
+  }
+  .cat-meta { position: static; }
+  .repo-row {
+    grid-template-columns: 60px 1fr;
+    gap: 16px;
+  }
+  .repo-row .repo-delta {
+    grid-column: 2;
+    grid-row: 2;
+    margin-top: 4px;
+  }
+}
+@media (max-width: 720px) {
+  .catalog-controls { padding: 24px 20px 4px; }
+}

--- a/assets/js/ecosystem.js
+++ b/assets/js/ecosystem.js
@@ -1,0 +1,211 @@
+// /ecosystem/ catalog behavior — carved out of homepage.js when the catalog
+// moved to its own generated page. Covers: repo-row tooltips, live star
+// counts + weekly deltas + trending badges from /api/stars(-history), and the
+// progressive-enhancement search/sort controls. Masthead values are handled
+// by masthead-fetch.js; the theme toggle by theme-toggle.js.
+(function () {
+  // ── Tooltip ──
+  const tooltip = document.getElementById('tooltip');
+  const ttName = document.getElementById('tt-name');
+  const ttDesc = document.getElementById('tt-desc');
+
+  function positionTooltip(e) {
+    const pad = 12;
+    let x = e.clientX + pad, y = e.clientY + pad;
+    const w = 340, h = tooltip.getBoundingClientRect().height || 80;
+    if (x + w > window.innerWidth) x = e.clientX - w - pad;
+    if (y + h > window.innerHeight) y = e.clientY - h - pad;
+    tooltip.style.left = x + 'px';
+    tooltip.style.top = y + 'px';
+  }
+
+  function initTooltips() {
+    if (!tooltip) return;
+    document.querySelectorAll('.repo-row[data-desc]').forEach(item => {
+      item.addEventListener('mouseenter', e => {
+        const nameEl = item.querySelector('.repo-name');
+        ttName.textContent = nameEl ? nameEl.textContent.replace('official', '').trim() : '';
+        ttDesc.textContent = item.getAttribute('data-desc') || '';
+        tooltip.style.display = 'block';
+        positionTooltip(e);
+      });
+      item.addEventListener('mousemove', positionTooltip);
+      item.addEventListener('mouseleave', () => { tooltip.style.display = 'none'; });
+    });
+  }
+  initTooltips();
+
+  // ── Add data-repo attributes to repo rows ──
+  document.querySelectorAll('.repo-row[data-github]').forEach(item => {
+    const match = item.getAttribute('data-github').match(/github\.com\/([^/]+\/[^/]+)/);
+    if (match) item.setAttribute('data-repo', match[1]);
+  });
+
+  function formatStars(n) {
+    if (n >= 1000) return (n / 1000).toFixed(1) + 'K';
+    return String(n);
+  }
+
+  // ── Live star counts + weekly deltas + trending ──
+  async function fetchStars() {
+    try {
+      const [starsRes, historyRes] = await Promise.all([
+        fetch('/api/stars'),
+        fetch('/api/stars-history?days=30').catch(() => null)
+      ]);
+
+      if (!starsRes.ok) return;
+      const data = await starsRes.json();
+
+      let history = null;
+      let historyIsFresh = false;
+      if (historyRes && historyRes.ok) {
+        const histData = await historyRes.json();
+        history = histData.history || [];
+        historyIsFresh = histData.stale === false;
+      }
+
+      if (data.stale) {
+        console.warn('[stars] displaying a stale snapshot:', data.degradedReason || data.source);
+      }
+
+      const timeSeries = {};
+      if (historyIsFresh && history && history.length > 0) {
+        for (const snapshot of history) {
+          for (const [key, stars] of Object.entries(snapshot.data || {})) {
+            if (!timeSeries[key]) timeSeries[key] = [];
+            timeSeries[key].push(stars);
+          }
+        }
+      }
+
+      const deltas = {};
+      const growthPct = {};
+      for (const [key, series] of Object.entries(timeSeries)) {
+        // Require 8 snapshots (= 7 full days, since cron runs daily) before
+        // showing weekly growth — sparse history mislabels "since first
+        // snapshot" as "weekly" and inflates trending badges.
+        if (series.length < 8) continue;
+        const current = series[series.length - 1];
+        const weekAgo = series[series.length - 8];
+        const delta = current - weekAgo;
+        deltas[key] = delta;
+        if (weekAgo > 0) growthPct[key] = (delta / weekAgo) * 100;
+      }
+
+      const trendingSet = new Set(
+        Object.entries(growthPct)
+          .filter(([_, pct]) => pct > 0)
+          .sort((a, b) => b[1] - a[1])
+          .slice(0, 5)
+          .map(([key]) => key)
+      );
+
+      document.querySelectorAll('.repo-row[data-repo]').forEach(item => {
+        const key = item.getAttribute('data-repo');
+        const info = data.repos?.[key];
+        if (!info) return;
+
+        const starsEl = item.querySelector('.repo-stars');
+        if (starsEl) starsEl.textContent = '★ ' + formatStars(info.stars);
+        item.setAttribute('data-stars', info.stars);
+        if (info.updatedAt) item.setAttribute('data-updated', info.updatedAt);
+
+        const deltaEl = item.querySelector('.repo-delta');
+        if (deltaEl) {
+          const delta = deltas[key];
+          if (delta === undefined) {
+            deltaEl.textContent = '— / wk';
+            deltaEl.className = 'repo-delta zero';
+          } else if (delta === 0) {
+            deltaEl.textContent = '0 / wk';
+            deltaEl.className = 'repo-delta zero';
+          } else if (delta > 0) {
+            deltaEl.innerHTML = '+' + formatStars(delta) + ' / wk' + (trendingSet.has(key) ? '<span class="hot"> · hot</span>' : '');
+            deltaEl.className = 'repo-delta';
+          } else {
+            deltaEl.textContent = '-' + formatStars(Math.abs(delta)) + ' / wk';
+            deltaEl.className = 'repo-delta negative';
+          }
+        }
+      });
+    } catch (e) {
+      console.log('Stars API unavailable, using static counts', e);
+    }
+  }
+
+  // Catalog search + sort (progressive enhancement). Reveals the controls
+  // (hidden by default so no-JS users get the full browsable list) and wires
+  // live text filtering + within-category sorting over the existing repo rows.
+  function initCatalogControls() {
+    const controls = document.getElementById('catalog-controls');
+    if (!controls) return;
+    const search = document.getElementById('catalog-search');
+    const sortSel = document.getElementById('catalog-sort');
+    const countEl = document.getElementById('catalog-result-count');
+    const sections = Array.from(document.querySelectorAll('section.cat'));
+    const rows = [];
+    sections.forEach(sec => {
+      sec.querySelectorAll('.repo-row').forEach(row => {
+        const slug = (row.getAttribute('href') || '').replace('/projects/', '').toLowerCase();
+        const desc = (row.getAttribute('data-desc') || '').toLowerCase();
+        rows.push({ row, sec, hay: slug + ' ' + desc });
+      });
+    });
+    const starsOf = row => {
+      const attr = row.getAttribute('data-stars');
+      if (attr) return parseInt(attr, 10) || 0;
+      const el = row.querySelector('.repo-stars');
+      return el ? parseInt(el.textContent.replace(/[^0-9]/g, ''), 10) || 0 : 0;
+    };
+    const nameOf = row => (row.getAttribute('href') || '').toLowerCase();
+    const updatedOf = row => row.getAttribute('data-updated') || '';
+    function applyFilter() {
+      const q = search.value.trim().toLowerCase();
+      let visible = 0;
+      rows.forEach(({ row, hay }) => {
+        const show = !q || hay.indexOf(q) !== -1;
+        row.style.display = show ? '' : 'none';
+        if (show) visible++;
+      });
+      sections.forEach(sec => {
+        const any = Array.from(sec.querySelectorAll('.repo-row')).some(r => r.style.display !== 'none');
+        sec.style.display = any ? '' : 'none';
+      });
+      countEl.textContent = q ? visible + ' match' + (visible === 1 ? '' : 'es') : '';
+    }
+    function applySort() {
+      const key = sortSel.value;
+      document.querySelectorAll('.cat-list').forEach(list => {
+        Array.from(list.querySelectorAll('.repo-row'))
+          .sort((a, b) => {
+            if (key === 'name') return nameOf(a).localeCompare(nameOf(b));
+            if (key === 'active') return updatedOf(b).localeCompare(updatedOf(a));
+            return starsOf(b) - starsOf(a);
+          })
+          .forEach(it => list.appendChild(it));
+      });
+    }
+    search.addEventListener('input', applyFilter);
+    sortSel.addEventListener('change', applySort);
+    controls.hidden = false;
+    applySort();
+  }
+
+  // Initialize data-stars from current star text. Must run before
+  // initCatalogControls(): its initial sort reads data-stars, and its
+  // text-parsing fallback can't handle "1.2K"-style abbreviations.
+  document.querySelectorAll('.repo-row').forEach(item => {
+    const starsEl = item.querySelector('.repo-stars');
+    if (starsEl && !item.getAttribute('data-stars')) {
+      const text = starsEl.textContent.replace('★', '').trim().replace(',', '');
+      let val = 0;
+      if (text.includes('K')) val = parseFloat(text) * 1000;
+      else val = parseInt(text) || 0;
+      item.setAttribute('data-stars', val);
+    }
+  });
+
+  fetchStars();
+  initCatalogControls();
+})();

--- a/data/categories.json
+++ b/data/categories.json
@@ -1,0 +1,74 @@
+[
+  {
+    "category": "Core & Official",
+    "num": "§01",
+    "title": "Core & official",
+    "description": "Repositories maintained directly by Nous Research — the official stack."
+  },
+  {
+    "category": "Workspaces & GUIs",
+    "num": "§02",
+    "title": "Workspaces & GUIs",
+    "description": "Web and desktop interfaces — chat UIs, memory browsers, config dashboards."
+  },
+  {
+    "category": "Skills & Skill Registries",
+    "num": "§03",
+    "title": "Skills & skill registries",
+    "description": "Reusable capabilities following the agentskills.io open standard — libraries, registries, and meta-tools."
+  },
+  {
+    "category": "Memory & Context",
+    "num": "§04",
+    "title": "Memory & context",
+    "description": "Long-term semantic memory, graph-based retrieval, cross-session persistence."
+  },
+  {
+    "category": "Plugins & Extensions",
+    "num": "§05",
+    "title": "Plugins & extensions",
+    "description": "Drop-in modules that add tools, safety, payments, or new capabilities."
+  },
+  {
+    "category": "Multi-Agent & Orchestration",
+    "num": "§06",
+    "title": "Multi-agent & orchestration",
+    "description": "Fleet management, swarm coordinators, and multi-agent delegation systems."
+  },
+  {
+    "category": "Deployment & Infra",
+    "num": "§07",
+    "title": "Deployment & infra",
+    "description": "Docker, Nix, systemd, and managed cloud templates — from a $5 VPS to enterprise Kubernetes."
+  },
+  {
+    "category": "Integrations & Bridges",
+    "num": "§08",
+    "title": "Integrations & bridges",
+    "description": "Connect Hermes to other agents, platforms, and specialized systems."
+  },
+  {
+    "category": "Developer Tools",
+    "num": "§09",
+    "title": "Developer tools",
+    "description": "CLIs, linters, migration helpers, token trackers, and other dev utilities."
+  },
+  {
+    "category": "Domain Applications",
+    "num": "§10",
+    "title": "Domain applications",
+    "description": "Purpose-built agents for specific verticals — SRE, jobs, gaming, blockchain, robotics."
+  },
+  {
+    "category": "Guides & Docs",
+    "num": "§11",
+    "title": "Guides & docs",
+    "description": "Curated lists, optimization playbooks, setup walkthroughs, and community wikis."
+  },
+  {
+    "category": "Forks & Derivatives",
+    "num": "§12",
+    "title": "Forks & derivatives",
+    "description": "Patched, cloud-deployed, or fine-tuned variants of Hermes Agent."
+  }
+]

--- a/data/repos.json
+++ b/data/repos.json
@@ -287,7 +287,8 @@
     "stars": 64302,
     "url": "https://github.com/mem0ai/mem0",
     "official": false,
-    "category": "Memory & Context"
+    "category": "Memory & Context",
+    "blurb": "Universal memory layer for AI Agents — official Hermes Agent memory provider, managed cloud or Apache-2.0 self-hosted OSS"
   },
   {
     "owner": "vectorize-io",
@@ -1117,7 +1118,8 @@
     "stars": 888,
     "url": "https://github.com/xaspx/hermes-control-interface",
     "official": false,
-    "category": "Workspaces & GUIs"
+    "category": "Workspaces & GUIs",
+    "blurb": "Self-hosted web dashboard — terminal, file explorer, cron, metrics, and agent status panel"
   },
   {
     "owner": "ksimback",
@@ -1127,7 +1129,8 @@
     "stars": 1237,
     "url": "https://github.com/ksimback/hermes-ecosystem",
     "official": false,
-    "category": "Guides & Docs"
+    "category": "Guides & Docs",
+    "blurb": "Hermes Atlas — the community map of every tool, skill, and integration for Hermes Agent"
   },
   {
     "owner": "dodo-reach",
@@ -1207,7 +1210,8 @@
     "stars": 1087,
     "url": "https://github.com/stephenschoettler/hermes-lcm",
     "official": false,
-    "category": "Memory & Context"
+    "category": "Memory & Context",
+    "blurb": "Lossless Context Management — DAG-based context engine that never loses a message"
   },
   {
     "owner": "Codename-11",
@@ -1437,7 +1441,8 @@
     "stars": 34222,
     "url": "https://github.com/volcengine/OpenViking",
     "official": false,
-    "category": "Memory & Context"
+    "category": "Memory & Context",
+    "blurb": "Filesystem-first context database — official Hermes memory provider with tiered loading and 91% token reduction on LoCoMo10"
   },
   {
     "owner": "supermemoryai",
@@ -1447,7 +1452,8 @@
     "stars": 29126,
     "url": "https://github.com/supermemoryai/supermemory",
     "official": false,
-    "category": "Memory & Context"
+    "category": "Memory & Context",
+    "blurb": "Memory engine and API — official Hermes provider with sub-300ms recall at 100B+ tokens/month and context fencing"
   },
   {
     "owner": "campfirein",
@@ -1457,7 +1463,8 @@
     "stars": 4950,
     "url": "https://github.com/campfirein/byterover-cli",
     "official": false,
-    "category": "Memory & Context"
+    "category": "Memory & Context",
+    "blurb": "ByteRover CLI (brv) — official Hermes memory provider storing memory as a git-versionable markdown context tree"
   },
   {
     "owner": "yantrikos",
@@ -1467,7 +1474,8 @@
     "stars": 84,
     "url": "https://github.com/yantrikos/yantrikdb-hermes-plugin",
     "official": false,
-    "category": "Memory & Context"
+    "category": "Memory & Context",
+    "blurb": "Self-maintaining Hermes memory plugin with explainable retrieval — every recall comes with a why_retrieved tag"
   },
   {
     "owner": "Ladybug-Memory",
@@ -1477,7 +1485,8 @@
     "stars": 21,
     "url": "https://github.com/Ladybug-Memory/hermes-memory-plugin",
     "official": false,
-    "category": "Memory & Context"
+    "category": "Memory & Context",
+    "blurb": "Local-only Hermes memory plugin with built-in 1-10 importance ranking so what matters most surfaces first"
   },
   {
     "owner": "MukundaKatta",
@@ -1487,7 +1496,8 @@
     "stars": 10,
     "url": "https://github.com/MukundaKatta/hermes-agentmemory",
     "official": false,
-    "category": "Memory & Context"
+    "category": "Memory & Context",
+    "blurb": "Pull-model Hermes memory plugin with real deletion (no persistent summaries) and full audit trace"
   },
   {
     "owner": "BORT-AGENTS",

--- a/ecosystem/index.html
+++ b/ecosystem/index.html
@@ -1,0 +1,2282 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Hermes Agent Ecosystem — 240+ open-source tools, skills &amp; integrations | Hermes Atlas</title>
+<meta name="description" content="The complete Hermes Agent ecosystem catalog — 240+ open-source tools, skills, plugins, workspaces, and integrations across 12 categories, with live GitHub data. Quality-filtered and curated weekly.">
+<link rel="canonical" href="https://hermesatlas.com/ecosystem/">
+<meta property="og:title" content="The Hermes Agent Ecosystem">
+<meta property="og:description" content="The complete Hermes Agent ecosystem catalog — 240+ open-source tools, skills, plugins, workspaces, and integrations across 12 categories, with live GitHub data. Quality-filtered and curated weekly.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://hermesatlas.com/ecosystem/">
+<meta property="og:site_name" content="Hermes Atlas">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=The+Hermes+Agent+Ecosystem&amp;subtitle=240%2B+open-source+tools%2C+skills%2C+plugins+%26+integrations+%E2%80%94+live+GitHub+data&amp;kind=lists">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="The Hermes Agent Ecosystem">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=The+Hermes+Agent+Ecosystem&amp;subtitle=240%2B+open-source+tools%2C+skills%2C+plugins+%26+integrations+%E2%80%94+live+GitHub+data&amp;kind=lists">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "home",
+      "item": "https://hermesatlas.com/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "ecosystem"
+    }
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "@id": "https://hermesatlas.com/ecosystem/",
+  "name": "The Hermes Agent Ecosystem — full catalog",
+  "description": "The complete Hermes Agent ecosystem catalog — 240+ open-source tools, skills, plugins, workspaces, and integrations across 12 categories, with live GitHub data. Quality-filtered and curated weekly.",
+  "url": "https://hermesatlas.com/ecosystem/",
+  "isPartOf": {
+    "@id": "https://hermesatlas.com/#website"
+  },
+  "mainEntity": {
+    "@id": "https://hermesatlas.com/#catalog"
+  }
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "@id": "https://hermesatlas.com/#catalog",
+  "name": "Hermes Agent Ecosystem Catalog",
+  "description": "Machine-readable catalog of community-built tools, skills, plugins, workspaces, and integrations for Nous Research's Hermes Agent. 240+ projects across 12 categories with live GitHub metadata and AI-generated summaries.",
+  "url": "https://hermesatlas.com/ecosystem/",
+  "keywords": "Hermes Agent, Nous Research, AI agents, LLM tools, agent skills, MCP servers, agent plugins",
+  "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+  "isAccessibleForFree": true,
+  "creator": {
+    "@id": "https://hermesatlas.com/#organization"
+  },
+  "publisher": {
+    "@id": "https://hermesatlas.com/#organization"
+  },
+  "distribution": [
+    {
+      "@type": "DataDownload",
+      "encodingFormat": "application/json",
+      "contentUrl": "https://hermesatlas.com/data/repos.json"
+    },
+    {
+      "@type": "DataDownload",
+      "encodingFormat": "application/json",
+      "contentUrl": "https://hermesatlas.com/data/summaries.json"
+    },
+    {
+      "@type": "DataDownload",
+      "encodingFormat": "application/json",
+      "contentUrl": "https://hermesatlas.com/data/list-summaries.json"
+    },
+    {
+      "@type": "DataDownload",
+      "encodingFormat": "text/plain",
+      "contentUrl": "https://hermesatlas.com/llms-full.txt"
+    },
+    {
+      "@type": "DataDownload",
+      "encodingFormat": "application/xml",
+      "contentUrl": "https://hermesatlas.com/sitemap.xml"
+    }
+  ]
+}
+</script>
+<link rel="alternate" type="application/rss+xml" title="Hermes Atlas — new projects" href="/rss.xml">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+<link rel="apple-touch-icon" href="/apple-touch-icon.png">
+<link rel="manifest" href="/site.webmanifest">
+<script src="/assets/js/theme-init.js"></script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap">
+<link rel="stylesheet" href="/assets/css/tokens.css">
+<link rel="stylesheet" href="/assets/css/base.css">
+<link rel="stylesheet" href="/assets/css/page.css">
+<link rel="stylesheet" href="/assets/css/ecosystem.css">
+</head>
+<body>
+
+<a class="skip-link" href="#main">Skip to content</a>
+
+<header class="masthead">
+  <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
+  <div class="mast-meta" aria-label="Site metadata">
+    <span id="meta-count">244·repos</span>
+    <span id="meta-version">hermes·v0.20.6</span>
+    <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
+  </div>
+  <nav class="mast-nav" aria-label="Primary">
+    <a href="/">map</a>
+    <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
+    <a href="/use-cases/">use cases</a>
+    <a href="/guide/">handbook</a>
+    <a href="/masterclass/">masterclass</a>
+    <a href="/dev/">dev</a>
+    <a href="/reports/">reports</a>
+    <a href="/#newsletter">newsletter</a>
+    <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
+  </nav>
+  <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
+  </button>
+</header>
+
+<div class="breadcrumb" aria-label="Breadcrumb">
+  <a href="/">home</a><span class="sep">/</span>ecosystem
+</div>
+
+<main id="main">
+
+<section class="list-page">
+  <h1 class="list-title">The Hermes Agent ecosystem</h1>
+  <p class="list-intro">Every open-source tool, skill, plugin, workspace, and integration in the Hermes Agent ecosystem — <strong>244 projects across 12 categories</strong>, quality-filtered, with live GitHub data. Know what you want to build? <a href="/use-cases/">Find repos by use case →</a> Looking for skills? <a href="/skills/">Best picks by use case →</a></p>
+</section>
+
+<!-- Catalog search + sort. Progressive enhancement: hidden by default and
+     revealed + wired by initCatalogControls(); with JS off, the full
+     categorized list below stays fully browsable. -->
+<div class="catalog-controls" id="catalog-controls" hidden>
+  <input type="search" id="catalog-search" class="catalog-search" placeholder="filter projects by name or description…" aria-label="Filter projects">
+  <label class="catalog-sort-wrap">
+    <span class="catalog-sort-label">sort</span>
+    <select id="catalog-sort" class="catalog-sort" aria-label="Sort projects">
+      <option value="stars">most stars</option>
+      <option value="name">name a–z</option>
+      <option value="active">recently active</option>
+    </select>
+  </label>
+  <span class="catalog-result-count" id="catalog-result-count" aria-live="polite"></span>
+</div>
+
+<section class="cat" data-category="Core &amp; Official">
+  <div class="cat-meta">
+    <div class="cat-num">§01</div>
+    <h2 class="cat-title">Core &amp; official</h2>
+    <p class="cat-desc">Repositories maintained directly by Nous Research — the official stack.</p>
+    <div class="cat-count"><span class="cat-count-n">6</span> repos</div>
+  </div>
+  <div class="cat-list">
+    <a class="repo-row" href="/projects/NousResearch/hermes-agent" data-github="https://github.com/NousResearch/hermes-agent" data-desc="The self-improving AI agent that grows with you — persistent memory, auto-generated skills, 14 platforms, 6 execution backends">
+      <div class="repo-stars">★ 237,940</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">NousResearch /</span> hermes-agent <span class="repo-flag">official</span></div>
+        <div class="repo-desc">The self-improving AI agent that grows with you — persistent memory, auto-generated skills, 14 platforms, 6 execution backends.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/NousResearch/hermes-agent-self-evolution" data-github="https://github.com/NousResearch/hermes-agent-self-evolution" data-desc="Evolutionary self-improvement using DSPy + GEPA — optimizes skills, prompts, and code">
+      <div class="repo-stars">★ 5,190</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">NousResearch /</span> hermes-agent-self-evolution <span class="repo-flag">official</span></div>
+        <div class="repo-desc">Evolutionary self-improvement using DSPy + GEPA — optimizes skills, prompts, and code.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/NousResearch/hermes-paperclip-adapter" data-github="https://github.com/NousResearch/hermes-paperclip-adapter" data-desc="Run Hermes as a managed employee in Paperclip company systems">
+      <div class="repo-stars">★ 1,844</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">NousResearch /</span> hermes-paperclip-adapter <span class="repo-flag">official</span></div>
+        <div class="repo-desc">Run Hermes as a managed employee in Paperclip company systems.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/NousResearch/autonovel" data-github="https://github.com/NousResearch/autonovel" data-desc="Autonomous novel-writing pipeline generating 100k+ word manuscripts">
+      <div class="repo-stars">★ 1,529</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">NousResearch /</span> autonovel <span class="repo-flag">official</span></div>
+        <div class="repo-desc">Autonomous novel-writing pipeline generating 100k+ word manuscripts.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/NousResearch/Hermes-Function-Calling" data-github="https://github.com/NousResearch/Hermes-Function-Calling" data-desc="Function calling examples and training data for Hermes LLM models">
+      <div class="repo-stars">★ 1,461</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">NousResearch /</span> Hermes-Function-Calling <span class="repo-flag">official</span></div>
+        <div class="repo-desc">Function calling examples and training data for Hermes LLM models.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/NousResearch/atropos" data-github="https://github.com/NousResearch/atropos" data-desc="RL training environments framework for tool-calling models">
+      <div class="repo-stars">★ 1,350</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">NousResearch /</span> atropos <span class="repo-flag">official</span></div>
+        <div class="repo-desc">RL training environments framework for tool-calling models.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+  </div>
+</section>
+
+<section class="cat" data-category="Workspaces &amp; GUIs">
+  <div class="cat-meta">
+    <div class="cat-num">§02</div>
+    <h2 class="cat-title">Workspaces &amp; GUIs</h2>
+    <p class="cat-desc">Web and desktop interfaces — chat UIs, memory browsers, config dashboards.</p>
+    <div class="cat-count"><span class="cat-count-n">24</span> repos</div>
+  </div>
+  <div class="cat-list">
+    <a class="repo-row" href="/projects/farion1231/cc-switch" data-github="https://github.com/farion1231/cc-switch" data-desc="Cross-platform all-in-one manager for Claude Code, Codex, OpenCode, OpenClaw, Gemini CLI, and Hermes Agent">
+      <div class="repo-stars">★ 130,038</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">farion1231 /</span> cc-switch</div>
+        <div class="repo-desc">Cross-platform all-in-one manager for Claude Code, Codex, OpenCode, OpenClaw, Gemini CLI, and Hermes Agent.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/iOfficeAI/AionUi" data-github="https://github.com/iOfficeAI/AionUi" data-desc="Local open-source cowork app for OpenClaw, Hermes Agent, Claude Code, Codex, OpenCode, Gemini CLI, and other agent CLIs">
+      <div class="repo-stars">★ 32,390</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">iOfficeAI /</span> AionUi</div>
+        <div class="repo-desc">Local open-source cowork app for OpenClaw, Hermes Agent, Claude Code, Codex, OpenCode, Gemini CLI, and other agent CLIs.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/nesquena/hermes-webui" data-github="https://github.com/nesquena/hermes-webui" data-desc="Hermes WebUI: The best way to use Hermes Agent from the web or from your phone!">
+      <div class="repo-stars">★ 17,856</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">nesquena /</span> hermes-webui</div>
+        <div class="repo-desc">Hermes WebUI: The best way to use Hermes Agent from the web or from your phone!.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/fathah/hermes-desktop" data-github="https://github.com/fathah/hermes-desktop" data-desc="Desktop companion app for installing, configuring, and chatting with Hermes Agent">
+      <div class="repo-stars">★ 14,065</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">fathah /</span> hermes-desktop</div>
+        <div class="repo-desc">Desktop companion app for installing, configuring, and chatting with Hermes Agent.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/EKKOLearnAI/hermes-studio" data-github="https://github.com/EKKOLearnAI/hermes-studio" data-desc="Web dashboard for Hermes Agent — multi-platform AI chat, session management, scheduled jobs, usage analytics &amp; channel configuration (Telegram, Discord, Slack, WhatsApp)">
+      <div class="repo-stars">★ 10,673</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">EKKOLearnAI /</span> hermes-studio</div>
+        <div class="repo-desc">Web dashboard for Hermes Agent — multi-platform AI chat, session management, scheduled jobs, usage analytics &amp; channel configuration (Telegram, Discord, Slack, WhatsApp).</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/outsourc-e/hermes-workspace" data-github="https://github.com/outsourc-e/hermes-workspace" data-desc="Native web workspace — chat, terminal, memory browser, skills manager, and inspector panel">
+      <div class="repo-stars">★ 6,533</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">outsourc-e /</span> hermes-workspace</div>
+        <div class="repo-desc">Native web workspace — chat, terminal, memory browser, skills manager, and inspector panel.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/xintaofei/codeg" data-github="https://github.com/xintaofei/codeg" data-desc="Collaborative multi-agent coding workspace that aggregates sessions from Hermes, Claude Code, Codex, OpenCode, and others as a desktop or self-hosted app.">
+      <div class="repo-stars">★ 3,050</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">xintaofei /</span> codeg</div>
+        <div class="repo-desc">Collaborative multi-agent coding workspace that aggregates sessions from Hermes, Claude Code, Codex, OpenCode, and others as a desktop or self-hosted app.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/dodo-reach/hermes-desktop" data-github="https://github.com/dodo-reach/hermes-desktop" data-desc="A native Mac workspace for Hermes: real SSH, real terminal, real session data.">
+      <div class="repo-stars">★ 2,005</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">dodo-reach /</span> hermes-desktop</div>
+        <div class="repo-desc">A native Mac workspace for Hermes: real SSH, real terminal, real session data.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Eynzof/Hermes-CN-Desktop" data-github="https://github.com/Eynzof/Hermes-CN-Desktop" data-desc="Windows-first Chinese desktop app for Hermes Agent built with Tauri, TypeScript, and Rust">
+      <div class="repo-stars">★ 1,636</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Eynzof /</span> Hermes-CN-Desktop</div>
+        <div class="repo-desc">Windows-first Chinese desktop app for Hermes Agent built with Tauri, TypeScript, and Rust.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/abundantbeing/hermes-browser-extension" data-github="https://github.com/abundantbeing/hermes-browser-extension" data-desc="Chromium side-panel extension that connects active browser context to a local or remote Hermes Agent runtime">
+      <div class="repo-stars">★ 1,452</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">abundantbeing /</span> hermes-browser-extension</div>
+        <div class="repo-desc">Chromium side-panel extension that connects active browser context to a local or remote Hermes Agent runtime.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/uzairansaruzi/hermex" data-github="https://github.com/uzairansaruzi/hermex" data-desc="Native SwiftUI iPhone app for driving a self-hosted Hermes agent from your phone, pairing with a hermes-webui server.">
+      <div class="repo-stars">★ 1,175</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">uzairansaruzi /</span> hermex</div>
+        <div class="repo-desc">Native SwiftUI iPhone app for driving a self-hosted Hermes agent from your phone, pairing with a hermes-webui server.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/freestylefly/wesight" data-github="https://github.com/freestylefly/wesight" data-desc="Desktop AI agent workspace with one-click setup for Hermes Agent, Claude Code, Codex, and OpenClaw, plus custom LLM model routing.">
+      <div class="repo-stars">★ 904</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">freestylefly /</span> wesight</div>
+        <div class="repo-desc">Desktop AI agent workspace with one-click setup for Hermes Agent, Claude Code, Codex, and OpenClaw, plus custom LLM model routing.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/joeynyc/hermes-hud" data-github="https://github.com/joeynyc/hermes-hud" data-desc="TUI consciousness monitor for Hermes">
+      <div class="repo-stars">★ 900</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">joeynyc /</span> hermes-hud</div>
+        <div class="repo-desc">TUI consciousness monitor for Hermes.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/xaspx/hermes-control-interface" data-github="https://github.com/xaspx/hermes-control-interface" data-desc="Self-hosted web dashboard — terminal, file explorer, cron, metrics, and agent status panel">
+      <div class="repo-stars">★ 888</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">xaspx /</span> hermes-control-interface</div>
+        <div class="repo-desc">Self-hosted web dashboard — terminal, file explorer, cron, metrics, and agent status panel.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/jazzyalex/agent-sessions" data-github="https://github.com/jazzyalex/agent-sessions" data-desc="Native macOS session browser, agent cockpit, analytics, and limits tracker for Hermes agents and other coding-agent CLIs">
+      <div class="repo-stars">★ 819</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">jazzyalex /</span> agent-sessions</div>
+        <div class="repo-desc">Native macOS session browser, agent cockpit, analytics, and limits tracker for Hermes agents and other coding-agent CLIs.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/nickvasilescu/hermes-desktop-os1" data-github="https://github.com/nickvasilescu/hermes-desktop-os1" data-desc="Native macOS workspace for Hermes Agent running on Orgo cloud computers and SSH hosts">
+      <div class="repo-stars">★ 528</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">nickvasilescu /</span> hermes-desktop-os1</div>
+        <div class="repo-desc">Native macOS workspace for Hermes Agent running on Orgo cloud computers and SSH hosts.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/sharbelxyz/hermes-agent-mission-control" data-github="https://github.com/sharbelxyz/hermes-agent-mission-control" data-desc="Self-hostable mission-control dashboard template that pairs with your own local Hermes agent over a Postgres message bus.">
+      <div class="repo-stars">★ 358</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">sharbelxyz /</span> hermes-agent-mission-control</div>
+        <div class="repo-desc">Self-hostable mission-control dashboard template that pairs with your own local Hermes agent over a Postgres message bus.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/liftaris/herm" data-github="https://github.com/liftaris/herm" data-desc="Alternative Hermes TUI and dashboard built with OpenTUI.">
+      <div class="repo-stars">★ 293</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">liftaris /</span> herm</div>
+        <div class="repo-desc">Alternative Hermes TUI and dashboard built with OpenTUI.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/clawvader-tech/hermes-telegram-miniapp" data-github="https://github.com/clawvader-tech/hermes-telegram-miniapp" data-desc="React SPA dashboard for Telegram Mini App v2.0 — 10-page mobile-first UI. Runs locally.">
+      <div class="repo-stars">★ 264</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">clawvader-tech /</span> hermes-telegram-miniapp</div>
+        <div class="repo-desc">React SPA dashboard for Telegram Mini App v2.0 — 10-page mobile-first UI. Runs locally.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/aivrar/portable-hermes-agent" data-github="https://github.com/aivrar/portable-hermes-agent" data-desc="Hermes Agent made portable desktop for Windows — 100 tools, GUI, local models via LM Studio, TTS, Music, ComfyUI, workflows, tool maker. No install. No Docker. No admin rights.">
+      <div class="repo-stars">★ 211</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">aivrar /</span> portable-hermes-agent</div>
+        <div class="repo-desc">Hermes Agent made portable desktop for Windows — 100 tools, GUI, local models via LM Studio, TTS, Music, ComfyUI, workflows, tool maker. No install. No Docker. No admin rights.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/pyrate-llama/hermes-ui" data-github="https://github.com/pyrate-llama/hermes-ui" data-desc="Glassmorphic web interface for Hermes Agent — your self-hosted AI assistant">
+      <div class="repo-stars">★ 196</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">pyrate-llama /</span> hermes-ui</div>
+        <div class="repo-desc">Glassmorphic web interface for Hermes Agent — your self-hosted AI assistant.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/sanchomuzax/hermes-webui" data-github="https://github.com/sanchomuzax/hermes-webui" data-desc="Process monitoring and configuration dashboard for Hermes">
+      <div class="repo-stars">★ 114</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">sanchomuzax /</span> hermes-webui</div>
+        <div class="repo-desc">Process monitoring and configuration dashboard for Hermes.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Euraika-Labs/pan-ui" data-github="https://github.com/Euraika-Labs/pan-ui" data-desc="Self-hosted AI workspace with chat, skills, extensions, memory, profiles, and runtime controls">
+      <div class="repo-stars">★ 99</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Euraika-Labs /</span> pan-ui</div>
+        <div class="repo-desc">Self-hosted AI workspace with chat, skills, extensions, memory, profiles, and runtime controls.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Felix-Forever/hermes-agent-desktop" data-github="https://github.com/Felix-Forever/hermes-agent-desktop" data-desc="Multi-agent Hermes Agent desktop client with specialists, visual skill store, PM orchestrator, and streaming chat">
+      <div class="repo-stars">★ 63</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Felix-Forever /</span> hermes-agent-desktop</div>
+        <div class="repo-desc">Multi-agent Hermes Agent desktop client with specialists, visual skill store, PM orchestrator, and streaming chat.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+  </div>
+</section>
+
+<section class="cat" data-category="Skills &amp; Skill Registries">
+  <div class="cat-meta">
+    <div class="cat-num">§03</div>
+    <h2 class="cat-title">Skills &amp; skill registries</h2>
+    <p class="cat-desc">Reusable capabilities following the agentskills.io open standard — libraries, registries, and meta-tools.</p>
+    <div class="cat-count"><span class="cat-count-n">48</span> repos</div>
+  </div>
+  <div class="cat-list">
+    <a class="repo-row" href="/projects/obra/superpowers" data-github="https://github.com/obra/superpowers" data-desc="An agentic skills framework &amp; software development methodology that works.">
+      <div class="repo-stars">★ 279,236</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">obra /</span> superpowers</div>
+        <div class="repo-desc">An agentic skills framework &amp; software development methodology that works.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/nexu-io/open-design" data-github="https://github.com/nexu-io/open-design" data-desc="Local-first open-source design/prototyping system with coding-agent CLI support including Hermes Agent">
+      <div class="repo-stars">★ 92,528</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">nexu-io /</span> open-design</div>
+        <div class="repo-desc">Local-first open-source design/prototyping system with coding-agent CLI support including Hermes Agent.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/mukul975/Anthropic-Cybersecurity-Skills" data-github="https://github.com/mukul975/Anthropic-Cybersecurity-Skills" data-desc="754 structured cybersecurity skills mapped to MITRE ATT&amp;CK, NIST CSF 2.0, ATLAS, D3FEND &amp; NIST AI RMF">
+      <div class="repo-stars">★ 31,573</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">mukul975 /</span> Anthropic-Cybersecurity-Skills</div>
+        <div class="repo-desc">754 structured cybersecurity skills mapped to MITRE ATT&amp;CK, NIST CSF 2.0, ATLAS, D3FEND &amp; NIST AI RMF.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/topoteretes/cognee" data-github="https://github.com/topoteretes/cognee" data-desc="Cognee is the open-source AI memory platform for agents. Give your AI agents persistent long-term memory across sessions with a self-hosted knowledge graph engine.">
+      <div class="repo-stars">★ 30,334</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">topoteretes /</span> cognee</div>
+        <div class="repo-desc">Cognee is the open-source AI memory platform for agents. Give your AI agents persistent long-term memory across sessions with a self-hosted knowledge graph engine.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Agents365-ai/drawio-skill" data-github="https://github.com/Agents365-ai/drawio-skill" data-desc="Generate draw.io diagrams from natural language descriptions">
+      <div class="repo-stars">★ 8,266</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Agents365-ai /</span> drawio-skill</div>
+        <div class="repo-desc">Generate draw.io diagrams from natural language descriptions.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/internet-court/internet-court-skill" data-github="https://github.com/internet-court/internet-court-skill" data-desc="The trust layer for agent-to-agent commerce — natural-language mandates, ERC-7710 delegated permissions, x402 payments, escrow, and dispute resolution as one open, catch-all Agent Skill / Claude Code">
+      <div class="repo-stars">★ 4,991</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">internet-court /</span> internet-court-skill</div>
+        <div class="repo-desc">The trust layer for agent-to-agent commerce — natural-language mandates, ERC-7710 delegated permissions, x402 payments, escrow, and dispute resolution as one open, catch-all Agent Skill / Claude Code.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/conorbronsdon/avoid-ai-writing" data-github="https://github.com/conorbronsdon/avoid-ai-writing" data-desc="Audits and rewrites content to eliminate detectable AI writing patterns">
+      <div class="repo-stars">★ 3,709</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">conorbronsdon /</span> avoid-ai-writing</div>
+        <div class="repo-desc">Audits and rewrites content to eliminate detectable AI writing patterns.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/AMAP-ML/SkillClaw" data-github="https://github.com/AMAP-ML/SkillClaw" data-desc="Let Skills Evolve Collectively with Agentic Evolver">
+      <div class="repo-stars">★ 2,529</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">AMAP-ML /</span> SkillClaw</div>
+        <div class="repo-desc">Let Skills Evolve Collectively with Agentic Evolver.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/wondelai/skills" data-github="https://github.com/wondelai/skills" data-desc="Cross-platform skills library for Claude Code and agentskills.io-compatible agents">
+      <div class="repo-stars">★ 2,051</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">wondelai /</span> skills</div>
+        <div class="repo-desc">Cross-platform skills library for Claude Code and agentskills.io-compatible agents.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/mohitagw15856/pm-claude-skills" data-github="https://github.com/mohitagw15856/pm-claude-skills" data-desc="822 professional agent skills that run natively in Hermes Agent and Claude Code, with ready-to-paste exports for other assistants.">
+      <div class="repo-stars">★ 1,320</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">mohitagw15856 /</span> pm-claude-skills</div>
+        <div class="repo-desc">822 professional agent skills that run natively in Hermes Agent and Claude Code, with ready-to-paste exports for other assistants.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/ZeroPointRepo/youtube-skills" data-github="https://github.com/ZeroPointRepo/youtube-skills" data-desc="YouTube transcript, search, channel, and playlist skills for Hermes Agent, OpenClaw, Claude Code, Cursor, and Windsurf">
+      <div class="repo-stars">★ 580</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">ZeroPointRepo /</span> youtube-skills</div>
+        <div class="repo-desc">YouTube transcript, search, channel, and playlist skills for Hermes Agent, OpenClaw, Claude Code, Cursor, and Windsurf.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Romanescu11/hermes-skill-factory" data-github="https://github.com/Romanescu11/hermes-skill-factory" data-desc="Meta-skill plugin that watches workflows and auto-generates reusable skills">
+      <div class="repo-stars">★ 542</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Romanescu11 /</span> hermes-skill-factory</div>
+        <div class="repo-desc">Meta-skill plugin that watches workflows and auto-generates reusable skills.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Cranot/super-hermes" data-github="https://github.com/Cranot/super-hermes" data-desc="Skills that teach Hermes Agent to write its own analytical prompts">
+      <div class="repo-stars">★ 414</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Cranot /</span> super-hermes</div>
+        <div class="repo-desc">Skills that teach Hermes Agent to write its own analytical prompts.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/DougTrajano/pydantic-ai-skills" data-github="https://github.com/DougTrajano/pydantic-ai-skills" data-desc="Type-safe agentskills.io support with progressive disclosure for Pydantic AI">
+      <div class="repo-stars">★ 363</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">DougTrajano /</span> pydantic-ai-skills</div>
+        <div class="repo-desc">Type-safe agentskills.io support with progressive disclosure for Pydantic AI.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/AkoliteZA/hermes-agent-idea-workflow" data-github="https://github.com/AkoliteZA/hermes-agent-idea-workflow" data-desc="Pre-build idea-to-spec workflow skills for Hermes Agent that turn rough ideas into design docs and implementation handoffs">
+      <div class="repo-stars">★ 265</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">AkoliteZA /</span> hermes-agent-idea-workflow</div>
+        <div class="repo-desc">Pre-build idea-to-spec workflow skills for Hermes Agent that turn rough ideas into design docs and implementation handoffs.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/tlehman/litprog-skill" data-github="https://github.com/tlehman/litprog-skill" data-desc="Literate programming skill — weave code and documentation across agents">
+      <div class="repo-stars">★ 254</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">tlehman /</span> litprog-skill</div>
+        <div class="repo-desc">Literate programming skill — weave code and documentation across agents.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/ReinaMacCredy/maestro" data-github="https://github.com/ReinaMacCredy/maestro" data-desc="Harness for long-running AI agents — structured memory, cross-feature learning, plan-approve-execute">
+      <div class="repo-stars">★ 230</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">ReinaMacCredy /</span> maestro</div>
+        <div class="repo-desc">Harness for long-running AI agents — structured memory, cross-feature learning, plan-approve-execute.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/esaradev/icarus-plugin" data-github="https://github.com/esaradev/icarus-plugin" data-desc="Self-memory and replacement models — remember your work, train your replacement">
+      <div class="repo-stars">★ 143</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">esaradev /</span> icarus-plugin</div>
+        <div class="repo-desc">Self-memory and replacement models — remember your work, train your replacement.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/smartcontractkit/chainlink-agent-skills" data-github="https://github.com/smartcontractkit/chainlink-agent-skills" data-desc="Oracle network and smart contract interaction skills (agentskills.io spec)">
+      <div class="repo-stars">★ 125</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">smartcontractkit /</span> chainlink-agent-skills</div>
+        <div class="repo-desc">Oracle network and smart contract interaction skills (agentskills.io spec).</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Hermes-brasil/hermes-brasil" data-github="https://github.com/Hermes-brasil/hermes-brasil" data-desc="Comunidade brasileira de Hermes Agent (Nous Research) — skills, guias e integrações em português.">
+      <div class="repo-stars">★ 118</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Hermes-brasil /</span> hermes-brasil</div>
+        <div class="repo-desc">Comunidade brasileira de Hermes Agent (Nous Research) — skills, guias e integrações em português.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/black-forest-labs/skills" data-github="https://github.com/black-forest-labs/skills" data-desc="Official FLUX image generation skills — prompting guidelines and API integration">
+      <div class="repo-stars">★ 107</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">black-forest-labs /</span> skills</div>
+        <div class="repo-desc">Official FLUX image generation skills — prompting guidelines and API integration.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/armelhbobdad/bmad-module-skill-forge" data-github="https://github.com/armelhbobdad/bmad-module-skill-forge" data-desc="Converts repos, docs, and developer discourse into agentskills.io-compliant skills">
+      <div class="repo-stars">★ 94</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">armelhbobdad /</span> bmad-module-skill-forge</div>
+        <div class="repo-desc">Converts repos, docs, and developer discourse into agentskills.io-compliant skills.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/chigwell/skilldock.io" data-github="https://github.com/chigwell/skilldock.io" data-desc="Registry of reusable AI skills based on AgentSkills specification">
+      <div class="repo-stars">★ 86</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">chigwell /</span> skilldock.io</div>
+        <div class="repo-desc">Registry of reusable AI skills based on AgentSkills specification.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/tiann/execplan-skill" data-github="https://github.com/tiann/execplan-skill" data-desc="Complex multi-step task execution with checkpoints and recovery">
+      <div class="repo-stars">★ 68</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">tiann /</span> execplan-skill</div>
+        <div class="repo-desc">Complex multi-step task execution with checkpoints and recovery.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/supernovae-st/nika" data-github="https://github.com/supernovae-st/nika" data-desc="Intent as Code | the workflow language for AI. One file, 4 verbs, one Rust binary. Local-first, any model, AGPL-3.0. 🦋">
+      <div class="repo-stars">★ 60</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">supernovae-st /</span> nika</div>
+        <div class="repo-desc">Intent as Code | the workflow language for AI. One file, 4 verbs, one Rust binary. Local-first, any model, AGPL-3.0. 🦋.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/adnw-vinc/hermes-nextcloud" data-github="https://github.com/adnw-vinc/hermes-nextcloud" data-desc="Hermes Agent skill for Nextcloud — manage files, notes, calendar, tasks, and contacts via WebDAV and CalDAV.">
+      <div class="repo-stars">★ 50</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">adnw-vinc /</span> hermes-nextcloud</div>
+        <div class="repo-desc">Hermes Agent skill for Nextcloud — manage files, notes, calendar, tasks, and contacts via WebDAV and CalDAV.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/cablate/Agentic-MCP-Skill" data-github="https://github.com/cablate/Agentic-MCP-Skill" data-desc="Progressive MCP client with three-layer lazy loading — validates agentskills.io pattern">
+      <div class="repo-stars">★ 39</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">cablate /</span> Agentic-MCP-Skill</div>
+        <div class="repo-desc">Progressive MCP client with three-layer lazy loading — validates agentskills.io pattern.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/willingning-coder/eagle-eye" data-github="https://github.com/willingning-coder/eagle-eye" data-desc="5-layer intelligent skill retrieval for Hermes Agent with hard triggers, FTS5, synonyms, dense embeddings, and RRF fusion.">
+      <div class="repo-stars">★ 34</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">willingning-coder /</span> eagle-eye</div>
+        <div class="repo-desc">5-layer intelligent skill retrieval for Hermes Agent with hard triggers, FTS5, synonyms, dense embeddings, and RRF fusion.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/amanning3390/hermeshub" data-github="https://github.com/amanning3390/hermeshub" data-desc="Community skill browsing, search, and one-click installation hub">
+      <div class="repo-stars">★ 31</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">amanning3390 /</span> hermeshub</div>
+        <div class="repo-desc">Community skill browsing, search, and one-click installation hub.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/EntangledQuantum/Life_OS" data-github="https://github.com/EntangledQuantum/Life_OS" data-desc="ADHD-friendly personal execution OS: habits, study blocks, agent control (Hermes/MCP), local SQLite">
+      <div class="repo-stars">★ 29</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">EntangledQuantum /</span> Life_OS</div>
+        <div class="repo-desc">ADHD-friendly personal execution OS: habits, study blocks, agent control (Hermes/MCP), local SQLite.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Sahil-SS9/hermaguard" data-github="https://github.com/Sahil-SS9/hermaguard" data-desc="Adversarial bug-hunting code review for AI agents. 3 parallel subagents attack code from different angles, then a consolidator merges and triages findings. Read-only — finds problems, doesn't fix.">
+      <div class="repo-stars">★ 26</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Sahil-SS9 /</span> hermaguard</div>
+        <div class="repo-desc">Adversarial bug-hunting code review for AI agents. 3 parallel subagents attack code from different angles, then a consolidator merges and triages findings. Read-only — finds problems, doesn't fix.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Sahil-SS9/hermes-multichannel-prompt-optimizer" data-github="https://github.com/Sahil-SS9/hermes-multichannel-prompt-optimizer" data-desc="Hermes Agent plugin that rewrites and scores prompts across CLI, TUI, Discord, Telegram, and other surfaces.">
+      <div class="repo-stars">★ 23</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Sahil-SS9 /</span> hermes-multichannel-prompt-optimizer</div>
+        <div class="repo-desc">Hermes Agent plugin that rewrites and scores prompts across CLI, TUI, Discord, Telegram, and other surfaces.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/teixeirazeus/fablize-for-hermes" data-github="https://github.com/teixeirazeus/fablize-for-hermes" data-desc="This project adapts fablize's verified procedures — verification grounding, multi-story evidence gating, investigation protocol, and early-stop prevention.">
+      <div class="repo-stars">★ 15</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">teixeirazeus /</span> fablize-for-hermes</div>
+        <div class="repo-desc">This project adapts fablize's verified procedures — verification grounding, multi-story evidence gating, investigation protocol, and early-stop prevention.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Sahil-SS9/hermes-simplify-swarm" data-github="https://github.com/Sahil-SS9/hermes-simplify-swarm" data-desc="Multi-agent code simplification skill for Hermes Agent. 3 parallel sub-agents (Hygiene, Clarity, Correctness) with risk-tiered application. Inspired by Claude Code's /simplify.">
+      <div class="repo-stars">★ 14</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Sahil-SS9 /</span> hermes-simplify-swarm</div>
+        <div class="repo-desc">Multi-agent code simplification skill for Hermes Agent. 3 parallel sub-agents (Hygiene, Clarity, Correctness) with risk-tiered application. Inspired by Claude Code's /simplify.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/PederHP/skillsdotnet" data-github="https://github.com/PederHP/skillsdotnet" data-desc="C# / .NET implementation of agentskills.io with MCP integration">
+      <div class="repo-stars">★ 12</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">PederHP /</span> skillsdotnet</div>
+        <div class="repo-desc">C# / .NET implementation of agentskills.io with MCP integration.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/handnewb/hermes-cybersec-lab" data-github="https://github.com/handnewb/hermes-cybersec-lab" data-desc="🛡️ Turnkey cybersecurity lab for Hermes Agent — 397 CVE-driven skills, 152 tools, 28 frameworks (MITRE ATT&amp;CK, MISP, CVSS, EPSS, OWASP, NIST, Sigma, YARA). Real exploits 2015–2026.">
+      <div class="repo-stars">★ 11</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">handnewb /</span> hermes-cybersec-lab</div>
+        <div class="repo-desc">🛡️ Turnkey cybersecurity lab for Hermes Agent — 397 CVE-driven skills, 152 tools, 28 frameworks (MITRE ATT&amp;CK, MISP, CVSS, EPSS, OWASP, NIST, Sigma, YARA). Real exploits 2015–2026.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/conorbronsdon/agent-skills" data-github="https://github.com/conorbronsdon/agent-skills" data-desc="Production-tested agent skills for Claude Code, Codex, Cursor, and OpenCode — session management, multi-session reconciliation, worktree recovery, PR review, and skill scaffolding. The proportionate-r">
+      <div class="repo-stars">★ 9</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">conorbronsdon /</span> agent-skills</div>
+        <div class="repo-desc">Production-tested agent skills for Claude Code, Codex, Cursor, and OpenCode — session management, multi-session reconciliation, worktree recovery, PR review, and skill scaffolding. The proportionate-r.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/conorbronsdon/demo-gif-skill" data-github="https://github.com/conorbronsdon/demo-gif-skill" data-desc="Claude Code skill: add a reproducible demo GIF to any repo's README (vhs, Playwright, ffmpeg, gifsicle)">
+      <div class="repo-stars">★ 6</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">conorbronsdon /</span> demo-gif-skill</div>
+        <div class="repo-desc">Claude Code skill: add a reproducible demo GIF to any repo's README (vhs, Playwright, ffmpeg, gifsicle).</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/conorbronsdon/agent-skill-builder" data-github="https://github.com/conorbronsdon/agent-skill-builder" data-desc="A skill that builds agent skills — and doesn't rot. Spec-current frontmatter plus a validator that fails on drift.">
+      <div class="repo-stars">★ 4</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">conorbronsdon /</span> agent-skill-builder</div>
+        <div class="repo-desc">A skill that builds agent skills — and doesn't rot. Spec-current frontmatter plus a validator that fails on drift.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/aidevelopers2/remoteopenclaw-mcp" data-github="https://github.com/aidevelopers2/remoteopenclaw-mcp" data-desc="Search 13,870+ MCP servers, 4,384+ agent skills, and plugins from your terminal or AI agent. CLI + MCP server for remoteopenclaw.com">
+      <div class="repo-stars">★ 3</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">aidevelopers2 /</span> remoteopenclaw-mcp</div>
+        <div class="repo-desc">Search 13,870+ MCP servers, 4,384+ agent skills, and plugins from your terminal or AI agent. CLI + MCP server for remoteopenclaw.com.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Carlo1911/skill-evolution" data-github="https://github.com/Carlo1911/skill-evolution" data-desc="Self-improvement feedback loop for AI agent skills — analyzes past sessions, drafts structured improvement proposals, and gates auto-apply behind an evaluation framework. Host-agnostic (Hermes, Claude">
+      <div class="repo-stars">★ 3</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Carlo1911 /</span> skill-evolution</div>
+        <div class="repo-desc">Self-improvement feedback loop for AI agent skills — analyzes past sessions, drafts structured improvement proposals, and gates auto-apply behind an evaluation framework. Host-agnostic (Hermes, Claude.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/mag3nt-com/openclaw-skill" data-github="https://github.com/mag3nt-com/openclaw-skill" data-desc="Openclaw Skills">
+      <div class="repo-stars">★ 1</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">mag3nt-com /</span> openclaw-skill</div>
+        <div class="repo-desc">Openclaw Skills.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/skillseal/skillseal" data-github="https://github.com/skillseal/skillseal" data-desc="Functional quality seal for AI agent skills. Tests every skill in an isolated Docker environment - structure, functionality and security - and certifies it actually works.">
+      <div class="repo-stars">★ 1</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">skillseal /</span> skillseal</div>
+        <div class="repo-desc">Functional quality seal for AI agent skills. Tests every skill in an isolated Docker environment - structure, functionality and security - and certifies it actually works.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/CorsenAI/hermes-windows-runtime-skills" data-github="https://github.com/CorsenAI/hermes-windows-runtime-skills" data-desc="Hermes Agent skills for deterministic path routing and non-installing Python runtime selection across Windows, Git Bash/MSYS, and WSL.">
+      <div class="repo-stars">★ 1</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">CorsenAI /</span> hermes-windows-runtime-skills</div>
+        <div class="repo-desc">Hermes Agent skills for deterministic path routing and non-installing Python runtime selection across Windows, Git Bash/MSYS, and WSL.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/webmilmind1/hermes-bounty-board" data-github="https://github.com/webmilmind1/hermes-bounty-board" data-desc="Hermes Agent plugin: earn USDC answering real support bounties, or run your own bounty board, over x402. No account, no API key. A human approves the winning answer and the wallet is paid 85% automati">
+      <div class="repo-stars">★ 1</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">webmilmind1 /</span> hermes-bounty-board</div>
+        <div class="repo-desc">Hermes Agent plugin: earn USDC answering real support bounties, or run your own bounty board, over x402. No account, no API key. A human approves the winning answer and the wallet is paid 85% automati.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Shine8592/china-briefing" data-github="https://github.com/Shine8592/china-briefing" data-desc="多尺度中文资讯简报技能 - Multi-scale Chinese news briefing generator for Hermes Agent. From global to street level, with quality gates and AI analysis.">
+      <div class="repo-stars">★ 0</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Shine8592 /</span> china-briefing</div>
+        <div class="repo-desc">多尺度中文资讯简报技能 - Multi-scale Chinese news briefing generator for Hermes Agent. From global to street level, with quality gates and AI analysis.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/jiawood2006/hermes-skills" data-github="https://github.com/jiawood2006/hermes-skills" data-desc="Hermes Skills: 视频转文字 / AI文案去味 / 文档OCR / 电商素材工坊 (Video-to-text, AI text de-humanizer, OCR, E-commerce Material Studio)">
+      <div class="repo-stars">★ 0</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">jiawood2006 /</span> hermes-skills</div>
+        <div class="repo-desc">Hermes Skills: 视频转文字 / AI文案去味 / 文档OCR / 电商素材工坊 (Video-to-text, AI text de-humanizer, OCR, E-commerce Material Studio).</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/scavio-ai/hermes-agent" data-github="https://github.com/scavio-ai/hermes-agent" data-desc="Scavio for Hermes Agent - structured web data across 31 platforms via the hosted MCP server, plus 5 ready-to-use workflow skills.">
+      <div class="repo-stars">★ 0</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">scavio-ai /</span> hermes-agent</div>
+        <div class="repo-desc">Scavio for Hermes Agent - structured web data across 31 platforms via the hosted MCP server, plus 5 ready-to-use workflow skills.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+  </div>
+</section>
+
+<section class="cat" data-category="Memory &amp; Context">
+  <div class="cat-meta">
+    <div class="cat-num">§04</div>
+    <h2 class="cat-title">Memory &amp; context</h2>
+    <p class="cat-desc">Long-term semantic memory, graph-based retrieval, cross-session persistence.</p>
+    <div class="cat-count"><span class="cat-count-n">35</span> repos</div>
+  </div>
+  <div class="cat-list">
+    <a class="repo-row" href="/projects/mem0ai/mem0" data-github="https://github.com/mem0ai/mem0" data-desc="Universal memory layer for AI Agents — official Hermes Agent memory provider, managed cloud or Apache-2.0 self-hosted OSS">
+      <div class="repo-stars">★ 64,302</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">mem0ai /</span> mem0</div>
+        <div class="repo-desc">Universal memory layer for AI Agents — official Hermes Agent memory provider, managed cloud or Apache-2.0 self-hosted OSS.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/volcengine/OpenViking" data-github="https://github.com/volcengine/OpenViking" data-desc="Filesystem-first context database — official Hermes memory provider with tiered loading and 91% token reduction on LoCoMo10">
+      <div class="repo-stars">★ 34,222</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">volcengine /</span> OpenViking</div>
+        <div class="repo-desc">Filesystem-first context database — official Hermes memory provider with tiered loading and 91% token reduction on LoCoMo10.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/garrytan/gbrain" data-github="https://github.com/garrytan/gbrain" data-desc="Garry's Opinionated OpenClaw/Hermes Agent Brain">
+      <div class="repo-stars">★ 29,269</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">garrytan /</span> gbrain</div>
+        <div class="repo-desc">Garry's Opinionated OpenClaw/Hermes Agent Brain.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/supermemoryai/supermemory" data-github="https://github.com/supermemoryai/supermemory" data-desc="Memory engine and API — official Hermes provider with sub-300ms recall at 100B+ tokens/month and context fencing">
+      <div class="repo-stars">★ 29,126</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">supermemoryai /</span> supermemory</div>
+        <div class="repo-desc">Memory engine and API — official Hermes provider with sub-300ms recall at 100B+ tokens/month and context fencing.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/vectorize-io/hindsight" data-github="https://github.com/vectorize-io/hindsight" data-desc="Agent memory that learns — long-term retain/recall/reflect workflows">
+      <div class="repo-stars">★ 21,633</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">vectorize-io /</span> hindsight <span class="repo-flag">official</span></div>
+        <div class="repo-desc">Agent memory that learns — long-term retain/recall/reflect workflows.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/plastic-labs/honcho" data-github="https://github.com/plastic-labs/honcho" data-desc="Memory library for building stateful agents — the upstream library that the elkimek/honcho-self-hosted Hermes wrapper builds on.">
+      <div class="repo-stars">★ 6,915</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">plastic-labs /</span> honcho <span class="repo-flag">official</span></div>
+        <div class="repo-desc">Memory library for building stateful agents — the upstream library that the elkimek/honcho-self-hosted Hermes wrapper builds on.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/campfirein/byterover-cli" data-github="https://github.com/campfirein/byterover-cli" data-desc="ByteRover CLI (brv) — official Hermes memory provider storing memory as a git-versionable markdown context tree">
+      <div class="repo-stars">★ 4,950</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">campfirein /</span> byterover-cli</div>
+        <div class="repo-desc">ByteRover CLI (brv) — official Hermes memory provider storing memory as a git-versionable markdown context tree.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/mnemosyne-oss/mnemosyne" data-github="https://github.com/mnemosyne-oss/mnemosyne" data-desc="The Zero-Dependency, Sub-Millisecond AI Memory System for Hermes Agents">
+      <div class="repo-stars">★ 2,879</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">mnemosyne-oss /</span> mnemosyne</div>
+        <div class="repo-desc">The Zero-Dependency, Sub-Millisecond AI Memory System for Hermes Agents.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/ClaudioDrews/memory-os" data-github="https://github.com/ClaudioDrews/memory-os" data-desc="Seven-layer memory system for Hermes Agent: persistent memory on Qdrant, structured facts, fabric recall, and an auto-curated wiki.">
+      <div class="repo-stars">★ 1,343</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">ClaudioDrews /</span> memory-os</div>
+        <div class="repo-desc">Seven-layer memory system for Hermes Agent: persistent memory on Qdrant, structured facts, fabric recall, and an auto-curated wiki.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/greyhaven-ai/autocontext" data-github="https://github.com/greyhaven-ai/autocontext" data-desc="Recursive self-improving context harness — helps agents succeed on complex tasks">
+      <div class="repo-stars">★ 1,288</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">greyhaven-ai /</span> autocontext</div>
+        <div class="repo-desc">Recursive self-improving context harness — helps agents succeed on complex tasks.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/stephenschoettler/hermes-lcm" data-github="https://github.com/stephenschoettler/hermes-lcm" data-desc="Lossless Context Management — DAG-based context engine that never loses a message">
+      <div class="repo-stars">★ 1,087</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">stephenschoettler /</span> hermes-lcm</div>
+        <div class="repo-desc">Lossless Context Management — DAG-based context engine that never loses a message.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/elkimek/honcho-self-hosted" data-github="https://github.com/elkimek/honcho-self-hosted" data-desc="Self-hosted Honcho memory backend for cross-session persistence">
+      <div class="repo-stars">★ 368</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">elkimek /</span> honcho-self-hosted</div>
+        <div class="repo-desc">Self-hosted Honcho memory backend for cross-session persistence.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Signet-AI/signetai" data-github="https://github.com/Signet-AI/signetai" data-desc="Local-first identity, memory, and secrets layer for AI agents — portable state across Hermes Agent, Claude Code, Codex, OpenCode, OpenClaw, and MCP clients">
+      <div class="repo-stars">★ 262</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Signet-AI /</span> signetai</div>
+        <div class="repo-desc">Local-first identity, memory, and secrets layer for AI agents — portable state across Hermes Agent, Claude Code, Codex, OpenCode, OpenClaw, and MCP clients.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/plur-ai/plur" data-github="https://github.com/plur-ai/plur" data-desc="Shared memory layer with open engram YAML format for multi-agent systems">
+      <div class="repo-stars">★ 243</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">plur-ai /</span> plur</div>
+        <div class="repo-desc">Shared memory layer with open engram YAML format for multi-agent systems.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/yoloshii/ClawMem" data-github="https://github.com/yoloshii/ClawMem" data-desc="On-device memory and context engine for agents — local-first, no cloud dependencies">
+      <div class="repo-stars">★ 203</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">yoloshii /</span> ClawMem</div>
+        <div class="repo-desc">On-device memory and context engine for agents — local-first, no cloud dependencies.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/EfficientContext/ContextPilot" data-github="https://github.com/EfficientContext/ContextPilot" data-desc="Accelerating Long Context LLM Inference with Accuracy-Preserving Context Optimization in SGLang, vLLM, llama.cpp, OpenClaw, RAG, and Agentic AI.">
+      <div class="repo-stars">★ 131</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">EfficientContext /</span> ContextPilot</div>
+        <div class="repo-desc">Accelerating Long Context LLM Inference with Accuracy-Preserving Context Optimization in SGLang, vLLM, llama.cpp, OpenClaw, RAG, and Agentic AI.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Sibyl-Labs/Sibyl-Memory" data-github="https://github.com/Sibyl-Labs/Sibyl-Memory" data-desc="Durable, file-based long-term memory for AI agents. Five-package plugin family: SDK, CLI, MCP server, Hermes adapter, and a LangGraph BaseStore. No vector database, no embeddings.">
+      <div class="repo-stars">★ 105</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Sibyl-Labs /</span> Sibyl-Memory</div>
+        <div class="repo-desc">Durable, file-based long-term memory for AI agents. Five-package plugin family: SDK, CLI, MCP server, Hermes adapter, and a LangGraph BaseStore. No vector database, no embeddings.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/yantrikos/yantrikdb-hermes-plugin" data-github="https://github.com/yantrikos/yantrikdb-hermes-plugin" data-desc="Self-maintaining Hermes memory plugin with explainable retrieval — every recall comes with a why_retrieved tag">
+      <div class="repo-stars">★ 84</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">yantrikos /</span> yantrikdb-hermes-plugin</div>
+        <div class="repo-desc">Self-maintaining Hermes memory plugin with explainable retrieval — every recall comes with a why_retrieved tag.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/yepyhun/Brainstack" data-github="https://github.com/yepyhun/Brainstack" data-desc="Memory kernel stack for Hermes agent">
+      <div class="repo-stars">★ 47</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">yepyhun /</span> Brainstack</div>
+        <div class="repo-desc">Memory kernel stack for Hermes agent.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/ccf/agentcairn" data-github="https://github.com/ccf/agentcairn" data-desc="Long-term, cross-project memory for AI coding agents. Your own Obsidian vault as the source of truth. Daemonless and without opaque databases, your memory belongs to you.">
+      <div class="repo-stars">★ 46</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">ccf /</span> agentcairn</div>
+        <div class="repo-desc">Long-term, cross-project memory for AI coding agents. Your own Obsidian vault as the source of truth. Daemonless and without opaque databases, your memory belongs to you.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/amanning3390/flowstate-qmd" data-github="https://github.com/amanning3390/flowstate-qmd" data-desc="Anticipatory memory with RAG and vector search — Hermes 2026 Hackathon entry">
+      <div class="repo-stars">★ 45</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">amanning3390 /</span> flowstate-qmd</div>
+        <div class="repo-desc">Anticipatory memory with RAG and vector search — Hermes 2026 Hackathon entry.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Perseus-Computing-LLC/perseus" data-github="https://github.com/Perseus-Computing-LLC/perseus" data-desc="The memory &amp; context layer for AI agents: load only the context they actually need. Resolves live workspace state into verified facts before the context window opens. 94% fewer prompt tokens, 0 ms ove">
+      <div class="repo-stars">★ 41</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Perseus-Computing-LLC /</span> perseus</div>
+        <div class="repo-desc">The memory &amp; context layer for AI agents: load only the context they actually need. Resolves live workspace state into verified facts before the context window opens. 94% fewer prompt tokens, 0 ms ove.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/generalbusiness-ai/keep" data-github="https://github.com/generalbusiness-ai/keep" data-desc="Reflective memory for AI agents">
+      <div class="repo-stars">★ 40</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">generalbusiness-ai /</span> keep</div>
+        <div class="repo-desc">Reflective memory for AI agents.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/alias8818/hermes-tool-slimmer" data-github="https://github.com/alias8818/hermes-tool-slimmer" data-desc="Reduce Hermes Agent tool-schema overhead with keyword selection and Tool Search support">
+      <div class="repo-stars">★ 34</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">alias8818 /</span> hermes-tool-slimmer</div>
+        <div class="repo-desc">Reduce Hermes Agent tool-schema overhead with keyword selection and Tool Search support.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Ladybug-Memory/hermes-memory-plugin" data-github="https://github.com/Ladybug-Memory/hermes-memory-plugin" data-desc="Local-only Hermes memory plugin with built-in 1-10 importance ranking so what matters most surfaces first">
+      <div class="repo-stars">★ 21</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Ladybug-Memory /</span> hermes-memory-plugin</div>
+        <div class="repo-desc">Local-only Hermes memory plugin with built-in 1-10 importance ranking so what matters most surfaces first.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/conorbronsdon/claude-context-os" data-github="https://github.com/conorbronsdon/claude-context-os" data-desc="A Git-backed context and workflow layer for Claude Code, Codex, and compatible coding agents.">
+      <div class="repo-stars">★ 15</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">conorbronsdon /</span> claude-context-os</div>
+        <div class="repo-desc">A Git-backed context and workflow layer for Claude Code, Codex, and compatible coding agents.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/MukundaKatta/hermes-agentmemory" data-github="https://github.com/MukundaKatta/hermes-agentmemory" data-desc="Pull-model Hermes memory plugin with real deletion (no persistent summaries) and full audit trace">
+      <div class="repo-stars">★ 10</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">MukundaKatta /</span> hermes-agentmemory</div>
+        <div class="repo-desc">Pull-model Hermes memory plugin with real deletion (no persistent summaries) and full audit trace.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/yonro/hermes-xmemo-plugin" data-github="https://github.com/yonro/hermes-xmemo-plugin" data-desc="XMemo memory provider for Hermes Agent — durable cross-session AI memory with semantic search">
+      <div class="repo-stars">★ 7</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">yonro /</span> hermes-xmemo-plugin</div>
+        <div class="repo-desc">XMemo memory provider for Hermes Agent — durable cross-session AI memory with semantic search.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/piprail/piprail" data-github="https://github.com/piprail/piprail" data-desc="x402 (HTTP 402 Payment Required) SDK + MCP server: let any API charge for itself and any AI agent pay for itself, USDC &amp; stablecoins across EVM, Solana &amp; 8 more chain families, in a couple of lines. B">
+      <div class="repo-stars">★ 7</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">piprail /</span> piprail</div>
+        <div class="repo-desc">x402 (HTTP 402 Payment Required) SDK + MCP server: let any API charge for itself and any AI agent pay for itself, USDC &amp; stablecoins across EVM, Solana &amp; 8 more chain families, in a couple of lines. B.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/stepanov1975/hermes-local-knowledge" data-github="https://github.com/stepanov1975/hermes-local-knowledge" data-desc="Reusable Hermes Agent plugin for local capability indexing and routing">
+      <div class="repo-stars">★ 6</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">stepanov1975 /</span> hermes-local-knowledge</div>
+        <div class="repo-desc">Reusable Hermes Agent plugin for local capability indexing and routing.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/futurebrowser/hermes-exabase-plugin" data-github="https://github.com/futurebrowser/hermes-exabase-plugin" data-desc="Exabase memory plugin for Hermes Agent.">
+      <div class="repo-stars">★ 5</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">futurebrowser /</span> hermes-exabase-plugin</div>
+        <div class="repo-desc">Exabase memory plugin for Hermes Agent.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/visorcraft/MongrelDB-Hermes" data-github="https://github.com/visorcraft/MongrelDB-Hermes" data-desc="AI-native long-term memory for Hermes Agent with AES-256-GCM encryption at rest, dense HNSW ANN, sparse and exact-text recall, metadata/range filters, and MinHash dedup, backed by an embedded or multi">
+      <div class="repo-stars">★ 5</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">visorcraft /</span> MongrelDB-Hermes</div>
+        <div class="repo-desc">AI-native long-term memory for Hermes Agent with AES-256-GCM encryption at rest, dense HNSW ANN, sparse and exact-text recall, metadata/range filters, and MinHash dedup, backed by an embedded or multi.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/sourcevault-ai/sourcevault-code-tools" data-github="https://github.com/sourcevault-ai/sourcevault-code-tools" data-desc="Hermes Agent plugin — private local code memory for your repos (semantic search, file reads, grounded Q&amp;A)">
+      <div class="repo-stars">★ 4</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">sourcevault-ai /</span> sourcevault-code-tools</div>
+        <div class="repo-desc">Hermes Agent plugin — private local code memory for your repos (semantic search, file reads, grounded Q&amp;A).</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/penfieldlabs/hermes-penfield" data-github="https://github.com/penfieldlabs/hermes-penfield" data-desc="🧠 Penfield memory providers for Hermes agent">
+      <div class="repo-stars">★ 3</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">penfieldlabs /</span> hermes-penfield</div>
+        <div class="repo-desc">🧠 Penfield memory providers for Hermes agent.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/conorbronsdon/agent-memory-kit" data-github="https://github.com/conorbronsdon/agent-memory-kit" data-desc="The curation pass for agent memory: a thin, file-based loop that finds rot and contradictions and proposes evidence-cited diffs you review. Markdown in, JSON out, no database. The memory-hygiene leg o">
+      <div class="repo-stars">★ 2</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">conorbronsdon /</span> agent-memory-kit</div>
+        <div class="repo-desc">The curation pass for agent memory: a thin, file-based loop that finds rot and contradictions and proposes evidence-cited diffs you review. Markdown in, JSON out, no database. The memory-hygiene leg o.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+  </div>
+</section>
+
+<section class="cat" data-category="Plugins &amp; Extensions">
+  <div class="cat-meta">
+    <div class="cat-num">§05</div>
+    <h2 class="cat-title">Plugins &amp; extensions</h2>
+    <p class="cat-desc">Drop-in modules that add tools, safety, payments, or new capabilities.</p>
+    <div class="cat-count"><span class="cat-count-n">41</span> repos</div>
+  </div>
+  <div class="cat-list">
+    <a class="repo-row" href="/projects/jau123/MeiGen-AI-Design-MCP" data-github="https://github.com/jau123/MeiGen-AI-Design-MCP" data-desc="Supports GPT Image 2, Nanobanana &amp; ComfyUI, with a 1,400+ prompt library, carefully crafted hooks and a multi-task orchestration system">
+      <div class="repo-stars">★ 1,725</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">jau123 /</span> MeiGen-AI-Design-MCP</div>
+        <div class="repo-desc">Supports GPT Image 2, Nanobanana &amp; ComfyUI, with a 1,400+ prompt library, carefully crafted hooks and a multi-task orchestration system.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/indranilbanerjee/digital-marketing-pro" data-github="https://github.com/indranilbanerjee/digital-marketing-pro" data-desc="Open-source AI marketing plugin for agencies &amp; in-house teams — 158 skills, 25 specialist agents, 12-Part Strategy Flow, Cowork team-persistent, EU AI Act Article 50 ready, 6-platform AEO/GEO incl. Go">
+      <div class="repo-stars">★ 774</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">indranilbanerjee /</span> digital-marketing-pro</div>
+        <div class="repo-desc">Open-source AI marketing plugin for agencies &amp; in-house teams — 158 skills, 25 specialist agents, 12-Part Strategy Flow, Cowork team-persistent, EU AI Act Article 50 ready, 6-platform AEO/GEO incl. Go.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/42-evey/hermes-plugins" data-github="https://github.com/42-evey/hermes-plugins" data-desc="Goal management, inter-agent bridge, model selection, and cost control plugins">
+      <div class="repo-stars">★ 441</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">42-evey /</span> hermes-plugins</div>
+        <div class="repo-desc">Goal management, inter-agent bridge, model selection, and cost control plugins.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/robbyczgw-cla/hermes-web-search-plus" data-github="https://github.com/robbyczgw-cla/hermes-web-search-plus" data-desc="Multi-provider web search (Serper, Tavily, Exa, Querit, Perplexity) with auto-routing">
+      <div class="repo-stars">★ 387</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">robbyczgw-cla /</span> hermes-web-search-plus</div>
+        <div class="repo-desc">Multi-provider web search (Serper, Tavily, Exa, Querit, Perplexity) with auto-routing.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server" data-github="https://github.com/Shelpuk-AI-Technology-Consulting/kindly-web-search-mcp-server" data-desc="Web search and content retrieval MCP server supporting Hermes Agent, OpenClaw, Claude Code, Codex, Cursor, and other AI tools">
+      <div class="repo-stars">★ 377</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Shelpuk-AI-Technology-Consulting /</span> kindly-web-search-mcp-server</div>
+        <div class="repo-desc">Web search and content retrieval MCP server supporting Hermes Agent, OpenClaw, Claude Code, Codex, Cursor, and other AI tools.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/runta-dev/clawshell" data-github="https://github.com/runta-dev/clawshell" data-desc="The Runtime Security Layer for OpenClaw/Hermes-agent, the essential safety harness for PII &amp; sensitive credentials protection.">
+      <div class="repo-stars">★ 342</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">runta-dev /</span> clawshell</div>
+        <div class="repo-desc">The Runtime Security Layer for OpenClaw/Hermes-agent, the essential safety harness for PII &amp; sensitive credentials protection.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/stainlu/hermes-labyrinth" data-github="https://github.com/stainlu/hermes-labyrinth" data-desc="Read-only observability plugin for Hermes Agent with journeys, crossings, guideposts, and reports">
+      <div class="repo-stars">★ 304</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">stainlu /</span> hermes-labyrinth</div>
+        <div class="repo-desc">Read-only observability plugin for Hermes Agent with journeys, crossings, guideposts, and reports.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/335234131/agent-browser-mcp" data-github="https://github.com/335234131/agent-browser-mcp" data-desc="让 Agent 直接操作真实 Chrome 的 MCP 服务，支持页面扫描、CDP、截图与物理输入">
+      <div class="repo-stars">★ 241</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">335234131 /</span> agent-browser-mcp</div>
+        <div class="repo-desc">让 Agent 直接操作真实 Chrome 的 MCP 服务，支持页面扫描、CDP、截图与物理输入.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/8bit64k/cronalytics" data-github="https://github.com/8bit64k/cronalytics" data-desc="Hermes Agent cron analytics and observability plugin for attributing scheduled-run usage and estimated cost.">
+      <div class="repo-stars">★ 107</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">8bit64k /</span> cronalytics</div>
+        <div class="repo-desc">Hermes Agent cron analytics and observability plugin for attributing scheduled-run usage and estimated cost.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/briancaffey/hermes-otel" data-github="https://github.com/briancaffey/hermes-otel" data-desc="OTel Plugin for Hermes Agent">
+      <div class="repo-stars">★ 59</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">briancaffey /</span> hermes-otel</div>
+        <div class="repo-desc">OTel Plugin for Hermes Agent.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/raulvidis/hermes-cloudflare" data-github="https://github.com/raulvidis/hermes-cloudflare" data-desc="Cloudflare Browser Rendering plugin — crawl, scrape, extract content from web pages">
+      <div class="repo-stars">★ 51</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">raulvidis /</span> hermes-cloudflare</div>
+        <div class="repo-desc">Cloudflare Browser Rendering plugin — crawl, scrape, extract content from web pages.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/FahrenheitResearch/hermes-weather-plugin" data-github="https://github.com/FahrenheitResearch/hermes-weather-plugin" data-desc="NWS-grade model imagery, NEXRAD radar, and verified meteorological calculations. Pure Rust.">
+      <div class="repo-stars">★ 47</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">FahrenheitResearch /</span> hermes-weather-plugin</div>
+        <div class="repo-desc">NWS-grade model imagery, NEXRAD radar, and verified meteorological calculations. Pure Rust.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/bielcarpi/hermes-live-voice" data-github="https://github.com/bielcarpi/hermes-live-voice" data-desc="Continuous realtime voice for Hermes Agent. Talk while Hermes runs background tasks, with local Hugging Face, Gemini Live, and OpenAI Realtime.">
+      <div class="repo-stars">★ 37</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">bielcarpi /</span> hermes-live-voice</div>
+        <div class="repo-desc">Continuous realtime voice for Hermes Agent. Talk while Hermes runs background tasks, with local Hugging Face, Gemini Live, and OpenAI Realtime.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/indranilbanerjee/socialforge" data-github="https://github.com/indranilbanerjee/socialforge" data-desc="Open-source agency-grade social media production plugin — 16 skills, 25 commands, AI image (Nano Banana Pro) + AI video (Kling v3.0 Pro) + C2PA signing (EU AI Act Article 50). Installs on Claude Code,">
+      <div class="repo-stars">★ 36</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">indranilbanerjee /</span> socialforge</div>
+        <div class="repo-desc">Open-source agency-grade social media production plugin — 16 skills, 25 commands, AI image (Nano Banana Pro) + AI video (Kling v3.0 Pro) + C2PA signing (EU AI Act Article 50). Installs on Claude Code,.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/nujovich/hermes-telemetry" data-github="https://github.com/nujovich/hermes-telemetry" data-desc="Budget enforcement + observability plugin for Hermes Agent. Stops runaway costs before they happen.">
+      <div class="repo-stars">★ 32</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">nujovich /</span> hermes-telemetry</div>
+        <div class="repo-desc">Budget enforcement + observability plugin for Hermes Agent. Stops runaway costs before they happen.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Xquik-dev/hermes-tweet" data-github="https://github.com/Xquik-dev/hermes-tweet" data-desc="Native Hermes Agent plugin for X automation through Xquik">
+      <div class="repo-stars">★ 31</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Xquik-dev /</span> hermes-tweet</div>
+        <div class="repo-desc">Native Hermes Agent plugin for X automation through Xquik.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/indranilbanerjee/contentforge" data-github="https://github.com/indranilbanerjee/contentforge" data-desc="Open-source enterprise content production plugin — 21 skills, 13 agents, 11 quality gates, 29-pattern AI humanizer, fact-checker, real .docx output with C2PA signing (EU AI Act Article 50 ready). Inst">
+      <div class="repo-stars">★ 25</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">indranilbanerjee /</span> contentforge</div>
+        <div class="repo-desc">Open-source enterprise content production plugin — 21 skills, 13 agents, 11 quality gates, 29-pattern AI humanizer, fact-checker, real .docx output with C2PA signing (EU AI Act Article 50 ready). Inst.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Capslockb/hermes-live-discord-agent-plugin" data-github="https://github.com/Capslockb/hermes-live-discord-agent-plugin" data-desc="Hermes Live Discord Agent Plugin — full-duplex Discord voice ↔ Google Gemini Multimodal Live API, with function calling, idle hangup, transcripts, and a 3-min oneshot installer.">
+      <div class="repo-stars">★ 19</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Capslockb /</span> hermes-live-discord-agent-plugin</div>
+        <div class="repo-desc">Hermes Live Discord Agent Plugin — full-duplex Discord voice ↔ Google Gemini Multimodal Live API, with function calling, idle hangup, transcripts, and a 3-min oneshot installer.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/42-evey/evey-bridge-plugin" data-github="https://github.com/42-evey/evey-bridge-plugin" data-desc="Claude Code and Hermes context sharing bridge — auto-checks messages, Mother Mode loop">
+      <div class="repo-stars">★ 16</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">42-evey /</span> evey-bridge-plugin</div>
+        <div class="repo-desc">Claude Code and Hermes context sharing bridge — auto-checks messages, Mother Mode loop.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Context4GPTs/klodi-plugin" data-github="https://github.com/Context4GPTs/klodi-plugin" data-desc="The agent-to-agent marketplace, in your agent host. Your agent lists, haggles, and closes deals for you while you live your life.">
+      <div class="repo-stars">★ 16</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Context4GPTs /</span> klodi-plugin</div>
+        <div class="repo-desc">The agent-to-agent marketplace, in your agent host. Your agent lists, haggles, and closes deals for you while you live your life.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Sahil-SS9/hermes-Custom-CLI-Themes" data-github="https://github.com/Sahil-SS9/hermes-Custom-CLI-Themes" data-desc="Custom YAML skin pack for the Hermes Agent CLI with themed palettes, spinners, branding, and ASCII banners.">
+      <div class="repo-stars">★ 15</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Sahil-SS9 /</span> hermes-Custom-CLI-Themes</div>
+        <div class="repo-desc">Custom YAML skin pack for the Hermes Agent CLI with themed palettes, spinners, branding, and ASCII banners.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/nativ3ai/hermes-payguard" data-github="https://github.com/nativ3ai/hermes-payguard" data-desc="Safe-by-design USDC and x402 payment plugin for Hermes Agent">
+      <div class="repo-stars">★ 14</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">nativ3ai /</span> hermes-payguard</div>
+        <div class="repo-desc">Safe-by-design USDC and x402 payment plugin for Hermes Agent.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/CorsenAI/hermes-connector" data-github="https://github.com/CorsenAI/hermes-connector" data-desc="Chrome browser extension for Hermes Agent — exact sessions, user-selected tabs, and local-first browser control.">
+      <div class="repo-stars">★ 14</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">CorsenAI /</span> hermes-connector</div>
+        <div class="repo-desc">Chrome browser extension for Hermes Agent — exact sessions, user-selected tabs, and local-first browser control.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Sahil-SS9/hermes-memlock" data-github="https://github.com/Sahil-SS9/hermes-memlock" data-desc="Re-assert standing instructions after context compaction. Pin anchors, detect drift, rehydrate before the model forgets">
+      <div class="repo-stars">★ 13</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Sahil-SS9 /</span> hermes-memlock</div>
+        <div class="repo-desc">Re-assert standing instructions after context compaction. Pin anchors, detect drift, rehydrate before the model forgets.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Sahil-SS9/Toolaria" data-github="https://github.com/Sahil-SS9/Toolaria" data-desc="Rescue oversized tool results before they flood context. SHA256-addressed blob store with per-session indexes">
+      <div class="repo-stars">★ 13</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Sahil-SS9 /</span> Toolaria</div>
+        <div class="repo-desc">Rescue oversized tool results before they flood context. SHA256-addressed blob store with per-session indexes.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/basilisk-labs/agentplane-hermes-plugin" data-github="https://github.com/basilisk-labs/agentplane-hermes-plugin" data-desc="Hermes plugin for spawning AgentPlane as an external Kanban worker lane.">
+      <div class="repo-stars">★ 6</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">basilisk-labs /</span> agentplane-hermes-plugin</div>
+        <div class="repo-desc">Hermes plugin for spawning AgentPlane as an external Kanban worker lane.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/IVRZ-da/agentiker-code-intel" data-github="https://github.com/IVRZ-da/agentiker-code-intel" data-desc="70 AST-aware code intelligence tools for Hermes Agent — tree-sitter + ast-grep + LSP bridge for Python, TypeScript, Go, Rust, and 5 more languages">
+      <div class="repo-stars">★ 5</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">IVRZ-da /</span> agentiker-code-intel</div>
+        <div class="repo-desc">70 AST-aware code intelligence tools for Hermes Agent — tree-sitter + ast-grep + LSP bridge for Python, TypeScript, Go, Rust, and 5 more languages.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/MnrGreg/hermes-venice-web" data-github="https://github.com/MnrGreg/hermes-venice-web" data-desc="Hermes plugin that uses Venice.AI web_search and web_scrape tools">
+      <div class="repo-stars">★ 4</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">MnrGreg /</span> hermes-venice-web</div>
+        <div class="repo-desc">Hermes plugin that uses Venice.AI web_search and web_scrape tools.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/hlothaire/hermes-trace" data-github="https://github.com/hlothaire/hermes-trace" data-desc="A Hermes Agent plugin that builds execution trace graphs using agent lifecycle hooks.">
+      <div class="repo-stars">★ 3</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">hlothaire /</span> hermes-trace</div>
+        <div class="repo-desc">A Hermes Agent plugin that builds execution trace graphs using agent lifecycle hooks.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/IVRZ-da/agentiker-scout" data-github="https://github.com/IVRZ-da/agentiker-scout" data-desc="Unified analysis, bug-hunt &amp; web-research plugin for Hermes Agent — 43 tools across code analysis, vulnerability scanning, and autonomous research">
+      <div class="repo-stars">★ 3</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">IVRZ-da /</span> agentiker-scout</div>
+        <div class="repo-desc">Unified analysis, bug-hunt &amp; web-research plugin for Hermes Agent — 43 tools across code analysis, vulnerability scanning, and autonomous research.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Fruxano/fruvisi" data-github="https://github.com/Fruxano/fruvisi" data-desc="Visual organization dashboard plugin for Hermes Agent — org chart with areas &amp; groups, one-click team lineups (functional presets), per-agent OpenRouter fallback, kanban integration and chat control.">
+      <div class="repo-stars">★ 3</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Fruxano /</span> fruvisi</div>
+        <div class="repo-desc">Visual organization dashboard plugin for Hermes Agent — org chart with areas &amp; groups, one-click team lineups (functional presets), per-agent OpenRouter fallback, kanban integration and chat control.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/chenwei791129/hermes-usage-hook" data-github="https://github.com/chenwei791129/hermes-usage-hook" data-desc="Hermes Agent footer hook: append your AI provider's rate-limit usage (Codex, MiniMax, …) under each reply.">
+      <div class="repo-stars">★ 3</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">chenwei791129 /</span> hermes-usage-hook</div>
+        <div class="repo-desc">Hermes Agent footer hook: append your AI provider's rate-limit usage (Codex, MiniMax, …) under each reply.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/chillerno1/hermes-yt-plugin" data-github="https://github.com/chillerno1/hermes-yt-plugin" data-desc="A floating YouTube player plugin for Hermes Desktop">
+      <div class="repo-stars">★ 3</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">chillerno1 /</span> hermes-yt-plugin</div>
+        <div class="repo-desc">A floating YouTube player plugin for Hermes Desktop.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Heybinshao/hermes-appearance-hub" data-github="https://github.com/Heybinshao/hermes-appearance-hub" data-desc="Hermes Desktop 外观整合插件：纸纹 + 霞鹜文楷字体，状态栏一键开关">
+      <div class="repo-stars">★ 3</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Heybinshao /</span> hermes-appearance-hub</div>
+        <div class="repo-desc">Hermes Desktop 外观整合插件：纸纹 + 霞鹜文楷字体，状态栏一键开关.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/IVRZ-da/agentiker-plan-follow" data-github="https://github.com/IVRZ-da/agentiker-plan-follow" data-desc="Structured plan creation &amp; task enforcement for Hermes Agent — review gates, parallel groups, auto-verify, git integration, 12 templates">
+      <div class="repo-stars">★ 2</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">IVRZ-da /</span> agentiker-plan-follow</div>
+        <div class="repo-desc">Structured plan creation &amp; task enforcement for Hermes Agent — review gates, parallel groups, auto-verify, git integration, 12 templates.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/allmodels-io/hermes-speech" data-github="https://github.com/allmodels-io/hermes-speech" data-desc="Hermes Agent TTS and STT plugin for AllModels speech models and voices.">
+      <div class="repo-stars">★ 2</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">allmodels-io /</span> hermes-speech</div>
+        <div class="repo-desc">Hermes Agent TTS and STT plugin for AllModels speech models and voices.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/masterlf/hermes-ai-usage" data-github="https://github.com/masterlf/hermes-ai-usage" data-desc="Read-only provider quota and token telemetry for Hermes Agent Desktop and Web Dashboard">
+      <div class="repo-stars">★ 2</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">masterlf /</span> hermes-ai-usage</div>
+        <div class="repo-desc">Read-only provider quota and token telemetry for Hermes Agent Desktop and Web Dashboard.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/corsur/swarm-tips" data-github="https://github.com/corsur/swarm-tips" data-desc="Swarm Tips — AI agent discovery and coordination. Smart contracts, MCP server, shared crates.">
+      <div class="repo-stars">★ 1</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">corsur /</span> swarm-tips</div>
+        <div class="repo-desc">Swarm Tips — AI agent discovery and coordination. Smart contracts, MCP server, shared crates.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Cyber-Yichen/hermes-xiaomi-mimo-tts" data-github="https://github.com/Cyber-Yichen/hermes-xiaomi-mimo-tts" data-desc="Xiaomi MiMo V2.5 TTS provider for Hermes Agent with native Feishu/Lark OGG/Opus voice-message delivery.">
+      <div class="repo-stars">★ 0</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Cyber-Yichen /</span> hermes-xiaomi-mimo-tts</div>
+        <div class="repo-desc">Xiaomi MiMo V2.5 TTS provider for Hermes Agent with native Feishu/Lark OGG/Opus voice-message delivery.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Cyber-Yichen/hermes-feishu-group-context" data-github="https://github.com/Cyber-Yichen/hermes-feishu-group-context" data-desc="Local Feishu/Lark group chat archiving and on-demand context for Hermes Agent.">
+      <div class="repo-stars">★ 0</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Cyber-Yichen /</span> hermes-feishu-group-context</div>
+        <div class="repo-desc">Local Feishu/Lark group chat archiving and on-demand context for Hermes Agent.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/pomponchik/incontext" data-github="https://github.com/pomponchik/incontext" data-desc="Exact dynamic output budgeting for Hermes Agent">
+      <div class="repo-stars">★ 0</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">pomponchik /</span> incontext</div>
+        <div class="repo-desc">Exact dynamic output budgeting for Hermes Agent.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+  </div>
+</section>
+
+<section class="cat" data-category="Multi-Agent &amp; Orchestration">
+  <div class="cat-meta">
+    <div class="cat-num">§06</div>
+    <h2 class="cat-title">Multi-agent &amp; orchestration</h2>
+    <p class="cat-desc">Fleet management, swarm coordinators, and multi-agent delegation systems.</p>
+    <div class="cat-count"><span class="cat-count-n">12</span> repos</div>
+  </div>
+  <div class="cat-list">
+    <a class="repo-row" href="/projects/TauricResearch/TradingAgents" data-github="https://github.com/TauricResearch/TradingAgents" data-desc="TradingAgents: Multi-Agents LLM Financial Trading Framework">
+      <div class="repo-stars">★ 101,647</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">TauricResearch /</span> TradingAgents</div>
+        <div class="repo-desc">TradingAgents: Multi-Agents LLM Financial Trading Framework.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/builderz-labs/mission-control" data-github="https://github.com/builderz-labs/mission-control" data-desc="Self-hosted AI agent orchestration — dispatch tasks, run multi-agent workflows, monitor spend">
+      <div class="repo-stars">★ 6,129</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">builderz-labs /</span> mission-control</div>
+        <div class="repo-desc">Self-hosted AI agent orchestration — dispatch tasks, run multi-agent workflows, monitor spend.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/agent-of-empires/agent-of-empires" data-github="https://github.com/agent-of-empires/agent-of-empires" data-desc="TUI and web control surface for managing multiple coding agents including Hermes Agent, Claude Code, OpenCode, Codex, Gemini, and others">
+      <div class="repo-stars">★ 3,154</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">agent-of-empires /</span> agent-of-empires</div>
+        <div class="repo-desc">TUI and web control surface for managing multiple coding agents including Hermes Agent, Claude Code, OpenCode, Codex, Gemini, and others.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/CryptoDmitry/hermes-agent-control-room" data-github="https://github.com/CryptoDmitry/hermes-agent-control-room" data-desc="Control Room-first template for managing Hermes agents from one VPS agent to specialist teams and orchestrated workflows">
+      <div class="repo-stars">★ 749</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">CryptoDmitry /</span> hermes-agent-control-room</div>
+        <div class="repo-desc">Control Room-first template for managing Hermes agents from one VPS agent to specialist teams and orchestrated workflows.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/shannhk/hermes-agent-control-room" data-github="https://github.com/shannhk/hermes-agent-control-room" data-desc="Control Room-first template for scaling Hermes Agent from one VPS agent to specialist teams and automated workflows">
+      <div class="repo-stars">★ 699</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">shannhk /</span> hermes-agent-control-room</div>
+        <div class="repo-desc">Control Room-first template for scaling Hermes Agent from one VPS agent to specialist teams and automated workflows.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/swarmclawai/swarmclaw" data-github="https://github.com/swarmclawai/swarmclaw" data-desc="Build autonomous AI agent swarms with orchestration, skills, and multiple model providers">
+      <div class="repo-stars">★ 654</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">swarmclawai /</span> swarmclaw</div>
+        <div class="repo-desc">Build autonomous AI agent swarms with orchestration, skills, and multiple model providers.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/agent37-platform/minions" data-github="https://github.com/agent37-platform/minions" data-desc="Mission Control for Hermes agents: create, supervise, and review autonomous Hermes Agent work from one screen">
+      <div class="repo-stars">★ 624</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">agent37-platform /</span> minions</div>
+        <div class="repo-desc">Mission Control for Hermes agents: create, supervise, and review autonomous Hermes Agent work from one screen.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/1ilkhamov/opencode-hermes-multiagent" data-github="https://github.com/1ilkhamov/opencode-hermes-multiagent" data-desc="17 specialized agents for research, planning, implementation, quality, and infrastructure">
+      <div class="repo-stars">★ 184</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">1ilkhamov /</span> opencode-hermes-multiagent</div>
+        <div class="repo-desc">17 specialized agents for research, planning, implementation, quality, and infrastructure.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/linke-ai/hermes-agent-team" data-github="https://github.com/linke-ai/hermes-agent-team" data-desc="Local multi-agent team collaboration web system built on Hermes Agent profiles, MCP, ACP, and Hermes Kanban">
+      <div class="repo-stars">★ 181</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">linke-ai /</span> hermes-agent-team</div>
+        <div class="repo-desc">Local multi-agent team collaboration web system built on Hermes Agent profiles, MCP, ACP, and Hermes Kanban.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/howdymary/hermes-agent-metaharness" data-github="https://github.com/howdymary/hermes-agent-metaharness" data-desc="Meta-harness for Hermes Agent — meta-optimization with arxiv paper reference">
+      <div class="repo-stars">★ 112</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">howdymary /</span> hermes-agent-metaharness</div>
+        <div class="repo-desc">Meta-harness for Hermes Agent — meta-optimization with arxiv paper reference.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/runtimenoteslabs/gladiator" data-github="https://github.com/runtimenoteslabs/gladiator" data-desc="Autonomous AI companies competing for GitHub stars — agent-vs-agent arena">
+      <div class="repo-stars">★ 79</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">runtimenoteslabs /</span> gladiator</div>
+        <div class="repo-desc">Autonomous AI companies competing for GitHub stars — agent-vs-agent arena.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/InfiniteWhispers/HermesAgent-MultiModel" data-github="https://github.com/InfiniteWhispers/HermesAgent-MultiModel" data-desc="Fully-local multi-model agent framework running a Mixture-of-Agents stack on consumer GPUs with Hermes and Ollama, no cloud dependencies.">
+      <div class="repo-stars">★ 55</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">InfiniteWhispers /</span> HermesAgent-MultiModel</div>
+        <div class="repo-desc">Fully-local multi-model agent framework running a Mixture-of-Agents stack on consumer GPUs with Hermes and Ollama, no cloud dependencies.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+  </div>
+</section>
+
+<section class="cat" data-category="Deployment &amp; Infra">
+  <div class="cat-meta">
+    <div class="cat-num">§07</div>
+    <h2 class="cat-title">Deployment &amp; infra</h2>
+    <p class="cat-desc">Docker, Nix, systemd, and managed cloud templates — from a $5 VPS to enterprise Kubernetes.</p>
+    <div class="cat-count"><span class="cat-count-n">12</span> repos</div>
+  </div>
+  <div class="cat-list">
+    <a class="repo-row" href="/projects/numtide/llm-agents.nix" data-github="https://github.com/numtide/llm-agents.nix" data-desc="Nix packages for AI coding agents including Hermes">
+      <div class="repo-stars">★ 1,848</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">numtide /</span> llm-agents.nix</div>
+        <div class="repo-desc">Nix packages for AI coding agents including Hermes.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/marshallrichards/ClawPhone" data-github="https://github.com/marshallrichards/ClawPhone" data-desc="Scripts and notes for running agent CLIs including Hermes Agent on Android smartphones through Termux">
+      <div class="repo-stars">★ 548</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">marshallrichards /</span> ClawPhone</div>
+        <div class="repo-desc">Scripts and notes for running agent CLIs including Hermes Agent on Android smartphones through Termux.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/AbuZar-Ansarii/Hermes-Agent-On-Android" data-github="https://github.com/AbuZar-Ansarii/Hermes-Agent-On-Android" data-desc="Termux-based installer and guide for running Hermes Agent on Android devices">
+      <div class="repo-stars">★ 206</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">AbuZar-Ansarii /</span> Hermes-Agent-On-Android</div>
+        <div class="repo-desc">Termux-based installer and guide for running Hermes Agent on Android devices.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/ultraworkers/hermes-agent-helm-chart" data-github="https://github.com/ultraworkers/hermes-agent-helm-chart" data-desc="Unofficial community Helm chart for deploying Hermes Agent on Kubernetes with cloud-native state-safety guardrails">
+      <div class="repo-stars">★ 134</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">ultraworkers /</span> hermes-agent-helm-chart</div>
+        <div class="repo-desc">Unofficial community Helm chart for deploying Hermes Agent on Kubernetes with cloud-native state-safety guardrails.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/amirghm/hermes-agent-mobile" data-github="https://github.com/amirghm/hermes-agent-mobile" data-desc="One-command installer that brings the Hermes AI assistant to Android and iOS.">
+      <div class="repo-stars">★ 86</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">amirghm /</span> hermes-agent-mobile</div>
+        <div class="repo-desc">One-command installer that brings the Hermes AI assistant to Android and iOS.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/TheAiSingularity/hermesclaw" data-github="https://github.com/TheAiSingularity/hermesclaw" data-desc="Hermes Agent sandboxed with hardware-level enforcement">
+      <div class="repo-stars">★ 64</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">TheAiSingularity /</span> hermesclaw</div>
+        <div class="repo-desc">Hermes Agent sandboxed with hardware-level enforcement.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/xmbshwll/hermes-agent-docker" data-github="https://github.com/xmbshwll/hermes-agent-docker" data-desc="Simple Docker sandbox image for Hermes Agent">
+      <div class="repo-stars">★ 48</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">xmbshwll /</span> hermes-agent-docker</div>
+        <div class="repo-desc">Simple Docker sandbox image for Hermes Agent.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/solomon2773/nora" data-github="https://github.com/solomon2773/nora" data-desc="Self-hosted control plane to deploy, monitor, and operate OpenClaw and Hermes AI agents on Docker/Kubernetes — with REST, CLI, and MCP.">
+      <div class="repo-stars">★ 48</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">solomon2773 /</span> nora</div>
+        <div class="repo-desc">Self-hosted control plane to deploy, monitor, and operate OpenClaw and Hermes AI agents on Docker/Kubernetes — with REST, CLI, and MCP.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/0xrsydn/nix-hermes-agent" data-github="https://github.com/0xrsydn/nix-hermes-agent" data-desc="Nix package and NixOS module for reproducible Hermes deployment">
+      <div class="repo-stars">★ 42</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">0xrsydn /</span> nix-hermes-agent</div>
+        <div class="repo-desc">Nix package and NixOS module for reproducible Hermes deployment.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/jpalmae/hermeshq" data-github="https://github.com/jpalmae/hermeshq" data-desc="HermesHQ is a Docker-first control plane for running and operating multiple Hermes Agent instances from one web application.">
+      <div class="repo-stars">★ 25</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">jpalmae /</span> hermeshq</div>
+        <div class="repo-desc">HermesHQ is a Docker-first control plane for running and operating multiple Hermes Agent instances from one web application.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/JackTheGit/hermes-autonomous-server" data-github="https://github.com/JackTheGit/hermes-autonomous-server" data-desc="Headless systemd deployment with Nous Portal integration — production-ready">
+      <div class="repo-stars">★ 15</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">JackTheGit /</span> hermes-autonomous-server</div>
+        <div class="repo-desc">Headless systemd deployment with Nous Portal integration — production-ready.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/MilkyWay008/Hermes-OTG" data-github="https://github.com/MilkyWay008/Hermes-OTG" data-desc="Hermes OTG — The Portable Hermes Agent That Does *Everything*. Full production package distributed via GitHub Releases (see PACKAGE-STRUCTURE.md).">
+      <div class="repo-stars">★ 10</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">MilkyWay008 /</span> Hermes-OTG</div>
+        <div class="repo-desc">Hermes OTG — The Portable Hermes Agent That Does *Everything*. Full production package distributed via GitHub Releases (see PACKAGE-STRUCTURE.md).</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+  </div>
+</section>
+
+<section class="cat" data-category="Integrations &amp; Bridges">
+  <div class="cat-meta">
+    <div class="cat-num">§08</div>
+    <h2 class="cat-title">Integrations &amp; bridges</h2>
+    <p class="cat-desc">Connect Hermes to other agents, platforms, and specialized systems.</p>
+    <div class="cat-count"><span class="cat-count-n">13</span> repos</div>
+  </div>
+  <div class="cat-list">
+    <a class="repo-row" href="/projects/AaronWong1999/hermesclaw" data-github="https://github.com/AaronWong1999/hermesclaw" data-desc="Run Hermes Agent and OpenClaw on the same WeChat account">
+      <div class="repo-stars">★ 719</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">AaronWong1999 /</span> hermesclaw</div>
+        <div class="repo-desc">Run Hermes Agent and OpenClaw on the same WeChat account.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/chainbase-labs/Agentkey" data-github="https://github.com/chainbase-labs/Agentkey" data-desc="Connect your AI agent to the world — Web search, Social media, Crypto &amp; On-chain data. One plugin, zero extra config.">
+      <div class="repo-stars">★ 620</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">chainbase-labs /</span> Agentkey</div>
+        <div class="repo-desc">Connect your AI agent to the world — Web search, Social media, Crypto &amp; On-chain data. One plugin, zero extra config.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/raulvidis/hermes-android" data-github="https://github.com/raulvidis/hermes-android" data-desc="Android device control — bridge app + Python toolset for mobile automation">
+      <div class="repo-stars">★ 483</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">raulvidis /</span> hermes-android</div>
+        <div class="repo-desc">Android device control — bridge app + Python toolset for mobile automation.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Codename-11/hermes-relay" data-github="https://github.com/Codename-11/hermes-relay" data-desc="Hermes Companion — Android app for Hermes agent platform. Chat, terminal, and device control over WSS.">
+      <div class="repo-stars">★ 173</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Codename-11 /</span> hermes-relay</div>
+        <div class="repo-desc">Hermes Companion — Android app for Hermes agent platform. Chat, terminal, and device control over WSS.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/sandbaseai/cli" data-github="https://github.com/sandbaseai/cli" data-desc="Open-source AI CLI and local MCP server connecting 25 AI clients—including Claude Code, Cursor, Codex, and ChatGPT—to 2,000+ models and APIs, with OAuth and rollback.">
+      <div class="repo-stars">★ 72</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">sandbaseai /</span> cli</div>
+        <div class="repo-desc">Open-source AI CLI and local MCP server connecting 25 AI clients—including Claude Code, Cursor, Codex, and ChatGPT—to 2,000+ models and APIs, with OAuth and rollback.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/teknium1/hermes-miniverse" data-github="https://github.com/teknium1/hermes-miniverse" data-desc="Bridge Hermes to Miniverse pixel worlds — agent embodiment in virtual environments">
+      <div class="repo-stars">★ 55</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">teknium1 /</span> hermes-miniverse</div>
+        <div class="repo-desc">Bridge Hermes to Miniverse pixel worlds — agent embodiment in virtual environments.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Ridwannurudeen/hermes-council" data-github="https://github.com/Ridwannurudeen/hermes-council" data-desc="Adversarial multi-perspective council MCP server for decision-making">
+      <div class="repo-stars">★ 51</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Ridwannurudeen /</span> hermes-council</div>
+        <div class="repo-desc">Adversarial multi-perspective council MCP server for decision-making.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/gizdusum/hermes-blockchain-oracle" data-github="https://github.com/gizdusum/hermes-blockchain-oracle" data-desc="Solana blockchain intelligence MCP server — wallets, whales, tokens, NFTs, network health">
+      <div class="repo-stars">★ 6</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">gizdusum /</span> hermes-blockchain-oracle</div>
+        <div class="repo-desc">Solana blockchain intelligence MCP server — wallets, whales, tokens, NFTs, network health.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/kevinmarmstrong/hermes-claude-code-rc" data-github="https://github.com/kevinmarmstrong/hermes-claude-code-rc" data-desc="Hermes Agent plugin for remote controlling Claude Code sessions via Telegram">
+      <div class="repo-stars">★ 3</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">kevinmarmstrong /</span> hermes-claude-code-rc</div>
+        <div class="repo-desc">Hermes Agent plugin for remote controlling Claude Code sessions via Telegram.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/BORT-AGENTS/hermes-bort" data-github="https://github.com/BORT-AGENTS/hermes-bort" data-desc="No description">
+      <div class="repo-stars">★ 3</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">BORT-AGENTS /</span> hermes-bort</div>
+        <div class="repo-desc">No description.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/DanielLi202/hermes-tag" data-github="https://github.com/DanielLi202/hermes-tag" data-desc="Post images, add notes, let the thread run, then @ it — Hermes Tag pulls the few messages that matter (originals + your notes + relevant replies), not your last line, not your whole history. Claude-Ta">
+      <div class="repo-stars">★ 3</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">DanielLi202 /</span> hermes-tag</div>
+        <div class="repo-desc">Post images, add notes, let the thread run, then @ it — Hermes Tag pulls the few messages that matter (originals + your notes + relevant replies), not your last line, not your whole history. Claude-Ta.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/kfa-ai/hermes-timetree-sync" data-github="https://github.com/kfa-ai/hermes-timetree-sync" data-desc="Non-interactive TimeTree calendar bridge for Hermes Agent">
+      <div class="repo-stars">★ 1</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">kfa-ai /</span> hermes-timetree-sync</div>
+        <div class="repo-desc">Non-interactive TimeTree calendar bridge for Hermes Agent.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/AgentLineHQ/agentline-skill" data-github="https://github.com/AgentLineHQ/agentline-skill" data-desc="No description">
+      <div class="repo-stars">★ 1</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">AgentLineHQ /</span> agentline-skill</div>
+        <div class="repo-desc">No description.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+  </div>
+</section>
+
+<section class="cat" data-category="Developer Tools">
+  <div class="cat-meta">
+    <div class="cat-num">§09</div>
+    <h2 class="cat-title">Developer tools</h2>
+    <p class="cat-desc">CLIs, linters, migration helpers, token trackers, and other dev utilities.</p>
+    <div class="cat-count"><span class="cat-count-n">19</span> repos</div>
+  </div>
+  <div class="cat-list">
+    <a class="repo-row" href="/projects/colbymchenry/codegraph" data-github="https://github.com/colbymchenry/codegraph" data-desc="Local pre-indexed code knowledge graph for Hermes Agent and other coding agents to reduce token usage and tool calls">
+      <div class="repo-stars">★ 68,565</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">colbymchenry /</span> codegraph</div>
+        <div class="repo-desc">Local pre-indexed code knowledge graph for Hermes Agent and other coding agents to reduce token usage and tool calls.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/junhoyeo/tokscale" data-github="https://github.com/junhoyeo/tokscale" data-desc="CLI tool for tracking token usage from Claude Code, OpenClaw, Hermes, Codex, Gemini, and more">
+      <div class="repo-stars">★ 5,210</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">junhoyeo /</span> tokscale</div>
+        <div class="repo-desc">CLI tool for tracking token usage from Claude Code, OpenClaw, Hermes, Codex, Gemini, and more.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/liaohch3/claude-tap" data-github="https://github.com/liaohch3/claude-tap" data-desc="Local trace viewer for inspecting coding-agent API traffic from Hermes Agent, Claude Code, Codex, Gemini, Cursor, OpenCode, and others">
+      <div class="repo-stars">★ 3,144</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">liaohch3 /</span> claude-tap</div>
+        <div class="repo-desc">Local trace viewer for inspecting coding-agent API traffic from Hermes Agent, Claude Code, Codex, Gemini, Cursor, OpenCode, and others.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/bergside/typeui" data-github="https://github.com/bergside/typeui" data-desc="Build better UI with AI">
+      <div class="repo-stars">★ 1,840</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">bergside /</span> typeui</div>
+        <div class="repo-desc">Build better UI with AI.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Javis603/token-monitor" data-github="https://github.com/Javis603/token-monitor" data-desc="Real-time token, cost, and rate-limit widget with multi-device sync, reading Hermes Agent state directly alongside Claude Code, Codex, and other CLIs.">
+      <div class="repo-stars">★ 1,798</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Javis603 /</span> token-monitor</div>
+        <div class="repo-desc">Real-time token, cost, and rate-limit widget with multi-device sync, reading Hermes Agent state directly alongside Claude Code, Codex, and other CLIs.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Salomondiei08/oh-my-hermes" data-github="https://github.com/Salomondiei08/oh-my-hermes" data-desc="Opinionated workflow layer for building, shipping, and operating apps with Hermes Agent">
+      <div class="repo-stars">★ 855</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Salomondiei08 /</span> oh-my-hermes</div>
+        <div class="repo-desc">Opinionated workflow layer for building, shipping, and operating apps with Hermes Agent.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/joeynyc/hermes-skins" data-github="https://github.com/joeynyc/hermes-skins" data-desc="Community CLI skins and themes for Hermes terminal UI">
+      <div class="repo-stars">★ 563</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">joeynyc /</span> hermes-skins</div>
+        <div class="repo-desc">Community CLI skins and themes for Hermes terminal UI.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/AlexAI-MCP/hermes-CCC" data-github="https://github.com/AlexAI-MCP/hermes-CCC" data-desc="Hermes Agent ported to Claude Code Channel — 46 native skills, no OAuth, no external process">
+      <div class="repo-stars">★ 134</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">AlexAI-MCP /</span> hermes-CCC</div>
+        <div class="repo-desc">Hermes Agent ported to Claude Code Channel — 46 native skills, no OAuth, no external process.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/tinyhumansai/tiny.place" data-github="https://github.com/tinyhumansai/tiny.place" data-desc="The social economy for autonomous AI agents.">
+      <div class="repo-stars">★ 130</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">tinyhumansai /</span> tiny.place</div>
+        <div class="repo-desc">The social economy for autonomous AI agents.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/unmodeled-tyler/vessel-browser" data-github="https://github.com/unmodeled-tyler/vessel-browser" data-desc="AI-native browser built for autonomous agent control via MCP">
+      <div class="repo-stars">★ 129</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">unmodeled-tyler /</span> vessel-browser</div>
+        <div class="repo-desc">AI-native browser built for autonomous agent control via MCP.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/topoteretes/cognee-integrations" data-github="https://github.com/topoteretes/cognee-integrations" data-desc="No description">
+      <div class="repo-stars">★ 83</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">topoteretes /</span> cognee-integrations</div>
+        <div class="repo-desc">No description.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/adityahimaone/hermes-agent-rtk-caveman" data-github="https://github.com/adityahimaone/hermes-agent-rtk-caveman" data-desc="Hermes Agent RTK and Caveman setup with preconfigured skills and token-saving CLI workflows">
+      <div class="repo-stars">★ 77</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">adityahimaone /</span> hermes-agent-rtk-caveman</div>
+        <div class="repo-desc">Hermes Agent RTK and Caveman setup with preconfigured skills and token-saving CLI workflows.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Abruptive/Ankh.md" data-github="https://github.com/Abruptive/Ankh.md" data-desc="TAW Agent framework for creating scoped Hermes Agents">
+      <div class="repo-stars">★ 74</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Abruptive /</span> Ankh.md</div>
+        <div class="repo-desc">TAW Agent framework for creating scoped Hermes Agents.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/42-evey/evey-setup" data-github="https://github.com/42-evey/evey-setup" data-desc="Get a hermes-agent stack running in minutes — free models, 29 plugins, zero cost">
+      <div class="repo-stars">★ 66</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">42-evey /</span> evey-setup</div>
+        <div class="repo-desc">Get a hermes-agent stack running in minutes — free models, 29 plugins, zero cost.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/hermes-labs-ai/lintlang" data-github="https://github.com/hermes-labs-ai/lintlang" data-desc="Static linter for AI agent configs, tool descriptions, and system prompts. HERM v1.1 scoring.">
+      <div class="repo-stars">★ 63</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">hermes-labs-ai /</span> lintlang</div>
+        <div class="repo-desc">Static linter for AI agent configs, tool descriptions, and system prompts. HERM v1.1 scoring.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/0xNyk/openclaw-to-hermes" data-github="https://github.com/0xNyk/openclaw-to-hermes" data-desc="Migration tool from OpenClaw to Hermes Agent">
+      <div class="repo-stars">★ 37</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">0xNyk /</span> openclaw-to-hermes</div>
+        <div class="repo-desc">Migration tool from OpenClaw to Hermes Agent.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/observeco/observeco" data-github="https://github.com/observeco/observeco" data-desc="Self-healing observability for AI agents. Discover, monitor, and auto-recover multi-agent systems — without a cloud dependency.">
+      <div class="repo-stars">★ 8</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">observeco /</span> observeco</div>
+        <div class="repo-desc">Self-healing observability for AI agents. Discover, monitor, and auto-recover multi-agent systems — without a cloud dependency.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/handnewb/hermes-voice" data-github="https://github.com/handnewb/hermes-voice" data-desc="Voice-enabled personal assistant for Hermes Agent. Open mic with wake word, fully local — no API keys, no accounts, 35 languages.">
+      <div class="repo-stars">★ 1</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">handnewb /</span> hermes-voice</div>
+        <div class="repo-desc">Voice-enabled personal assistant for Hermes Agent. Open mic with wake word, fully local — no API keys, no accounts, 35 languages.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/33hodl/hermes-startup" data-github="https://github.com/33hodl/hermes-startup" data-desc="Make your first genuine dollar online using Hermes Agent.">
+      <div class="repo-stars">★ 1</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">33hodl /</span> hermes-startup</div>
+        <div class="repo-desc">Make your first genuine dollar online using Hermes Agent.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+  </div>
+</section>
+
+<section class="cat" data-category="Domain Applications">
+  <div class="cat-meta">
+    <div class="cat-num">§10</div>
+    <h2 class="cat-title">Domain applications</h2>
+    <p class="cat-desc">Purpose-built agents for specific verticals — SRE, jobs, gaming, blockchain, robotics.</p>
+    <div class="cat-count"><span class="cat-count-n">11</span> repos</div>
+  </div>
+  <div class="cat-list">
+    <a class="repo-row" href="/projects/ucsandman/DashClaw" data-github="https://github.com/ucsandman/DashClaw" data-desc="Decision infrastructure with guard policies and risk assessment for agents">
+      <div class="repo-stars">★ 297</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">ucsandman /</span> DashClaw</div>
+        <div class="repo-desc">Decision infrastructure with guard policies and risk assessment for agents.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/longsizhuo/openInvest" data-github="https://github.com/longsizhuo/openInvest" data-desc="基于multiple LLM的风险投资助手">
+      <div class="repo-stars">★ 82</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">longsizhuo /</span> openInvest</div>
+        <div class="repo-desc">基于multiple LLM的风险投资助手.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Lethe044/hermes-incident-commander" data-github="https://github.com/Lethe044/hermes-incident-commander" data-desc="Autonomous SRE agent — detects, heals, and learns from production incidents">
+      <div class="repo-stars">★ 67</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Lethe044 /</span> hermes-incident-commander</div>
+        <div class="repo-desc">Autonomous SRE agent — detects, heals, and learns from production incidents.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/bigph00t/hermescraft" data-github="https://github.com/bigph00t/hermescraft" data-desc="Embodied AI companion for Minecraft — persistent memory, vision, learning, multi-agent">
+      <div class="repo-stars">★ 65</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">bigph00t /</span> hermescraft</div>
+        <div class="repo-desc">Embodied AI companion for Minecraft — persistent memory, vision, learning, multi-agent.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Christabel337/job-scout-agent" data-github="https://github.com/Christabel337/job-scout-agent" data-desc="Autonomous job hunting — scans listings, writes cover letters, tracks applications">
+      <div class="repo-stars">★ 56</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Christabel337 /</span> job-scout-agent</div>
+        <div class="repo-desc">Autonomous job hunting — scans listings, writes cover letters, tracks applications.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/JackTheGit/hermes-ai-infrastructure-monitoring-toolkit" data-github="https://github.com/JackTheGit/hermes-ai-infrastructure-monitoring-toolkit" data-desc="Autonomous monitoring — cron-based research ingestion, cost forecasting, headless systemd">
+      <div class="repo-stars">★ 34</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">JackTheGit /</span> hermes-ai-infrastructure-monitoring-toolkit</div>
+        <div class="repo-desc">Autonomous monitoring — cron-based research ingestion, cost forecasting, headless systemd.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/hxsteric/mercury" data-github="https://github.com/hxsteric/mercury" data-desc="Blockchain cash flow analyzer — multi-chain analysis, fraud detection, WebGL dashboard">
+      <div class="repo-stars">★ 18</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">hxsteric /</span> mercury</div>
+        <div class="repo-desc">Blockchain cash flow analyzer — multi-chain analysis, fraud detection, WebGL dashboard.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/rodmarkun/anihermes" data-github="https://github.com/rodmarkun/anihermes" data-desc="Local anime server and tracker via natural language for Hermes Agent">
+      <div class="repo-stars">★ 16</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">rodmarkun /</span> anihermes</div>
+        <div class="repo-desc">Local anime server and tracker via natural language for Hermes Agent.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/bryercowan/hermes-embodied" data-github="https://github.com/bryercowan/hermes-embodied" data-desc="Self-improving robotics via VLA model fine-tuning on cloud GPUs">
+      <div class="repo-stars">★ 13</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">bryercowan /</span> hermes-embodied</div>
+        <div class="repo-desc">Self-improving robotics via VLA model fine-tuning on cloud GPUs.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/Sahil-SS9/MrHermagi-tutorbot" data-github="https://github.com/Sahil-SS9/MrHermagi-tutorbot" data-desc="Discord AI tutor bot built on Hermes Agent profiles, cron jobs, forum delivery, HTML lessons, and TTS audio.">
+      <div class="repo-stars">★ 5</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">Sahil-SS9 /</span> MrHermagi-tutorbot</div>
+        <div class="repo-desc">Discord AI tutor bot built on Hermes Agent profiles, cron jobs, forum delivery, HTML lessons, and TTS audio.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/handnewb/lock-on-absence" data-github="https://github.com/handnewb/lock-on-absence" data-desc="🔒 Auto-lock your screen when you walk away. Face recognition via LBPH, SFace, or LLM (OpenAI, Anthropic, Ollama, Hermes Agent). Privacy-first: local-first, egress gate, TrustPolicy tiers T3→T0.">
+      <div class="repo-stars">★ 2</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">handnewb /</span> lock-on-absence</div>
+        <div class="repo-desc">🔒 Auto-lock your screen when you walk away. Face recognition via LBPH, SFace, or LLM (OpenAI, Anthropic, Ollama, Hermes Agent). Privacy-first: local-first, egress gate, TrustPolicy tiers T3→T0.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+  </div>
+</section>
+
+<section class="cat" data-category="Guides &amp; Docs">
+  <div class="cat-meta">
+    <div class="cat-num">§11</div>
+    <h2 class="cat-title">Guides &amp; docs</h2>
+    <p class="cat-desc">Curated lists, optimization playbooks, setup walkthroughs, and community wikis.</p>
+    <div class="cat-count"><span class="cat-count-n">17</span> repos</div>
+  </div>
+  <div class="cat-list">
+    <a class="repo-row" href="/projects/0xNyk/awesome-hermes-agent" data-github="https://github.com/0xNyk/awesome-hermes-agent" data-desc="Curated list of awesome skills, tools, integrations, and resources for Hermes Agent">
+      <div class="repo-stars">★ 5,491</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">0xNyk /</span> awesome-hermes-agent</div>
+        <div class="repo-desc">Curated list of awesome skills, tools, integrations, and resources for Hermes Agent.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/alchaincyf/hermes-agent-orange-book" data-github="https://github.com/alchaincyf/hermes-agent-orange-book" data-desc="Hermes Agent practical guide — Orange Book series (Chinese language)">
+      <div class="repo-stars">★ 4,887</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">alchaincyf /</span> hermes-agent-orange-book</div>
+        <div class="repo-desc">Hermes Agent practical guide — Orange Book series (Chinese language).</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/ksimback/hermes-ecosystem" data-github="https://github.com/ksimback/hermes-ecosystem" data-desc="Hermes Atlas — the community map of every tool, skill, and integration for Hermes Agent">
+      <div class="repo-stars">★ 1,237</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">ksimback /</span> hermes-ecosystem</div>
+        <div class="repo-desc">Hermes Atlas — the community map of every tool, skill, and integration for Hermes Agent.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/jwangkun/hermes-agent-guide" data-github="https://github.com/jwangkun/hermes-agent-guide" data-desc="A systematic Chinese-language guide to Hermes Agent — 16 books, 300K+ words, covering installation, advanced development, single- and multi-agent orchestration.">
+      <div class="repo-stars">★ 659</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">jwangkun /</span> hermes-agent-guide</div>
+        <div class="repo-desc">A systematic Chinese-language guide to Hermes Agent — 16 books, 300K+ words, covering installation, advanced development, single- and multi-agent orchestration.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/OnlyTerp/hermes-optimization-guide" data-github="https://github.com/OnlyTerp/hermes-optimization-guide" data-desc="Performance optimization guide for Hermes deployments">
+      <div class="repo-stars">★ 614</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">OnlyTerp /</span> hermes-optimization-guide</div>
+        <div class="repo-desc">Performance optimization guide for Hermes deployments.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/longyunfeigu/learn-hermes-agent" data-github="https://github.com/longyunfeigu/learn-hermes-agent" data-desc="A 27-chapter hands-on tutorial for building an autonomous AI agent from zero in Python — agent loop, tool system, memory, skills, MCP, multi-platform gateway, and self-evolution.">
+      <div class="repo-stars">★ 220</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">longyunfeigu /</span> learn-hermes-agent</div>
+        <div class="repo-desc">A 27-chapter hands-on tutorial for building an autonomous AI agent from zero in Python — agent loop, tool system, memory, skills, MCP, multi-platform gateway, and self-evolution.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/anneheartrecord/hermes-agent-anatomy" data-github="https://github.com/anneheartrecord/hermes-agent-anatomy" data-desc="Chinese Hermes Agent source-code anatomy and architecture analysis">
+      <div class="repo-stars">★ 97</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">anneheartrecord /</span> hermes-agent-anatomy</div>
+        <div class="repo-desc">Chinese Hermes Agent source-code anatomy and architecture analysis.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/bookunt3d/hermes-agent-fa" data-github="https://github.com/bookunt3d/hermes-agent-fa" data-desc="Complete Persian translation of the official Hermes Agent documentation.">
+      <div class="repo-stars">★ 81</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">bookunt3d /</span> hermes-agent-fa</div>
+        <div class="repo-desc">Complete Persian translation of the official Hermes Agent documentation.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/mudrii/hermes-agent-docs" data-github="https://github.com/mudrii/hermes-agent-docs" data-desc="Community documentation covering deployment patterns and v0.2.0+ workflows">
+      <div class="repo-stars">★ 74</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">mudrii /</span> hermes-agent-docs</div>
+        <div class="repo-desc">Community documentation covering deployment patterns and v0.2.0+ workflows.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/jefferyjob/awesome-hermes-agent-zh" data-github="https://github.com/jefferyjob/awesome-hermes-agent-zh" data-desc="Chinese awesome list of practical Hermes Agent skills, tools, integrations, and resources">
+      <div class="repo-stars">★ 64</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">jefferyjob /</span> awesome-hermes-agent-zh</div>
+        <div class="repo-desc">Chinese awesome list of practical Hermes Agent skills, tools, integrations, and resources.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/0xarkstar/awesome-hermes-agent" data-github="https://github.com/0xarkstar/awesome-hermes-agent" data-desc="Curated list of resources, tools, and projects for Hermes Agent by Nous Research.">
+      <div class="repo-stars">★ 50</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">0xarkstar /</span> awesome-hermes-agent</div>
+        <div class="repo-desc">Curated list of resources, tools, and projects for Hermes Agent by Nous Research.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/zcweah1981/awesome-hermes-agent-zh" data-github="https://github.com/zcweah1981/awesome-hermes-agent-zh" data-desc="Chinese-language Hermes Agent hub: onboarding paths, local deployment guidance, OpenClaw migration notes, and troubleshooting references.">
+      <div class="repo-stars">★ 47</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">zcweah1981 /</span> awesome-hermes-agent-zh</div>
+        <div class="repo-desc">Chinese-language Hermes Agent hub: onboarding paths, local deployment guidance, OpenClaw migration notes, and troubleshooting references.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/metantonio/hermes-wsl-ubuntu" data-github="https://github.com/metantonio/hermes-wsl-ubuntu" data-desc="Step-by-step WSL2 Ubuntu setup guide for Windows users">
+      <div class="repo-stars">★ 41</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">metantonio /</span> hermes-wsl-ubuntu</div>
+        <div class="repo-desc">Step-by-step WSL2 Ubuntu setup guide for Windows users.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/xiaonancs/hermes-agent-study" data-github="https://github.com/xiaonancs/hermes-agent-study" data-desc="Chinese deep research series on Hermes Agent internals, OpenClaw lineage, self-evolution, and source-code architecture">
+      <div class="repo-stars">★ 35</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">xiaonancs /</span> hermes-agent-study</div>
+        <div class="repo-desc">Chinese deep research series on Hermes Agent internals, OpenClaw lineage, self-evolution, and source-code architecture.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/vectrocomputers/Hermes-Agent-Action-Plan" data-github="https://github.com/vectrocomputers/Hermes-Agent-Action-Plan" data-desc="Privacy-first practical guidance for configuring and operating Hermes Agent effectively">
+      <div class="repo-stars">★ 24</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">vectrocomputers /</span> Hermes-Agent-Action-Plan</div>
+        <div class="repo-desc">Privacy-first practical guidance for configuring and operating Hermes Agent effectively.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/martymcenroe/HermesWiki" data-github="https://github.com/martymcenroe/HermesWiki" data-desc="Community wiki with deployment patterns and recipes">
+      <div class="repo-stars">★ 17</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">martymcenroe /</span> HermesWiki</div>
+        <div class="repo-desc">Community wiki with deployment patterns and recipes.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/freehul/progressive-skill" data-github="https://github.com/freehul/progressive-skill" data-desc="Smart skill index compaction for Hermes Agent — progressive disclosure with budget control and usage-frequency learning. Cuts skills index ~70% tokens (issue #22620).">
+      <div class="repo-stars">★ 6</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">freehul /</span> progressive-skill</div>
+        <div class="repo-desc">Smart skill index compaction for Hermes Agent — progressive disclosure with budget control and usage-frequency learning. Cuts skills index ~70% tokens (issue #22620).</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+  </div>
+</section>
+
+<section class="cat" data-category="Forks &amp; Derivatives">
+  <div class="cat-meta">
+    <div class="cat-num">§12</div>
+    <h2 class="cat-title">Forks &amp; derivatives</h2>
+    <p class="cat-desc">Patched, cloud-deployed, or fine-tuned variants of Hermes Agent.</p>
+    <div class="cat-count"><span class="cat-count-n">6</span> repos</div>
+  </div>
+  <div class="cat-list">
+    <a class="repo-row" href="/projects/kaminocorp/hermes-alpha" data-github="https://github.com/kaminocorp/hermes-alpha" data-desc="Cloud-deployed Hermes with pre-configured templates and managed infrastructure">
+      <div class="repo-stars">★ 228</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">kaminocorp /</span> hermes-alpha</div>
+        <div class="repo-desc">Cloud-deployed Hermes with pre-configured templates and managed infrastructure.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/nativ3ai/hermes-agent-camel" data-github="https://github.com/nativ3ai/hermes-agent-camel" data-desc="Hermes with integrated CaMeL trust boundaries for safer autonomous execution">
+      <div class="repo-stars">★ 194</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">nativ3ai /</span> hermes-agent-camel</div>
+        <div class="repo-desc">Hermes with integrated CaMeL trust boundaries for safer autonomous execution.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/sheawinkler/hermes-agent-ultra" data-github="https://github.com/sheawinkler/hermes-agent-ultra" data-desc="Rust-based Hermes Agent Ultra derivative focused on performance and Hermes Agent feature parity">
+      <div class="repo-stars">★ 84</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">sheawinkler /</span> hermes-agent-ultra</div>
+        <div class="repo-desc">Rust-based Hermes Agent Ultra derivative focused on performance and Hermes Agent feature parity.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/pengchengxia75-arch/hermes-agent-windows" data-github="https://github.com/pengchengxia75-arch/hermes-agent-windows" data-desc="Windows-native Hermes Agent adaptation with one-line PowerShell installer and no WSL requirement">
+      <div class="repo-stars">★ 39</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">pengchengxia75-arch /</span> hermes-agent-windows</div>
+        <div class="repo-desc">Windows-native Hermes Agent adaptation with one-line PowerShell installer and no WSL requirement.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/carterwayneskhizeine/hermes-agent-windows-R" data-github="https://github.com/carterwayneskhizeine/hermes-agent-windows-R" data-desc="Windows-native adaptation fork of Hermes Agent with runtime, path, process, and terminal backend compatibility improvements">
+      <div class="repo-stars">★ 20</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">carterwayneskhizeine /</span> hermes-agent-windows-R</div>
+        <div class="repo-desc">Windows-native adaptation fork of Hermes Agent with runtime, path, process, and terminal backend compatibility improvements.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+    <a class="repo-row" href="/projects/beardthelion/hermes-skill-distillation" data-github="https://github.com/beardthelion/hermes-skill-distillation" data-desc="Generate agentic training trajectories from real-world tasks for Hermes 4 fine-tuning">
+      <div class="repo-stars">★ 15</div>
+      <div class="repo-body">
+        <div class="repo-name"><span class="org">beardthelion /</span> hermes-skill-distillation</div>
+        <div class="repo-desc">Generate agentic training trajectories from real-world tasks for Hermes 4 fine-tuning.</div>
+      </div>
+      <div class="repo-delta">— / wk</div>
+    </a>
+  </div>
+</section>
+
+</main>
+
+<!-- Tooltip (single shared element, positioned via JS) -->
+<div class="tooltip" id="tooltip" role="tooltip">
+  <div class="tt-name" id="tt-name"></div>
+  <div class="tt-desc" id="tt-desc"></div>
+  <div class="tt-link">view project page →</div>
+</div>
+
+<footer class="page-footer">
+  <div class="fn-left">hermes atlas · curated by <a href="https://github.com/ksimback">ksimback</a> · <a href="https://github.com/ksimback/hermes-ecosystem/issues">suggest a repo</a> · <a href="/privacy">privacy</a></div>
+  <div>v2 · 2026.04</div>
+</footer>
+
+<script src="/assets/js/theme-toggle.js" defer></script>
+<script src="/assets/js/masthead-fetch.js" defer></script>
+<script src="/assets/js/ecosystem.js" defer></script>
+<!-- Cloudflare Web Analytics -->
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js"
+        data-cf-beacon='{"token": "fe0d4d79280b4386b6b0cd99b2d94dbc"}'></script>
+<!-- End Cloudflare Web Analytics -->
+</body>
+</html>

--- a/lib/build-artifacts.js
+++ b/lib/build-artifacts.js
@@ -21,6 +21,7 @@ export const GENERATED_ARTIFACT_PATHS = [
   "masterclass/",
   "projects/",
   "lists/",
+  "ecosystem/",
   "use-cases/",
   "skills/",
   "reports/",

--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -244,6 +244,13 @@ if (fs.existsSync(reportsPath)) {
 // than at import time; held here so the render pass can reach it.
 let skillsData = null;
 
+// Catalog category presentation (order, § numbers, display titles, intro
+// lines) for the generated /ecosystem/ page. Hand-curated; every category in
+// repos.json must have an entry — enforced fail-loud in renderEcosystemPage.
+const categories = JSON.parse(
+  fs.readFileSync(path.join(ROOT, "data", "categories.json"), "utf-8")
+);
+
 let latestHermesVersion = "v0.15.2";
 const latestReleasePath = path.join(ROOT, "data", "latest-release.json");
 if (fs.existsSync(latestReleasePath)) {
@@ -669,6 +676,9 @@ A hands-on developer tutorial for building on the Hermes Agent codebase, written
 - [Glossary](${SITE_URL}/dev/glossary): Plain-English definitions of every Hermes term.
 - [Codebase map & cheat sheet](${SITE_URL}/dev/codebase-map): Where to edit X — key files, the ~/.hermes data dir, and commands.
 - [Skill authoring template](${SITE_URL}/dev/skill-template): A copy-paste SKILL.md with annotated frontmatter.
+
+## Ecosystem Catalog
+- [The full ecosystem catalog](${SITE_URL}/ecosystem/): All ${repos.length} tracked projects across ${categoryCount} categories on one page, with live GitHub data.
 
 ## Top Projects
 ${topProjects.map((r) => `- [${r.owner}/${r.repo}](${SITE_URL}/projects/${r.owner}/${r.repo}): ${r.description} (${(r.stars || 0).toLocaleString()} stars${r.official ? ", official" : ""})`).join("\n")}
@@ -1223,6 +1233,188 @@ ${PAGE_FOOTER}
 
 <script src="/assets/js/theme-toggle.js" defer></script>
 <script src="/assets/js/masthead-fetch.js" defer></script>
+<!-- Cloudflare Web Analytics -->
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js"
+        data-cf-beacon='{"token": "fe0d4d79280b4386b6b0cd99b2d94dbc"}'></script>
+<!-- End Cloudflare Web Analytics -->
+</body>
+</html>`;
+}
+
+// ── Ecosystem catalog (/ecosystem/) ──
+// The full 12-category repo catalog, fully generated from data/repos.json +
+// data/categories.json (row blurbs come from the optional hand-curated
+// `blurb` field). This page replaces the old homepage-embedded catalog that
+// syncHomepageRepos() maintained append-only inside hand-authored HTML.
+function renderEcosystemPage(repos) {
+  const roundedCount = Math.floor(repos.length / 10) * 10;
+  const title = `Hermes Agent Ecosystem — ${roundedCount}+ open-source tools, skills & integrations | Hermes Atlas`;
+  const desc = `The complete Hermes Agent ecosystem catalog — ${roundedCount}+ open-source tools, skills, plugins, workspaces, and integrations across 12 categories, with live GitHub data. Quality-filtered and curated weekly.`;
+  const canonicalUrl = `${SITE_URL}/ecosystem/`;
+  const ogTitle = "The Hermes Agent Ecosystem";
+  const ogSubtitle = `${roundedCount}+ open-source tools, skills, plugins & integrations — live GitHub data`;
+
+  // Fail loud if a catalog category has no presentation entry: a silently
+  // dropped section is exactly the class of bug the old homepage sync hid.
+  const metaByCategory = new Map(categories.map((c) => [c.category, c]));
+  const missingMeta = [...new Set(repos.map((r) => r.category))].filter(
+    (c) => !metaByCategory.has(c)
+  );
+  if (missingMeta.length > 0) {
+    throw new Error(
+      `data/categories.json is missing entries for: ${missingMeta.join(", ")}`
+    );
+  }
+
+  const byCategory = new Map(categories.map((c) => [c.category, []]));
+  for (const r of repos) byCategory.get(r.category).push(r);
+
+  const sections = categories
+    .map((c) => {
+      const catRepos = (byCategory.get(c.category) || []).sort(
+        (a, b) => (b.stars || 0) - (a.stars || 0)
+      );
+      const rows = catRepos.map(renderHomepageRepoRow).join("");
+      return `<section class="cat" data-category="${escapeHtml(c.category)}">
+  <div class="cat-meta">
+    <div class="cat-num">${escapeHtml(c.num)}</div>
+    <h2 class="cat-title">${escapeHtml(c.title)}</h2>
+    <p class="cat-desc">${escapeHtml(c.description)}</p>
+    <div class="cat-count"><span class="cat-count-n">${catRepos.length}</span> repos</div>
+  </div>
+  <div class="cat-list">
+${rows.trimEnd()}
+  </div>
+</section>`;
+    })
+    .join("\n\n");
+
+  const breadcrumbLD = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "home", item: "https://hermesatlas.com/" },
+      { "@type": "ListItem", position: 2, name: "ecosystem" },
+    ],
+  };
+
+  const collectionLD = {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "@id": canonicalUrl,
+    name: "The Hermes Agent Ecosystem — full catalog",
+    description: desc,
+    url: canonicalUrl,
+    isPartOf: { "@id": "https://hermesatlas.com/#website" },
+    mainEntity: { "@id": "https://hermesatlas.com/#catalog" },
+  };
+
+  // The machine-readable catalog Dataset. Canonical home is this page (the
+  // homepage's copy of the same node is retired with the homepage redesign).
+  const datasetLD = {
+    "@context": "https://schema.org",
+    "@type": "Dataset",
+    "@id": "https://hermesatlas.com/#catalog",
+    name: "Hermes Agent Ecosystem Catalog",
+    description: `Machine-readable catalog of community-built tools, skills, plugins, workspaces, and integrations for Nous Research's Hermes Agent. ${roundedCount}+ projects across 12 categories with live GitHub metadata and AI-generated summaries.`,
+    url: canonicalUrl,
+    keywords:
+      "Hermes Agent, Nous Research, AI agents, LLM tools, agent skills, MCP servers, agent plugins",
+    license: "https://creativecommons.org/publicdomain/zero/1.0/",
+    isAccessibleForFree: true,
+    creator: { "@id": "https://hermesatlas.com/#organization" },
+    publisher: { "@id": "https://hermesatlas.com/#organization" },
+    distribution: [
+      { "@type": "DataDownload", encodingFormat: "application/json", contentUrl: "https://hermesatlas.com/data/repos.json" },
+      { "@type": "DataDownload", encodingFormat: "application/json", contentUrl: "https://hermesatlas.com/data/summaries.json" },
+      { "@type": "DataDownload", encodingFormat: "application/json", contentUrl: "https://hermesatlas.com/data/list-summaries.json" },
+      { "@type": "DataDownload", encodingFormat: "text/plain", contentUrl: "https://hermesatlas.com/llms-full.txt" },
+      { "@type": "DataDownload", encodingFormat: "application/xml", contentUrl: "https://hermesatlas.com/sitemap.xml" },
+    ],
+  };
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>${escapeHtml(title)}</title>
+<meta name="description" content="${escapeHtml(desc)}">
+<link rel="canonical" href="${canonicalUrl}">
+<meta property="og:title" content="${escapeHtml(ogTitle)}">
+<meta property="og:description" content="${escapeHtml(desc)}">
+<meta property="og:type" content="website">
+<meta property="og:url" content="${canonicalUrl}">
+<meta property="og:site_name" content="Hermes Atlas">
+<meta property="og:image" content="${escapeHtml(ogImageUrl({ title: ogTitle, subtitle: ogSubtitle, kind: "lists" }))}">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="${escapeHtml(ogTitle)}">
+<meta name="twitter:image" content="${escapeHtml(ogImageUrl({ title: ogTitle, subtitle: ogSubtitle, kind: "lists" }))}">
+${ldJson(breadcrumbLD)}
+${ldJson(collectionLD)}
+${ldJson(datasetLD)}
+<link rel="alternate" type="application/rss+xml" title="Hermes Atlas — new projects" href="/rss.xml">
+${FAVICON}
+<script src="/assets/js/theme-init.js"></script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap">
+<link rel="stylesheet" href="/assets/css/tokens.css">
+<link rel="stylesheet" href="/assets/css/base.css">
+<link rel="stylesheet" href="/assets/css/page.css">
+<link rel="stylesheet" href="/assets/css/ecosystem.css">
+</head>
+<body>
+
+<a class="skip-link" href="#main">Skip to content</a>
+
+${renderMasthead("ecosystem")}
+
+<div class="breadcrumb" aria-label="Breadcrumb">
+  <a href="/">home</a><span class="sep">/</span>ecosystem
+</div>
+
+<main id="main">
+
+<section class="list-page">
+  <h1 class="list-title">The Hermes Agent ecosystem</h1>
+  <p class="list-intro">Every open-source tool, skill, plugin, workspace, and integration in the Hermes Agent ecosystem — <strong>${repos.length} projects across 12 categories</strong>, quality-filtered, with live GitHub data. Know what you want to build? <a href="/use-cases/">Find repos by use case →</a> Looking for skills? <a href="/skills/">Best picks by use case →</a></p>
+</section>
+
+<!-- Catalog search + sort. Progressive enhancement: hidden by default and
+     revealed + wired by initCatalogControls(); with JS off, the full
+     categorized list below stays fully browsable. -->
+<div class="catalog-controls" id="catalog-controls" hidden>
+  <input type="search" id="catalog-search" class="catalog-search" placeholder="filter projects by name or description…" aria-label="Filter projects">
+  <label class="catalog-sort-wrap">
+    <span class="catalog-sort-label">sort</span>
+    <select id="catalog-sort" class="catalog-sort" aria-label="Sort projects">
+      <option value="stars">most stars</option>
+      <option value="name">name a–z</option>
+      <option value="active">recently active</option>
+    </select>
+  </label>
+  <span class="catalog-result-count" id="catalog-result-count" aria-live="polite"></span>
+</div>
+
+${sections}
+
+</main>
+
+<!-- Tooltip (single shared element, positioned via JS) -->
+<div class="tooltip" id="tooltip" role="tooltip">
+  <div class="tt-name" id="tt-name"></div>
+  <div class="tt-desc" id="tt-desc"></div>
+  <div class="tt-link">view project page →</div>
+</div>
+
+${PAGE_FOOTER}
+
+<script src="/assets/js/theme-toggle.js" defer></script>
+<script src="/assets/js/masthead-fetch.js" defer></script>
+<script src="/assets/js/ecosystem.js" defer></script>
 <!-- Cloudflare Web Analytics -->
 <script defer src="https://static.cloudflareinsights.com/beacon.min.js"
         data-cf-beacon='{"token": "fe0d4d79280b4386b6b0cd99b2d94dbc"}'></script>
@@ -2234,6 +2426,10 @@ function generateSitemap(projectPages, listPages, reportPages = [], useCasePages
     urls += entry(`/projects/${page.owner}/${page.repo}`, `projects/${page.owner}/${page.repo}.html`, "weekly", "0.8");
   }
 
+  // The full catalog page — the homepage's former primary content, now its
+  // own routed destination.
+  urls += entry("/ecosystem/", "ecosystem/index.html", "daily", "0.9");
+
   urls += entry("/lists/", "lists/index.html", "weekly", "0.7");
   for (const list of listPages) {
     urls += entry(`/lists/${list.slug}`, `lists/${list.slug}.html`, "weekly", "0.6");
@@ -2259,7 +2455,8 @@ function generateSitemap(projectPages, listPages, reportPages = [], useCasePages
 function renderHomepageRepoRow(r) {
   const stars = (r.stars || 0).toLocaleString("en-US");
   const flag = r.official ? ' <span class="repo-flag">official</span>' : "";
-  const desc = (r.description || "").trim();
+  // Hand-curated catalog blurb wins over the raw GitHub description.
+  const desc = (r.blurb || r.description || "").trim();
   const descPunctuated = desc.endsWith(".") ? desc : desc + ".";
   return `    <a class="repo-row" href="/projects/${r.owner}/${r.repo}" data-github="https://github.com/${r.owner}/${r.repo}" data-desc="${escapeHtml(desc)}">
       <div class="repo-stars">★ ${stars}</div>
@@ -2792,6 +2989,12 @@ async function main() {
 
   // Generate the lists index page (/lists/)
   writePage(path.join(listsDir, "index.html"), renderListsIndex(lists, repos));
+
+  // Full catalog page (/ecosystem/) — generated from repos.json + categories.json
+  console.log("\nGenerating /ecosystem/ catalog page...");
+  const ecosystemDir = path.join(ROOT, "ecosystem");
+  if (!fs.existsSync(ecosystemDir)) fs.mkdirSync(ecosystemDir, { recursive: true });
+  writePage(path.join(ecosystemDir, "index.html"), renderEcosystemPage(repos));
   console.log(`  index (${lists.length} lists)`);
 
   // Generate use-case pages (/use-cases/)

--- a/scripts/smoke-test-prod.js
+++ b/scripts/smoke-test-prod.js
@@ -300,8 +300,10 @@ async function section(title, fn) {
 await section("1. Critical pages return 2xx", async () => {
   const paths = [
     "/",
+    "/ecosystem/",
     "/guide/",
     "/lists/",
+    "/skills/",
     "/use-cases/",
     "/reports/",
     "/privacy/",

--- a/scripts/validate-repos-json.js
+++ b/scripts/validate-repos-json.js
@@ -130,6 +130,16 @@ export function validateRepos(repos) {
       errors.push(`${label} official must be boolean`);
     }
 
+    // Optional hand-curated catalog blurb (rendered on /ecosystem/ in place of
+    // the GitHub description). Kept short so rows stay scannable.
+    if ("blurb" in entry) {
+      if (!isNonEmptyString(entry.blurb)) {
+        errors.push(`${label} blurb, when present, must be a non-empty string`);
+      } else if (entry.blurb.length > 200) {
+        errors.push(`${label} blurb must be ≤ 200 characters`);
+      }
+    }
+
     if (
       "stars" in entry &&
       (!Number.isInteger(entry.stars) || entry.stars < 0)

--- a/tests/build-artifacts.test.js
+++ b/tests/build-artifacts.test.js
@@ -18,6 +18,7 @@ test("generated artifact manifest covers current build outputs", () => {
     "masterclass/",
     "projects/",
     "lists/",
+    "ecosystem/",
     "use-cases/",
     "skills/",
     "reports/",

--- a/tests/ecosystem-page.test.js
+++ b/tests/ecosystem-page.test.js
@@ -1,0 +1,153 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { JSDOM } from "jsdom";
+
+// The /ecosystem/ catalog page is fully generated from data/repos.json +
+// data/categories.json (the homepage catalog's replacement). These tests run
+// against the committed artifact: every repo renders exactly once, category
+// counts match the data, hand-curated blurbs win over GitHub descriptions,
+// and the search/sort controls behave like the homepage originals they
+// replaced (progressive enhancement contract included).
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.join(__dirname, "..");
+const html = fs.readFileSync(path.join(ROOT, "ecosystem", "index.html"), "utf8");
+const repos = JSON.parse(
+  fs.readFileSync(path.join(ROOT, "data", "repos.json"), "utf8"),
+);
+const categories = JSON.parse(
+  fs.readFileSync(path.join(ROOT, "data", "categories.json"), "utf8"),
+);
+const appJs = fs.readFileSync(
+  path.join(ROOT, "assets", "js", "ecosystem.js"),
+  "utf8",
+);
+
+function loadPage({ runScripts = true } = {}) {
+  const window = new JSDOM(html, {
+    url: "https://hermesatlas.com/ecosystem/",
+    runScripts: "dangerously",
+    beforeParse(window) {
+      window.fetch = () => Promise.reject(new Error("network disabled in test"));
+    },
+  }).window;
+  if (runScripts) {
+    window.eval(appJs);
+  }
+  return window;
+}
+
+test("every catalog repo renders exactly one row", () => {
+  const { document } = loadPage({ runScripts: false });
+  const hrefs = Array.from(document.querySelectorAll("a.repo-row")).map((a) =>
+    a.getAttribute("href"),
+  );
+  assert.equal(hrefs.length, repos.length, "one row per repos.json entry");
+  assert.equal(new Set(hrefs).size, hrefs.length, "no duplicate rows");
+  for (const r of repos) {
+    assert.ok(
+      hrefs.includes(`/projects/${r.owner}/${r.repo}`),
+      `missing row for ${r.owner}/${r.repo}`,
+    );
+  }
+});
+
+test("all 12 category sections render in categories.json order with correct counts", () => {
+  const { document } = loadPage({ runScripts: false });
+  const sections = Array.from(document.querySelectorAll("section.cat"));
+  assert.equal(sections.length, categories.length);
+  sections.forEach((sec, i) => {
+    const cat = categories[i];
+    assert.equal(sec.getAttribute("data-category"), cat.category);
+    const expected = repos.filter((r) => r.category === cat.category).length;
+    assert.equal(
+      parseInt(sec.querySelector(".cat-count-n").textContent, 10),
+      expected,
+      `count for ${cat.category}`,
+    );
+    assert.equal(sec.querySelectorAll("a.repo-row").length, expected);
+  });
+});
+
+test("hand-curated blurbs win over GitHub descriptions in rendered rows", () => {
+  const { document } = loadPage({ runScripts: false });
+  const withBlurb = repos.filter((r) => r.blurb);
+  assert.ok(withBlurb.length > 0, "expected at least one blurb in repos.json");
+  for (const r of withBlurb) {
+    const row = document.querySelector(
+      `a.repo-row[href="/projects/${r.owner}/${r.repo}"]`,
+    );
+    assert.ok(row, `row missing for ${r.owner}/${r.repo}`);
+    assert.equal(row.getAttribute("data-desc"), r.blurb);
+    assert.ok(
+      row.querySelector(".repo-desc").textContent.startsWith(r.blurb.replace(/\.$/, "")),
+      `rendered desc for ${r.owner}/${r.repo} should use the blurb`,
+    );
+  }
+});
+
+test("rows within each category are sorted by stars descending (no-JS order)", () => {
+  const { document } = loadPage({ runScripts: false });
+  const starsByKey = new Map(
+    repos.map((r) => [`/projects/${r.owner}/${r.repo}`, r.stars || 0]),
+  );
+  for (const list of document.querySelectorAll(".cat-list")) {
+    const stars = Array.from(list.querySelectorAll("a.repo-row")).map((a) =>
+      starsByKey.get(a.getAttribute("href")),
+    );
+    const sorted = [...stars].sort((a, b) => b - a);
+    assert.deepEqual(stars, sorted);
+  }
+});
+
+test("catalog controls are progressive enhancement: hidden without JS, revealed with JS", () => {
+  const noJs = loadPage({ runScripts: false });
+  assert.equal(noJs.document.getElementById("catalog-controls").hidden, true);
+
+  const withJs = loadPage();
+  assert.equal(withJs.document.getElementById("catalog-controls").hidden, false);
+});
+
+test("filter narrows visible rows and clearing restores all", () => {
+  const window = loadPage();
+  const { document } = window;
+
+  const rows = Array.from(document.querySelectorAll(".repo-row"));
+  assert.ok(rows.length > 100, `expected a populated catalog, got ${rows.length} rows`);
+  const visibleCount = () => rows.filter((r) => r.style.display !== "none").length;
+
+  assert.equal(visibleCount(), rows.length);
+
+  const search = document.getElementById("catalog-search");
+  search.value = "memory";
+  search.dispatchEvent(new window.Event("input", { bubbles: true }));
+
+  const narrowed = visibleCount();
+  assert.ok(narrowed > 0, "filter should match at least one row");
+  assert.ok(narrowed < rows.length, "filter should hide non-matching rows");
+
+  search.value = "";
+  search.dispatchEvent(new window.Event("input", { bubbles: true }));
+  assert.equal(visibleCount(), rows.length);
+});
+
+test("page head is self-describing: canonical, Dataset JSON-LD, no chat widget", () => {
+  const { document } = loadPage({ runScripts: false });
+  assert.equal(
+    document.querySelector('link[rel="canonical"]').getAttribute("href"),
+    "https://hermesatlas.com/ecosystem/",
+  );
+  const ldBlocks = Array.from(
+    document.querySelectorAll('script[type="application/ld+json"]'),
+  ).map((s) => JSON.parse(s.textContent));
+  assert.ok(
+    ldBlocks.some((b) => b["@type"] === "Dataset"),
+    "Dataset JSON-LD present",
+  );
+  // Chat stays homepage-only.
+  assert.equal(document.getElementById("chat-panel"), null);
+});

--- a/tests/smoke-test-prod.test.js
+++ b/tests/smoke-test-prod.test.js
@@ -52,7 +52,7 @@ async function withAtlasFixture({ stars = {}, releaseTag = "v2026.7.7.2" } = {})
     };
 
     if (url.pathname === "/") return send(200, "text/html", homepage());
-    if (["/guide/", "/lists/", "/use-cases/", "/reports/", "/privacy/", "/robots.txt"].includes(url.pathname)) return send(200, "text/plain", "ok");
+    if (["/ecosystem/", "/guide/", "/lists/", "/skills/", "/use-cases/", "/reports/", "/privacy/", "/robots.txt"].includes(url.pathname)) return send(200, "text/plain", "ok");
     if (url.pathname === "/sitemap.xml") return send(200, "application/xml", sitemap(base));
     if (url.pathname === "/rss.xml") return send(200, "application/xml", "<rss><channel><item>ok</item></channel></rss>");
     if (url.pathname === "/llms.txt") return send(200, "text/plain", `Hermes Atlas has ${repos.length}+ tools.`);


### PR DESCRIPTION
## What

PR 1 of 2 for the homepage redesign (per the 08-17 strategy review + GSC traffic addendum: "the decision layer for Hermes Agent"). This PR is **purely additive** — the homepage is untouched.

The full 12-category catalog gets its own **fully generated** page at `/ecosystem/`, rendered from `data/repos.json` + new `data/categories.json` on every build. PR 2 will rewrite the homepage as a journey-stage decision router (New to Hermes / Power User / Explore) and retire the `syncHomepageRepos` append-only machinery + the mixed-EOL trap with it.

## Changes

- **Blurb migration (one-time):** the 10 hand-curated homepage row descriptions moved into `repos.json` as an optional `blurb` field (validator-enforced, ≤200 chars). `renderHomepageRepoRow` prefers `blurb` over `description`, so hand curation survives the move to a generated page.
- **`data/categories.json`:** category order, § numbers, display titles, intro lines — previously trapped in homepage markup.
- **`renderEcosystemPage()`:** same catalog markup shape as the homepage (`.cat` / `.repo-row` — CSS/JS/smoke parsers port unchanged), stars-desc within category, fail-loud when a repo category lacks presentation metadata. CollectionPage + Dataset JSON-LD (this page becomes the canonical home of the `#catalog` Dataset node).
- **Assets:** `ecosystem.css` (catalog rules extracted from `index.css`) + `ecosystem.js` (tooltips, live stars/deltas/trending, search+sort controls — carved from `homepage.js`). Progressive enhancement contract preserved: controls hidden without JS, full list browsable.
- **Wiring:** sitemap entry (daily / 0.9), llms.txt "Ecosystem Catalog" section, `GENERATED_ARTIFACT_PATHS`, smoke-test Section 1 now also checks `/ecosystem/` **and `/skills/`** (closing the open Skills Hub follow-up).
- **Tests:** `tests/ecosystem-page.test.js` — 7 jsdom tests: one row per repos.json entry (no dupes), per-category counts match data, blurb precedence, no-JS sort order, progressive-enhancement reveal, filter behavior, canonical/Dataset/no-chat-widget.

## Verification

- `npm test`: **305/305 pass** (was 303/305 before fixture route updates)
- Build idempotence: `ecosystem/index.html` byte-identical (sha256) across two consecutive builds; pure LF, no mixed EOLs
- Generated page: 244 rows / 12 sections / all blurbs applied / no chat widget
- Offline-build artifacts (project pages regenerated without GITHUB_TOKEN, sitemap lastmod pollution) deliberately **not** committed — CI rebuilds those post-merge as usual

## Review notes

- `/ecosystem/` has no masthead nav item yet — nav changes site-wide in PR 2 (map → home + ecosystem). Until then it's reachable via sitemap/llms and directly.
- The homepage's Dataset JSON-LD node still exists (same `@id`) until PR 2 removes it; one-PR-window duplication, harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
