### PR TITLE
Add mode decision hub (/guide/modes/) + Hermes Desktop guide (/guide/desktop/)

### DIFF
--- a/drafts/guide-desktop.md
+++ b/drafts/guide-desktop.md
@@ -1,0 +1,55 @@
+# Hermes Desktop: The Complete Guide — Install, Features, Plugins
+
+The Hermes Desktop guide. Live version: https://hermesatlas.com/guide/desktop/ — facts sourced from the official Hermes Desktop docs. Current release is v0.20.6 (as of 2026-08-27).
+
+## TL;DR
+
+Hermes Desktop is not a separate product — it is the same agent as the CLI with a native UI. Official docs: same config, same API keys, same sessions, same skills, same memory; "anything you do here shows up there." Runs on macOS, Windows, and Linux; launches its own backend (a `hermes serve` process) so it never requires separate server setup. Best starting point for most new users.
+
+## Install (macOS · Windows · Ubuntu/Linux)
+
+- Fresh install: download from the official Hermes Desktop page. macOS is Apple Silicon only (Intel Macs are officially unsupported); Windows 10/11 x86_64 and aarch64; Linux builds target mainstream glibc distros (the team tests latest Ubuntu).
+- Already run the CLI? Type `hermes desktop` — the app picks up your existing config, keys, sessions, and skills. Nothing to migrate. On Ubuntu, this route is usually smoother than hunting a distro package.
+
+## Desktop-only capabilities
+
+- Multi-session, multi-window chat with live tool activity, drag-and-drop attachments, side-by-side preview rail, queue editing, find-in-transcript.
+- Bot Mode: a roster of named agent profiles (each bot IS a Hermes profile), on by default, with group rooms and CLI parity (`hermes -p <bot> chat`).
+- Memory Graph, HUD floating mode, Quick Entry global hotkey.
+- Multi-connection: attach to several backends at once — local agent plus remote gateways on a VPS, home server, or managed Hermes Cloud instances.
+- Per-session YOLO toggle and a live context-usage meter with token breakdown by category.
+
+## Plugins and skills
+
+Desktop uses the same skills, plugins, and MCP servers as every other Hermes surface — there is no separate desktop plugin format. Anything installed for the CLI is live in the app; Bot Mode profiles inherit the same capabilities. Curated picks: the Hermes Skills Hub (hermesatlas.com/skills/); community plugins & extensions in the ecosystem catalog (hermesatlas.com/ecosystem/); memory setups in the Memory Guidebook (hermesatlas.com/guide/memory/).
+
+## Connecting to a VPS or cloud instance
+
+"Remote backend" means a `hermes serve` process you keep running on the remote machine (systemd/tmux) — the app attaches to it; it does not start it for you. Non-loopback binds engage the auth gate. Provider guidance from the docs: OAuth (Nous Portal) preferred for anything reachable beyond your own machine (VPS, public host, cloud); username/password only for trusted LAN or VPN (Tailscale — bind to the tailscale IP); never expose a password-protected backend to the open internet. The messaging gateway is a separate long-running process from `hermes serve` — keep both alive on a remote host.
+
+## Known rough edges
+
+- Electron download (~114MB) on install/build can hang on throttling networks; recent versions self-heal via a mirror fallback.
+- macOS TCC permission prompts and Gatekeeper on first run are expected — the backend runs real agent commands; a signing-identity setup reduces the friction.
+- If a remote host's SSH key changes, Desktop hard-fails ("latches") rather than silently retrying.
+- It is the heaviest way to run Hermes; the lightest server install is Docker, not Desktop.
+
+## Recent changes (v2026.8.27 line)
+
+Consent-gated browsing with your real Chrome profile (Windows close-with-approval flow), the built-in browser in its own OS window, opt-in OS-keychain encryption for secrets (no more per-launch macOS Keychain prompts), fleet profile rail, managed SSH remote-update engine. Prior release: Bot Mode group-room threads and desktop rendering performance work.
+
+## Desktop vs CLI/TUI
+
+Same agent, shared state — start in one, resume in the other. Desktop is best at multi-session work, the Bot Mode roster, remote-gateway management, and visual context controls. The CLI/TUI is best at worktree-parallel agents (`hermes -w`), background sessions, shell passthrough, and scripting; the TUI is officially "the recommended way to run Hermes interactively." Choose Desktop if you're new or juggle several agents/machines; choose the terminal if you script your tools.
+
+## FAQ
+
+**Is Hermes Desktop different from the CLI?** No — same agent, native UI ("not a separate product or a lightweight clone"). Sessions move freely between app and terminal.
+
+**Install on Ubuntu?** Download the Linux build, or run `hermes desktop` if the CLI is installed.
+
+**Plugins?** Yes — same skills/plugins/MCP servers as every surface; browse curated skills and community plugins on the Atlas.
+
+**Connect to a VPS or Hermes Cloud?** Yes, several at once. OAuth for public reachability; username/password only over LAN/VPN.
+
+**Why the macOS permission prompts?** The backend executes real commands; TCC/Gatekeeper gating is expected on first run.

--- a/drafts/guide-modes.md
+++ b/drafts/guide-modes.md
@@ -1,0 +1,59 @@
+# How to Run Hermes Agent: Desktop vs CLI vs Docker/VPS vs Bot Gateway
+
+The decision guide to every way of running Hermes Agent. Live version: https://hermesatlas.com/guide/modes/ — facts sourced from the official docs. Current release is v0.20.6 (as of 2026-08-27).
+
+## TL;DR
+
+You don't choose a front-end — you choose where the agent lives. Hermes Desktop, the CLI/TUI, and the web dashboard are front-ends to the same agent core: same config, API keys, sessions, skills, and memory. The official docs say "Pick whichever fits the moment. They share state." The real decision is where the agent process runs: your own machine (simplest), a Docker container on a VPS or home server (always-on), managed Hermes Cloud (hosted), or your phone via Termux (best-effort).
+
+## The front-ends
+
+- **Hermes Desktop** — native app for macOS, Windows, Linux; same agent core as the CLI ("not a separate product or a lightweight clone"). Best default for most people: multi-session chat windows, Bot Mode roster, Memory Graph, Quick Entry global hotkey, and multi-connection to several remote gateways/VPS/Cloud instances at once. If you run the CLI, `hermes desktop` launches the app against your existing config.
+- **CLI / TUI** — two terminal front-ends over one SQLite session store. The TUI (`hermes --tui`, Node.js ≥ 20) is officially "the recommended way to run Hermes interactively." Power features: worktree-isolated parallel agents (`hermes -w`), background sessions (`/bg`), shell passthrough (`!cmd`), skill slash-commands.
+- **Web dashboard** — `hermes dashboard`, a machine-level browser admin panel at 127.0.0.1:9119 managing every profile; for local use no data leaves localhost. Its optional Chat tab embeds the TUI via pseudo-terminal (POSIX PTY — WSL2 rather than native Windows).
+
+## Where the agent lives
+
+- **Your machine (default):** install.sh (macOS/Linux/WSL2) or install.ps1/Desktop installer (Windows). Simplest; updates via `hermes update`. The agent sleeps when your laptop does — cron and bots included.
+- **Docker on a VPS/home server (always-on):** official image `nousresearch/hermes-agent` (x86_64 + aarch64, Tier 1) with s6-overlay supervising gateway + dashboard (auto-restart). One container can host several profiles (now the recommended pattern). Minimum 1GB/1 core; 2–4GB with browser tools. Docker installs do NOT support `hermes update` — pull a new image. Never point two gateway containers at one data dir (session/memory corruption).
+- **Security on VPS:** binding the dashboard/backend to a non-loopback address engages a mandatory auth gate; `--insecure` is a deprecated no-op. In June 2026 unauthenticated public dashboards were the entry point for a real campaign that planted SSH-key backdoors via MCP-config persistence. Official guidance: OAuth via Nous Portal for anything public; username/password only on a trusted LAN or VPN (Tailscale).
+- **Managed Hermes Cloud:** hosted instances via portal.nousresearch.com/cloud — create/start/stop/destroy from the Portal or via its MCP server. The convenience path; docs are thinner than Docker's. Desktop connects to Cloud instances like any remote gateway.
+- **Your phone (Termux, Tier 2):** tested bundle is CLI + cron + background terminal + best-effort Telegram gateway + MCP + memory. Android may suspend background jobs, so gateway persistence is best-effort; voice and full browser bootstrap are unavailable. Most people instead pair a VPS gateway with Telegram on the phone.
+
+## Bots and messaging
+
+"Bot mode" is the messaging gateway: one background process connecting to all configured platforms — Telegram, Discord, Slack, Google Chat, WhatsApp, Signal, SMS and 15+ more, each with different feature support (voice/images/files/threads/streaming) per the official platform comparison. `hermes gateway setup` is the entry point from any install mode. In Desktop, Bot Mode is built in and on by default; a bot is a Hermes profile with CLI parity (`hermes -p <bot> chat`).
+
+## Platform support tiers (official)
+
+- **Tier 1** (fixes take first priority; installs/updates should never break): macOS Apple Silicon, Windows 10/11 native (x86_64 + aarch64), Linux & WSL2, Docker.
+- **Tier 2** (best effort; releases may break them): Android/Termux, Nix — Nix "breaks often due to node.js packaging woes."
+- **Unsupported** (may break anytime; PRs not accepted): AUR, Intel Macs, pip/uv tool installs, brew.
+
+## Windows: native or WSL2?
+
+Both Tier 1. Pick WSL2 if: you want the dashboard's embedded terminal tab (POSIX PTY, WSL2-only), you do POSIX-heavy development and want Hermes on the same Linux filesystem as your tools, or you already maintain WSL2. Native is fine or better otherwise: chat, gateway, cron, browser tool, and MCP all run natively, and you avoid crossing the WSL↔Windows boundary for files and URLs.
+
+## Recommendations
+
+- Just trying Hermes → Hermes Desktop on a Tier-1 machine.
+- Terminal person → install.sh + `hermes --tui`.
+- Always-on bot → Docker on a small VPS (or Hermes Cloud), dashboard behind OAuth or a tailnet; manage from Desktop remote connections.
+- Phone → Telegram against a VPS gateway first; Termux only for phone-local execution.
+- NixOS → extensive official guide, still Tier 2.
+
+## FAQ
+
+**Does Hermes Agent have a desktop app?** Yes — Hermes Desktop for macOS, Windows, Linux; same agent core as the CLI. Install from the official page or run `hermes desktop`.
+
+**Desktop or CLI?** Not either/or — they share state. Desktop adds visual multi-session and bot management; the TUI is the officially recommended interactive terminal experience.
+
+**Raspberry Pi / home server?** Yes — Docker is Tier 1 on aarch64. 1GB/1 core minimum (2–4GB with browser tools); update by pulling a new image.
+
+**Android?** Yes via Termux (Tier 2): CLI, cron, MCP, memory, best-effort Telegram gateway. Android suspends background jobs, so not an always-on host.
+
+**Need a VPS for a Telegram/Discord bot?** No — the gateway runs anywhere including Desktop's Bot Mode — but a VPS or Hermes Cloud is right once the bot must outlive your laptop's lid.
+
+**Safe to expose the dashboard on a VPS?** Only behind the auth gate: OAuth for public reachability, username/password strictly LAN/VPN. Unauthenticated dashboards were exploited in June 2026; `--insecure` is now a no-op.
+
+**Windows native or WSL2?** Native for most; WSL2 for the dashboard's embedded terminal or a real POSIX dev environment.

