### PR TITLE
rebuild-chunks: trigger on the guide drafts added in #939

### DIFF
--- a/.github/workflows/rebuild-chunks.yml
+++ b/.github/workflows/rebuild-chunks.yml
@@ -26,6 +26,9 @@ on:
       - 'data/user-stories.json'
       - 'drafts/handbook-hub.md'
       - 'drafts/handbook-vs-claude-code.md'
+      - 'drafts/guide-memory.md'
+      - 'drafts/guide-modes.md'
+      - 'drafts/guide-desktop.md'
       - 'scripts/build-chunks.js'
       - 'lib/chunk-text.js'
   workflow_dispatch:


### PR DESCRIPTION
Three-line workflow fix: the new RAG guide drafts (`guide-memory.md`, `guide-modes.md`, `guide-desktop.md`) are registered in `build-chunks.js` guideSources but were missing from `rebuild-chunks.yml`'s push trigger paths — a future edit to any of them would silently not re-embed until the 06:20 UTC reconciliation cron. Found while verifying #939's post-merge chunks rebuild (which fired only because that PR happened to touch `build-chunks.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)