--- a/guide/desktop/index.html
+++ b/guide/desktop/index.html
@@ -1,0 +1,246 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Hermes Desktop: The Complete Guide — Install, Features, Plugins | Hermes Atlas</title>
+<meta name="description" content="Hermes Desktop explained: what the app is, how to install it on macOS, Windows, and Ubuntu/Linux, what's desktop-only (Bot Mode, Memory Graph, multi-connection), how plugins and skills work, and the known rough edges.">
+<meta name="keywords" content="hermes desktop, hermes desktop app, hermes agent desktop, hermes desktop ubuntu, hermes desktop plugins, hermes desktop install, hermes desktop vs cli, hermes workspace">
+<link rel="canonical" href="https://hermesatlas.com/guide/desktop/">
+<meta property="og:title" content="Hermes Desktop: The Complete Guide">
+<meta property="og:description" content="What Hermes Desktop is, how to install it on macOS/Windows/Linux, what's desktop-only, how plugins work, and the known rough edges.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://hermesatlas.com/guide/desktop/">
+<meta property="og:site_name" content="Hermes Atlas">
+<meta property="article:published_time" content="2026-08-31T00:00:00Z">
+<meta property="article:modified_time" content="2026-08-31T00:00:00Z">
+<meta property="article:author" content="https://x.com/ksimback">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=Hermes+Desktop&amp;subtitle=Install%2C+desktop-only+features%2C+plugins%2C+and+the+rough+edges&amp;kind=handbook+%C2%B7+guide">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Hermes Desktop: The Complete Guide">
+<meta name="twitter:description" content="Install on macOS/Windows/Linux, desktop-only features, plugins, and the known rough edges.">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Hermes+Desktop&amp;subtitle=Install%2C+desktop-only+features%2C+plugins%2C+and+the+rough+edges&amp;kind=handbook+%C2%B7+guide">
+<meta name="twitter:creator" content="@ksimback">
+<meta name="author" content="Kevin Simback">
+<link rel="alternate" type="application/rss+xml" title="Hermes Atlas — new projects" href="/rss.xml">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+<link rel="apple-touch-icon" href="/apple-touch-icon.png">
+<link rel="manifest" href="/site.webmanifest">
+<script src="/assets/js/theme-init.js"></script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap">
+<link rel="stylesheet" href="/assets/css/tokens.css">
+<link rel="stylesheet" href="/assets/css/base.css">
+<link rel="stylesheet" href="/assets/css/page.css">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Hermes Desktop: The Complete Guide — Install, Features, Plugins",
+  "description": "What Hermes Desktop is, how to install it on macOS, Windows, and Linux, what's desktop-only, how plugins and skills work, and the known rough edges.",
+  "image": "https://hermesatlas.com/api/og?title=Hermes+Desktop&subtitle=Install%2C+desktop-only+features%2C+plugins%2C+and+the+rough+edges&kind=handbook+%C2%B7+guide",
+  "keywords": ["hermes desktop", "hermes desktop app", "hermes desktop ubuntu", "hermes desktop plugins", "hermes desktop vs cli"],
+  "datePublished": "2026-08-31T00:00:00Z",
+  "dateModified": "2026-08-31T00:00:00Z",
+  "author": {"@type": "Person", "name": "Kevin Simback", "url": "https://x.com/ksimback"},
+  "publisher": {"@type": "Organization", "name": "Hermes Atlas", "url": "https://hermesatlas.com"},
+  "mainEntityOfPage": {"@type": "WebPage", "@id": "https://hermesatlas.com/guide/desktop/"}
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Is Hermes Desktop different from the Hermes Agent CLI?",
+      "acceptedAnswer": {"@type": "Answer", "text": "No — it is the same agent with a native UI. Same config, API keys, sessions, skills, and memory; the docs describe it as 'not a separate product or a lightweight clone.' Sessions started in the app resume in the CLI/TUI and vice versa."}
+    },
+    {
+      "@type": "Question",
+      "name": "How do I install Hermes Desktop on Ubuntu or other Linux distros?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Download the Linux build from the official Hermes Desktop page, or — if the CLI is already installed via install.sh — just run `hermes desktop`, which launches the app against your existing config and sessions. It runs on macOS, Windows, and Linux."}
+    },
+    {
+      "@type": "Question",
+      "name": "Does Hermes Desktop support plugins and skills?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Yes. Desktop uses the same skills, plugins, and MCP servers as every other Hermes surface, because it drives the same agent core. Anything you install for the CLI is available in the app; Bot Mode profiles get the same capabilities."}
+    },
+    {
+      "@type": "Question",
+      "name": "Can Hermes Desktop connect to a Hermes instance on a VPS or in the cloud?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Yes — the app can attach to a remote `hermes serve` backend and manage several remote gateways, VPS boxes, or Hermes Cloud instances at once. Official guidance: use OAuth via Nous Portal for anything reachable from the public internet; username/password only over a trusted LAN or VPN such as Tailscale."}
+    },
+    {
+      "@type": "Question",
+      "name": "Why does Hermes Desktop ask for so many permissions on macOS?",
+      "acceptedAnswer": {"@type": "Answer", "text": "The backend runs agent commands, so macOS gates it behind TCC permissions (files, automation) and Gatekeeper. This is expected first-run friction; the docs cover the prompts and the signing-identity setup that reduces them."}
+    }
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {"@type": "ListItem", "position": 1, "name": "home", "item": "https://hermesatlas.com/"},
+    {"@type": "ListItem", "position": 2, "name": "handbook", "item": "https://hermesatlas.com/guide/"},
+    {"@type": "ListItem", "position": 3, "name": "desktop"}
+  ]
+}
+</script>
+</head>
+<body>
+<a class="skip-link" href="#main">Skip to content</a>
+<header class="masthead">
+  <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
+  <div class="mast-meta" aria-label="Site metadata">
+    <span id="meta-count">246·repos</span>
+    <span id="meta-version">hermes·v0.20.6</span>
+    <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
+  </div>
+  <nav class="mast-nav" aria-label="Primary">
+    <a href="/">home</a>
+    <a href="/ecosystem/">ecosystem</a>
+    <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
+    <a href="/use-cases/">use cases</a>
+    <a href="/guide/" class="active">handbook</a>
+    <a href="/masterclass/">masterclass</a>
+    <a href="/dev/">dev</a>
+    <a href="/reports/">reports</a>
+    <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
+  </nav>
+  <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
+  </button>
+</header>
+<div class="breadcrumb" aria-label="Breadcrumb">
+  <a href="/">home</a><span class="sep">/</span><a href="/guide/">handbook</a><span class="sep">/</span>desktop
+</div>
+<main class="article" id="main">
+
+<header class="article-header">
+  <div class="article-badge">handbook · desktop</div>
+  <h1>Hermes Desktop: The Complete Guide</h1>
+  <p class="subtitle">What the app actually is, how to install it on macOS, Windows, and Linux, what you can only do here — and the rough edges the download page won't mention. A satellite of <a href="/guide/">The Hermes Handbook</a>.</p>
+  <p class="meta">By <a href="https://x.com/ksimback">Kevin Simback</a> · Hermes Atlas maintainer · Updated 2026-08-31 · ~7 min read</p>
+</header>
+
+<h2 id="tldr">TL;DR</h2>
+
+<p><strong>Hermes Desktop is not a separate product — it's the same agent as the CLI with a native UI.</strong> The <a href="https://hermes-agent.nousresearch.com/docs/user-guide/desktop">official docs</a> are explicit: same config, same API keys, same sessions, same skills, same memory; "anything you do here shows up there." It runs on macOS, Windows, and Linux, launches its own backend (a <code>hermes serve</code> process — no separate server setup needed), and is the best starting point for most new users. Current release is v0.20.6 (as of 2026-08-27). Deciding between modes first? Read <a href="/guide/modes/">How to run Hermes Agent</a>.</p>
+
+<h2 id="install">Install (macOS · Windows · Ubuntu/Linux)</h2>
+
+<p>Two paths, per the <a href="https://hermes-agent.nousresearch.com/docs/user-guide/desktop">docs</a>:</p>
+<ul>
+  <li><strong>Fresh install:</strong> download the app for your OS from the <a href="https://hermes-agent.nousresearch.com/desktop">official Hermes Desktop page</a>. macOS is Apple Silicon only (Intel Macs are officially unsupported); Windows 10/11 x86_64 and aarch64; Linux builds cover mainstream glibc distros — the team tests on the latest Ubuntu.</li>
+  <li><strong>Already run the CLI?</strong> Just type <code>hermes desktop</code>. The app picks up your existing config, keys, sessions, and skills — nothing to migrate, because there's nothing separate to migrate to.</li>
+</ul>
+<p>The app is self-contained: it starts and manages its own local backend and never requires you to run the web dashboard. On Ubuntu and other distros, if you installed the CLI via <code>install.sh</code>, the <code>hermes desktop</code> route is usually smoother than hunting a package for your distro.</p>
+
+<h2 id="desktop-only">What you can only do in Desktop</h2>
+
+<ul>
+  <li><strong>Multi-session, multi-window chat</strong> — parallel conversations with live tool activity, drag-and-drop file attachments, a side-by-side preview rail, queue editing, and find-in-transcript.</li>
+  <li><strong>Bot Mode</strong> — a roster of named agent profiles (each "bot" is just a Hermes profile), built in and on by default, with group rooms and full CLI parity (<code>hermes -p &lt;bot&gt; chat</code>).</li>
+  <li><strong>Memory Graph, HUD floating mode, and Quick Entry</strong> — a global hotkey that drops a prompt into your agent from anywhere in the OS.</li>
+  <li><strong>Multi-connection</strong> — attach to <em>several</em> backends at once: your local agent plus remote gateways on a VPS, a home server, or managed Hermes Cloud instances, all in one window (<a href="https://hermes-agent.nousresearch.com/docs/user-guide/multi-connection-desktop">docs</a>).</li>
+  <li><strong>Session controls the terminal makes you memorize</strong> — per-session YOLO toggle, a live context-usage meter with a token breakdown popover, and a customizable status bar.</li>
+</ul>
+
+<h2 id="plugins">Desktop + plugins and skills</h2>
+
+<p>Because Desktop drives the same agent core, <strong>it uses the same skills, plugins, and MCP servers as every other surface</strong> — there is no separate "desktop plugin" format. Anything installed for the CLI is live in the app, and Bot Mode profiles inherit the same capabilities. To extend your setup:</p>
+<ul>
+  <li><a href="/skills/">The Hermes Skills Hub</a> — curated best skills by use case, with verified install commands.</li>
+  <li><a href="/ecosystem/">The ecosystem catalog</a> — community plugins &amp; extensions, memory providers, and workspace tools, with live GitHub data.</li>
+  <li><a href="/guide/memory/">The Memory Guidebook</a> — if the thing you want to add is persistent memory.</li>
+</ul>
+
+<h2 id="remote">Connecting Desktop to a VPS or cloud instance</h2>
+
+<p>Desktop can attach to a remote backend — meaning a <code>hermes serve</code> process that <em>you</em> keep running on the remote machine (systemd/tmux); the app connects to it, it doesn't start it for you. Binding that backend to a non-loopback address automatically engages its auth gate, and the <a href="https://hermes-agent.nousresearch.com/docs/user-guide/desktop">docs' guidance</a> on providers is unambiguous:</p>
+<ul>
+  <li><strong>OAuth (Nous Portal)</strong> — "preferred for anything reachable beyond your own machine": VPS, public host, cloud.</li>
+  <li><strong>Username/password</strong> — trusted LAN or VPN only (Tailscale is the clean option: bind to the tailscale IP). "Never expose a password-protected backend directly to the open internet."</li>
+</ul>
+<p>Note the gateway (Telegram/Discord/etc.) is a separate long-running process from the <code>hermes serve</code> backend — on a remote host you keep both alive. Setup details: <a href="/guide/modes/#docker-vps">the modes guide's Docker/VPS section</a>.</p>
+
+<h2 id="rough-edges">Known rough edges (honest section)</h2>
+
+<ul>
+  <li><strong>Electron download on install/build</strong> — roughly a 114MB fetch that some networks throttle or block; recent versions self-heal via a mirror fallback, but a hanging first launch is usually this.</li>
+  <li><strong>macOS permission friction</strong> — TCC prompts (files, automation) and Gatekeeper on first run are expected: the backend runs real agent commands. The docs cover the prompts and the signing-identity setup that tames them.</li>
+  <li><strong>Remote hosts that change SSH keys</strong> — Desktop hard-fails ("latches") rather than silently retrying; you clear the host-key change and reconnect.</li>
+  <li><strong>It's the heaviest way to run Hermes</strong> — if you want the lightest possible install on a server, that's <a href="/guide/modes/#docker-vps">Docker</a>, not Desktop.</li>
+</ul>
+
+<h2 id="whats-new">What's new lately</h2>
+
+<p>The v2026.8.27 release line brought several desktop-visible changes: consent-gated browsing with your real Chrome profile (with a close-with-approval flow on Windows), the built-in browser getting its own OS window, opt-in OS-keychain encryption for secrets (ending the per-launch macOS Keychain prompt parade), a fleet profile rail, and a managed SSH remote-update engine. The prior release added Bot Mode group-room threads and a round of desktop rendering performance work. Full history: <a href="https://github.com/NousResearch/hermes-agent/releases">official releases</a>.</p>
+
+<h2 id="vs-cli">Desktop vs CLI/TUI at a glance</h2>
+
+<div class="article-table-scroll" tabindex="0">
+<table>
+<thead><tr><th></th><th><strong>Hermes Desktop</strong></th><th><strong>CLI / TUI</strong></th></tr></thead>
+<tbody>
+<tr><td><strong>Same agent?</strong></td><td colspan="2">Yes — shared config, sessions, skills, memory. Start in one, resume in the other.</td></tr>
+<tr><td><strong>Best at</strong></td><td>Multi-session work, Bot Mode roster, remote-gateway management, visual context controls</td><td>Worktree-parallel agents (<code>hermes -w</code>), background sessions (<code>/bg</code>), shell passthrough, scripting</td></tr>
+<tr><td><strong>Install weight</strong></td><td>Native app (Electron)</td><td><code>install.sh</code> / <code>install.ps1</code>; TUI needs Node.js ≥ 20</td></tr>
+<tr><td><strong>Official framing</strong></td><td>"Purpose-built UI for chat, configuration, and management"</td><td>TUI is "the recommended way to run Hermes interactively"</td></tr>
+<tr><td><strong>Choose it when</strong></td><td>You're new, or you juggle several agents/bots/machines</td><td>You live in a terminal and script your tools</td></tr>
+</tbody>
+</table>
+</div>
+
+<h2 id="frequently-asked-questions">FAQ</h2>
+
+<h3>Is Hermes Desktop different from the Hermes Agent CLI?</h3>
+<p>No — same agent, native UI. The docs call it "not a separate product or a lightweight clone." Sessions move freely between app and terminal.</p>
+
+<h3>How do I install Hermes Desktop on Ubuntu?</h3>
+<p>Download the Linux build from the official page, or run <code>hermes desktop</code> if the CLI is already installed — it launches against your existing config.</p>
+
+<h3>Does Hermes Desktop support plugins?</h3>
+<p>Yes — the same skills, plugins, and MCP servers as every Hermes surface. Browse <a href="/skills/">curated skills</a> and <a href="/ecosystem/">community plugins</a> on the Atlas.</p>
+
+<h3>Can Desktop connect to a VPS or Hermes Cloud instance?</h3>
+<p>Yes, to several at once. Use OAuth (Nous Portal) for anything public; username/password only over LAN/VPN like Tailscale.</p>
+
+<h3>Why all the macOS permission prompts?</h3>
+<p>The backend executes real commands, so macOS gates it behind TCC and Gatekeeper. Expected on first run; the docs show the reduced-friction signing setup.</p>
+
+<div class="article-footer">
+  <p>Maintained by <a href="https://x.com/ksimback">Kevin Simback</a> · Part of <a href="/guide/">The Hermes Handbook</a> · Facts sourced from the <a href="https://hermes-agent.nousresearch.com/docs/user-guide/desktop">official Hermes Desktop docs</a> · if this was useful, drop a ★ on <a href="https://github.com/ksimback/hermes-ecosystem">the atlas repo</a> →</p>
+</div>
+
+</main>
+
+<footer class="page-footer">
+  <div class="fn-left">hermes atlas · curated by <a href="https://github.com/ksimback">ksimback</a> · <a href="https://github.com/ksimback/hermes-ecosystem/issues">suggest a repo</a> · <a href="/privacy">privacy</a></div>
+  <div>v2 · 2026.04</div>
+</footer>
+
+<script src="/assets/js/theme-toggle.js" defer></script>
+<script src="/assets/js/masthead-fetch.js" defer></script>
+<!-- Cloudflare Web Analytics -->
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js"
+        data-cf-beacon='{"token": "fe0d4d79280b4386b6b0cd99b2d94dbc"}'></script>
+<!-- End Cloudflare Web Analytics -->
+</body>
+</html>

--- a/guide/index.html
+++ b/guide/index.html
@@ -244,7 +244,7 @@
   <p class="meta">By <a href="https://x.com/ksimback">Kevin Simback</a> · Hermes Atlas maintainer · Updated 2026-08-31 · ~18 min read</p>
 </header>
 
-<blockquote><strong>More handbook guides:</strong> if you are here for memory architecture, provider comparisons, or how to choose between GBrain, Mnemosyne, Mem0, Hindsight, Honcho, and Supermemory, read <a href="/guide/memory/"><strong>The Hermes Agent Memory Guidebook →</strong></a></blockquote>
+<blockquote><strong>More handbook guides:</strong> deciding how to run Hermes — Desktop vs CLI vs Docker/VPS vs bot gateway — read <a href="/guide/modes/"><strong>How to Run Hermes Agent →</strong></a> (and the <a href="/guide/desktop/"><strong>Hermes Desktop guide →</strong></a>). For memory architecture and how to choose between GBrain, Mnemosyne, Mem0, Hindsight, Honcho, and Supermemory, read <a href="/guide/memory/"><strong>The Hermes Agent Memory Guidebook →</strong></a></blockquote>
 
 <blockquote><strong>TL;DR</strong> — Hermes Agent is Nous Research's open-source autonomous AI agent. It runs on your laptop or a VPS, remembers everything across sessions, writes its own reusable skills as it works, and reaches you through 14+ messaging platforms (CLI, Telegram, Discord, Slack, email, and more). You install it with one command, pick any model from 20+ LLM providers, and it compounds in capability over the following thirty days. As of August 2026. Based on 100+ ecosystem projects reviewed, 33 research sources, and the live GitHub repo.</blockquote>
 
@@ -267,7 +267,7 @@
 
 <h2 id="1-what-hermes-agent-actually-is">1. What Hermes Agent actually is</h2>
 
-<p><strong>Hermes Agent is an open-source AI agent by <a href="https://nousresearch.com" target="_blank" rel="noopener">Nous Research</a> that runs on your own machine or a cheap VPS, remembers what it learns across sessions, and writes its own reusable skills as it works. It talks to you through a CLI, Telegram, Discord, email, and many other messaging providers. It hit 238,658 GitHub stars (as of 2026-08-31), and it's the fastest-growing open-source agent of 2026.</strong></p>
+<p><strong>Hermes Agent is an open-source AI agent by <a href="https://nousresearch.com" target="_blank" rel="noopener">Nous Research</a> that runs on your own machine or a cheap VPS, remembers what it learns across sessions, and writes its own reusable skills as it works. It talks to you through a CLI, Telegram, Discord, email, and many other messaging providers. It hit 238,724 GitHub stars (as of 2026-08-31), and it's the fastest-growing open-source agent of 2026.</strong></p>
 
 <h3>The 30-second version</h3>
 
@@ -665,7 +665,7 @@ hermes skills info &lt;name&gt;      # inspect before installing</code></pre>
   <p><strong>Last updated:</strong> 2026-08-31 · Version and star figures re-stamp automatically with every site build.</p>
   <p><strong>Cited stats:</strong></p>
   <ul>
-    <li>238,658 GitHub stars (as of 2026-08-31) — source: <code>api.github.com/repos/NousResearch/hermes-agent</code></li>
+    <li>238,724 GitHub stars (as of 2026-08-31) — source: <code>api.github.com/repos/NousResearch/hermes-agent</code></li>
     <li>246+ projects in the Hermes Atlas (as of 2026-08-31)</li>
     <li>643 skills in the community Hub (as of 2026-04-19)</li>
   </ul>

--- a/guide/modes/index.html
+++ b/guide/modes/index.html
@@ -1,0 +1,287 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>How to Run Hermes Agent: Desktop vs CLI vs Docker/VPS vs Bot Gateway | Hermes Atlas</title>
+<meta name="description" content="Every way to run Hermes Agent compared — Desktop app, CLI/TUI, web dashboard, Docker on a VPS, managed Hermes Cloud, messaging bots, and Android/Termux. Which mode fits you, with tradeoffs from the official docs.">
+<meta name="keywords" content="hermes desktop, hermes agent desktop, hermes cli, hermes docker, hermes vps, hermes bot mode, hermes agent modes, run hermes agent, hermes workspace, hermes android">
+<link rel="canonical" href="https://hermesatlas.com/guide/modes/">
+<meta property="og:title" content="How to Run Hermes Agent: Desktop vs CLI vs Docker/VPS vs Bot Gateway">
+<meta property="og:description" content="Every way to run Hermes Agent compared — Desktop, CLI/TUI, dashboard, Docker/VPS, managed cloud, messaging bots, Android. Which mode fits you.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://hermesatlas.com/guide/modes/">
+<meta property="og:site_name" content="Hermes Atlas">
+<meta property="article:published_time" content="2026-08-31T00:00:00Z">
+<meta property="article:modified_time" content="2026-08-31T00:00:00Z">
+<meta property="article:author" content="https://x.com/ksimback">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=How+to+Run+Hermes+Agent&amp;subtitle=Desktop+vs+CLI+vs+Docker%2FVPS+vs+bot+gateway+-+pick+your+mode&amp;kind=handbook+%C2%B7+decision">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="How to Run Hermes Agent: Desktop vs CLI vs Docker/VPS vs Bot Gateway">
+<meta name="twitter:description" content="Every way to run Hermes Agent compared — which mode fits you, with tradeoffs from the official docs.">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=How+to+Run+Hermes+Agent&amp;subtitle=Desktop+vs+CLI+vs+Docker%2FVPS+vs+bot+gateway+-+pick+your+mode&amp;kind=handbook+%C2%B7+decision">
+<meta name="twitter:creator" content="@ksimback">
+<meta name="author" content="Kevin Simback">
+<link rel="alternate" type="application/rss+xml" title="Hermes Atlas — new projects" href="/rss.xml">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+<link rel="apple-touch-icon" href="/apple-touch-icon.png">
+<link rel="manifest" href="/site.webmanifest">
+<script src="/assets/js/theme-init.js"></script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap">
+<link rel="stylesheet" href="/assets/css/tokens.css">
+<link rel="stylesheet" href="/assets/css/base.css">
+<link rel="stylesheet" href="/assets/css/page.css">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "How to Run Hermes Agent: Desktop vs CLI vs Docker/VPS vs Bot Gateway",
+  "description": "Every way to run Hermes Agent compared — Desktop app, CLI/TUI, web dashboard, Docker on a VPS, managed Hermes Cloud, messaging bots, and Android/Termux — with tradeoffs sourced from the official docs.",
+  "image": "https://hermesatlas.com/api/og?title=How+to+Run+Hermes+Agent&subtitle=Desktop+vs+CLI+vs+Docker%2FVPS+vs+bot+gateway+-+pick+your+mode&kind=handbook+%C2%B7+decision",
+  "keywords": ["hermes desktop", "hermes cli", "hermes docker", "hermes vps", "hermes bot mode", "run hermes agent"],
+  "datePublished": "2026-08-31T00:00:00Z",
+  "dateModified": "2026-08-31T00:00:00Z",
+  "author": {"@type": "Person", "name": "Kevin Simback", "url": "https://x.com/ksimback"},
+  "publisher": {"@type": "Organization", "name": "Hermes Atlas", "url": "https://hermesatlas.com"},
+  "mainEntityOfPage": {"@type": "WebPage", "@id": "https://hermesatlas.com/guide/modes/"}
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Does Hermes Agent have a desktop app?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Yes. Hermes Desktop is a native app for macOS, Windows, and Linux built around the same agent core as the CLI — same config, keys, sessions, skills, and memory. Install it from the official download page, or run `hermes desktop` from an existing CLI install."}
+    },
+    {
+      "@type": "Question",
+      "name": "Should I use Hermes Desktop or the CLI?",
+      "acceptedAnswer": {"@type": "Answer", "text": "They are front-ends to the same agent and share state, so it is not either/or — you can start a session in one and resume it in the other. Desktop adds multi-session windows, the Bot Mode roster, and remote-gateway management; the TUI (hermes --tui) is the officially recommended interactive terminal experience."}
+    },
+    {
+      "@type": "Question",
+      "name": "Can I run Hermes Agent on a Raspberry Pi or home server?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Yes — the Docker image (Tier 1, x86_64 and aarch64) is the supported path for always-on Linux boxes including ARM single-board computers. Plan for at least 1GB RAM and one core, 2–4GB if you enable browser tools. Docker installs update by pulling a new image rather than `hermes update`."}
+    },
+    {
+      "@type": "Question",
+      "name": "Can I run Hermes Agent on Android?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Yes, via Termux — a Tier 2 (best-effort) platform. The tested bundle covers the CLI, cron, background terminal, a Telegram gateway, MCP, and memory. Android may suspend background jobs, so gateway persistence is best-effort; heavy extras like voice are not available."}
+    },
+    {
+      "@type": "Question",
+      "name": "Do I need a VPS to run Hermes as a Telegram or Discord bot?",
+      "acceptedAnswer": {"@type": "Answer", "text": "No, but it helps. The messaging gateway is one background process that connects to all your configured platforms and runs anywhere — your laptop, Desktop's built-in Bot Mode, or a Docker container. A VPS (or managed Hermes Cloud) is the right home when you want the bot to stay up after your laptop sleeps."}
+    },
+    {
+      "@type": "Question",
+      "name": "Is it safe to expose the Hermes dashboard on a VPS?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Only behind real authentication. Binding to a non-loopback address engages a mandatory auth gate; the official guidance is OAuth via Nous Portal for anything reachable from the public internet, and username/password only on a trusted LAN or VPN like Tailscale. Unauthenticated public dashboards were the entry point for a real attack campaign in June 2026."}
+    },
+    {
+      "@type": "Question",
+      "name": "Should I install Hermes on Windows natively or in WSL2?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Native Windows is Tier 1 and runs chat, the gateway, cron, browser tools, and MCP directly — fine for most users. Pick WSL2 if you want the dashboard's embedded terminal (POSIX PTY, WSL2-only) or do POSIX-heavy development and want Hermes on the same Linux filesystem as your tools."}
+    }
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {"@type": "ListItem", "position": 1, "name": "home", "item": "https://hermesatlas.com/"},
+    {"@type": "ListItem", "position": 2, "name": "handbook", "item": "https://hermesatlas.com/guide/"},
+    {"@type": "ListItem", "position": 3, "name": "modes"}
+  ]
+}
+</script>
+</head>
+<body>
+<a class="skip-link" href="#main">Skip to content</a>
+<header class="masthead">
+  <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
+  <div class="mast-meta" aria-label="Site metadata">
+    <span id="meta-count">246·repos</span>
+    <span id="meta-version">hermes·v0.20.6</span>
+    <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
+  </div>
+  <nav class="mast-nav" aria-label="Primary">
+    <a href="/">home</a>
+    <a href="/ecosystem/">ecosystem</a>
+    <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
+    <a href="/use-cases/">use cases</a>
+    <a href="/guide/" class="active">handbook</a>
+    <a href="/masterclass/">masterclass</a>
+    <a href="/dev/">dev</a>
+    <a href="/reports/">reports</a>
+    <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
+  </nav>
+  <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
+  </button>
+</header>
+<div class="breadcrumb" aria-label="Breadcrumb">
+  <a href="/">home</a><span class="sep">/</span><a href="/guide/">handbook</a><span class="sep">/</span>modes
+</div>
+<main class="article" id="main">
+
+<header class="article-header">
+  <div class="article-badge">handbook · decision guide</div>
+  <h1>How to Run Hermes Agent: Desktop vs CLI vs Docker/VPS vs Bot Gateway</h1>
+  <p class="subtitle">Every way to run Hermes, compared honestly — so you pick the right mode the first time. A decision page of <a href="/guide/">The Hermes Handbook</a>, cross-checked against the official docs.</p>
+  <p class="meta">By <a href="https://x.com/ksimback">Kevin Simback</a> · Hermes Atlas maintainer · Updated 2026-08-31 · ~9 min read</p>
+</header>
+
+<h2 id="tldr">TL;DR</h2>
+
+<p><strong>You don't have to choose a front-end — you have to choose where the agent lives.</strong> Hermes Desktop, the CLI/TUI, and the web dashboard are all front-ends to the <em>same agent core</em>: same config, same API keys, same sessions, same skills, same memory. The <a href="https://hermes-agent.nousresearch.com/docs/user-guide/desktop">official docs</a> put it plainly: "Pick whichever fits the moment. They share state." The decision that actually matters is where the agent process runs: your own machine (simplest), a Docker container on a VPS or home server (always-on), managed Hermes Cloud (hosted for you), or your phone via Termux (best-effort). Current release is v0.20.6 (as of 2026-08-27).</p>
+
+<p>Quick router: brand new? <a href="/guide/desktop/">Start with Hermes Desktop</a>. Terminal person? The TUI (<code>hermes --tui</code>) is the officially recommended interactive experience. Want a Telegram/Discord bot that never sleeps? Docker on a $5 VPS. On the fence about Windows native vs WSL2? <a href="#windows">There's an official answer</a>.</p>
+
+<h2 id="four-decisions">The two decisions (and the two that aren't)</h2>
+
+<p>People searching "hermes desktop vs cli" are usually asking four different questions at once. Two of them are real decisions; two aren't:</p>
+
+<ul>
+  <li><strong>Which front-end do I look at?</strong> — <em>not really a decision.</em> Desktop, CLI/TUI, and dashboard share one session store; you can start a chat in the app and resume it in the terminal.</li>
+  <li><strong>Which platform am I on?</strong> — <em>mostly decided for you.</em> The official <a href="https://hermes-agent.nousresearch.com/docs/getting-started/platform-support">platform-support tiers</a> tell you what's safe (see the matrix below).</li>
+  <li><strong>Where does the agent process live?</strong> — <em>the real decision.</em> Laptop vs container/VPS vs managed cloud vs phone changes uptime, security posture, and how you update.</li>
+  <li><strong>Which channels reach it?</strong> — <em>the second real decision.</em> Terminal-only, or the messaging gateway (Telegram, Discord, Slack, WhatsApp, Signal, SMS and 15+ more) — one background process that connects to every platform you configure.</li>
+</ul>
+
+<h2 id="comparison">The modes at a glance</h2>
+
+<div class="article-table-scroll" tabindex="0">
+<table>
+<thead><tr><th>Mode</th><th>Best for</th><th>Requirements</th><th>Main tradeoff</th></tr></thead>
+<tbody>
+<tr><td><strong><a href="/guide/desktop/">Desktop app</a></strong></td><td>First-timers; multi-session work; managing bots and remote gateways visually</td><td>macOS (Apple Silicon), Windows 10/11, or Linux</td><td>Heaviest install (Electron); macOS permission prompts on first run</td></tr>
+<tr><td><strong>CLI / TUI</strong></td><td>Terminal workflows, worktree-parallel agents, background sessions</td><td>Tier-1 OS; TUI needs Node.js ≥ 20</td><td>No visual session roster; terminal-emulator quirks vary</td></tr>
+<tr><td><strong>Web dashboard</strong></td><td>Browser admin panel for every profile on a machine</td><td><code>hermes dashboard</code> (optional web extras)</td><td>Embedded terminal tab needs a POSIX PTY (not Windows-native)</td></tr>
+<tr><td><strong>Docker / VPS</strong></td><td>Always-on gateways and bots; reproducible upgrades; ARM boards</td><td>1GB/1 core minimum (2–4GB with browser tools)</td><td>No <code>hermes update</code> — you update by pulling a new image</td></tr>
+<tr><td><strong>Managed Hermes Cloud</strong></td><td>Hosted instances without owning a server</td><td>Nous Portal account</td><td>Newest option; managed through the Portal or its MCP server</td></tr>
+<tr><td><strong>Bot / messaging gateway</strong></td><td>Hermes in Telegram, Discord, Slack, WhatsApp, Signal, SMS…</td><td>Any install mode + <code>hermes gateway setup</code></td><td>Needs a home that stays awake (see Docker/VPS)</td></tr>
+<tr><td><strong>Android (Termux)</strong></td><td>Hermes in your pocket; phone-local CLI + Telegram gateway</td><td>aarch64 Android + Termux</td><td>Tier 2: Android suspends background jobs; no voice extra</td></tr>
+<tr><td><strong>Nix / NixOS</strong></td><td>Declarative systemd services; reproducible fleets</td><td>Nix on macOS/Linux/NixOS</td><td>Tier 2: "breaks often due to node.js packaging woes" — official words</td></tr>
+</tbody>
+</table>
+</div>
+
+<h2 id="front-ends">The front-ends: Desktop, CLI/TUI, dashboard</h2>
+
+<p><strong><a href="/guide/desktop/">Hermes Desktop</a></strong> is a native app for macOS, Windows, and Linux built around the same agent core — "not a separate product or a lightweight clone" per the <a href="https://hermes-agent.nousresearch.com/docs/user-guide/desktop">docs</a>. It's the best default for most people: multi-session chat windows, the Bot Mode roster, Memory Graph, a global Quick Entry hotkey, and the ability to connect to several remote gateways, VPS boxes, or Cloud instances at once. If you already run the CLI, <code>hermes desktop</code> launches it against your existing config. We wrote a <a href="/guide/desktop/">full Hermes Desktop guide</a> covering install, desktop-only features, plugins, and the known rough edges.</p>
+
+<p><strong>The CLI and TUI</strong> are two terminal front-ends over one SQLite session store. The classic CLI is what <code>hermes</code> gives you by default; the newer TUI (<code>hermes --tui</code>, Node.js ≥ 20) is what the <a href="https://hermes-agent.nousresearch.com/docs/user-guide/tui">official docs call "the recommended way to run Hermes interactively"</a>. Power-user features live here: worktree-isolated parallel agents (<code>hermes -w</code>), background sessions (<code>/bg</code>), shell passthrough (<code>!cmd</code>), and skill slash-commands.</p>
+
+<p><strong>The web dashboard</strong> (<code>hermes dashboard</code>) is a machine-level admin panel at <code>127.0.0.1:9119</code> that manages every profile on the box; for local use "no data leaves localhost" per the <a href="https://hermes-agent.nousresearch.com/docs/user-guide/features/web-dashboard">docs</a>. Its optional Chat tab embeds the full TUI in the browser through a pseudo-terminal — the one feature with a real platform constraint (POSIX PTY, so WSL2 rather than native Windows).</p>
+
+<h2 id="where-it-lives">Where the agent lives</h2>
+
+<h3 id="your-machine">Your machine (default)</h3>
+<p>The standard install (<code>install.sh</code> on macOS/Linux/WSL2, <code>install.ps1</code> or the Desktop installer on Windows) runs everything locally. Simplest to set up, updates via <code>hermes update</code>, and everything above applies. The only catch: the agent sleeps when your laptop does — cron jobs and bots included.</p>
+
+<h3 id="docker-vps">Docker on a VPS or home server (always-on)</h3>
+<p>The official image (<code>nousresearch/hermes-agent</code>, x86_64 + aarch64, Tier 1) is the supported path for anything that should stay up: bot gateways, cron-driven agents, team instances. Under the hood it's Debian with s6-overlay supervising the gateway and dashboard — crashed processes restart themselves. One container can host several profiles, which the <a href="https://hermes-agent.nousresearch.com/docs/user-guide/docker">docs now recommend</a> over one-container-per-profile. Plan for 1GB/1 core minimum, 2–4GB with browser tools. Two rules that save real pain: never point two gateway containers at one data directory (session/memory corruption), and remember Docker installs update by pulling a new image — <code>hermes update</code> is intentionally unsupported there.</p>
+<p><strong>Security, in one paragraph:</strong> binding the dashboard or backend to a non-loopback address engages a mandatory auth gate, and the old <code>--insecure</code> escape hatch is now a deprecated no-op — because in June 2026 internet scanners used unauthenticated public dashboards as the entry point for a real campaign that planted SSH-key backdoors via MCP-config persistence. The official guidance since: <strong>OAuth via Nous Portal for anything reachable from the public internet; username/password only on a trusted LAN or VPN (Tailscale)</strong>. Details in the <a href="https://hermes-agent.nousresearch.com/docs/user-guide/docker">Docker guide</a> and <a href="https://hermes-agent.nousresearch.com/docs/user-guide/features/web-dashboard">dashboard docs</a>.</p>
+<p>Browsing deployment tooling? The Atlas catalogs community <a href="/lists/deployment-options">deployment options</a> — Docker Compose stacks, Nix flakes, systemd templates, Kubernetes charts.</p>
+
+<h3 id="cloud">Managed Hermes Cloud</h3>
+<p>Nous also runs <a href="https://portal.nousresearch.com/cloud">Hermes Cloud</a> — hosted instances you create, start, stop, and destroy from the Portal's agents page (or, fittingly, from an agent via its MCP server). It's the "I want an always-on Hermes without owning a server" answer. The public docs on it are still thin compared to Docker, so treat this as the convenience path rather than the deeply documented one; Desktop connects to Cloud instances the same way it connects to any remote gateway.</p>
+
+<h3 id="phone">Your phone (Termux, Tier 2)</h3>
+<p>Hermes runs on Android via Termux with a tested bundle: CLI, cron, background terminal, a best-effort Telegram gateway, MCP, and memory. The honest limits from the <a href="https://hermes-agent.nousresearch.com/docs/getting-started/termux">official Termux guide</a>: Android may suspend background jobs, so "gateway persistence is best-effort rather than a normal managed service," and heavy extras (voice, full browser bootstrap) aren't available. For a phone-centric setup that works today, most people pair a VPS-hosted gateway with Telegram on the phone — see the <a href="/use-cases/hermes-in-your-pocket">Hermes in your pocket</a> use case.</p>
+
+<h2 id="channels">Bots and messaging: the gateway</h2>
+
+<p>"Bot mode" isn't a separate install — it's the messaging gateway: <em>one background process that connects to all your configured platforms</em>. Telegram, Discord, Slack, Google Chat, WhatsApp, Signal, SMS and more each have setup pages, and the <a href="https://hermes-agent.nousresearch.com/docs/user-guide/messaging/">official platform comparison</a> shows exactly which features (voice, images, files, threads, reactions, streaming) each channel supports. <code>hermes gateway setup</code> is the entry point from every install mode. In Hermes Desktop, Bot Mode is built in and on by default — a "bot" is just a Hermes profile with a face, and everything has CLI parity (<code>hermes -p &lt;bot&gt; chat</code>).</p>
+
+<h2 id="tiers">Platform support tiers (official)</h2>
+
+<div class="article-table-scroll" tabindex="0">
+<table>
+<thead><tr><th>Tier</th><th>Platforms</th><th>What it means</th></tr></thead>
+<tbody>
+<tr><td><strong>Tier 1</strong></td><td>macOS (Apple Silicon) · Windows 10/11 (native) · Linux &amp; WSL2 · Docker</td><td>"We strive to never break installations and updates for these." First-priority fixes.</td></tr>
+<tr><td><strong>Tier 2</strong></td><td>Android (Termux) · Nix (macOS/Linux/NixOS)</td><td>Best effort. "Releases may break them" — Nix in particular "breaks often due to node.js packaging woes."</td></tr>
+<tr><td><strong>Unsupported</strong></td><td>AUR · Intel Macs · <code>pip</code>/<code>uv tool</code> installs · <code>brew</code></td><td>May be broken now, may break more; compat code can be removed at any point. Migrate to a supported method.</td></tr>
+</tbody>
+</table>
+</div>
+
+<p>Source: <a href="https://hermes-agent.nousresearch.com/docs/getting-started/platform-support">official platform support page</a>. Yes, Intel Macs are unsupported; yes, <code>brew install hermes-agent</code> is a trap.</p>
+
+<h2 id="windows">Windows: native or WSL2?</h2>
+
+<p>Both are Tier 1, and the <a href="https://hermes-agent.nousresearch.com/docs/user-guide/windows-wsl-quickstart">official WSL2 guide</a> gives a refreshingly direct answer. Pick <strong>WSL2</strong> if: you want the dashboard's embedded terminal tab (POSIX PTY, WSL2-only), you do POSIX-heavy development and want Hermes on the same Linux filesystem as your tools, or you already maintain a WSL2 environment. <strong>Native is fine — or better</strong> — for everyone else: chat, the gateway, cron, browser tools, and MCP all run natively, and you skip crossing the WSL↔Windows boundary every time you touch a file or URL. The <a href="https://hermes-agent.nousresearch.com/docs/user-guide/windows-native">native guide's feature matrix</a> lists the exact deltas.</p>
+
+<h2 id="recommendations">If you're still deciding</h2>
+
+<ul>
+  <li><strong>"I just want to try Hermes"</strong> → <a href="/guide/desktop/">Hermes Desktop</a> on your Tier-1 machine. Everything transfers to the CLI later because it's the same agent.</li>
+  <li><strong>"I live in a terminal"</strong> → <code>install.sh</code> + <code>hermes --tui</code>. Add the dashboard when you want a browser view.</li>
+  <li><strong>"I want a bot that answers at 3am"</strong> → Docker on a small VPS (or Hermes Cloud), gateway configured, dashboard behind OAuth or a tailnet. Manage it from Desktop's remote-gateway connections.</li>
+  <li><strong>"I want it on my phone"</strong> → Telegram against a VPS gateway first; Termux if you genuinely need phone-local execution.</li>
+  <li><strong>"I run NixOS"</strong> → you already know the tradeoff you signed up for. The <a href="https://hermes-agent.nousresearch.com/docs/getting-started/nix-setup">Nix setup guide</a> is extensive; it's still Tier 2.</li>
+</ul>
+
+<p>Next steps: <a href="/guide/install/">the install guide</a> for your platform, <a href="/skills/">the Skills Hub</a> once you're running, and <a href="/lists/deployment-options">deployment options</a> from the community catalog. Comparing agents instead of modes? <a href="/guide/vs-claude-code/">Hermes vs Claude Code</a>.</p>
+
+<h2 id="frequently-asked-questions">FAQ</h2>
+
+<h3>Does Hermes Agent have a desktop app?</h3>
+<p>Yes — <a href="/guide/desktop/">Hermes Desktop</a>, a native app for macOS, Windows, and Linux built on the same agent core as the CLI. Install it from the official download page, or run <code>hermes desktop</code> from an existing install.</p>
+
+<h3>Should I use Hermes Desktop or the CLI?</h3>
+<p>It's not either/or: they share config, sessions, skills, and memory, so you can move between them freely. Desktop adds visual multi-session and bot management; the TUI is the officially recommended interactive terminal experience.</p>
+
+<h3>Can I run Hermes Agent on a Raspberry Pi or home server?</h3>
+<p>Yes — the Docker image is Tier 1 on aarch64, which covers ARM single-board computers. Budget 1GB RAM/1 core minimum (2–4GB with browser tools), and update by pulling a new image.</p>
+
+<h3>Can I run Hermes Agent on Android?</h3>
+<p>Yes, via Termux (Tier 2). CLI, cron, MCP, memory, and a best-effort Telegram gateway are tested; Android may suspend background jobs, so don't rely on it as an always-on host.</p>
+
+<h3>Do I need a VPS to run Hermes as a Telegram or Discord bot?</h3>
+<p>No — the gateway runs anywhere, including Desktop's built-in Bot Mode. But a VPS or Hermes Cloud is the right home once you want the bot to outlive your laptop's lid.</p>
+
+<h3>Is it safe to expose the Hermes dashboard on a VPS?</h3>
+<p>Only behind the auth gate — OAuth (Nous Portal) for anything public, username/password strictly for LAN/VPN. Unauthenticated dashboards were exploited in a real June 2026 campaign; the <code>--insecure</code> flag is now a deprecated no-op.</p>
+
+<h3>Should I install on Windows natively or in WSL2?</h3>
+<p>Native for most people (it's Tier 1 and nearly everything works). WSL2 if you want the dashboard's embedded terminal or a real POSIX environment shared with your dev tools.</p>
+
+<div class="article-footer">
+  <p>Maintained by <a href="https://x.com/ksimback">Kevin Simback</a> · Part of <a href="/guide/">The Hermes Handbook</a> · Facts sourced from the <a href="https://hermes-agent.nousresearch.com/docs/">official Hermes Agent docs</a> · if this was useful, drop a ★ on <a href="https://github.com/ksimback/hermes-ecosystem">the atlas repo</a> →</p>
+</div>
+
+</main>
+
+<footer class="page-footer">
+  <div class="fn-left">hermes atlas · curated by <a href="https://github.com/ksimback">ksimback</a> · <a href="https://github.com/ksimback/hermes-ecosystem/issues">suggest a repo</a> · <a href="/privacy">privacy</a></div>
+  <div>v2 · 2026.04</div>
+</footer>
+
+<script src="/assets/js/theme-toggle.js" defer></script>
+<script src="/assets/js/masthead-fetch.js" defer></script>
+<!-- Cloudflare Web Analytics -->
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js"
+        data-cf-beacon='{"token": "fe0d4d79280b4386b6b0cd99b2d94dbc"}'></script>
+<!-- End Cloudflare Web Analytics -->
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -117,9 +117,7 @@
   </p>
 </main>
 
-<!-- Journey doors: route by where the visitor is, not by what a project is.
-     The "pick your mode" link points at the handbook until the mode decision
-     hub ships (strategy addendum move 2) — swap the href when it lands. -->
+<!-- Journey doors: route by where the visitor is, not by what a project is. -->
 <section class="doors" aria-label="Start here">
   <div class="door">
     <div class="door-num">§·start</div>
@@ -128,7 +126,7 @@
     <ul class="door-links">
       <li><a href="/guide/">what hermes agent is →</a></li>
       <li><a href="/guide/install/">install it on your machine →</a></li>
-      <li><a href="/guide/">pick your mode — desktop, cli, cloud →</a></li>
+      <li><a href="/guide/modes/">pick your mode — desktop, cli, cloud →</a></li>
       <li><a href="/guide/vs-claude-code/">hermes vs claude code →</a></li>
     </ul>
   </div>

--- a/lib/build-artifacts.js
+++ b/lib/build-artifacts.js
@@ -7,9 +7,13 @@ export const REFRESHED_CONTENT_PATHS = [
   "guide/install/index.html",
   "guide/memory/index.html",
   "guide/vs-claude-code/index.html",
+  "guide/modes/index.html",
+  "guide/desktop/index.html",
   "drafts/handbook-hub.md",
   "drafts/handbook-vs-claude-code.md",
   "drafts/guide-memory.md",
+  "drafts/guide-modes.md",
+  "drafts/guide-desktop.md",
 ];
 
 export const GENERATED_ARTIFACT_PATHS = [

--- a/scripts/build-chunks.js
+++ b/scripts/build-chunks.js
@@ -68,6 +68,11 @@ async function main() {
   const guideSources = [
     { file: "handbook-hub.md", source: "guide/" },
     { file: "handbook-vs-claude-code.md", source: "guide/vs-claude-code/" },
+    // guide-memory.md existed before this list gained it — the Memory
+    // Guidebook was never chunked for RAG until the modes/desktop pass.
+    { file: "guide-memory.md", source: "guide/memory/" },
+    { file: "guide-modes.md", source: "guide/modes/" },
+    { file: "guide-desktop.md", source: "guide/desktop/" },
   ];
   for (const g of guideSources) {
     const filePath = path.join(ROOT, "drafts", g.file);

--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -661,6 +661,8 @@ Hermes Atlas tracks every open-source project in the Hermes Agent ecosystem acro
 - [Beginner's Guide to Hermes Agent](${SITE_URL}/guide/): Install, pick a model, ship your first workflow, with the best community tool for every step.
 - [Install Hermes Agent](${SITE_URL}/guide/install/): Step-by-step install for macOS, Linux, Windows, and WSL, with troubleshooting.
 - [The Hermes Agent Memory Guidebook](${SITE_URL}/guide/memory/): Kevin Simback's guide to native memory, MemoryProviders, and community memory plug-ins.
+- [How to Run Hermes Agent: Desktop vs CLI vs Docker/VPS vs Bot Gateway](${SITE_URL}/guide/modes/): Every way to run Hermes compared — front-ends share state; the real decision is where the agent lives.
+- [Hermes Desktop: The Complete Guide](${SITE_URL}/guide/desktop/): Install on macOS/Windows/Linux, desktop-only features, plugins, remote/VPS connections, and known rough edges.
 - [Hermes Agent vs. Claude Code](${SITE_URL}/guide/vs-claude-code/): Feature-by-feature comparison for choosing between the two.
 
 ## Masterclass
@@ -753,6 +755,16 @@ This file is the companion to ${SITE_URL}/llms.txt (the concise index).`);
   try {
     const memoryDraft = fs.readFileSync(path.join(ROOT, "drafts", "guide-memory.md"), "utf-8");
     sections.push(`# The Hermes Agent Memory Guidebook (/guide/memory/)\n\nCanonical URL: ${SITE_URL}/guide/memory/\n\n${memoryDraft}`);
+  } catch {}
+
+  try {
+    const modesDraft = fs.readFileSync(path.join(ROOT, "drafts", "guide-modes.md"), "utf-8");
+    sections.push(`# How to Run Hermes Agent (/guide/modes/)\n\nCanonical URL: ${SITE_URL}/guide/modes/\n\n${modesDraft}`);
+  } catch {}
+
+  try {
+    const desktopDraft = fs.readFileSync(path.join(ROOT, "drafts", "guide-desktop.md"), "utf-8");
+    sections.push(`# Hermes Desktop: The Complete Guide (/guide/desktop/)\n\nCanonical URL: ${SITE_URL}/guide/desktop/\n\n${desktopDraft}`);
   } catch {}
 
   try {

--- a/tests/build-artifacts.test.js
+++ b/tests/build-artifacts.test.js
@@ -8,6 +8,22 @@ import {
   parsePorcelainStatus,
 } from "../lib/build-artifacts.js";
 
+test("refreshed content manifest covers the hand-authored pages + drafts", () => {
+  assert.deepEqual(REFRESHED_CONTENT_PATHS, [
+    "guide/index.html",
+    "guide/install/index.html",
+    "guide/memory/index.html",
+    "guide/vs-claude-code/index.html",
+    "guide/modes/index.html",
+    "guide/desktop/index.html",
+    "drafts/handbook-hub.md",
+    "drafts/handbook-vs-claude-code.md",
+    "drafts/guide-memory.md",
+    "drafts/guide-modes.md",
+    "drafts/guide-desktop.md",
+  ]);
+});
+
 test("generated artifact manifest covers current build outputs", () => {
   assert.deepEqual(GENERATED_ARTIFACT_PATHS, [
     "index.html",

--- a/tests/mode-pages.test.js
+++ b/tests/mode-pages.test.js
@@ -1,0 +1,118 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { JSDOM } from "jsdom";
+
+// The mode decision hub (/guide/modes/) and its desktop satellite
+// (/guide/desktop/) are hand-authored pages targeting the largest unserved
+// GSC queries ("hermes desktop": 13K impressions). These tests pin the
+// contract: pages exist with the guide-page anatomy (Article + FAQPage +
+// BreadcrumbList JSON-LD, current-version masthead, comparison tables),
+// their internal links resolve, the homepage mode door points at the hub,
+// and their RAG drafts stay registered in build-chunks.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.join(__dirname, "..");
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel), "utf8");
+const version = JSON.parse(read("data/latest-release.json")).version;
+
+const PAGES = ["guide/modes/index.html", "guide/desktop/index.html"];
+
+for (const rel of PAGES) {
+  test(`${rel} has the guide-page anatomy`, () => {
+    const html = read(rel);
+    const { document } = new JSDOM(html).window;
+
+    const canonical = document.querySelector('link[rel="canonical"]');
+    assert.ok(canonical, "canonical present");
+    assert.match(canonical.getAttribute("href"), /^https:\/\/hermesatlas\.com\/guide\/(modes|desktop)\/$/);
+
+    const ldTypes = Array.from(
+      document.querySelectorAll('script[type="application/ld+json"]'),
+    ).map((s) => JSON.parse(s.textContent)["@type"]);
+    for (const t of ["Article", "FAQPage", "BreadcrumbList"]) {
+      assert.ok(ldTypes.includes(t), `${t} JSON-LD present`);
+    }
+
+    assert.ok(document.querySelector("header.masthead"), "masthead present");
+    assert.ok(html.includes(`hermes·${version}`), "masthead version is current");
+    assert.ok(document.querySelector("main.article"), "article layout");
+    assert.ok(document.querySelector(".article-table-scroll table"), "comparison table present");
+    assert.ok(document.querySelector("#theme-toggle"), "theme toggle present");
+
+    // CSP contract: no inline executable scripts, no style attrs, no on* handlers.
+    for (const s of document.querySelectorAll("script")) {
+      assert.ok(
+        s.getAttribute("src") || s.getAttribute("type") === "application/ld+json",
+        "no inline executable scripts",
+      );
+    }
+    assert.equal(document.querySelectorAll("[style]").length, 0, "no style attributes");
+  });
+
+  test(`${rel} internal links resolve to files on disk`, () => {
+    const { document } = new JSDOM(read(rel)).window;
+    const hrefs = new Set();
+    for (const a of document.querySelectorAll("a[href]")) {
+      const href = a.getAttribute("href") || "";
+      if (href.startsWith("/") && !href.startsWith("//")) {
+        hrefs.add(href.split("#")[0].split("?")[0]);
+      }
+    }
+    for (const href of hrefs) {
+      if (!href || href === "/") continue;
+      const relPath = href.replace(/^\//, "").replace(/\/$/, "");
+      const candidates = [
+        path.join(ROOT, relPath, "index.html"),
+        path.join(ROOT, `${relPath}.html`),
+        path.join(ROOT, relPath),
+      ];
+      assert.ok(
+        candidates.some((p) => fs.existsSync(p)),
+        `${rel} links ${href} but no file exists for it`,
+      );
+    }
+  });
+
+  test(`${rel} FAQ JSON-LD questions appear on the page`, () => {
+    const html = read(rel);
+    const { document } = new JSDOM(html).window;
+    const faq = Array.from(
+      document.querySelectorAll('script[type="application/ld+json"]'),
+    )
+      .map((s) => JSON.parse(s.textContent))
+      .find((b) => b["@type"] === "FAQPage");
+    assert.ok(faq.mainEntity.length >= 5, "at least five FAQ entries");
+    for (const q of faq.mainEntity) {
+      assert.ok(
+        html.includes(q.name.replace(/&/g, "&amp;").slice(0, 30)) || html.includes(q.name.slice(0, 30)),
+        `FAQ question "${q.name}" appears in the page body`,
+      );
+    }
+  });
+}
+
+test("homepage 'pick your mode' door routes to /guide/modes/", () => {
+  const { document } = new JSDOM(read("index.html")).window;
+  const link = Array.from(document.querySelectorAll(".door-links a")).find((a) =>
+    /pick your mode/i.test(a.textContent),
+  );
+  assert.ok(link, "mode door link exists");
+  assert.equal(link.getAttribute("href"), "/guide/modes/");
+});
+
+test("mode drafts are registered as RAG guide sources", () => {
+  const chunks = read("scripts/build-chunks.js");
+  for (const [file, source] of [
+    ["guide-modes.md", "guide/modes/"],
+    ["guide-desktop.md", "guide/desktop/"],
+    ["guide-memory.md", "guide/memory/"],
+  ]) {
+    assert.ok(chunks.includes(`"${file}"`), `${file} in guideSources`);
+    assert.ok(chunks.includes(`"${source}"`), `${source} label in guideSources`);
+    assert.ok(fs.existsSync(path.join(ROOT, "drafts", file)), `drafts/${file} exists`);
+  }
+});

--- a/tests/seo-pages.test.js
+++ b/tests/seo-pages.test.js
@@ -55,6 +55,8 @@ test("guide pages carry the current Hermes release, not a stale one", () => {
     "guide/install/index.html",
     "guide/memory/index.html",
     "guide/vs-claude-code/index.html",
+    "guide/modes/index.html",
+    "guide/desktop/index.html",
   ]) {
     assert.ok(
       read(rel).includes(`hermes·${version}`),


### PR DESCRIPTION
## What

Strategy move 2 from the traffic addendum: the **mode decision hub**. Two hand-authored handbook pages targeting the site's largest unserved search demand:

- **"hermes desktop"** — 13,091 impressions, 0.1% CTR, position ~10, no matching page
- "hermes workspace" 3.6K impr; raspberry-pi / android / cli-install long tail at positions 7–9
- "hermes desktop plugins" already converts at **12.3% CTR** — that intent gets a dedicated section

## Pages

**`/guide/modes/`** — *How to Run Hermes Agent: Desktop vs CLI vs Docker/VPS vs Bot Gateway* (~2,200 words). Core message straight from the official docs: the front-ends share one agent core ("pick whichever fits the moment — they share state"); the real decision is where the agent lives. Includes an 8-row mode comparison table, the official Tier 1/2/unsupported platform matrix, VPS security guidance anchored on the dated June-2026 unauthenticated-dashboard campaign, the official Windows native-vs-WSL2 decision bullets, persona recommendations, and a 7-question FAQ with FAQPage JSON-LD.

**`/guide/desktop/`** — *Hermes Desktop: The Complete Guide* (~1,800 words). Install per OS (including the "ubuntu" query shape), desktop-only capabilities (Bot Mode roster, Memory Graph, multi-connection, Quick Entry), a plugins/skills section routing to `/skills/` + `/ecosystem/`, remote/VPS connection auth guidance (OAuth vs LAN/Tailscale-only passwords), an honest rough-edges section (Electron download, macOS TCC, SSH host-key latching), v2026.8.27 changes, a vs-CLI table, and FAQ + FAQPage JSON-LD.

**Every factual claim is sourced to the official docs mirror** — nothing invented (reliability-first). Both pages carry the `Current release is vX (as of …)` phrasing so the existing freshness pass keeps them stamped.

## Wiring

- `drafts/guide-modes.md` + `drafts/guide-desktop.md` = RAG/llms source of truth, registered in `build-chunks.js` `guideSources` → chat can answer "desktop or CLI?" with citations after the chunks rebuild. **Drive-by fix:** `drafts/guide-memory.md` was never in `guideSources` (the Memory Guidebook was invisible to RAG) — now registered.
- `REFRESHED_CONTENT_PATHS` + lockstep `build-artifacts.test.js` (which now also pins the refreshed-paths list explicitly), `llms.txt`/`llms-full` sections, `seo-pages.test.js` version assertions, handbook-hub cross-link blockquote.
- Homepage "pick your mode" door: `/guide/` placeholder → `/guide/modes/`.
- Sitemap/site-chrome/CSP coverage is automatic (`guide/*` discovery).
- New `tests/mode-pages.test.js` (15 assertions across both pages): anatomy (3× JSON-LD types, current version, tables, CSP contract), internal links resolve on disk, FAQ JSON-LD matches page body, homepage door target, RAG registration.

## Deliberately not in this PR

Regenerated bulk artifacts (project pages with fresh stars, sitemap, llms outputs) — the next scheduled build lands them, keeping this PR at 12 files so the smoke/validate gates actually run (the >300-file path-filter skip from #928).

## Verification

- `npm test`: **322/322** (15 new)
- Authenticated full build ran clean; freshness pass recognizes both pages; sitemap auto-gains both URLs on the next build
- Preview: please eyeball both pages (tables + article layout)
- Post-merge: request GSC indexing for `/guide/modes/` + `/guide/desktop/`; watch "hermes desktop" position (~10 → top 3 is the addendum's success metric)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
