### PR TITLE
Per-platform install split: /guide/install/{windows,macos,linux,raspberry-pi,vps}/ (strategy move 3)

### DIFF
--- a/.github/workflows/rebuild-chunks.yml
+++ b/.github/workflows/rebuild-chunks.yml
@@ -29,6 +29,11 @@ on:
       - 'drafts/guide-memory.md'
       - 'drafts/guide-modes.md'
       - 'drafts/guide-desktop.md'
+      - 'drafts/guide-install-windows.md'
+      - 'drafts/guide-install-macos.md'
+      - 'drafts/guide-install-linux.md'
+      - 'drafts/guide-install-raspberry-pi.md'
+      - 'drafts/guide-install-vps.md'
       - 'scripts/build-chunks.js'
       - 'lib/chunk-text.js'
   workflow_dispatch:

--- a/drafts/guide-install-linux.md
+++ b/drafts/guide-install-linux.md
@@ -1,0 +1,65 @@
+# How to Install Hermes Agent on Linux (Ubuntu, Debian, Fedora, Arch)
+
+The Linux install guide. Live version: https://hermesatlas.com/guide/install/linux/ — facts sourced from the official docs. Current release is v0.21.0 (as of 2026-08-31).
+
+## TL;DR
+
+One command on any supported distro:
+
+```
+curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+source ~/.bashrc
+hermes
+```
+
+Linux (x86_64 and aarch64) is **Tier 1**. Nous tests on the latest Ubuntu and WSL2; per the official matrix, "if your distro has glibc, systemd, and follows the Filesystem Hierarchy Standard, it's likely to work pretty well."
+
+This guide covers Hermes Agent **v0.21.0**.
+
+## Prerequisites
+
+- **Git**, plus **curl** and **xz-utils** (the installer downloads Node.js as a `.tar.xz`): `sudo apt install git curl xz-utils` on Debian/Ubuntu.
+- For the desktop app only: `build-essential` (g++) to compile native modules.
+- The installer handles the rest with no sudo: `uv`, Python 3.11, Node.js 26, ripgrep, ffmpeg.
+
+## Install layout: per-user vs system-wide
+
+- **Per-user (default):** code at `~/.hermes/hermes-agent/`, launcher symlinked to `~/.local/bin/hermes`, data at `~/.hermes/`.
+- **Root mode** (`curl … | sudo bash`): FHS layout — code at `/usr/local/lib/hermes-agent/`, binary at `/usr/local/bin/hermes`. Useful for shared machines; per-user config still lives in each user's `~/.hermes/`.
+
+## Ubuntu Server / headless / service-user installs
+
+Running Hermes as a dedicated unprivileged user (e.g. a `hermes` systemd service account) is officially supported. The only step that genuinely needs root is Playwright's Chromium system libraries:
+
+1. Once, as an admin: `sudo npx playwright install-deps chromium`.
+2. As the service user, run the normal installer — it detects missing sudo and degrades gracefully. Headless and don't need browser automation? Add `--skip-browser` (and `--skip-computer-use`).
+3. Make sure `~/.local/bin` is on the service user's PATH.
+4. Verify with `hermes doctor`.
+5. Running the messaging gateway from this account? `sudo loginctl enable-linger <service-user>` so the user-level service survives logout and starts at boot.
+
+The same pattern works on Arch, Fedora/RHEL, and openSUSE — those distros don't support Playwright's `--with-deps`, so the installer prints the exact `dnf`/`zypper` commands an admin should run.
+
+## Distro notes
+
+- **Ubuntu / Debian** — the tested reference platform. Fresh minimal cloud image: `apt-get install -y git curl xz-utils` first.
+- **Fedora / RHEL / openSUSE** — supported via the same installer; admin installs Chromium system libraries separately (commands printed by the installer).
+- **Arch** — the installer works (same sudo-detection logic, via pacman). **The AUR package is explicitly unsupported** — use the official installer.
+- **Nix / NixOS** — no longer an explicitly supported install path (Tier 2, best-effort): the official matrix says it "breaks often due to node.js packaging woes." There's a dedicated Nix setup guide with a flake and NixOS module if you accept that tradeoff.
+
+## Updating
+
+`hermes update` auto-detects the git-installer layout and updates in place. (Docker installs update by pulling a new image instead.)
+
+## FAQ
+
+**How do I install Hermes Agent on Ubuntu?** `curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash`, then `source ~/.bashrc`. Ubuntu is the distro Nous tests against.
+
+**Does the installer need sudo?** No for the core install — it's per-user under `~/.hermes/`. Root is only needed once for Playwright's Chromium system libraries (or skip browser tools with `--skip-browser`).
+
+**Which distros are supported?** Latest Ubuntu and WSL2 are tested; anything with glibc, systemd, and FHS is expected to work. Alpine (musl) doesn't fit that description.
+
+**Can I install from the AUR on Arch?** No — AUR installs are explicitly unsupported. Run the official installer on Arch instead.
+
+**How do I keep the gateway running on a server?** Install as a service user, run `hermes gateway setup` (it offers a systemd user unit), and enable lingering: `sudo loginctl enable-linger <user>`.
+
+**What about NixOS?** Tier 2 / best-effort — there's an extensive official Nix guide, but releases may break it. Docker or an FHS distro is the supported path.

--- a/drafts/guide-install-macos.md
+++ b/drafts/guide-install-macos.md
@@ -1,0 +1,51 @@
+# How to Install Hermes Agent on macOS (Apple Silicon)
+
+The macOS install guide. Live version: https://hermesatlas.com/guide/install/macos/ — facts sourced from the official docs. Current release is v0.21.0 (as of 2026-08-31).
+
+## TL;DR
+
+Two supported paths on a Mac, both Tier 1 on **Apple Silicon** (M1–M4):
+
+1. **Hermes Desktop installer** (recommended by Nous): download from the official site and run it — you get the desktop app and the CLI in one shot, sharing the same config and data.
+2. **CLI-only curl install**: `curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash`, then `source ~/.zshrc` and run `hermes`.
+
+Two paths that are explicitly **unsupported**: `brew install hermes-agent` and `pip`/`uv tool install` — the official platform-support page says they may be broken now, may break more, and compat code can be removed at any point.
+
+This guide covers Hermes Agent **v0.21.0**.
+
+## Intel Macs are unsupported
+
+The official support matrix lists **macOS on Intel (x86) processors as unsupported** — only Apple Silicon is Tier 1. If you're on an Intel Mac, the practical alternatives are running Hermes on a Linux box/VPS you SSH into, or the Docker image (Tier 1 on x86_64) on other hardware. Don't expect the installer to keep working on Intel.
+
+## Prerequisites
+
+Just **Git** (`git --version`). The installer handles the rest: `uv`, Python 3.11 (no sudo), Node.js 26 (existing Node 22.22+/24.11+/26+ is used as-is), ripgrep, and ffmpeg. For the desktop app it also needs a working compiler toolchain to build native modules.
+
+## Install and verify
+
+```
+curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+source ~/.zshrc     # macOS default shell since Catalina
+hermes version      # prints v0.21.0 (or newer)
+hermes doctor       # health check — every line should be green
+```
+
+Code lands in `~/.hermes/hermes-agent/`, the `hermes` command at `~/.local/bin/hermes`, and your data (config, keys, sessions, skills, memory) in `~/.hermes/`.
+
+First run: `hermes` starts the provider wizard. Fastest path is `hermes setup --portal` — one Nous Portal login covers 300+ models plus the Tool Gateway. Already running Hermes elsewhere? `hermes import` restores a full backup.
+
+If you installed CLI-only and want the app later: `hermes desktop` installs and launches Hermes Desktop against your existing config.
+
+## FAQ
+
+**Does Hermes work on Apple Silicon (M1, M2, M3, M4)?** Yes — macOS on Apple Silicon is Tier 1. The installer pulls native arm64 binaries; no Rosetta.
+
+**Does Hermes work on Intel Macs?** No — Intel Macs are explicitly listed as unsupported in the official platform matrix. Use a Linux machine, a VPS, or Docker on other hardware instead.
+
+**Can I install Hermes with Homebrew?** No — `brew install hermes-agent` is an unsupported path per the official docs. Use the Desktop installer or the curl one-liner.
+
+**Should I use the Desktop installer or the curl install?** Desktop installer if you want the app (Nous recommends it as the easy path); curl if you're terminal-only. They share the same agent core, config, and data — and `hermes desktop` upgrades a CLI install to the app any time.
+
+**Is a Mac mini a good always-on Hermes host?** An Apple Silicon Mac mini works well — it's a Tier 1 platform and popular for exactly this. For headless always-on setups, compare the Docker/VPS route in our modes guide.
+
+**How much disk space does it need?** Roughly 200 MB for a fresh install; budget another 100–500 MB for sessions, skills, and memory as you use it.

--- a/drafts/guide-install-raspberry-pi.md
+++ b/drafts/guide-install-raspberry-pi.md
@@ -1,0 +1,66 @@
+# How to Install Hermes Agent on a Raspberry Pi (4 & 5)
+
+The Raspberry Pi install guide. Live version: https://hermesatlas.com/guide/install/raspberry-pi/ — facts sourced from the official docs. Current release is v0.21.0 (as of 2026-08-31).
+
+## TL;DR
+
+Yes, Hermes Agent runs on a Raspberry Pi — there's no Pi-specific build because none is needed: **Linux on aarch64 is Tier 1**, and so is the official Docker image on aarch64. A Pi 4 or Pi 5 with **4+ GB RAM** running a **64-bit OS** (Raspberry Pi OS 64-bit or Ubuntu Server) is the sweet spot. Two install paths:
+
+1. **Direct install** (simplest): the standard Linux one-liner on Raspberry Pi OS 64-bit — `curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash`.
+2. **Docker** (best for always-on): `docker run` the official `nousresearch/hermes-agent` image (published for aarch64), with s6-supervised gateway auto-restart.
+
+The practical constraint isn't Hermes — it's the model. Pair the Pi with a hosted API (Nous Portal, Anthropic, OpenAI) and the agent host stays lightweight; don't plan on running local LLM inference on the Pi itself.
+
+This guide covers Hermes Agent **v0.21.0**.
+
+## Hardware requirements
+
+- **64-bit (aarch64) OS is required** — official support is for aarch64 Linux; use Raspberry Pi OS **64-bit** or Ubuntu Server 64-bit, not a 32-bit (armv7) image.
+- **Pi 4 / Pi 5 with 4 GB+ RAM recommended.** Docker minimums from the official docs: 1 GB RAM / 1 core, 2–4 GB recommended — browser automation (Playwright/Chromium) is the most memory-hungry feature; skip it (`--skip-browser`) on smaller Pis.
+- A Pi 3 technically has an aarch64 CPU but only 1 GB RAM — enough for a gateway-only setup without browser tools, but tight. Pi Zero–class boards are not realistic hosts.
+- Disk: ~200 MB for the install, plus 500 MB–2 GB+ as sessions and skills grow. Use a quality SD card or, better, USB/NVMe boot.
+
+## Path 1 — direct install on Raspberry Pi OS
+
+Raspberry Pi OS 64-bit is Debian-based, so the Pi is just a Tier-1 Linux aarch64 box:
+
+```
+sudo apt install -y git curl xz-utils
+curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+source ~/.bashrc
+hermes version   # prints v0.21.0 (or newer)
+```
+
+For an always-on Telegram/Discord bot: `hermes gateway setup` (offers a systemd user unit) and `sudo loginctl enable-linger <user>` so the gateway survives logout and starts at boot. Headless Pi? Add `--skip-browser` to the installer to skip Chromium entirely.
+
+## Path 2 — Docker (recommended for set-and-forget)
+
+The official image is published for aarch64 and supervises the gateway with s6 (auto-restart on crash):
+
+```
+mkdir -p ~/.hermes
+docker run -it --rm -v ~/.hermes:/opt/data nousresearch/hermes-agent setup
+docker run -d --name hermes --restart unless-stopped \
+  -v ~/.hermes:/opt/data -p 8642:8642 \
+  nousresearch/hermes-agent gateway run
+```
+
+Updating is `docker pull` + recreate (Docker installs intentionally don't support `hermes update`). Never run two gateway containers against the same data directory.
+
+## What people actually run on Pis
+
+Community reports in our user-story corpus include a Raspberry Pi 5 running Hermes 24/7 as an always-on personal agent and Pi-hosted gateways on residential IPs. Treat these as community anecdotes rather than official benchmarks — but they match what the Tier-1 aarch64 support implies.
+
+## FAQ
+
+**Can Hermes Agent run on a Raspberry Pi 5?** Yes — aarch64 Linux and aarch64 Docker are both Tier 1. A Pi 5 (4 or 8 GB) handles the agent, gateway, and cron comfortably with a hosted model API.
+
+**Can it run on a Raspberry Pi 4?** Yes — same paths. Prefer the 4 GB or 8 GB model; on 2 GB, skip browser tools.
+
+**What about a Raspberry Pi 3?** Borderline: it's aarch64 but has 1 GB RAM — the documented Docker minimum with no headroom. Gateway-only without browser tools can work; expect swap pressure.
+
+**Do I need a 64-bit OS?** Yes. Official support targets aarch64; install Raspberry Pi OS 64-bit or Ubuntu Server 64-bit, not the 32-bit image.
+
+**Can the Pi run the model locally?** Not realistically — pair Hermes on the Pi with a hosted API (Nous Portal, Anthropic, OpenAI) or a model server on beefier hardware on your LAN.
+
+**Docker or direct install on the Pi?** Docker for set-and-forget uptime (supervised auto-restart, clean upgrades by pulling a new image); direct install for the lightest footprint and `hermes update`.

--- a/drafts/guide-install-vps.md
+++ b/drafts/guide-install-vps.md
@@ -1,0 +1,60 @@
+# How to Install Hermes Agent on a VPS (Always-On Server Setup)
+
+The VPS/server install guide. Live version: https://hermesatlas.com/guide/install/vps/ — facts sourced from the official docs. Current release is v0.21.0 (as of 2026-08-31).
+
+## TL;DR
+
+A **$5 VPS (1 CPU, 1 GB RAM)** is enough to run Hermes as an always-on agent — Telegram/Discord bot, cron jobs, remote backend for Hermes Desktop — as long as the model is a hosted API (Nous Portal, Anthropic, OpenAI), not local inference. Recommended path: **Docker** (`nousresearch/hermes-agent`, Tier 1 on x86_64 and aarch64) with `--restart unless-stopped`; the image's s6 supervisor auto-restarts a crashed gateway. Direct install works too via the standard Linux one-liner.
+
+**Connect over SSH, not your provider's browser console** — official docs warn that browser-based VPS consoles (Hetzner Cloud and others) mis-transmit characters like `:` and `@`, silently corrupting `docker run -v/-e` arguments and pasted API keys.
+
+This guide covers Hermes Agent **v0.21.0**.
+
+## Sizing
+
+From the official Docker resource table: minimum 1 GB RAM / 1 core / 500 MB disk; recommended 2–4 GB RAM / 2 cores / 2 GB+ disk. Browser automation (Playwright/Chromium) is the most memory-hungry feature — a 1 GB box is fine if you skip it. Any glibc/systemd/FHS distro is likely to work; Ubuntu is the tested reference.
+
+## Path A — Docker (recommended)
+
+```
+ssh root@<your-vps>
+mkdir -p ~/.hermes
+docker run -it --rm -v ~/.hermes:/opt/data nousresearch/hermes-agent setup
+docker run -d --name hermes --restart unless-stopped \
+  -v ~/.hermes:/opt/data -p 8642:8642 \
+  nousresearch/hermes-agent gateway run
+```
+
+All state lives in the mounted `~/.hermes` — the container is stateless, so upgrading is `docker pull` + recreate (no `hermes update` in Docker, by design). One container can host multiple profiles (the officially recommended pattern), each gateway s6-supervised with per-profile rotated logs. Never point two gateway containers at one data directory.
+
+## Path B — direct install (service user)
+
+The standard installer, run as a dedicated unprivileged user: `curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash` (add `--skip-browser` on headless boxes to skip Chromium). One-time admin step for browser tools: `sudo npx playwright install-deps chromium`. Then `hermes gateway setup` (installs a systemd user unit) and `sudo loginctl enable-linger <user>` so the gateway starts at boot and survives logout.
+
+## Security: the part people get wrong
+
+Exposing the dashboard or API server on a VPS means a non-loopback bind, and that **engages a mandatory auth gate** — unauthenticated public dashboards were the entry point for a real June 2026 attack campaign (internet scanners drove exposed agents into planting SSH-key backdoors), and the old `--insecure` escape hatch is now a deprecated no-op. Official guidance:
+
+- **OAuth via Nous Portal** for anything reachable from the public internet.
+- **Username/password** only on a trusted LAN or VPN (e.g. Tailscale).
+- Or bind to `127.0.0.1` and reach the dashboard over an SSH tunnel — no public exposure at all.
+- The gateway's OpenAI-compatible API server is off by default; enabling it beyond loopback requires `API_SERVER_KEY`.
+
+## Using the VPS from your desktop and phone
+
+- **Hermes Desktop** connects to the VPS as a remote gateway: keep `hermes serve` running on the VPS (systemd), then add it under Settings → Gateways in the app — OAuth (Nous Portal) is the preferred provider for a VPS backend. One connection serves every profile on the box.
+- **Phone**: configure the messaging gateway (`hermes gateway setup`) and talk to your agent over Telegram/Discord/WhatsApp — the reason most people put Hermes on a VPS in the first place.
+
+## FAQ
+
+**How small a VPS can run Hermes Agent?** 1 GB RAM / 1 core is the documented minimum (without browser tools); 2–4 GB recommended. The typical $5 tier works with a hosted model API.
+
+**Which provider should I use?** Any standard Ubuntu/Debian VPS works — Hermes has no provider-specific requirements. Whatever you pick, do the install over SSH: official docs warn that browser-based VPS consoles (e.g. Hetzner's) corrupt special characters in pasted commands.
+
+**Docker or direct install on a VPS?** Docker for supervised auto-restart and clean image-based upgrades; direct install if you want `hermes update` and the lightest footprint.
+
+**Is it safe to expose the Hermes dashboard on a VPS?** Only behind the mandatory auth gate — OAuth (Nous Portal) for public reachability; username/password strictly for LAN/VPN; or keep it loopback-only behind an SSH tunnel. `--insecure` no longer bypasses anything.
+
+**Can Hermes Desktop connect to my VPS?** Yes — run `hermes serve` on the VPS and add it as a remote gateway in Desktop's Settings → Gateways, protected by OAuth.
+
+**How do I update Hermes on the VPS?** Docker: `docker pull nousresearch/hermes-agent:latest`, then recreate the container (data persists in `~/.hermes`). Direct install: `hermes update`.

--- a/drafts/guide-install-windows.md
+++ b/drafts/guide-install-windows.md
@@ -1,0 +1,62 @@
+# How to Install Hermes Agent on Windows 10/11: PowerShell, Desktop Installer, or WSL2
+
+The Windows install guide. Live version: https://hermesatlas.com/guide/install/windows/ — facts sourced from the official docs. Current release is v0.21.0 (as of 2026-08-31).
+
+## TL;DR
+
+Native Windows is **Tier 1** — Hermes runs on Windows 10 and 11 (x86_64 and aarch64) with no WSL, no Cygwin, no Docker. Three install paths:
+
+1. **PowerShell one-liner** (fastest if you're in a terminal): `iex (irm https://hermes-agent.nousresearch.com/install.ps1)` — no admin rights required.
+2. **Hermes Desktop installer** (recommended by Nous for most people): download the `.exe` from the official site; on first launch it runs `install.ps1` under the hood, and the GUI and CLI share the same install.
+3. **WSL2** — only if you specifically want a POSIX environment (see below for the official when-to-pick guidance).
+
+This guide covers Hermes Agent **v0.21.0**.
+
+## What the PowerShell installer does
+
+- Installs everything to `%LOCALAPPDATA%\hermes\` and adds `hermes` to your **User PATH** — open a new terminal after it finishes. No admin rights, no UAC.
+- Bootstraps `uv`, Python 3.11, Node.js 26 (winget or a portable tarball), and — if `git` isn't already on PATH — a self-contained PortableGit (~45 MB) under `%LOCALAPPDATA%\hermes\git`.
+- Sets `HERMES_GIT_BASH_PATH` so Hermes can run shell commands through Git Bash (the same strategy Claude Code uses on Windows).
+- Runs the `hermes setup` wizard at the end (skip with `-SkipSetup`).
+
+Installer parameters (scriptblock form required): `-Branch`, `-Commit`, `-Tag` (pin a version), `-NoVenv`, `-SkipSetup`, `-HermesHome`, `-InstallDir`.
+
+## What works natively
+
+Per the official feature matrix, everything except one feature runs natively on Windows: CLI, interactive TUI (`hermes --tui`), the full messaging gateway (Telegram, Discord, Slack, WhatsApp, 15+ platforms), cron scheduler, browser tool, MCP servers, local Ollama/LM Studio, web dashboard, and auto-start at login (via Scheduled Tasks, no admin). The one exception: the dashboard's `/chat` embedded terminal pane needs a POSIX PTY and is WSL2-only.
+
+## Native or WSL2?
+
+Both are Tier 1. Official guidance: pick **WSL2** if you want the dashboard's embedded terminal, you do POSIX-heavy development and want Hermes on the same Linux filesystem as your tools, or you already maintain WSL2. **Native is fine — or better** — for everyone else: you skip crossing the WSL↔Windows boundary every time you touch a file or URL.
+
+WSL2 path: `wsl --install` in Admin PowerShell, reboot, then run the Linux installer inside Ubuntu: `curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash`. Native data lives under `%LOCALAPPDATA%\hermes`, WSL data under `~/.hermes` — the two coexist cleanly.
+
+## Gateway at Windows login
+
+`hermes gateway install` registers a Scheduled Task (`ONLOGON`, non-elevated — no UAC) with a Startup-folder fallback, and spawns the gateway detached via `pythonw.exe` so a stray Ctrl+C can't kill it. Manage with `hermes gateway status/start/stop/restart/uninstall`.
+
+## Common pitfalls
+
+- **`hermes: command not found` right after install** — open a NEW PowerShell window; existing shells don't see the updated User PATH.
+- **`[scriptblock]::Create(...)` fails** — your `install.ps1` download picked up a UTF-8 BOM; use the plain `irm | iex` form instead.
+- **`/edit` does nothing** — Hermes defaults `EDITOR=notepad`; to use VS Code set `$env:EDITOR = "code --wait"` (the `--wait` is critical).
+- **Non-Latin characters show as `?`** — the UTF-8 stdio shim didn't activate; check `HERMES_DISABLE_WINDOWS_UTF8` is unset, or switch to Windows Terminal.
+- **Weird Node version errors** — an older system Node is earlier on PATH than Hermes's bundled Node 26.
+
+## Uninstall
+
+`hermes uninstall` removes the scheduled task, launchers, and the `hermes-agent\` checkout but keeps your config/sessions/skills in `%LOCALAPPDATA%\hermes`. To remove everything: also `Remove-Item -Recurse -Force "$env:LOCALAPPDATA\hermes"`.
+
+## FAQ
+
+**Do I need admin rights to install Hermes on Windows?** No. The PowerShell installer writes only to `%LOCALAPPDATA%\hermes` and your User PATH; gateway auto-start uses a non-elevated Scheduled Task.
+
+**Is native Windows still "early beta"?** No — Windows 10/11 native is a Tier 1 platform in the official support matrix, alongside macOS and Linux. Only the dashboard's embedded terminal pane is WSL2-only.
+
+**Should I install natively or in WSL2?** Native for most people. WSL2 if you want the dashboard's embedded terminal or a real POSIX dev environment shared with your tools.
+
+**Where does Hermes install on Windows?** Code at `%LOCALAPPDATA%\hermes\hermes-agent\`, your data (config, keys, sessions, skills) directly under `%LOCALAPPDATA%\hermes\`. Reinstalls replace only the checkout; your data survives.
+
+**Does the messaging gateway (Telegram/Discord) work on native Windows?** Yes — the full gateway is in the native feature matrix, and `hermes gateway install` keeps it running at login via Scheduled Tasks.
+
+**Windows on ARM?** Yes — the official matrix lists Windows 10/11 on both x86_64 and aarch64 as Tier 1.

--- a/drafts/handbook-hub.md
+++ b/drafts/handbook-hub.md
@@ -23,11 +23,7 @@ By [Kevin Simback](https://x.com/ksimback) · Hermes Atlas maintainer · Updated
 
 ## 1. What Hermes Agent actually is
 
-<<<<<<< HEAD
-**Hermes Agent is an open-source AI agent by [Nous Research](https://nousresearch.com) that runs on your own machine or a cheap VPS, remembers what it learns across sessions, and writes its own reusable skills as it works. It talks to you through a CLI, Telegram, Discord, email, and many other messaging providers. It hit 238,978 GitHub stars (as of 2026-08-31), and it's the fastest-growing open-source agent of 2026.**
-=======
-**Hermes Agent is an open-source AI agent by [Nous Research](https://nousresearch.com) that runs on your own machine or a cheap VPS, remembers what it learns across sessions, and writes its own reusable skills as it works. It talks to you through a CLI, Telegram, Discord, email, and many other messaging providers. It hit 238,978 GitHub stars (as of 2026-08-31), and it's the fastest-growing open-source agent of 2026.**
->>>>>>> origin/main
+**Hermes Agent is an open-source AI agent by [Nous Research](https://nousresearch.com) that runs on your own machine or a cheap VPS, remembers what it learns across sessions, and writes its own reusable skills as it works. It talks to you through a CLI, Telegram, Discord, email, and many other messaging providers. It hit 238,983 GitHub stars (as of 2026-08-31), and it's the fastest-growing open-source agent of 2026.**
 
 ### The 30-second version
 
@@ -441,13 +437,8 @@ If something is wrong, unclear, or out of date, open an issue on [the Atlas repo
 **Last updated:** 2026-08-31 · Version and star figures re-stamp automatically with every site build.
 
 **Cited stats:**
-<<<<<<< HEAD
-- 238,978 GitHub stars (as of 2026-08-31) — source: `api.github.com/repos/NousResearch/hermes-agent`
+- 238,983 GitHub stars (as of 2026-08-31) — source: `api.github.com/repos/NousResearch/hermes-agent`
 - 247+ projects in the Hermes Atlas (as of 2026-08-31)
-=======
-- 238,978 GitHub stars (as of 2026-08-31) — source: `api.github.com/repos/NousResearch/hermes-agent`
-- 247+ projects in the Hermes Atlas (as of 2026-08-31)
->>>>>>> origin/main
 - 643 skills in the community Hub (as of 2026-04-19)
 
 **Corrections and feedback:** [open an issue](https://github.com/ksimback/hermes-ecosystem/issues/new) or message on X.

--- a/guide/index.html
+++ b/guide/index.html
@@ -119,7 +119,7 @@
       "name": "Does Hermes Agent work on Windows?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes. Native Windows is supported as an early beta via a PowerShell installer (irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 | iex). For a more road-tested setup, run wsl --install in PowerShell to get WSL2 + Ubuntu, then run the standard Linux curl installer from inside WSL."
+        "text": "Yes — native Windows 10/11 is a Tier 1 platform. Run the PowerShell installer (iex (irm https://hermes-agent.nousresearch.com/install.ps1)) or the Hermes Desktop installer; no admin rights needed. WSL2 is equally supported if you prefer a POSIX environment."
       }
     },
     {
@@ -244,7 +244,7 @@
   <p class="meta">By <a href="https://x.com/ksimback">Kevin Simback</a> · Hermes Atlas maintainer · Updated 2026-08-31 · ~18 min read</p>
 </header>
 
-<blockquote><strong>More handbook guides:</strong> deciding how to run Hermes — Desktop vs CLI vs Docker/VPS vs bot gateway — read <a href="/guide/modes/"><strong>How to Run Hermes Agent →</strong></a> (and the <a href="/guide/desktop/"><strong>Hermes Desktop guide →</strong></a>). For memory architecture and how to choose between GBrain, Mnemosyne, Mem0, Hindsight, Honcho, and Supermemory, read <a href="/guide/memory/"><strong>The Hermes Agent Memory Guidebook →</strong></a></blockquote>
+<blockquote><strong>More handbook guides:</strong> deciding how to run Hermes — Desktop vs CLI vs Docker/VPS vs bot gateway — read <a href="/guide/modes/"><strong>How to Run Hermes Agent →</strong></a> (and the <a href="/guide/desktop/"><strong>Hermes Desktop guide →</strong></a>). Installing? There's a dedicated guide for your platform: <a href="/guide/install/windows/"><strong>Windows</strong></a>, <a href="/guide/install/macos/"><strong>macOS</strong></a>, <a href="/guide/install/linux/"><strong>Linux</strong></a>, <a href="/guide/install/raspberry-pi/"><strong>Raspberry Pi</strong></a>, or <a href="/guide/install/vps/"><strong>VPS</strong></a>. For memory architecture and how to choose between GBrain, Mnemosyne, Mem0, Hindsight, Honcho, and Supermemory, read <a href="/guide/memory/"><strong>The Hermes Agent Memory Guidebook →</strong></a></blockquote>
 
 <blockquote><strong>TL;DR</strong> — Hermes Agent is Nous Research's open-source autonomous AI agent. It runs on your laptop or a VPS, remembers everything across sessions, writes its own reusable skills as it works, and reaches you through 14+ messaging platforms (CLI, Telegram, Discord, Slack, email, and more). You install it with one command, pick any model from 20+ LLM providers, and it compounds in capability over the following thirty days. As of August 2026. Based on 100+ ecosystem projects reviewed, 33 research sources, and the live GitHub repo.</blockquote>
 
@@ -267,7 +267,7 @@
 
 <h2 id="1-what-hermes-agent-actually-is">1. What Hermes Agent actually is</h2>
 
-<p><strong>Hermes Agent is an open-source AI agent by <a href="https://nousresearch.com" target="_blank" rel="noopener">Nous Research</a> that runs on your own machine or a cheap VPS, remembers what it learns across sessions, and writes its own reusable skills as it works. It talks to you through a CLI, Telegram, Discord, email, and many other messaging providers. It hit 238,978 GitHub stars (as of 2026-08-31), and it's the fastest-growing open-source agent of 2026.</strong></p>
+<p><strong>Hermes Agent is an open-source AI agent by <a href="https://nousresearch.com" target="_blank" rel="noopener">Nous Research</a> that runs on your own machine or a cheap VPS, remembers what it learns across sessions, and writes its own reusable skills as it works. It talks to you through a CLI, Telegram, Discord, email, and many other messaging providers. It hit 238,983 GitHub stars (as of 2026-08-31), and it's the fastest-growing open-source agent of 2026.</strong></p>
 
 <h3>The 30-second version</h3>
 
@@ -380,7 +380,7 @@
 <h3>Prerequisites</h3>
 
 <ul>
-<li><strong>macOS, Linux, Windows, Android (Termux).</strong> Linux, macOS, and WSL2 are first-class. Native Windows works via an early-beta PowerShell installer. Termux on Android works via a curated install path.</li>
+<li><strong>macOS, Linux, Windows, Android (Termux).</strong> Linux, macOS (Apple Silicon), WSL2, and native Windows are all Tier 1. Termux on Android works via a curated install path (Tier 2).</li>
 <li><strong>A terminal.</strong> Any shell works — bash, zsh, fish.</li>
 <li><strong>An API key or a local model.</strong> If you don't have a model provider or want to set up a new one for your agent, a great place to start is the <a href="https://portal.nousresearch.com" target="_blank" rel="noopener">Nous Portal</a> — otherwise just grab an API key from your model provider, or a local Ollama/LM Studio install. You can always swap model providers later.</li>
 <li><strong>~200 MB of disk</strong> for the install plus whatever you use for memory and skills.</li>
@@ -392,7 +392,7 @@
 
 <pre><code>curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash</code></pre>
 
-<p><strong>Native Windows (PowerShell, early beta):</strong></p>
+<p><strong>Native Windows (PowerShell, Tier 1):</strong></p>
 
 <pre><code>irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 | iex</code></pre>
 
@@ -630,7 +630,7 @@ hermes skills info &lt;name&gt;      # inspect before installing</code></pre>
 <p>Hermes itself is free and open-source (MIT licensed). You pay only for the model API you use. With some API model providers or a local Ollama model, your total cost can be $0. With Claude or GPT, you can easily spend $100+ per month depending on volume.</p>
 
 <h3>Does it work on Windows?</h3>
-<p>Yes — two paths. <strong>WSL2</strong> is the road-tested option: run <code>wsl --install</code> in PowerShell, install Ubuntu, then run the standard Linux curl installer from inside WSL. <strong>Native Windows</strong> works via an early-beta PowerShell installer (<code>irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 | iex</code>) — Nous's own framing is "not road-tested as broadly," so prefer WSL2 if you're using Hermes for real work.</p>
+<p>Yes — <strong>native Windows 10/11 is Tier 1</strong>: run <code>iex (irm https://hermes-agent.nousresearch.com/install.ps1)</code> in PowerShell (no admin rights) or use the Desktop installer. <strong>WSL2</strong> is equally supported and the right pick for POSIX-heavy workflows. The official native-vs-WSL2 guidance, feature matrix, and pitfalls are in the <a href="/guide/install/windows/">Windows install guide</a>.</p>
 
 <h3>Can I run it fully offline?</h3>
 <p>Yes. Install Hermes, pair it with Ollama or LM Studio, and disconnect your network. Memory, skills, and cron all work offline. The catch: local models are weaker at tool calling, so complex multi-step workflows degrade. For offline <em>coding</em>, you're fine to an extent based on the capabilities of your local model. For offline <em>automation with many tool calls</em>, expect rough edges.</p>
@@ -665,7 +665,7 @@ hermes skills info &lt;name&gt;      # inspect before installing</code></pre>
   <p><strong>Last updated:</strong> 2026-08-31 · Version and star figures re-stamp automatically with every site build.</p>
   <p><strong>Cited stats:</strong></p>
   <ul>
-    <li>238,978 GitHub stars (as of 2026-08-31) — source: <code>api.github.com/repos/NousResearch/hermes-agent</code></li>
+    <li>238,983 GitHub stars (as of 2026-08-31) — source: <code>api.github.com/repos/NousResearch/hermes-agent</code></li>
     <li>247+ projects in the Hermes Atlas (as of 2026-08-31)</li>
     <li>643 skills in the community Hub (as of 2026-04-19)</li>
   </ul>

--- a/guide/install/index.html
+++ b/guide/install/index.html
@@ -3,11 +3,11 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>How to Install Hermes Agent: Complete 2026 Setup Guide (macOS, Linux, Windows WSL2) | Hermes Atlas</title>
-<meta name="description" content="Install Hermes Agent (Nous Research's self-improving AI agent, v0.21.0) in 2 minutes on macOS, Linux, or Windows WSL2. With the complete troubleshooting tree for every common install error. Updated August 2026.">
+<title>How to Install Hermes Agent: Complete 2026 Setup Guide for Every Platform | Hermes Atlas</title>
+<meta name="description" content="Install Hermes Agent (Nous Research's self-improving AI agent, v0.21.0) in 2 minutes — macOS, Windows, Linux, Raspberry Pi, or a VPS — with dedicated per-platform guides and the complete troubleshooting tree. Updated August 2026.">
 <link rel="canonical" href="https://hermesatlas.com/guide/install/">
 <meta property="og:title" content="How to Install Hermes Agent (2026 Setup Guide)">
-<meta property="og:description" content="Install Hermes Agent v0.21.0 in 2 minutes — macOS, Linux, Windows WSL2 — with the full troubleshooting tree.">
+<meta property="og:description" content="Install Hermes Agent v0.21.0 in 2 minutes — macOS, Windows, Linux, Raspberry Pi, or VPS — with the full troubleshooting tree.">
 <meta property="og:type" content="article">
 <meta property="og:url" content="https://hermesatlas.com/guide/install/">
 <meta property="og:site_name" content="Hermes Atlas">
@@ -19,7 +19,7 @@
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="How to Install Hermes Agent (2026 Setup Guide)">
-<meta name="twitter:description" content="Install Hermes Agent v0.21.0 in 2 minutes — macOS, Linux, Windows WSL2 — with the full troubleshooting tree.">
+<meta name="twitter:description" content="Install Hermes Agent v0.21.0 in 2 minutes — macOS, Windows, Linux, Raspberry Pi, or VPS — with the full troubleshooting tree.">
 <meta name="twitter:image" content="https://hermesatlas.com/api/og?title=How+to+install+Hermes+Agent&amp;subtitle=The+complete+2026+setup+guide+for+macOS%2C+Linux%2C+and+Windows+%28WSL2%29.&amp;kind=handbook+%C2%B7+install">
 <meta name="twitter:creator" content="@ksimback">
 <meta name="author" content="Kevin Simback">
@@ -41,8 +41,8 @@
 {
   "@context": "https://schema.org",
   "@type": "Article",
-  "headline": "How to Install Hermes Agent: Complete 2026 Setup Guide (macOS, Linux, Windows WSL2)",
-  "description": "Install Hermes Agent, Nous Research's self-improving AI agent, in 2 minutes on macOS, Linux, or Windows WSL2. Includes the complete troubleshooting tree.",
+  "headline": "How to Install Hermes Agent: Complete 2026 Setup Guide for Every Platform",
+  "description": "Install Hermes Agent, Nous Research's self-improving AI agent, in 2 minutes — macOS, Windows, Linux, Raspberry Pi, or VPS. Includes the complete troubleshooting tree.",
   "image": "https://hermesatlas.com/api/og?title=How+to+install+Hermes+Agent&subtitle=The+complete+2026+setup+guide+for+macOS%2C+Linux%2C+and+Windows+%28WSL2%29.&kind=handbook+%C2%B7+install",
   "datePublished": "2026-04-23T00:00:00Z",
   "dateModified": "2026-08-31T00:00:00Z",
@@ -77,7 +77,7 @@
   "@context": "https://schema.org",
   "@type": "HowTo",
   "name": "How to install Hermes Agent",
-  "description": "Install Hermes Agent v0.21.0 on macOS, Linux, WSL2, native Windows (PowerShell, early beta), or Termux on Android.",
+  "description": "Install Hermes Agent v0.21.0 on macOS, Linux, WSL2, native Windows (PowerShell), Raspberry Pi, a VPS, or Termux on Android.",
   "totalTime": "PT2M",
   "tool": [
     { "@type": "HowToTool", "name": "Terminal (bash, zsh, or PowerShell)" },
@@ -126,7 +126,7 @@
       "name": "Does Hermes Agent work on bare Windows?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes, in early beta. Since v0.10.0 the Nous team ships a native Windows PowerShell installer: irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 | iex. It installs to %LOCALAPPDATA%\\hermes with a bundled portable Git Bash. For a more road-tested setup, use WSL2: run wsl --install in PowerShell, install Ubuntu, then run the standard Linux curl installer from inside WSL."
+        "text": "Yes — native Windows 10/11 is a Tier 1 platform in the official support matrix. Run the PowerShell installer (iex (irm https://hermes-agent.nousresearch.com/install.ps1)) or the Hermes Desktop installer; no admin rights needed. WSL2 is equally supported if you want a POSIX environment. Everything except the dashboard's embedded terminal pane runs natively."
       }
     },
     {
@@ -134,7 +134,7 @@
       "name": "Does Hermes work on Apple Silicon (M1, M2, M3, M4)?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes, natively. Apple Silicon is a first-class target. The installer detects arm64 and pulls native binaries. No Rosetta required."
+        "text": "Yes, natively — Apple Silicon is Tier 1. The installer detects arm64 and pulls native binaries; no Rosetta required. Note that Intel (x86) Macs are explicitly unsupported in the official platform matrix."
       }
     },
     {
@@ -142,7 +142,7 @@
       "name": "Can I run Hermes Agent on a Raspberry Pi or low-end VPS?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes. Hermes itself runs comfortably on a $5 VPS (1 CPU, 1 GB RAM) or a Raspberry Pi 4 or 5 with 4+ GB RAM. The practical constraint is not Hermes but the model you pair with it — if you use a hosted API like Nous Portal or Anthropic, the agent host is lightweight."
+        "text": "Yes. Hermes itself runs comfortably on a $5 VPS (1 CPU, 1 GB RAM) or a Raspberry Pi 4 or 5 with 4+ GB RAM — we maintain dedicated setup guides for both. The practical constraint is not Hermes but the model you pair with it — if you use a hosted API like Nous Portal or Anthropic, the agent host is lightweight."
       }
     },
     {
@@ -177,6 +177,18 @@
         "text": "Re-running the same curl command is safe — the installer is idempotent. If it fails again, fall back to the manual install steps further down this page, which give you step-by-step control over uv, Python 3.11, Node.js 22, and the venv setup."
       }
     }
+  ]
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {"@type": "ListItem", "position": 1, "name": "home", "item": "https://hermesatlas.com/"},
+    {"@type": "ListItem", "position": 2, "name": "handbook", "item": "https://hermesatlas.com/guide/"},
+    {"@type": "ListItem", "position": 3, "name": "install"}
   ]
 }
 </script>
@@ -215,7 +227,7 @@
 </header>
 
 <div class="breadcrumb" aria-label="Breadcrumb">
-  <a href="/">map</a><span class="sep">/</span><a href="/guide/">handbook</a><span class="sep">/</span>install
+  <a href="/">home</a><span class="sep">/</span><a href="/guide/">handbook</a><span class="sep">/</span>install
 </div>
 
 <main class="article" id="main">
@@ -223,11 +235,11 @@
 <header class="article-header">
   <div class="article-badge">handbook · satellite · install</div>
   <h1>How to install Hermes Agent</h1>
-  <p class="subtitle">The complete 2026 setup guide for macOS, Linux, and Windows (WSL2). With the full troubleshooting tree for every common install error.</p>
+  <p class="subtitle">The complete 2026 setup guide for every platform — with dedicated pages for <a href="/guide/install/windows/">Windows</a>, <a href="/guide/install/macos/">macOS</a>, <a href="/guide/install/linux/">Linux</a>, <a href="/guide/install/raspberry-pi/">Raspberry Pi</a>, and <a href="/guide/install/vps/">VPS</a>, plus the full troubleshooting tree for every common install error.</p>
   <p class="meta">By <a href="https://x.com/ksimback">Kevin Simback</a> · Hermes Atlas maintainer · Updated 2026-08-31 · ~8 min read</p>
 </header>
 
-<blockquote><strong>TL;DR</strong> — Hermes Agent installs with a single curl command on macOS, Linux, or Windows via WSL2. The installer takes two to three minutes end-to-end and is maintained in lockstep with the main repo. This guide covers Hermes Agent <strong>v0.21.0</strong> (<a href="https://github.com/NousResearch/hermes-agent/releases" target="_blank" rel="noopener">current release</a> as of August 2026; 238,978 GitHub stars as of 2026-08-31).</blockquote>
+<blockquote><strong>TL;DR</strong> — Hermes Agent installs with a single curl command on macOS, Linux, or Windows via WSL2. The installer takes two to three minutes end-to-end and is maintained in lockstep with the main repo. This guide covers Hermes Agent <strong>v0.21.0</strong> (<a href="https://github.com/NousResearch/hermes-agent/releases" target="_blank" rel="noopener">current release</a> as of August 2026; 238,983 GitHub stars as of 2026-08-31).</blockquote>
 
 <h2>TL;DR</h2>
 
@@ -239,6 +251,8 @@ hermes             # start chatting</code></pre>
 
 <p>If that worked, skip to <a href="#first-run">first run and model provider</a>. If it didn't, the <a href="#troubleshooting">troubleshooting tree</a> covers the nine failure modes I've seen, in the order you should check them.</p>
 
+<p><strong>Want the full walkthrough for your exact setup?</strong> Each platform has a dedicated page with its own installer specifics, pitfalls, and FAQ: <a href="/guide/install/windows/">Windows 10/11</a> · <a href="/guide/install/macos/">macOS (Apple Silicon)</a> · <a href="/guide/install/linux/">Linux &amp; servers</a> · <a href="/guide/install/raspberry-pi/">Raspberry Pi</a> · <a href="/guide/install/vps/">VPS</a>.</p>
+
 <hr>
 
 <h2 id="before-you-start">Before you start</h2>
@@ -246,10 +260,11 @@ hermes             # start chatting</code></pre>
 <p><strong>Supported OSes</strong> (as of v0.21.0):</p>
 
 <ul>
-<li><strong>macOS</strong> 13 Ventura or newer. Apple Silicon (M1/M2/M3/M4) and Intel both supported. Apple Silicon is faster for local-model workloads.</li>
-<li><strong>Linux</strong> — Ubuntu 22.04 or newer, Debian 12, Fedora 39+, Arch rolling. Any modern distro with glibc 2.35+ should work.</li>
-<li><strong>Windows</strong> — two options. <strong>WSL2</strong> with Ubuntu or Debian inside is the road-tested path. Native Windows works via an <strong>early-beta PowerShell installer</strong> (Nous's wording: "not road-tested as broadly"). See <a href="#install-windows">Install on Windows</a> below.</li>
-<li><strong>Termux (Android)</strong> — supported via a curated <code>.[termux]</code> extra. The same curl one-liner works inside Termux; voice dependencies are excluded.</li>
+<li><strong>macOS</strong> — <strong>Apple Silicon (M1/M2/M3/M4) only</strong>, Tier 1. Intel (x86) Macs are explicitly <a href="https://hermes-agent.nousresearch.com/docs/getting-started/platform-support" target="_blank" rel="noopener">unsupported</a>, as are <code>brew</code> and <code>pip</code> installs. Details: <a href="/guide/install/macos/">macOS install guide</a>.</li>
+<li><strong>Windows 10/11</strong> — <strong>native is Tier 1</strong> (x86_64 and aarch64), via the PowerShell installer or the Hermes Desktop installer; WSL2 is equally Tier 1 for POSIX workflows. Details: <a href="/guide/install/windows/">Windows install guide</a>.</li>
+<li><strong>Linux &amp; WSL2</strong> — Tier 1 (x86_64 and aarch64). Nous tests on the latest Ubuntu; any glibc + systemd + FHS distro is expected to work. Details: <a href="/guide/install/linux/">Linux install guide</a>.</li>
+<li><strong>Docker</strong> — Tier 1 (x86_64 and aarch64); the always-on path for <a href="/guide/install/vps/">VPS boxes</a> and <a href="/guide/install/raspberry-pi/">Raspberry Pis</a>. Updates by pulling a new image, not <code>hermes update</code>.</li>
+<li><strong>Termux (Android)</strong> and <strong>Nix</strong> — Tier 2, best-effort. The same curl one-liner works inside Termux (voice excluded); Nix is no longer an explicitly supported path.</li>
 </ul>
 
 <p><strong>Prerequisites</strong> — Hermes's installer is aggressive about setting up its own stack, so you need almost nothing pre-installed:</p>
@@ -267,89 +282,52 @@ hermes             # start chatting</code></pre>
 
 <h2 id="install-macos">Install on macOS</h2>
 
-<p>Open Terminal (or iTerm, or Warp — any shell). Run:</p>
+<p><strong>Apple Silicon only (Tier 1)</strong> — Intel Macs, <code>brew</code>, and <code>pip</code> installs are officially unsupported. Two paths: the <a href="https://hermes-agent.nousresearch.com/" target="_blank" rel="noopener">Hermes Desktop installer</a> (recommended — app + CLI in one), or terminal-only:</p>
 
-<pre><code>curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash</code></pre>
+<pre><code>curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+source ~/.zshrc   # macOS default since Catalina
+hermes version</code></pre>
 
-<p>Reload your shell so <code>hermes</code> is on PATH:</p>
-
-<pre><code>source ~/.zshrc   # macOS default since Catalina
-# or: source ~/.bashrc if you switched to bash</code></pre>
-
-<p>Test it:</p>
-
-<pre><code>hermes version</code></pre>
-
-<h3>Apple Silicon (M1/M2/M3/M4) notes</h3>
-
-<p>The installer auto-detects <code>arm64</code> and pulls native binaries. No Rosetta required. If you already have Homebrew installed, the installer uses it to pull missing dependencies — otherwise it installs Homebrew for you (and prints what it's doing).</p>
-
-<h3>Intel Mac notes</h3>
-
-<p>Everything works identically. The only caveat: local-model inference via Ollama is meaningfully slower than Apple Silicon — budget a frontier API key (Anthropic, OpenAI, GLM) for real work.</p>
+<p><strong><a href="/guide/install/macos/">Full macOS guide →</a></strong> — Desktop vs CLI install, the Intel-Mac situation, Mac-specific pitfalls, and the Mac mini always-on setup.</p>
 
 <hr>
 
 <h2 id="install-linux">Install on Linux</h2>
 
-<p>The command is identical across distros:</p>
+<p>Tier 1 on x86_64 and aarch64; the command is identical across distros (make sure <code>git</code>, <code>curl</code>, and <code>xz-utils</code> are present first):</p>
 
-<pre><code>curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+<pre><code>curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
 source ~/.bashrc</code></pre>
 
-<h3>Distro-specific notes</h3>
-
-<ul>
-<li><strong>Ubuntu 22.04 / 24.04, Debian 12</strong> — works out of the box. If you're on a fresh minimal cloud image, <code>apt-get install -y git curl</code> first.</li>
-<li><strong>Fedora 39+</strong> — identical. Uses <code>dnf</code> under the hood for any missing system packages.</li>
-<li><strong>Arch / Manjaro</strong> — works; installer uses <code>pacman</code> for missing deps. The AUR has a community <code>hermes-agent</code> package too, but the official curl installer is what the Nous team ships against.</li>
-<li><strong>Alpine</strong> — works with caveats. glibc is required; the installer will fall back to a statically-linked path, but memory and skills with native deps (ffmpeg audio handling, image cache) can be flaky. A $5 Debian VPS is the path of least resistance.</li>
-</ul>
+<p><strong><a href="/guide/install/linux/">Full Linux guide →</a></strong> — distro notes (Ubuntu, Debian, Fedora, Arch — and why the AUR is a trap), per-user vs FHS layouts, and the complete Ubuntu Server / headless / systemd service-user recipe.</p>
 
 <hr>
 
 <h2 id="install-windows">Install on Windows</h2>
 
-<p>Two supported paths. <strong>WSL2</strong> is the road-tested option that most users should pick. <strong>Native Windows via PowerShell</strong> is shipped as an early beta in the official installer — Nous's wording is "not road-tested as broadly" — and is the right call if you can't or won't enable WSL.</p>
+<p><strong>Native Windows 10/11 is Tier 1</strong> — no WSL required, no admin rights. Open PowerShell and run:</p>
 
-<h3 id="install-windows-wsl">Option A — WSL2 (recommended)</h3>
+<pre><code>iex (irm https://hermes-agent.nousresearch.com/install.ps1)</code></pre>
 
-<p>WSL2 runs a real Linux kernel inside Windows 11 with near-native performance.</p>
+<p>Or use the <a href="https://hermes-agent.nousresearch.com/" target="_blank" rel="noopener">Hermes Desktop installer</a> for a double-click install. <strong>WSL2</strong> is equally supported and the right pick for POSIX-heavy workflows (it's the standard Linux install inside Ubuntu).</p>
 
-<h4>1. Install WSL2</h4>
+<p><strong><a href="/guide/install/windows/">Full Windows guide →</a></strong> — the official native-vs-WSL2 guidance, what the installer does, the feature matrix, gateway auto-start at login, and every Windows-specific pitfall.</p>
 
-<p>Open PowerShell as Administrator:</p>
+<hr>
 
-<pre><code>wsl --install</code></pre>
+<h2 id="install-raspberry-pi">Install on a Raspberry Pi</h2>
 
-<p>This installs WSL2 + Ubuntu by default. Reboot when prompted. On first boot of Ubuntu, create a username and password.</p>
+<p>A Pi 4 or 5 with 4+ GB RAM and a <strong>64-bit OS</strong> is a legitimate Tier-1 host (aarch64 Linux and aarch64 Docker are both Tier 1). Direct install uses the Linux one-liner above; Docker gives set-and-forget supervision.</p>
 
-<h4>2. Install Hermes inside WSL</h4>
+<p><strong><a href="/guide/install/raspberry-pi/">Full Raspberry Pi guide →</a></strong> — hardware requirements by board, both install paths, and the always-on gateway setup.</p>
 
-<p>Open the Ubuntu terminal (from Start Menu) and run the same Linux install command:</p>
+<hr>
 
-<pre><code>curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
-source ~/.bashrc
-hermes version</code></pre>
+<h2 id="install-vps">Install on a VPS</h2>
 
-<h4>3. Use Windows Terminal</h4>
+<p>A $5 VPS (1 CPU, 1 GB RAM) runs Hermes as an always-on bot or remote backend when paired with a hosted model API. Docker is the recommended path — and do the install over SSH, not your provider's browser console.</p>
 
-<p>The default WSL console is workable but Windows Terminal (free, Microsoft Store) is substantially better — tabs, font control, and proper Unicode. Set Ubuntu as your default profile and you're done.</p>
-
-<h3 id="install-windows-native">Option B — Native Windows via PowerShell (early beta)</h3>
-
-<p>Open <strong>PowerShell</strong> (not WSL, not cmd) and run:</p>
-
-<pre><code>irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 | iex</code></pre>
-
-<p>The installer drops Hermes into <code>%LOCALAPPDATA%\hermes</code> and unpacks a portable Git Bash (~45 MB MinGit) into <code>%LOCALAPPDATA%\hermes\git</code> so shell-based tools work without a system-wide Git install. It also sets up <code>uv</code>, Python 3.11, Node.js, <code>ripgrep</code>, and <code>ffmpeg</code> in the same directory.</p>
-
-<p>After the script finishes, close and reopen PowerShell so <code>hermes</code> is on PATH, then:</p>
-
-<pre><code>hermes version
-hermes doctor</code></pre>
-
-<p><strong>What "early beta" actually means.</strong> The Nous team's own framing in the README: "not road-tested as broadly" as the Linux/macOS path. Expect more rough edges in the messaging gateway and any tool that shells out to native binaries. If something breaks and you have the option, WSL2 is the safer fallback.</p>
+<p><strong><a href="/guide/install/vps/">Full VPS guide →</a></strong> — sizing from the official docs, Docker and direct-install paths, the mandatory-auth security guidance, and connecting Hermes Desktop or your phone to the box.</p>
 
 <hr>
 
@@ -624,15 +602,15 @@ curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scri
 
 <h3>Does Hermes Agent work on bare Windows?</h3>
 
-<p>Yes, in early beta. Since v0.10.0, Nous ships a native Windows installer you run from PowerShell: <code>irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 | iex</code>. It installs to <code>%LOCALAPPDATA%\hermes</code> and bundles a portable Git Bash. Nous explicitly flags this path as "not road-tested as broadly" — for production use, prefer WSL2: <code>wsl --install</code> in PowerShell, install Ubuntu, then run the standard curl installer from inside WSL.</p>
+<p>Yes — native Windows 10/11 is a <strong>Tier 1</strong> platform. Run <code>iex (irm https://hermes-agent.nousresearch.com/install.ps1)</code> in PowerShell (no admin rights), or use the Desktop installer. It installs to <code>%LOCALAPPDATA%\hermes</code> and bundles a portable Git Bash. Everything except the dashboard's embedded terminal runs natively; WSL2 is equally supported for POSIX workflows. Full details: <a href="/guide/install/windows/">the Windows install guide</a>.</p>
 
 <h3>Does Hermes work on Apple Silicon (M1, M2, M3, M4)?</h3>
 
-<p>Yes, natively. Apple Silicon is a first-class target. The installer detects <code>arm64</code> and pulls native binaries. No Rosetta required.</p>
+<p>Yes, natively — Apple Silicon is Tier 1. The installer detects <code>arm64</code> and pulls native binaries; no Rosetta required. Intel (x86) Macs are explicitly unsupported — see <a href="/guide/install/macos/">the macOS install guide</a>.</p>
 
 <h3>Can I run Hermes Agent on a Raspberry Pi or low-end VPS?</h3>
 
-<p>Yes. Hermes itself runs comfortably on a $5 VPS (1 CPU, 1 GB RAM) or a Raspberry Pi 4/5 with 4+ GB RAM. The practical constraint is not Hermes but the model — pair it with a hosted API (Nous Portal, Anthropic) and the agent host stays lightweight.</p>
+<p>Yes. Hermes itself runs comfortably on a $5 VPS (1 CPU, 1 GB RAM) or a Raspberry Pi 4/5 with 4+ GB RAM — we maintain dedicated <a href="/guide/install/raspberry-pi/">Raspberry Pi</a> and <a href="/guide/install/vps/">VPS</a> setup guides. The practical constraint is not Hermes but the model — pair it with a hosted API (Nous Portal, Anthropic) and the agent host stays lightweight.</p>
 
 <h3>How much disk space does Hermes Agent use?</h3>
 
@@ -655,7 +633,7 @@ curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scri
   <p><strong>Last updated:</strong> 2026-08-31 · Version and star figures re-stamp automatically with every site build.</p>
   <p><strong>Cited stats:</strong></p>
   <ul>
-    <li>238,978 GitHub stars (as of 2026-08-31) — source: <code>api.github.com/repos/NousResearch/hermes-agent</code></li>
+    <li>238,983 GitHub stars (as of 2026-08-31) — source: <code>api.github.com/repos/NousResearch/hermes-agent</code></li>
     <li>Hermes Agent v0.21.0 — <a href="https://github.com/NousResearch/hermes-agent/releases" target="_blank" rel="noopener">release notes</a></li>
   </ul>
   <p><strong>Corrections and feedback:</strong> <a href="https://github.com/ksimback/hermes-ecosystem/issues/new">open an issue</a> or message <a href="https://x.com/ksimback">@ksimback</a> on X.</p>

--- a/guide/install/linux/index.html
+++ b/guide/install/linux/index.html
@@ -1,0 +1,246 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>How to Install Hermes Agent on Linux: Ubuntu, Debian, Fedora, Arch & Servers | Hermes Atlas</title>
+<meta name="description" content="Install Hermes Agent on Linux with one command — Ubuntu, Debian, Fedora, Arch — plus the full Ubuntu Server / headless / systemd service-user recipe from the official docs. Tier 1 on x86_64 and aarch64.">
+<meta name="keywords" content="hermes agent install ubuntu, install hermes agent ubuntu, hermes install linux, hermes agent install debian, hermes agent ubuntu server, hermes linux install, hermes systemd">
+<link rel="canonical" href="https://hermesatlas.com/guide/install/linux/">
+<meta property="og:title" content="How to Install Hermes Agent on Linux: Ubuntu, Debian, Fedora, Arch & Servers">
+<meta property="og:description" content="One command on any glibc/systemd/FHS distro, plus the full headless server and systemd service-user recipe.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://hermesatlas.com/guide/install/linux/">
+<meta property="og:site_name" content="Hermes Atlas">
+<meta property="article:published_time" content="2026-08-31T00:00:00Z">
+<meta property="article:modified_time" content="2026-08-31T00:00:00Z">
+<meta property="article:author" content="https://x.com/ksimback">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=Install+Hermes+Agent+on+Linux&amp;subtitle=Ubuntu%2C+Debian%2C+Fedora%2C+Arch+-+one+command%2C+plus+the+server+recipe&amp;kind=handbook+%C2%B7+install">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="How to Install Hermes Agent on Linux">
+<meta name="twitter:description" content="One command on any glibc/systemd/FHS distro, plus the full headless server recipe.">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Install+Hermes+Agent+on+Linux&amp;subtitle=Ubuntu%2C+Debian%2C+Fedora%2C+Arch+-+one+command%2C+plus+the+server+recipe&amp;kind=handbook+%C2%B7+install">
+<meta name="twitter:creator" content="@ksimback">
+<meta name="author" content="Kevin Simback">
+<link rel="alternate" type="application/rss+xml" title="Hermes Atlas — new projects" href="/rss.xml">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+<link rel="apple-touch-icon" href="/apple-touch-icon.png">
+<link rel="manifest" href="/site.webmanifest">
+<script src="/assets/js/theme-init.js"></script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap">
+<link rel="stylesheet" href="/assets/css/tokens.css">
+<link rel="stylesheet" href="/assets/css/base.css">
+<link rel="stylesheet" href="/assets/css/page.css">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "How to Install Hermes Agent on Linux: Ubuntu, Debian, Fedora, Arch & Servers",
+  "description": "Install Hermes Agent on Linux with one command — Ubuntu, Debian, Fedora, Arch — plus the full headless server and systemd service-user recipe from the official docs.",
+  "image": "https://hermesatlas.com/api/og?title=Install+Hermes+Agent+on+Linux&subtitle=Ubuntu%2C+Debian%2C+Fedora%2C+Arch+-+one+command%2C+plus+the+server+recipe&kind=handbook+%C2%B7+install",
+  "keywords": ["hermes agent install ubuntu", "hermes install linux", "hermes agent install debian", "hermes agent ubuntu server"],
+  "datePublished": "2026-08-31T00:00:00Z",
+  "dateModified": "2026-08-31T00:00:00Z",
+  "author": {"@type": "Person", "name": "Kevin Simback", "url": "https://x.com/ksimback"},
+  "publisher": {"@type": "Organization", "name": "Hermes Atlas", "url": "https://hermesatlas.com"},
+  "mainEntityOfPage": {"@type": "WebPage", "@id": "https://hermesatlas.com/guide/install/linux/"},
+  "isPartOf": {"@type": "Article", "@id": "https://hermesatlas.com/guide/install/", "name": "How to install Hermes Agent"}
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "How do I install Hermes Agent on Ubuntu?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Run curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash, then source ~/.bashrc and start hermes. Ubuntu is the distro Nous tests against; on a fresh minimal image, apt install git curl xz-utils first."}
+    },
+    {
+      "@type": "Question",
+      "name": "Does the Hermes installer need sudo?",
+      "acceptedAnswer": {"@type": "Answer", "text": "No for the core install — it's per-user under ~/.hermes/ with its own Python via uv. Root is only needed once for Playwright's Chromium system libraries (sudo npx playwright install-deps chromium), and you can skip browser tools entirely with --skip-browser."}
+    },
+    {
+      "@type": "Question",
+      "name": "Which Linux distros does Hermes Agent support?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Latest Ubuntu and WSL2 are what Nous tests. The official matrix says any distro with glibc, systemd, and the Filesystem Hierarchy Standard is likely to work well — that covers Debian, Fedora, Arch, and openSUSE, but not musl-based Alpine."}
+    },
+    {
+      "@type": "Question",
+      "name": "Can I install Hermes from the AUR on Arch?",
+      "acceptedAnswer": {"@type": "Answer", "text": "No — AUR installs are explicitly unsupported in the official platform matrix. The official installer works on Arch (it uses pacman with the same sudo-detection logic); use that instead."}
+    },
+    {
+      "@type": "Question",
+      "name": "How do I keep the Hermes gateway running on a Linux server?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Install as a dedicated service user, run hermes gateway setup (it offers to install a systemd user unit), and enable lingering with sudo loginctl enable-linger <user> so the gateway starts at boot and survives logout."}
+    },
+    {
+      "@type": "Question",
+      "name": "Can I install Hermes with Nix or on NixOS?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Only as Tier 2 / best-effort — Nix is no longer an explicitly supported install path, and the official matrix says it breaks often due to node.js packaging woes. There's a dedicated Nix setup guide with a flake and NixOS module if you accept that tradeoff; Docker or an FHS distro is the supported path."}
+    }
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {"@type": "ListItem", "position": 1, "name": "home", "item": "https://hermesatlas.com/"},
+    {"@type": "ListItem", "position": 2, "name": "handbook", "item": "https://hermesatlas.com/guide/"},
+    {"@type": "ListItem", "position": 3, "name": "install", "item": "https://hermesatlas.com/guide/install/"},
+    {"@type": "ListItem", "position": 4, "name": "linux"}
+  ]
+}
+</script>
+</head>
+<body>
+<a class="skip-link" href="#main">Skip to content</a>
+<header class="masthead">
+  <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
+  <div class="mast-meta" aria-label="Site metadata">
+    <span id="meta-count">247·repos</span>
+    <span id="meta-version">hermes·v0.21.0</span>
+    <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
+  </div>
+  <nav class="mast-nav" aria-label="Primary">
+    <a href="/">home</a>
+    <a href="/ecosystem/">ecosystem</a>
+    <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
+    <a href="/use-cases/">use cases</a>
+    <a href="/guide/" class="active">handbook</a>
+    <a href="/masterclass/">masterclass</a>
+    <a href="/dev/">dev</a>
+    <a href="/reports/">reports</a>
+    <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
+  </nav>
+  <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
+  </button>
+</header>
+<div class="breadcrumb" aria-label="Breadcrumb">
+  <a href="/">home</a><span class="sep">/</span><a href="/guide/">handbook</a><span class="sep">/</span><a href="/guide/install/">install</a><span class="sep">/</span>linux
+</div>
+<main class="article" id="main">
+
+<header class="article-header">
+  <div class="article-badge">handbook · install · linux</div>
+  <h1>How to Install Hermes Agent on Linux</h1>
+  <p class="subtitle">Ubuntu, Debian, Fedora, Arch — one command — plus the headless server and systemd service-user recipe. A platform page of <a href="/guide/install/">the install guide</a>, cross-checked against the official docs.</p>
+  <p class="meta">By <a href="https://x.com/ksimback">Kevin Simback</a> · Hermes Atlas maintainer · Updated 2026-08-31 · ~6 min read</p>
+</header>
+
+<h2 id="tldr">TL;DR</h2>
+
+<p><strong>One command on any supported distro.</strong> Linux (x86_64 and aarch64) is Tier 1; Nous tests on the latest Ubuntu, and the <a href="https://hermes-agent.nousresearch.com/docs/getting-started/platform-support">official matrix</a> says "if your distro has glibc, systemd, and follows the Filesystem Hierarchy Standard, it's likely to work pretty well."</p>
+
+<pre><code>curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+source ~/.bashrc
+hermes              # start chatting</code></pre>
+
+<p>This guide covers Hermes Agent <strong>v0.21.0</strong>. On other platforms? See <a href="/guide/install/windows/">Windows</a>, <a href="/guide/install/macos/">macOS</a>, <a href="/guide/install/raspberry-pi/">Raspberry Pi</a>, or <a href="/guide/install/vps/">VPS</a>.</p>
+
+<h2 id="prerequisites">Prerequisites</h2>
+
+<p>Per the <a href="https://hermes-agent.nousresearch.com/docs/getting-started/installation">official install docs</a>: <strong>Git</strong>, plus <code>curl</code> and <code>xz-utils</code> (the installer downloads Node.js as a <code>.tar.xz</code>) — on Debian/Ubuntu that's <code>sudo apt install git curl xz-utils</code>. The desktop app additionally needs <code>build-essential</code> to compile native modules. Everything else the installer handles itself, with no sudo: <code>uv</code>, Python 3.11, Node.js 26 (existing Node 22.22+/24.11+/26+ is used as-is), ripgrep, and ffmpeg.</p>
+
+<h2 id="layout">Install layout: per-user vs system-wide</h2>
+
+<div class="article-table-scroll" tabindex="0">
+<table>
+<thead><tr><th>Installer</th><th>Code lives at</th><th><code>hermes</code> binary</th><th>Data directory</th></tr></thead>
+<tbody>
+<tr><td><strong>Per-user</strong> (default)</td><td><code>~/.hermes/hermes-agent/</code></td><td><code>~/.local/bin/hermes</code> (symlink)</td><td><code>~/.hermes/</code></td></tr>
+<tr><td><strong>Root mode</strong> (<code>curl … | sudo bash</code>)</td><td><code>/usr/local/lib/hermes-agent/</code></td><td><code>/usr/local/bin/hermes</code></td><td><code>/root/.hermes/</code> or <code>$HERMES_HOME</code></td></tr>
+</tbody>
+</table>
+</div>
+
+<p>The root-mode FHS layout is for shared machines where one system install serves every user — per-user config (auth, skills, sessions) still lives under each user's own <code>~/.hermes/</code>. For a personal machine, the per-user default is what you want.</p>
+
+<h2 id="server">Ubuntu Server, headless boxes, and systemd service users</h2>
+
+<p>Running Hermes as a dedicated unprivileged user — a <code>hermes</code> systemd service account, or any user without sudo — is <a href="https://hermes-agent.nousresearch.com/docs/getting-started/installation">officially supported</a>. The only step on the install path that genuinely needs root is Playwright's Chromium system libraries. The recommended split:</p>
+
+<ol>
+  <li><strong>Once, as an admin:</strong> <code>sudo npx playwright install-deps chromium</code>.</li>
+  <li><strong>As the service user:</strong> run the regular installer. It detects the missing sudo and degrades gracefully — Chromium goes into the user's own Playwright cache. Headless and don't need browser automation at all? Add <code>--skip-browser</code> (and <code>--skip-computer-use</code>):
+  <pre><code>curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash -s -- --skip-browser</code></pre></li>
+  <li><strong>PATH:</strong> service accounts often lack <code>~/.local/bin</code> on PATH — add it to the user's profile, or symlink the venv launcher into <code>/usr/local/bin</code>.</li>
+  <li><strong>Verify:</strong> <code>hermes doctor</code> should run cleanly. (A <code>ModuleNotFoundError: dotenv</code> means you're invoking the repo source file with system Python instead of the venv launcher — fix step 3.)</li>
+  <li><strong>Gateway at boot:</strong> a user-level service stops at logout until you enable lingering — <code>sudo loginctl enable-linger &lt;service-user&gt;</code>. <code>hermes gateway setup</code> offers to install the systemd user unit itself.</li>
+</ol>
+
+<p>Doing this on a rented server? The <a href="/guide/install/vps/">VPS page</a> adds sizing, the Docker alternative, and the security guidance for exposing anything publicly.</p>
+
+<h2 id="distros">Distro notes</h2>
+
+<ul>
+  <li><strong>Ubuntu / Debian</strong> — the tested reference platform. Fresh minimal cloud image: <code>apt-get install -y git curl xz-utils</code> first.</li>
+  <li><strong>Fedora / RHEL / openSUSE</strong> — same installer; these distros don't support Playwright's <code>--with-deps</code>, so an admin installs the Chromium system libraries separately — the installer prints the exact <code>dnf</code>/<code>zypper</code> commands.</li>
+  <li><strong>Arch / Manjaro</strong> — the installer works (pacman, same sudo-detection). <strong>The AUR package is explicitly <a href="https://hermes-agent.nousresearch.com/docs/getting-started/platform-support">unsupported</a></strong> — use the official installer.</li>
+  <li><strong>Nix / NixOS</strong> — no longer an explicitly supported path (Tier 2, best-effort; "breaks often due to node.js packaging woes" per the official matrix). The <a href="https://hermes-agent.nousresearch.com/docs/getting-started/nix-setup">Nix setup guide</a> has a flake and NixOS module if you accept the tradeoff.</li>
+  <li><strong>Alpine</strong> — musl, not glibc: outside the "likely to work" description. A Debian container or VPS is the path of least resistance.</li>
+</ul>
+
+<h2 id="updating">Updating</h2>
+
+<p>Hermes auto-detects how it was installed, and <code>hermes update</code> updates a git-installer layout in place (Docker installs update by pulling a new image instead — <code>hermes update</code> is intentionally unsupported there). <code>hermes doctor</code> shows the detected install method.</p>
+
+<h2 id="frequently-asked-questions">FAQ</h2>
+
+<h3>How do I install Hermes Agent on Ubuntu?</h3>
+<p><code>curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash</code>, then <code>source ~/.bashrc</code>. Ubuntu is the distro Nous tests against; on a fresh minimal image, install <code>git curl xz-utils</code> first.</p>
+
+<h3>Does the installer need sudo?</h3>
+<p>No for the core install — it's per-user under <code>~/.hermes/</code>. Root is only needed once for Playwright's Chromium system libraries, and <code>--skip-browser</code> avoids even that.</p>
+
+<h3>Which distros are supported?</h3>
+<p>Latest Ubuntu and WSL2 are tested; anything with glibc, systemd, and FHS is expected to work — Debian, Fedora, Arch, openSUSE. Alpine (musl) doesn't fit that description.</p>
+
+<h3>Can I install from the AUR on Arch?</h3>
+<p>No — AUR installs are explicitly unsupported. Run the official installer on Arch instead.</p>
+
+<h3>How do I keep the gateway running on a server?</h3>
+<p>Install as a service user, run <code>hermes gateway setup</code> (systemd user unit), and <code>sudo loginctl enable-linger &lt;user&gt;</code> so it starts at boot and survives logout.</p>
+
+<h3>What about NixOS?</h3>
+<p>Tier 2 / best-effort — the official guide is extensive, but releases may break it. Docker or an FHS distro is the supported path.</p>
+
+<p>Next: <a href="/guide/install/#verify">verify the install</a>, <a href="/guide/install/#first-run">pick a model provider</a>, then <a href="/skills/">the Skills Hub</a>. Running on ARM or a rented box? <a href="/guide/install/raspberry-pi/">Raspberry Pi</a> and <a href="/guide/install/vps/">VPS</a> build on this page.</p>
+
+<div class="article-footer">
+  <p>Maintained by <a href="https://x.com/ksimback">Kevin Simback</a> · Part of <a href="/guide/">The Hermes Handbook</a> · Facts sourced from the <a href="https://hermes-agent.nousresearch.com/docs/">official Hermes Agent docs</a> · if this was useful, drop a ★ on <a href="https://github.com/ksimback/hermes-ecosystem">the atlas repo</a> →</p>
+</div>
+
+</main>
+
+<footer class="page-footer">
+  <div class="fn-left">hermes atlas · curated by <a href="https://github.com/ksimback">ksimback</a> · <a href="https://github.com/ksimback/hermes-ecosystem/issues">suggest a repo</a> · <a href="/privacy">privacy</a></div>
+  <div>v2 · 2026.04</div>
+</footer>
+
+<script src="/assets/js/theme-toggle.js" defer></script>
+<script src="/assets/js/masthead-fetch.js" defer></script>
+<!-- Cloudflare Web Analytics -->
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js"
+        data-cf-beacon='{"token": "fe0d4d79280b4386b6b0cd99b2d94dbc"}'></script>
+<!-- End Cloudflare Web Analytics -->
+</body>
+</html>

--- a/guide/install/macos/index.html
+++ b/guide/install/macos/index.html
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>How to Install Hermes Agent on Mac (Apple Silicon): Desktop App or CLI | Hermes Atlas</title>
+<meta name="description" content="Install Hermes Agent on macOS — Desktop installer or one curl command. Apple Silicon (M1–M4) is Tier 1; Intel Macs and brew installs are officially unsupported. The honest Mac setup guide.">
+<meta name="keywords" content="hermes install mac, install hermes agent macos, hermes agent mac, how to install hermes on mac, hermes apple silicon, hermes mac mini, hermes brew">
+<link rel="canonical" href="https://hermesatlas.com/guide/install/macos/">
+<meta property="og:title" content="How to Install Hermes Agent on Mac (Apple Silicon): Desktop App or CLI">
+<meta property="og:description" content="Desktop installer or one curl command. Apple Silicon is Tier 1; Intel Macs and brew installs are officially unsupported.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://hermesatlas.com/guide/install/macos/">
+<meta property="og:site_name" content="Hermes Atlas">
+<meta property="article:published_time" content="2026-08-31T00:00:00Z">
+<meta property="article:modified_time" content="2026-08-31T00:00:00Z">
+<meta property="article:author" content="https://x.com/ksimback">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=Install+Hermes+Agent+on+Mac&amp;subtitle=Apple+Silicon+is+Tier+1+-+Desktop+installer+or+one+curl+command&amp;kind=handbook+%C2%B7+install">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="How to Install Hermes Agent on Mac (Apple Silicon)">
+<meta name="twitter:description" content="Desktop installer or one curl command. Apple Silicon is Tier 1; Intel Macs and brew are unsupported.">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Install+Hermes+Agent+on+Mac&amp;subtitle=Apple+Silicon+is+Tier+1+-+Desktop+installer+or+one+curl+command&amp;kind=handbook+%C2%B7+install">
+<meta name="twitter:creator" content="@ksimback">
+<meta name="author" content="Kevin Simback">
+<link rel="alternate" type="application/rss+xml" title="Hermes Atlas — new projects" href="/rss.xml">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+<link rel="apple-touch-icon" href="/apple-touch-icon.png">
+<link rel="manifest" href="/site.webmanifest">
+<script src="/assets/js/theme-init.js"></script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap">
+<link rel="stylesheet" href="/assets/css/tokens.css">
+<link rel="stylesheet" href="/assets/css/base.css">
+<link rel="stylesheet" href="/assets/css/page.css">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "How to Install Hermes Agent on Mac (Apple Silicon): Desktop App or CLI",
+  "description": "Install Hermes Agent on macOS — Desktop installer or one curl command. Apple Silicon (M1–M4) is Tier 1; Intel Macs and brew installs are officially unsupported.",
+  "image": "https://hermesatlas.com/api/og?title=Install+Hermes+Agent+on+Mac&subtitle=Apple+Silicon+is+Tier+1+-+Desktop+installer+or+one+curl+command&kind=handbook+%C2%B7+install",
+  "keywords": ["hermes install mac", "install hermes agent macos", "hermes apple silicon", "hermes mac mini"],
+  "datePublished": "2026-08-31T00:00:00Z",
+  "dateModified": "2026-08-31T00:00:00Z",
+  "author": {"@type": "Person", "name": "Kevin Simback", "url": "https://x.com/ksimback"},
+  "publisher": {"@type": "Organization", "name": "Hermes Atlas", "url": "https://hermesatlas.com"},
+  "mainEntityOfPage": {"@type": "WebPage", "@id": "https://hermesatlas.com/guide/install/macos/"},
+  "isPartOf": {"@type": "Article", "@id": "https://hermesatlas.com/guide/install/", "name": "How to install Hermes Agent"}
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Does Hermes work on Apple Silicon (M1, M2, M3, M4)?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Yes — macOS on Apple Silicon is a Tier 1 platform. The installer pulls native arm64 binaries; no Rosetta required."}
+    },
+    {
+      "@type": "Question",
+      "name": "Does Hermes Agent work on Intel Macs?",
+      "acceptedAnswer": {"@type": "Answer", "text": "No — macOS on Intel (x86) processors is explicitly listed as unsupported in the official platform matrix. It may be broken now and may break more; compatibility code can be removed at any point. Use a Linux machine, a VPS, or the Docker image on other hardware instead."}
+    },
+    {
+      "@type": "Question",
+      "name": "Can I install Hermes with Homebrew?",
+      "acceptedAnswer": {"@type": "Answer", "text": "No — brew install hermes-agent is an officially unsupported path, as are pip and uv tool installs. Use the Hermes Desktop installer or the official curl one-liner."}
+    },
+    {
+      "@type": "Question",
+      "name": "Should I use the Desktop installer or the curl install on a Mac?",
+      "acceptedAnswer": {"@type": "Answer", "text": "The Desktop installer is the recommended easy path and gives you the app plus the CLI in one shot; the curl one-liner is for terminal-only installs. They share the same agent core, config, and data — and running hermes desktop later upgrades a CLI install to the app."}
+    },
+    {
+      "@type": "Question",
+      "name": "Is a Mac mini a good always-on Hermes host?",
+      "acceptedAnswer": {"@type": "Answer", "text": "An Apple Silicon Mac mini works well as an always-on host — it's a Tier 1 platform. For headless server-style setups, compare the Docker/VPS route, which adds supervised auto-restart."}
+    },
+    {
+      "@type": "Question",
+      "name": "How much disk space does Hermes use on a Mac?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Roughly 200 MB for a fresh install, plus another 100–500 MB over time for sessions, skills, and memory under ~/.hermes/."}
+    }
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {"@type": "ListItem", "position": 1, "name": "home", "item": "https://hermesatlas.com/"},
+    {"@type": "ListItem", "position": 2, "name": "handbook", "item": "https://hermesatlas.com/guide/"},
+    {"@type": "ListItem", "position": 3, "name": "install", "item": "https://hermesatlas.com/guide/install/"},
+    {"@type": "ListItem", "position": 4, "name": "macos"}
+  ]
+}
+</script>
+</head>
+<body>
+<a class="skip-link" href="#main">Skip to content</a>
+<header class="masthead">
+  <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
+  <div class="mast-meta" aria-label="Site metadata">
+    <span id="meta-count">247·repos</span>
+    <span id="meta-version">hermes·v0.21.0</span>
+    <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
+  </div>
+  <nav class="mast-nav" aria-label="Primary">
+    <a href="/">home</a>
+    <a href="/ecosystem/">ecosystem</a>
+    <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
+    <a href="/use-cases/">use cases</a>
+    <a href="/guide/" class="active">handbook</a>
+    <a href="/masterclass/">masterclass</a>
+    <a href="/dev/">dev</a>
+    <a href="/reports/">reports</a>
+    <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
+  </nav>
+  <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
+  </button>
+</header>
+<div class="breadcrumb" aria-label="Breadcrumb">
+  <a href="/">home</a><span class="sep">/</span><a href="/guide/">handbook</a><span class="sep">/</span><a href="/guide/install/">install</a><span class="sep">/</span>macos
+</div>
+<main class="article" id="main">
+
+<header class="article-header">
+  <div class="article-badge">handbook · install · macos</div>
+  <h1>How to Install Hermes Agent on a Mac</h1>
+  <p class="subtitle">Desktop installer or one curl command — Apple Silicon only, and honest about it. A platform page of <a href="/guide/install/">the install guide</a>, cross-checked against the official docs.</p>
+  <p class="meta">By <a href="https://x.com/ksimback">Kevin Simback</a> · Hermes Atlas maintainer · Updated 2026-08-31 · ~5 min read</p>
+</header>
+
+<h2 id="tldr">TL;DR</h2>
+
+<p><strong>Two supported paths, both Tier 1 on Apple Silicon (M1–M4).</strong> The <a href="https://hermes-agent.nousresearch.com/docs/getting-started/installation">official install page</a> recommends the <a href="https://hermes-agent.nousresearch.com/">Hermes Desktop installer</a> — download, run, and you get the desktop app <em>and</em> the CLI sharing one config. Terminal-only? One command:</p>
+
+<pre><code>curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+source ~/.zshrc     # macOS default shell since Catalina
+hermes              # start chatting</code></pre>
+
+<p>This guide covers Hermes Agent <strong>v0.21.0</strong>. On other platforms? See <a href="/guide/install/windows/">Windows</a>, <a href="/guide/install/linux/">Linux</a>, <a href="/guide/install/raspberry-pi/">Raspberry Pi</a>, or <a href="/guide/install/vps/">VPS</a>.</p>
+
+<h2 id="support">What's supported on a Mac — and what isn't</h2>
+
+<div class="article-table-scroll" tabindex="0">
+<table>
+<thead><tr><th>Setup</th><th>Status</th><th>Notes</th></tr></thead>
+<tbody>
+<tr><td><strong>Apple Silicon (M1–M4)</strong> + Desktop installer or <code>install.sh</code></td><td>Tier 1</td><td>"We strive to never break installations and updates for these" — first-priority fixes</td></tr>
+<tr><td><strong>Intel (x86) Macs</strong></td><td>Unsupported</td><td>Explicitly listed as unsupported; may be broken now, compat code can be removed any time</td></tr>
+<tr><td><strong><code>brew install hermes-agent</code></strong></td><td>Unsupported</td><td>Same list — migrate to the Desktop installer or <code>install.sh</code></td></tr>
+<tr><td><strong><code>pip</code> / <code>uv tool install</code></strong></td><td>Unsupported</td><td>PyPI installs are not a supported distribution method</td></tr>
+</tbody>
+</table>
+</div>
+
+<p>Source: the <a href="https://hermes-agent.nousresearch.com/docs/getting-started/platform-support">official platform support matrix</a>. If you're on an Intel Mac, the practical alternatives are Hermes on a <a href="/guide/install/linux/">Linux box</a> or <a href="/guide/install/vps/">VPS</a> you connect to remotely, or the Docker image (Tier 1 on x86_64) on other hardware.</p>
+
+<h2 id="prerequisites">Prerequisites</h2>
+
+<p>Just <strong>Git</strong> (<code>git --version</code> — macOS offers the Xcode Command Line Tools automatically if it's missing). Per the <a href="https://hermes-agent.nousresearch.com/docs/getting-started/installation">official docs</a>, the installer handles everything else itself: <code>uv</code>, Python 3.11 (no sudo), Node.js 26 (an existing Node 22.22+/24.11+/26+ is used as-is), ripgrep, and ffmpeg. You do <em>not</em> need to brew-install any of those first.</p>
+
+<h2 id="install">Install and verify</h2>
+
+<p><strong>Path 1 — Desktop installer (recommended):</strong> <a href="https://hermes-agent.nousresearch.com/">download Hermes Desktop</a>, run it, and it provisions the CLI runtime into <code>~/.hermes</code> — the same layout a CLI install uses, which is why the app and terminal are interchangeable afterwards. We cover the app itself in the <a href="/guide/desktop/">Hermes Desktop guide</a>.</p>
+
+<p><strong>Path 2 — CLI-only:</strong> the curl command from the TL;DR. Code lands in <code>~/.hermes/hermes-agent/</code>, the launcher at <code>~/.local/bin/hermes</code>, your data (config, keys, sessions, skills, memory) in <code>~/.hermes/</code>. Then verify:</p>
+
+<pre><code>hermes version      # prints v0.21.0 (or newer)
+hermes doctor       # health check — every line should be green</code></pre>
+
+<p>First run: <code>hermes</code> starts the provider wizard. The fastest path is <code>hermes setup --portal</code> — one Nous Portal login covers 300+ models plus the Tool Gateway. All four provider paths (Portal, your own API key, local Ollama, skip-for-now) are walked through in <a href="/guide/install/#first-run">first run and model provider</a>. Moving from another machine? <code>hermes import</code> restores a full backup instead of re-configuring.</p>
+
+<p>Installed CLI-only and want the app later? Run <code>hermes desktop</code> — it installs and launches Hermes Desktop against your existing config.</p>
+
+<h2 id="troubleshooting">If something breaks</h2>
+
+<p>The two Mac-specific failures we see: <strong>ffmpeg/ripgrep resolution on Apple Silicon</strong> when Homebrew's <code>/opt/homebrew/bin</code> isn't in your shell env (add <code>eval "$(/opt/homebrew/bin/brew shellenv)"</code> to <code>~/.zshrc</code>), and <strong><code>hermes: command not found</code></strong> right after install (reload with <code>source ~/.zshrc</code> or open a new terminal). Everything else — API-key errors, npm failures, hung downloads — is in the <a href="/guide/install/#troubleshooting">shared troubleshooting tree</a>, and <code>hermes doctor</code> diagnoses most of it.</p>
+
+<h2 id="frequently-asked-questions">FAQ</h2>
+
+<h3>Does Hermes work on Apple Silicon (M1, M2, M3, M4)?</h3>
+<p>Yes — macOS on Apple Silicon is Tier 1. The installer pulls native arm64 binaries; no Rosetta required.</p>
+
+<h3>Does Hermes Agent work on Intel Macs?</h3>
+<p>No — Intel Macs are explicitly <a href="https://hermes-agent.nousresearch.com/docs/getting-started/platform-support">unsupported</a>. Use a Linux machine, a <a href="/guide/install/vps/">VPS</a>, or Docker on other hardware instead.</p>
+
+<h3>Can I install Hermes with Homebrew?</h3>
+<p>No — <code>brew install hermes-agent</code> is an officially unsupported path, as are <code>pip</code>/<code>uv tool</code> installs. Use the Desktop installer or the curl one-liner.</p>
+
+<h3>Should I use the Desktop installer or the curl install?</h3>
+<p>Desktop installer if you want the app (it's the recommended easy path); curl if you're terminal-only. Same agent core, same config — and <code>hermes desktop</code> upgrades a CLI install any time.</p>
+
+<h3>Is a Mac mini a good always-on Hermes host?</h3>
+<p>An Apple Silicon Mac mini works well — Tier 1, quiet, and popular for exactly this. For headless server-style uptime, compare the <a href="/guide/install/vps/">Docker/VPS route</a>.</p>
+
+<h3>How much disk space does Hermes use?</h3>
+<p>Roughly 200 MB fresh, plus 100–500 MB over time for sessions, skills, and memory.</p>
+
+<p>Next: <a href="/guide/install/#verify">verify the install</a>, <a href="/guide/install/#first-run">pick a model provider</a>, then <a href="/skills/">the Skills Hub</a>. Deciding between the app and the terminal? <a href="/guide/modes/">Every mode compared</a>.</p>
+
+<div class="article-footer">
+  <p>Maintained by <a href="https://x.com/ksimback">Kevin Simback</a> · Part of <a href="/guide/">The Hermes Handbook</a> · Facts sourced from the <a href="https://hermes-agent.nousresearch.com/docs/">official Hermes Agent docs</a> · if this was useful, drop a ★ on <a href="https://github.com/ksimback/hermes-ecosystem">the atlas repo</a> →</p>
+</div>
+
+</main>
+
+<footer class="page-footer">
+  <div class="fn-left">hermes atlas · curated by <a href="https://github.com/ksimback">ksimback</a> · <a href="https://github.com/ksimback/hermes-ecosystem/issues">suggest a repo</a> · <a href="/privacy">privacy</a></div>
+  <div>v2 · 2026.04</div>
+</footer>
+
+<script src="/assets/js/theme-toggle.js" defer></script>
+<script src="/assets/js/masthead-fetch.js" defer></script>
+<!-- Cloudflare Web Analytics -->
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js"
+        data-cf-beacon='{"token": "fe0d4d79280b4386b6b0cd99b2d94dbc"}'></script>
+<!-- End Cloudflare Web Analytics -->
+</body>
+</html>

--- a/guide/install/raspberry-pi/index.html
+++ b/guide/install/raspberry-pi/index.html
@@ -1,0 +1,241 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>How to Install Hermes Agent on a Raspberry Pi 4 or 5 (Direct or Docker) | Hermes Atlas</title>
+<meta name="description" content="Run Hermes Agent on a Raspberry Pi 4 or 5 — direct install on Raspberry Pi OS 64-bit or the official aarch64 Docker image. Hardware requirements, always-on gateway setup, and what actually works, from the official docs.">
+<meta name="keywords" content="hermes agent raspberry pi, install hermes on raspberry pi, hermes raspberry pi 4, hermes raspberry pi 5, hermes agent on raspberry pi, hermes pi install, hermes aarch64">
+<link rel="canonical" href="https://hermesatlas.com/guide/install/raspberry-pi/">
+<meta property="og:title" content="How to Install Hermes Agent on a Raspberry Pi 4 or 5 (Direct or Docker)">
+<meta property="og:description" content="A Pi 4/5 with 4+ GB RAM and a 64-bit OS runs Hermes as an always-on agent. Direct install or the official aarch64 Docker image.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://hermesatlas.com/guide/install/raspberry-pi/">
+<meta property="og:site_name" content="Hermes Atlas">
+<meta property="article:published_time" content="2026-08-31T00:00:00Z">
+<meta property="article:modified_time" content="2026-08-31T00:00:00Z">
+<meta property="article:author" content="https://x.com/ksimback">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=Hermes+Agent+on+a+Raspberry+Pi&amp;subtitle=Pi+4%2F5%2C+64-bit+OS%2C+direct+install+or+aarch64+Docker&amp;kind=handbook+%C2%B7+install">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="How to Install Hermes Agent on a Raspberry Pi 4 or 5">
+<meta name="twitter:description" content="Pi 4/5 with 4+ GB RAM and a 64-bit OS. Direct install or the official aarch64 Docker image.">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Hermes+Agent+on+a+Raspberry+Pi&amp;subtitle=Pi+4%2F5%2C+64-bit+OS%2C+direct+install+or+aarch64+Docker&amp;kind=handbook+%C2%B7+install">
+<meta name="twitter:creator" content="@ksimback">
+<meta name="author" content="Kevin Simback">
+<link rel="alternate" type="application/rss+xml" title="Hermes Atlas — new projects" href="/rss.xml">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+<link rel="apple-touch-icon" href="/apple-touch-icon.png">
+<link rel="manifest" href="/site.webmanifest">
+<script src="/assets/js/theme-init.js"></script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap">
+<link rel="stylesheet" href="/assets/css/tokens.css">
+<link rel="stylesheet" href="/assets/css/base.css">
+<link rel="stylesheet" href="/assets/css/page.css">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "How to Install Hermes Agent on a Raspberry Pi 4 or 5 (Direct or Docker)",
+  "description": "Run Hermes Agent on a Raspberry Pi 4 or 5 — direct install on Raspberry Pi OS 64-bit or the official aarch64 Docker image. Hardware requirements and always-on gateway setup.",
+  "image": "https://hermesatlas.com/api/og?title=Hermes+Agent+on+a+Raspberry+Pi&subtitle=Pi+4%2F5%2C+64-bit+OS%2C+direct+install+or+aarch64+Docker&kind=handbook+%C2%B7+install",
+  "keywords": ["hermes agent raspberry pi", "install hermes on raspberry pi", "hermes raspberry pi 4", "hermes raspberry pi 5"],
+  "datePublished": "2026-08-31T00:00:00Z",
+  "dateModified": "2026-08-31T00:00:00Z",
+  "author": {"@type": "Person", "name": "Kevin Simback", "url": "https://x.com/ksimback"},
+  "publisher": {"@type": "Organization", "name": "Hermes Atlas", "url": "https://hermesatlas.com"},
+  "mainEntityOfPage": {"@type": "WebPage", "@id": "https://hermesatlas.com/guide/install/raspberry-pi/"},
+  "isPartOf": {"@type": "Article", "@id": "https://hermesatlas.com/guide/install/", "name": "How to install Hermes Agent"}
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Can Hermes Agent run on a Raspberry Pi 5?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Yes — Linux on aarch64 is Tier 1, and so is the official Docker image on aarch64. A Pi 5 with 4 or 8 GB RAM handles the agent, messaging gateway, and cron comfortably when paired with a hosted model API."}
+    },
+    {
+      "@type": "Question",
+      "name": "Can Hermes Agent run on a Raspberry Pi 4?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Yes — the same install paths apply. Prefer the 4 GB or 8 GB model; on a 2 GB Pi 4, install with --skip-browser to skip Chromium, the most memory-hungry component."}
+    },
+    {
+      "@type": "Question",
+      "name": "What about a Raspberry Pi 3?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Borderline. The Pi 3's CPU is aarch64-capable but it has only 1 GB RAM — exactly the documented Docker minimum, with no headroom. A gateway-only setup without browser tools can work; expect swap pressure. A Pi 4/5 is the realistic floor."}
+    },
+    {
+      "@type": "Question",
+      "name": "Do I need a 64-bit OS on the Pi?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Yes. Official support targets aarch64 — install Raspberry Pi OS 64-bit or Ubuntu Server 64-bit, not a 32-bit (armv7) image."}
+    },
+    {
+      "@type": "Question",
+      "name": "Can the Raspberry Pi run the language model locally?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Not realistically. The Pi runs the agent; the model should be a hosted API (Nous Portal, Anthropic, OpenAI) or a model server on beefier hardware on your LAN. That split is what keeps the Pi footprint light."}
+    },
+    {
+      "@type": "Question",
+      "name": "Should I use Docker or a direct install on the Pi?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Docker for set-and-forget uptime: the official image supervises the gateway with s6 (auto-restart on crash) and upgrades by pulling a new image. Direct install gives the lightest footprint and supports hermes update in place."}
+    }
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {"@type": "ListItem", "position": 1, "name": "home", "item": "https://hermesatlas.com/"},
+    {"@type": "ListItem", "position": 2, "name": "handbook", "item": "https://hermesatlas.com/guide/"},
+    {"@type": "ListItem", "position": 3, "name": "install", "item": "https://hermesatlas.com/guide/install/"},
+    {"@type": "ListItem", "position": 4, "name": "raspberry-pi"}
+  ]
+}
+</script>
+</head>
+<body>
+<a class="skip-link" href="#main">Skip to content</a>
+<header class="masthead">
+  <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
+  <div class="mast-meta" aria-label="Site metadata">
+    <span id="meta-count">247·repos</span>
+    <span id="meta-version">hermes·v0.21.0</span>
+    <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
+  </div>
+  <nav class="mast-nav" aria-label="Primary">
+    <a href="/">home</a>
+    <a href="/ecosystem/">ecosystem</a>
+    <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
+    <a href="/use-cases/">use cases</a>
+    <a href="/guide/" class="active">handbook</a>
+    <a href="/masterclass/">masterclass</a>
+    <a href="/dev/">dev</a>
+    <a href="/reports/">reports</a>
+    <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
+  </nav>
+  <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
+  </button>
+</header>
+<div class="breadcrumb" aria-label="Breadcrumb">
+  <a href="/">home</a><span class="sep">/</span><a href="/guide/">handbook</a><span class="sep">/</span><a href="/guide/install/">install</a><span class="sep">/</span>raspberry-pi
+</div>
+<main class="article" id="main">
+
+<header class="article-header">
+  <div class="article-badge">handbook · install · raspberry pi</div>
+  <h1>How to Install Hermes Agent on a Raspberry Pi</h1>
+  <p class="subtitle">Pi 4 or 5, 64-bit OS, direct install or the official aarch64 Docker image — the always-on pocket-server setup. A platform page of <a href="/guide/install/">the install guide</a>, cross-checked against the official docs.</p>
+  <p class="meta">By <a href="https://x.com/ksimback">Kevin Simback</a> · Hermes Atlas maintainer · Updated 2026-08-31 · ~6 min read</p>
+</header>
+
+<h2 id="tldr">TL;DR</h2>
+
+<p><strong>Yes, Hermes runs on a Raspberry Pi — and there's no Pi-specific build because none is needed.</strong> Linux on aarch64 is <a href="https://hermes-agent.nousresearch.com/docs/getting-started/platform-support">Tier 1</a>, and so is the official Docker image on aarch64. A <strong>Pi 4 or Pi 5 with 4+ GB RAM</strong> running a <strong>64-bit OS</strong> is the sweet spot. The one mental shift: the Pi runs the <em>agent</em>; the <em>model</em> is a hosted API (Nous Portal, Anthropic, OpenAI) — don't plan on local LLM inference on the Pi itself.</p>
+
+<pre><code>sudo apt install -y git curl xz-utils
+curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+source ~/.bashrc
+hermes version      # prints v0.21.0 (or newer)</code></pre>
+
+<p>This guide covers Hermes Agent <strong>v0.21.0</strong>. On other platforms? See <a href="/guide/install/windows/">Windows</a>, <a href="/guide/install/macos/">macOS</a>, <a href="/guide/install/linux/">Linux</a>, or <a href="/guide/install/vps/">VPS</a>.</p>
+
+<h2 id="hardware">Hardware requirements</h2>
+
+<div class="article-table-scroll" tabindex="0">
+<table>
+<thead><tr><th>Board</th><th>Verdict</th><th>Notes</th></tr></thead>
+<tbody>
+<tr><td><strong>Pi 5 (4/8 GB)</strong></td><td>Best fit</td><td>Comfortable headroom for agent + gateway + cron, even with browser tools</td></tr>
+<tr><td><strong>Pi 4 (4/8 GB)</strong></td><td>Good</td><td>The community workhorse; same install paths</td></tr>
+<tr><td><strong>Pi 4 (2 GB)</strong></td><td>Workable</td><td>Install with <code>--skip-browser</code> — Chromium is the memory hog</td></tr>
+<tr><td><strong>Pi 3 (1 GB)</strong></td><td>Borderline</td><td>aarch64-capable CPU, but 1 GB is the documented Docker minimum with zero headroom</td></tr>
+<tr><td><strong>Pi Zero / armv7 boards</strong></td><td>No</td><td>Not aarch64, or nowhere near the resource floor</td></tr>
+</tbody>
+</table>
+</div>
+
+<p>The resource numbers come from the <a href="https://hermes-agent.nousresearch.com/docs/user-guide/docker">official Docker docs</a>: minimum 1 GB RAM / 1 core, recommended 2–4 GB — and "browser automation (Playwright/Chromium) is the most memory-hungry feature. If you don't need browser tools, 1 GB is sufficient." Two non-negotiables: a <strong>64-bit OS</strong> (Raspberry Pi OS 64-bit or Ubuntu Server — official support targets aarch64, not 32-bit armv7), and decent storage (a quality SD card works; USB/NVMe boot is kinder for an always-on box, since sessions and logs grow — budget 500 MB–2 GB+ beyond the ~200 MB install).</p>
+
+<h2 id="direct">Path 1 — direct install on Raspberry Pi OS</h2>
+
+<p>Raspberry Pi OS 64-bit is Debian-based, which makes the Pi just another Tier-1 Linux aarch64 box — the standard installer from the TL;DR applies as-is, including the <a href="https://hermes-agent.nousresearch.com/docs/getting-started/installation">official prerequisites</a> (<code>git</code>, <code>curl</code>, <code>xz-utils</code>). Headless Pi? Add <code>--skip-browser</code> to skip Chromium entirely:</p>
+
+<pre><code>curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash -s -- --skip-browser</code></pre>
+
+<p>For an always-on Telegram/Discord bot: <code>hermes gateway setup</code> offers to install a systemd user unit, then <code>sudo loginctl enable-linger &lt;user&gt;</code> so the gateway starts at boot and survives logout. The full service-user recipe (Playwright system libraries, PATH for service accounts) is on the <a href="/guide/install/linux/#server">Linux page</a> — everything there applies to the Pi verbatim.</p>
+
+<h2 id="docker">Path 2 — Docker (recommended for set-and-forget)</h2>
+
+<p>The official image (<code>nousresearch/hermes-agent</code>) is published for aarch64 and supervises the gateway with s6 — a crashed process restarts itself within seconds, per the <a href="https://hermes-agent.nousresearch.com/docs/user-guide/docker">Docker docs</a>:</p>
+
+<pre><code>mkdir -p ~/.hermes
+docker run -it --rm -v ~/.hermes:/opt/data nousresearch/hermes-agent setup
+docker run -d --name hermes --restart unless-stopped \
+  -v ~/.hermes:/opt/data -p 8642:8642 \
+  nousresearch/hermes-agent gateway run</code></pre>
+
+<p>All state lives in the mounted <code>~/.hermes</code>; upgrading is <code>docker pull</code> + recreate (Docker installs intentionally don't support <code>hermes update</code>). Never point two gateway containers at the same data directory — the official docs warn it corrupts session files and memory stores.</p>
+
+<h2 id="community">What people actually run on Pis</h2>
+
+<p>Community reports in our <a href="/use-cases/">user-story corpus</a> include a Raspberry Pi 5 running Hermes 24/7 as an always-on personal agent, and Pi-hosted gateways serving Telegram from residential IPs. Treat these as community anecdotes rather than official benchmarks — but they match exactly what Tier-1 aarch64 support implies. The same always-on pattern on rented hardware is the <a href="/guide/install/vps/">VPS setup</a>; the tradeoffs between them are in the <a href="/guide/modes/">modes guide</a>.</p>
+
+<h2 id="frequently-asked-questions">FAQ</h2>
+
+<h3>Can Hermes Agent run on a Raspberry Pi 5?</h3>
+<p>Yes — aarch64 Linux and aarch64 Docker are both Tier 1. A Pi 5 (4 or 8 GB) handles the agent, gateway, and cron comfortably with a hosted model API.</p>
+
+<h3>Can Hermes Agent run on a Raspberry Pi 4?</h3>
+<p>Yes — same paths. Prefer the 4 GB or 8 GB model; on 2 GB, install with <code>--skip-browser</code>.</p>
+
+<h3>What about a Raspberry Pi 3?</h3>
+<p>Borderline: aarch64-capable but only 1 GB RAM — the documented minimum with no headroom. Gateway-only without browser tools can work; expect swap pressure.</p>
+
+<h3>Do I need a 64-bit OS?</h3>
+<p>Yes. Official support targets aarch64 — use Raspberry Pi OS 64-bit or Ubuntu Server 64-bit, not the 32-bit image.</p>
+
+<h3>Can the Pi run the model locally?</h3>
+<p>Not realistically — pair Hermes on the Pi with a hosted API or a model server on beefier LAN hardware.</p>
+
+<h3>Docker or direct install on the Pi?</h3>
+<p>Docker for set-and-forget uptime (s6 auto-restart, image-based upgrades); direct install for the lightest footprint and in-place <code>hermes update</code>.</p>
+
+<p>Next: <a href="/guide/install/#first-run">pick a model provider</a>, set up <a href="/guide/install/#verify">verification</a>, and browse community <a href="/lists/deployment-options">deployment options</a> — Compose stacks and systemd templates that drop straight onto a Pi.</p>
+
+<div class="article-footer">
+  <p>Maintained by <a href="https://x.com/ksimback">Kevin Simback</a> · Part of <a href="/guide/">The Hermes Handbook</a> · Facts sourced from the <a href="https://hermes-agent.nousresearch.com/docs/">official Hermes Agent docs</a> · if this was useful, drop a ★ on <a href="https://github.com/ksimback/hermes-ecosystem">the atlas repo</a> →</p>
+</div>
+
+</main>
+
+<footer class="page-footer">
+  <div class="fn-left">hermes atlas · curated by <a href="https://github.com/ksimback">ksimback</a> · <a href="https://github.com/ksimback/hermes-ecosystem/issues">suggest a repo</a> · <a href="/privacy">privacy</a></div>
+  <div>v2 · 2026.04</div>
+</footer>
+
+<script src="/assets/js/theme-toggle.js" defer></script>
+<script src="/assets/js/masthead-fetch.js" defer></script>
+<!-- Cloudflare Web Analytics -->
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js"
+        data-cf-beacon='{"token": "fe0d4d79280b4386b6b0cd99b2d94dbc"}'></script>
+<!-- End Cloudflare Web Analytics -->
+</body>
+</html>

--- a/guide/install/vps/index.html
+++ b/guide/install/vps/index.html
@@ -1,0 +1,246 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>How to Install Hermes Agent on a VPS: The Always-On Server Setup | Hermes Atlas</title>
+<meta name="description" content="Run Hermes Agent on a $5 VPS — Docker or direct install, sized from the official docs, with the mandatory-auth security guidance for exposing the dashboard and the SSH-not-browser-console warning.">
+<meta name="keywords" content="hermes agent vps, install hermes on vps, hermes agent server, hermes docker vps, hermes always on, hermes agent ubuntu server, hermes telegram bot server">
+<link rel="canonical" href="https://hermesatlas.com/guide/install/vps/">
+<meta property="og:title" content="How to Install Hermes Agent on a VPS: The Always-On Server Setup">
+<meta property="og:description" content="A $5 VPS runs Hermes as an always-on agent. Docker or direct install, with the official sizing and security guidance.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://hermesatlas.com/guide/install/vps/">
+<meta property="og:site_name" content="Hermes Atlas">
+<meta property="article:published_time" content="2026-08-31T00:00:00Z">
+<meta property="article:modified_time" content="2026-08-31T00:00:00Z">
+<meta property="article:author" content="https://x.com/ksimback">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=Hermes+Agent+on+a+VPS&amp;subtitle=The+always-on+server+setup+-+Docker+or+direct%2C+secured+properly&amp;kind=handbook+%C2%B7+install">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="How to Install Hermes Agent on a VPS">
+<meta name="twitter:description" content="A $5 VPS runs Hermes as an always-on agent. Docker or direct install, secured properly.">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Hermes+Agent+on+a+VPS&amp;subtitle=The+always-on+server+setup+-+Docker+or+direct%2C+secured+properly&amp;kind=handbook+%C2%B7+install">
+<meta name="twitter:creator" content="@ksimback">
+<meta name="author" content="Kevin Simback">
+<link rel="alternate" type="application/rss+xml" title="Hermes Atlas — new projects" href="/rss.xml">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+<link rel="apple-touch-icon" href="/apple-touch-icon.png">
+<link rel="manifest" href="/site.webmanifest">
+<script src="/assets/js/theme-init.js"></script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap">
+<link rel="stylesheet" href="/assets/css/tokens.css">
+<link rel="stylesheet" href="/assets/css/base.css">
+<link rel="stylesheet" href="/assets/css/page.css">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "How to Install Hermes Agent on a VPS: The Always-On Server Setup",
+  "description": "Run Hermes Agent on a $5 VPS — Docker or direct install, sized from the official docs, with the mandatory-auth security guidance for exposing the dashboard.",
+  "image": "https://hermesatlas.com/api/og?title=Hermes+Agent+on+a+VPS&subtitle=The+always-on+server+setup+-+Docker+or+direct%2C+secured+properly&kind=handbook+%C2%B7+install",
+  "keywords": ["hermes agent vps", "install hermes on vps", "hermes agent server", "hermes docker vps"],
+  "datePublished": "2026-08-31T00:00:00Z",
+  "dateModified": "2026-08-31T00:00:00Z",
+  "author": {"@type": "Person", "name": "Kevin Simback", "url": "https://x.com/ksimback"},
+  "publisher": {"@type": "Organization", "name": "Hermes Atlas", "url": "https://hermesatlas.com"},
+  "mainEntityOfPage": {"@type": "WebPage", "@id": "https://hermesatlas.com/guide/install/vps/"},
+  "isPartOf": {"@type": "Article", "@id": "https://hermesatlas.com/guide/install/", "name": "How to install Hermes Agent"}
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "How small a VPS can run Hermes Agent?",
+      "acceptedAnswer": {"@type": "Answer", "text": "The official minimum is 1 GB RAM / 1 core / 500 MB disk — the typical $5 tier — as long as the model is a hosted API and you skip browser tools. Recommended is 2–4 GB RAM and 2 cores; browser automation (Playwright/Chromium) is the most memory-hungry feature."}
+    },
+    {
+      "@type": "Question",
+      "name": "Which VPS provider should I use for Hermes?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Any standard Ubuntu/Debian VPS works — Hermes has no provider-specific requirements. Whichever you pick, do the install over SSH: the official docs warn that browser-based VPS consoles (Hetzner Cloud and others) mis-transmit characters like : and @, silently corrupting docker run arguments and pasted API keys."}
+    },
+    {
+      "@type": "Question",
+      "name": "Should I use Docker or a direct install on a VPS?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Docker for supervised auto-restart (s6 restarts a crashed gateway in seconds) and clean image-based upgrades; direct install if you want hermes update in place and the lightest footprint. Both are fully supported."}
+    },
+    {
+      "@type": "Question",
+      "name": "Is it safe to expose the Hermes dashboard on a VPS?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Only behind the mandatory auth gate. Official guidance: OAuth via Nous Portal for anything reachable from the public internet; username/password only on a trusted LAN or VPN like Tailscale; or bind to 127.0.0.1 and use an SSH tunnel. Unauthenticated public dashboards were the entry point for a real June 2026 attack campaign, and the old --insecure flag is now a deprecated no-op."}
+    },
+    {
+      "@type": "Question",
+      "name": "Can Hermes Desktop connect to my VPS?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Yes — keep a hermes serve backend running on the VPS (via systemd) and add it as a remote gateway in Desktop's Settings → Gateways, protected by OAuth. One connection serves every profile on the box."}
+    },
+    {
+      "@type": "Question",
+      "name": "How do I update Hermes on a VPS?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Docker: docker pull nousresearch/hermes-agent:latest, then recreate the container — all state persists in the mounted ~/.hermes. Direct install: hermes update."}
+    }
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {"@type": "ListItem", "position": 1, "name": "home", "item": "https://hermesatlas.com/"},
+    {"@type": "ListItem", "position": 2, "name": "handbook", "item": "https://hermesatlas.com/guide/"},
+    {"@type": "ListItem", "position": 3, "name": "install", "item": "https://hermesatlas.com/guide/install/"},
+    {"@type": "ListItem", "position": 4, "name": "vps"}
+  ]
+}
+</script>
+</head>
+<body>
+<a class="skip-link" href="#main">Skip to content</a>
+<header class="masthead">
+  <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
+  <div class="mast-meta" aria-label="Site metadata">
+    <span id="meta-count">247·repos</span>
+    <span id="meta-version">hermes·v0.21.0</span>
+    <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
+  </div>
+  <nav class="mast-nav" aria-label="Primary">
+    <a href="/">home</a>
+    <a href="/ecosystem/">ecosystem</a>
+    <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
+    <a href="/use-cases/">use cases</a>
+    <a href="/guide/" class="active">handbook</a>
+    <a href="/masterclass/">masterclass</a>
+    <a href="/dev/">dev</a>
+    <a href="/reports/">reports</a>
+    <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
+  </nav>
+  <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
+  </button>
+</header>
+<div class="breadcrumb" aria-label="Breadcrumb">
+  <a href="/">home</a><span class="sep">/</span><a href="/guide/">handbook</a><span class="sep">/</span><a href="/guide/install/">install</a><span class="sep">/</span>vps
+</div>
+<main class="article" id="main">
+
+<header class="article-header">
+  <div class="article-badge">handbook · install · vps</div>
+  <h1>How to Install Hermes Agent on a VPS</h1>
+  <p class="subtitle">The always-on server setup — Docker or direct install, sized from the official docs, secured properly. A platform page of <a href="/guide/install/">the install guide</a>.</p>
+  <p class="meta">By <a href="https://x.com/ksimback">Kevin Simback</a> · Hermes Atlas maintainer · Updated 2026-08-31 · ~7 min read</p>
+</header>
+
+<h2 id="tldr">TL;DR</h2>
+
+<p><strong>A $5 VPS (1 CPU, 1 GB RAM) is enough</strong> to run Hermes as an always-on agent — a Telegram/Discord bot that answers at 3am, cron automations, a remote backend for Hermes Desktop — as long as the model is a hosted API (Nous Portal, Anthropic, OpenAI) rather than local inference. Recommended path: <strong>Docker</strong> (<code>nousresearch/hermes-agent</code>, Tier 1 on x86_64 and aarch64) with <code>--restart unless-stopped</code>; the image's s6 supervisor restarts a crashed gateway within seconds. This guide covers Hermes Agent <strong>v0.21.0</strong>.</p>
+
+<p><strong>One rule before anything else: connect over SSH, not your provider's browser console.</strong> The <a href="https://hermes-agent.nousresearch.com/docs/user-guide/docker">official Docker docs</a> warn that browser-based VPS consoles (Hetzner Cloud and others) mis-transmit special characters — <code>:</code> may arrive as <code>;</code>, <code>@</code> gets mangled — silently corrupting <code>docker run -v/-e</code> arguments and pasted API keys.</p>
+
+<h2 id="sizing">Sizing</h2>
+
+<div class="article-table-scroll" tabindex="0">
+<table>
+<thead><tr><th>Resource</th><th>Minimum</th><th>Recommended</th></tr></thead>
+<tbody>
+<tr><td>Memory</td><td>1 GB</td><td>2–4 GB</td></tr>
+<tr><td>CPU</td><td>1 core</td><td>2 cores</td></tr>
+<tr><td>Disk (data)</td><td>500 MB</td><td>2+ GB (grows with sessions/skills)</td></tr>
+</tbody>
+</table>
+</div>
+
+<p>Straight from the <a href="https://hermes-agent.nousresearch.com/docs/user-guide/docker">official resource table</a>, which adds: "browser automation (Playwright/Chromium) is the most memory-hungry feature. If you don't need browser tools, 1 GB is sufficient." Distro-wise, anything glibc/systemd/FHS works; Ubuntu is the tested reference — details on the <a href="/guide/install/linux/">Linux page</a>.</p>
+
+<h2 id="docker">Path A — Docker (recommended)</h2>
+
+<pre><code>ssh root@&lt;your-vps&gt;
+mkdir -p ~/.hermes
+docker run -it --rm -v ~/.hermes:/opt/data nousresearch/hermes-agent setup
+docker run -d --name hermes --restart unless-stopped \
+  -v ~/.hermes:/opt/data -p 8642:8642 \
+  nousresearch/hermes-agent gateway run</code></pre>
+
+<p>The first command runs the setup wizard once (keys land in <code>~/.hermes/.env</code> on the host); the second starts the persistent gateway. All state lives in the mounted directory — the container is stateless, so upgrading is <code>docker pull</code> + recreate (<code>hermes update</code> is intentionally unsupported in Docker). One container hosts multiple profiles — the <a href="https://hermes-agent.nousresearch.com/docs/user-guide/docker">officially recommended pattern</a> — each gateway s6-supervised with per-profile rotated logs. Two rules that save real pain: never point two gateway containers at one data directory (session/memory corruption), and add <code>--shm-size=1g</code> if you enable browser tools.</p>
+
+<h2 id="direct">Path B — direct install (service user)</h2>
+
+<p>The standard Linux installer, run as a dedicated unprivileged user:</p>
+
+<pre><code>curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash -s -- --skip-browser</code></pre>
+
+<p>(<code>--skip-browser</code> skips Chromium on headless boxes; drop it if you want browser automation, in which case an admin first runs <code>sudo npx playwright install-deps chromium</code>.) Then <code>hermes gateway setup</code> — it offers to install a systemd user unit — and <code>sudo loginctl enable-linger &lt;user&gt;</code> so the gateway starts at boot and survives logout. The complete recipe, including PATH for service accounts, is on the <a href="/guide/install/linux/#server">Linux page</a>.</p>
+
+<h2 id="security">Security: the part people get wrong</h2>
+
+<p>Exposing the dashboard or API server on a VPS means binding to a non-loopback address, and that <strong>engages a mandatory auth gate</strong>. This isn't theoretical: per the <a href="https://hermes-agent.nousresearch.com/docs/user-guide/docker">official docs</a>, unauthenticated public dashboards were the entry point for a real June 2026 campaign in which internet scanners drove exposed agents into planting SSH-key backdoors — and the old <code>--insecure</code> escape hatch is now a deprecated no-op. The official guidance:</p>
+
+<ul>
+  <li><strong>OAuth via Nous Portal</strong> for anything reachable from the public internet.</li>
+  <li><strong>Username/password</strong> (<code>HERMES_DASHBOARD_BASIC_AUTH_USERNAME</code>/<code>_PASSWORD</code>) only on a trusted LAN or VPN such as Tailscale.</li>
+  <li>Or skip exposure entirely: bind to <code>127.0.0.1</code> and reach the dashboard over an SSH tunnel.</li>
+  <li>The gateway's OpenAI-compatible API server is off by default; enabling it beyond loopback requires an <code>API_SERVER_KEY</code>. "Opening any port on an internet-facing machine is a security risk" — the docs' words.</li>
+</ul>
+
+<h2 id="remote">Using the VPS from your desktop and phone</h2>
+
+<p><strong>Hermes Desktop</strong> connects to the VPS as a remote gateway: keep a <code>hermes serve</code> backend running on the VPS (systemd is the natural home), then add its URL under Settings → Gateways in the app — the <a href="https://hermes-agent.nousresearch.com/docs/user-guide/desktop">desktop docs</a> call OAuth "preferred for anything reachable beyond your own machine." One connection serves every profile on the box via the app's profile switcher.</p>
+
+<p><strong>Your phone</strong> is the reason most people do this at all: configure the messaging gateway (<code>hermes gateway setup</code>) and talk to your agent over Telegram, Discord, or WhatsApp from anywhere — the full pattern is in the <a href="/use-cases/hermes-in-your-pocket">Hermes in your pocket</a> use case. Community Compose stacks, systemd templates, and reverse-proxy configs live in <a href="/lists/deployment-options">deployment options</a>.</p>
+
+<h2 id="frequently-asked-questions">FAQ</h2>
+
+<h3>How small a VPS can run Hermes Agent?</h3>
+<p>1 GB RAM / 1 core is the documented minimum (without browser tools); 2–4 GB recommended. The typical $5 tier works with a hosted model API.</p>
+
+<h3>Which provider should I use?</h3>
+<p>Any standard Ubuntu/Debian VPS — Hermes has no provider-specific requirements. Whatever you pick, install over SSH: browser-based consoles (e.g. Hetzner's) corrupt special characters in pasted commands.</p>
+
+<h3>Docker or direct install on a VPS?</h3>
+<p>Docker for supervised auto-restart and image-based upgrades; direct install for in-place <code>hermes update</code> and the lightest footprint.</p>
+
+<h3>Is it safe to expose the Hermes dashboard on a VPS?</h3>
+<p>Only behind the mandatory auth gate — OAuth (Nous Portal) for public reachability, username/password strictly for LAN/VPN, or loopback-only behind an SSH tunnel. <code>--insecure</code> no longer bypasses anything.</p>
+
+<h3>Can Hermes Desktop connect to my VPS?</h3>
+<p>Yes — run <code>hermes serve</code> on the VPS and add it as a remote gateway in Desktop's Settings → Gateways, protected by OAuth.</p>
+
+<h3>How do I update Hermes on the VPS?</h3>
+<p>Docker: <code>docker pull</code> + recreate (state persists in <code>~/.hermes</code>). Direct install: <code>hermes update</code>.</p>
+
+<p>Next: <a href="/guide/install/#first-run">configure a model provider</a>, then decide what the box should do — the <a href="/guide/modes/">modes guide</a> compares always-on gateways, managed Hermes Cloud, and everything in between. On your own ARM hardware instead? <a href="/guide/install/raspberry-pi/">The Raspberry Pi setup</a> is this page without the rent.</p>
+
+<div class="article-footer">
+  <p>Maintained by <a href="https://x.com/ksimback">Kevin Simback</a> · Part of <a href="/guide/">The Hermes Handbook</a> · Facts sourced from the <a href="https://hermes-agent.nousresearch.com/docs/">official Hermes Agent docs</a> · if this was useful, drop a ★ on <a href="https://github.com/ksimback/hermes-ecosystem">the atlas repo</a> →</p>
+</div>
+
+</main>
+
+<footer class="page-footer">
+  <div class="fn-left">hermes atlas · curated by <a href="https://github.com/ksimback">ksimback</a> · <a href="https://github.com/ksimback/hermes-ecosystem/issues">suggest a repo</a> · <a href="/privacy">privacy</a></div>
+  <div>v2 · 2026.04</div>
+</footer>
+
+<script src="/assets/js/theme-toggle.js" defer></script>
+<script src="/assets/js/masthead-fetch.js" defer></script>
+<!-- Cloudflare Web Analytics -->
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js"
+        data-cf-beacon='{"token": "fe0d4d79280b4386b6b0cd99b2d94dbc"}'></script>
+<!-- End Cloudflare Web Analytics -->
+</body>
+</html>

--- a/guide/install/windows/index.html
+++ b/guide/install/windows/index.html
@@ -1,0 +1,258 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>How to Install Hermes Agent on Windows 10/11: PowerShell, Desktop Installer, or WSL2 | Hermes Atlas</title>
+<meta name="description" content="Install Hermes Agent natively on Windows 10/11 (Tier 1) — the PowerShell one-liner, the Desktop installer, or WSL2. No admin rights needed. With the official native-vs-WSL2 guidance and every Windows pitfall.">
+<meta name="keywords" content="install hermes agent windows, hermes install powershell, hermes agent windows 11, hermes windows install, hermes agent wsl2, hermes native windows, install hermes on windows 10">
+<link rel="canonical" href="https://hermesatlas.com/guide/install/windows/">
+<meta property="og:title" content="How to Install Hermes Agent on Windows 10/11: PowerShell, Desktop Installer, or WSL2">
+<meta property="og:description" content="Native Windows is Tier 1. One PowerShell line, no admin rights — plus the Desktop installer and the WSL2 path, with the official guidance on which to pick.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://hermesatlas.com/guide/install/windows/">
+<meta property="og:site_name" content="Hermes Atlas">
+<meta property="article:published_time" content="2026-08-31T00:00:00Z">
+<meta property="article:modified_time" content="2026-08-31T00:00:00Z">
+<meta property="article:author" content="https://x.com/ksimback">
+<meta property="og:image" content="https://hermesatlas.com/api/og?title=Install+Hermes+Agent+on+Windows&amp;subtitle=PowerShell%2C+Desktop+installer%2C+or+WSL2+-+no+admin+rights+needed&amp;kind=handbook+%C2%B7+install">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="How to Install Hermes Agent on Windows 10/11">
+<meta name="twitter:description" content="Native Windows is Tier 1. One PowerShell line, no admin rights — plus the Desktop installer and WSL2 paths.">
+<meta name="twitter:image" content="https://hermesatlas.com/api/og?title=Install+Hermes+Agent+on+Windows&amp;subtitle=PowerShell%2C+Desktop+installer%2C+or+WSL2+-+no+admin+rights+needed&amp;kind=handbook+%C2%B7+install">
+<meta name="twitter:creator" content="@ksimback">
+<meta name="author" content="Kevin Simback">
+<link rel="alternate" type="application/rss+xml" title="Hermes Atlas — new projects" href="/rss.xml">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png">
+<link rel="apple-touch-icon" href="/apple-touch-icon.png">
+<link rel="manifest" href="/site.webmanifest">
+<script src="/assets/js/theme-init.js"></script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap">
+<link rel="stylesheet" href="/assets/css/tokens.css">
+<link rel="stylesheet" href="/assets/css/base.css">
+<link rel="stylesheet" href="/assets/css/page.css">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "How to Install Hermes Agent on Windows 10/11: PowerShell, Desktop Installer, or WSL2",
+  "description": "Install Hermes Agent natively on Windows 10/11 (Tier 1) — the PowerShell one-liner, the Desktop installer, or WSL2. No admin rights needed, with the official native-vs-WSL2 guidance.",
+  "image": "https://hermesatlas.com/api/og?title=Install+Hermes+Agent+on+Windows&subtitle=PowerShell%2C+Desktop+installer%2C+or+WSL2+-+no+admin+rights+needed&kind=handbook+%C2%B7+install",
+  "keywords": ["install hermes agent windows", "hermes install powershell", "hermes agent windows 11", "hermes wsl2"],
+  "datePublished": "2026-08-31T00:00:00Z",
+  "dateModified": "2026-08-31T00:00:00Z",
+  "author": {"@type": "Person", "name": "Kevin Simback", "url": "https://x.com/ksimback"},
+  "publisher": {"@type": "Organization", "name": "Hermes Atlas", "url": "https://hermesatlas.com"},
+  "mainEntityOfPage": {"@type": "WebPage", "@id": "https://hermesatlas.com/guide/install/windows/"},
+  "isPartOf": {"@type": "Article", "@id": "https://hermesatlas.com/guide/install/", "name": "How to install Hermes Agent"}
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Do I need admin rights to install Hermes on Windows?",
+      "acceptedAnswer": {"@type": "Answer", "text": "No. The PowerShell installer writes only to %LOCALAPPDATA%\\hermes and your User PATH — no UAC prompt. Even gateway auto-start at login uses a non-elevated Scheduled Task."}
+    },
+    {
+      "@type": "Question",
+      "name": "Is native Windows still an early beta?",
+      "acceptedAnswer": {"@type": "Answer", "text": "No — Windows 10/11 native (x86_64 and aarch64) is a Tier 1 platform in the official support matrix, alongside macOS and Linux. Everything runs natively except one feature: the dashboard's embedded terminal pane, which needs a POSIX PTY and is WSL2-only."}
+    },
+    {
+      "@type": "Question",
+      "name": "Should I install Hermes natively or in WSL2?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Native for most people. The official guidance: pick WSL2 if you want the dashboard's embedded terminal, do POSIX-heavy development and want Hermes on the same Linux filesystem as your tools, or already maintain a WSL2 environment. Otherwise native is fine — or better — since you skip the WSL↔Windows boundary."}
+    },
+    {
+      "@type": "Question",
+      "name": "Where does Hermes install on Windows?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Code at %LOCALAPPDATA%\\hermes\\hermes-agent\\, your data (config, keys, sessions, skills) directly under %LOCALAPPDATA%\\hermes\\. Reinstalls only replace the checkout — your data survives. WSL2 installs live separately under ~/.hermes inside the distro."}
+    },
+    {
+      "@type": "Question",
+      "name": "Does the messaging gateway work on native Windows?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Yes — Telegram, Discord, Slack, WhatsApp and 15+ platforms all run natively, and hermes gateway install keeps the gateway running at login via a non-elevated Scheduled Task, spawned through pythonw.exe so a stray Ctrl+C can't kill it."}
+    },
+    {
+      "@type": "Question",
+      "name": "Does Hermes run on Windows on ARM?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Yes — the official platform matrix lists Windows 10/11 on both x86_64 and aarch64 as Tier 1."}
+    }
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {"@type": "ListItem", "position": 1, "name": "home", "item": "https://hermesatlas.com/"},
+    {"@type": "ListItem", "position": 2, "name": "handbook", "item": "https://hermesatlas.com/guide/"},
+    {"@type": "ListItem", "position": 3, "name": "install", "item": "https://hermesatlas.com/guide/install/"},
+    {"@type": "ListItem", "position": 4, "name": "windows"}
+  ]
+}
+</script>
+</head>
+<body>
+<a class="skip-link" href="#main">Skip to content</a>
+<header class="masthead">
+  <a href="/" class="brand" aria-label="Hermes Atlas — home">hermes atlas</a>
+  <div class="mast-meta" aria-label="Site metadata">
+    <span id="meta-count">247·repos</span>
+    <span id="meta-version">hermes·v0.21.0</span>
+    <a class="mast-star" id="meta-atlas" href="https://github.com/ksimback/hermes-ecosystem" target="_blank" rel="noopener" aria-label="Star Hermes Atlas on GitHub">★ star this repo</a>
+  </div>
+  <nav class="mast-nav" aria-label="Primary">
+    <a href="/">home</a>
+    <a href="/ecosystem/">ecosystem</a>
+    <a href="/lists/">lists</a>
+    <a href="/skills/">skills</a>
+    <a href="/use-cases/">use cases</a>
+    <a href="/guide/" class="active">handbook</a>
+    <a href="/masterclass/">masterclass</a>
+    <a href="/dev/">dev</a>
+    <a href="/reports/">reports</a>
+    <a href="https://github.com/ksimback/hermes-ecosystem">source</a>
+  </nav>
+  <button id="theme-toggle" class="mast-toggle" aria-label="Toggle light/dark theme" title="Toggle theme">
+    <span class="tt-icon tt-light" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><circle cx="12" cy="12" r="3.5"/><path d="M12 2v2.25M12 19.75V22M4.93 4.93l1.59 1.59M17.48 17.48l1.59 1.59M2 12h2.25M19.75 12H22M4.93 19.07l1.59-1.59M17.48 6.52l1.59-1.59"/></svg>
+    </span>
+    <span class="tt-icon tt-dark" aria-hidden="true">
+      <svg viewBox="0 0 24 24" focusable="false"><path d="M20.2 15.1A8.4 8.4 0 0 1 8.9 3.8 8.5 8.5 0 1 0 20.2 15.1Z"/></svg>
+    </span>
+  </button>
+</header>
+<div class="breadcrumb" aria-label="Breadcrumb">
+  <a href="/">home</a><span class="sep">/</span><a href="/guide/">handbook</a><span class="sep">/</span><a href="/guide/install/">install</a><span class="sep">/</span>windows
+</div>
+<main class="article" id="main">
+
+<header class="article-header">
+  <div class="article-badge">handbook · install · windows</div>
+  <h1>How to Install Hermes Agent on Windows 10/11</h1>
+  <p class="subtitle">PowerShell one-liner, Desktop installer, or WSL2 — with the official guidance on which to pick. A platform page of <a href="/guide/install/">the install guide</a>, cross-checked against the official docs.</p>
+  <p class="meta">By <a href="https://x.com/ksimback">Kevin Simback</a> · Hermes Atlas maintainer · Updated 2026-08-31 · ~7 min read</p>
+</header>
+
+<h2 id="tldr">TL;DR</h2>
+
+<p><strong>Native Windows is Tier 1.</strong> Hermes runs on Windows 10 and 11 (x86_64 and aarch64) with no WSL, no Cygwin, no Docker — the <a href="https://hermes-agent.nousresearch.com/docs/user-guide/windows-native">official native guide</a> opens with exactly those words. No admin rights required. Open PowerShell and run:</p>
+
+<pre><code>iex (irm https://hermes-agent.nousresearch.com/install.ps1)</code></pre>
+
+<p>Then open a <em>new</em> terminal (the installer updates your User PATH) and run <code>hermes</code>. This guide covers Hermes Agent <strong>v0.21.0</strong>. On other platforms? See <a href="/guide/install/macos/">macOS</a>, <a href="/guide/install/linux/">Linux</a>, <a href="/guide/install/raspberry-pi/">Raspberry Pi</a>, or <a href="/guide/install/vps/">VPS</a>.</p>
+
+<h2 id="paths">The three install paths</h2>
+
+<div class="article-table-scroll" tabindex="0">
+<table>
+<thead><tr><th>Path</th><th>Best for</th><th>How</th></tr></thead>
+<tbody>
+<tr><td><strong>PowerShell one-liner</strong></td><td>Anyone already in a terminal</td><td><code>iex (irm https://hermes-agent.nousresearch.com/install.ps1)</code> — no admin, installs to <code>%LOCALAPPDATA%\hermes</code></td></tr>
+<tr><td><strong>Hermes Desktop installer</strong></td><td>A familiar Windows install experience; handing Hermes to a non-developer</td><td><a href="https://hermes-agent.nousresearch.com/">Download the installer</a> and run it — on first launch it runs <code>install.ps1</code> under the hood; the app and the CLI share one install</td></tr>
+<tr><td><strong>WSL2</strong></td><td>POSIX-heavy development; the dashboard's embedded terminal</td><td><code>wsl --install</code>, reboot, then the Linux installer inside Ubuntu</td></tr>
+</tbody>
+</table>
+</div>
+
+<p>The <a href="https://hermes-agent.nousresearch.com/docs/getting-started/installation">official install page</a> recommends the Desktop installer as the easy path on Windows and macOS; the <a href="https://hermes-agent.nousresearch.com/docs/user-guide/windows-native">native guide</a> suggests the one-liner "when you're already in a terminal."</p>
+
+<h2 id="what-it-does">What the PowerShell installer does</h2>
+
+<p>Everything lands under <code>%LOCALAPPDATA%\hermes\</code> and <code>hermes</code> is added to your <strong>User PATH</strong> — no UAC prompt at any point. Per the <a href="https://hermes-agent.nousresearch.com/docs/user-guide/windows-native">official docs</a>, the installer bootstraps <code>uv</code>, Python 3.11, Node.js 26 (winget if available, else a portable tarball), and — only if <code>git</code> isn't already on PATH — a self-contained <strong>PortableGit</strong> (~45 MB, official git-for-windows build) under <code>%LOCALAPPDATA%\hermes\git</code>. It sets <code>HERMES_GIT_BASH_PATH</code> so Hermes runs shell commands through Git Bash — "same strategy Claude Code uses" — and finishes with the <code>hermes setup</code> wizard.</p>
+
+<p>Need installer options? The scriptblock form passes parameters — <code>-Branch</code> / <code>-Commit</code> / <code>-Tag</code> to pin a version, <code>-NoVenv</code>, <code>-SkipSetup</code>, <code>-HermesHome</code>, <code>-InstallDir</code>:</p>
+
+<pre><code>&amp; ([scriptblock]::Create((irm https://hermes-agent.nousresearch.com/install.ps1))) -SkipSetup</code></pre>
+
+<p>After it finishes, open a new PowerShell window and verify:</p>
+
+<pre><code>hermes version      # prints v0.21.0 (or newer)
+hermes doctor       # health check — every line should be green</code></pre>
+
+<p>Then configure a model — fastest is <code>hermes setup --portal</code> (one Nous Portal login covers 300+ models plus the tool gateway, which the docs call the highest-friction part of Windows setup solved in one command). Full first-run walkthrough: <a href="/guide/install/#first-run">first run and model provider</a> on the main install page.</p>
+
+<h2 id="feature-matrix">What works natively</h2>
+
+<p>Per the <a href="https://hermes-agent.nousresearch.com/docs/user-guide/windows-native#feature-matrix">official feature matrix</a>, "everything except the dashboard's embedded terminal pane runs natively on Windows": the CLI, the interactive TUI (<code>hermes --tui</code>), the full messaging gateway (Telegram, Discord, Slack, WhatsApp, 15+ platforms), the cron scheduler, the browser tool, MCP servers (stdio and HTTP), local Ollama / LM Studio, the web dashboard, and auto-start at login. The one exception — the dashboard's <code>/chat</code> embedded terminal — needs a POSIX PTY and shows a "use WSL2 for this" banner natively.</p>
+
+<h2 id="native-or-wsl2">Native or WSL2?</h2>
+
+<p>Both are Tier 1, and the <a href="https://hermes-agent.nousresearch.com/docs/user-guide/windows-wsl-quickstart">official WSL2 guide</a> answers directly. Pick <strong>WSL2</strong> if: you want the dashboard's embedded terminal tab, you do POSIX-heavy development and want Hermes on the same Linux filesystem as your tools, or you already maintain a WSL2 environment. <strong>Native is fine — or better</strong> — for everyone else: you skip crossing the WSL↔Windows boundary every time you touch a file or URL.</p>
+
+<p>The WSL2 path in three commands: <code>wsl --install</code> from Admin PowerShell (installs the WSL2 kernel + Ubuntu), reboot, then inside Ubuntu run the standard Linux installer — <code>curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash</code>. The two installs coexist cleanly: native data under <code>%LOCALAPPDATA%\hermes</code>, WSL data under <code>~/.hermes</code>. WSL2 specifics (filesystem boundaries, networking, systemd) are covered by our <a href="/guide/install/linux/">Linux install page</a> plus the official WSL2 guide.</p>
+
+<h2 id="gateway">Running the gateway at Windows login</h2>
+
+<p>For an always-on Telegram/Discord bot on your PC, <code>hermes gateway install</code> registers a <strong>Scheduled Task</strong> (<code>ONLOGON</code>, non-elevated — no UAC) with a Startup-folder fallback, and spawns the gateway detached via <code>pythonw.exe</code>, which the <a href="https://hermes-agent.nousresearch.com/docs/user-guide/windows-native">docs</a> note "immunizes it against CTRL_C_EVENT broadcasts" — a stray Ctrl+C elsewhere can't kill it. Manage it with <code>hermes gateway status / start / stop / restart / uninstall</code>. Want the bot to outlive your PC's uptime entirely? That's the <a href="/guide/install/vps/">VPS setup</a>.</p>
+
+<h2 id="pitfalls">Common pitfalls</h2>
+
+<ul>
+  <li><strong><code>hermes: command not found</code> right after install</strong> — open a <em>new</em> PowerShell window; existing shells don't pick up the User PATH change.</li>
+  <li><strong><code>[scriptblock]::Create(...)</code> fails with an assignment error</strong> — your <code>install.ps1</code> download picked up a UTF-8 BOM. Use the plain <code>irm | iex</code> form, which strips BOMs automatically.</li>
+  <li><strong><code>/edit</code> or <code>Ctrl-X Ctrl-E</code> opens nothing you want</strong> — Hermes defaults <code>EDITOR=notepad</code> on Windows. For VS Code: <code>$env:EDITOR = "code --wait"</code> (the <code>--wait</code> is critical), set at User scope to persist.</li>
+  <li><strong>Non-Latin characters render as <code>?</code></strong> — the UTF-8 console shim didn't activate. Check <code>HERMES_DISABLE_WINDOWS_UTF8</code> is unset, or switch to Windows Terminal.</li>
+  <li><strong>Weird Node version errors from the browser tool</strong> — an older system Node sits earlier on PATH than Hermes's bundled Node 26.</li>
+  <li><strong>Ran the Linux <code>curl | bash</code> in PowerShell</strong> — that command is for WSL2 only; use the <code>irm | iex</code> installer natively.</li>
+</ul>
+
+<p>Deeper failures: <code>hermes doctor</code> diagnoses most of them, and the <a href="/guide/install/#troubleshooting">shared troubleshooting tree</a> covers the cross-platform ones.</p>
+
+<h2 id="uninstall">Uninstall</h2>
+
+<p><code>hermes uninstall</code> is the clean path — it removes the scheduled task, launchers, and the <code>hermes-agent\</code> checkout but leaves your config, sessions, and skills in <code>%LOCALAPPDATA%\hermes</code> for a reinstall. To remove everything: also <code>Remove-Item -Recurse -Force "$env:LOCALAPPDATA\hermes"</code>.</p>
+
+<h2 id="frequently-asked-questions">FAQ</h2>
+
+<h3>Do I need admin rights to install Hermes on Windows?</h3>
+<p>No. The installer writes only to <code>%LOCALAPPDATA%\hermes</code> and your User PATH — no UAC prompt. Even gateway auto-start uses a non-elevated Scheduled Task.</p>
+
+<h3>Is native Windows still an early beta?</h3>
+<p>No — Windows 10/11 native (x86_64 and aarch64) is a <a href="https://hermes-agent.nousresearch.com/docs/getting-started/platform-support">Tier 1 platform</a>, alongside macOS and Linux. Everything runs natively except the dashboard's embedded terminal pane (WSL2-only).</p>
+
+<h3>Should I install Hermes natively or in WSL2?</h3>
+<p>Native for most people. WSL2 if you want the dashboard's embedded terminal, do POSIX-heavy development, or already maintain WSL2 — that's the official guidance verbatim.</p>
+
+<h3>Where does Hermes install on Windows?</h3>
+<p>Code at <code>%LOCALAPPDATA%\hermes\hermes-agent\</code>; your data (config, keys, sessions, skills) directly under <code>%LOCALAPPDATA%\hermes\</code>. Reinstalls only replace the checkout — your data survives.</p>
+
+<h3>Does the messaging gateway work on native Windows?</h3>
+<p>Yes — Telegram, Discord, Slack, WhatsApp and 15+ platforms all run natively, and <code>hermes gateway install</code> keeps it running at login.</p>
+
+<h3>Does Hermes run on Windows on ARM?</h3>
+<p>Yes — the official matrix lists Windows 10/11 on both x86_64 and aarch64 as Tier 1.</p>
+
+<p>Next: <a href="/guide/install/#verify">verify the install</a>, <a href="/guide/install/#first-run">pick a model provider</a>, then <a href="/skills/">the Skills Hub</a>. Deciding how to run Hermes long-term? <a href="/guide/modes/">Every mode compared</a>.</p>
+
+<div class="article-footer">
+  <p>Maintained by <a href="https://x.com/ksimback">Kevin Simback</a> · Part of <a href="/guide/">The Hermes Handbook</a> · Facts sourced from the <a href="https://hermes-agent.nousresearch.com/docs/">official Hermes Agent docs</a> · if this was useful, drop a ★ on <a href="https://github.com/ksimback/hermes-ecosystem">the atlas repo</a> →</p>
+</div>
+
+</main>
+
+<footer class="page-footer">
+  <div class="fn-left">hermes atlas · curated by <a href="https://github.com/ksimback">ksimback</a> · <a href="https://github.com/ksimback/hermes-ecosystem/issues">suggest a repo</a> · <a href="/privacy">privacy</a></div>
+  <div>v2 · 2026.04</div>
+</footer>
+
+<script src="/assets/js/theme-toggle.js" defer></script>
+<script src="/assets/js/masthead-fetch.js" defer></script>
+<!-- Cloudflare Web Analytics -->
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js"
+        data-cf-beacon='{"token": "fe0d4d79280b4386b6b0cd99b2d94dbc"}'></script>
+<!-- End Cloudflare Web Analytics -->
+</body>
+</html>

--- a/lib/build-artifacts.js
+++ b/lib/build-artifacts.js
@@ -9,11 +9,21 @@ export const REFRESHED_CONTENT_PATHS = [
   "guide/vs-claude-code/index.html",
   "guide/modes/index.html",
   "guide/desktop/index.html",
+  "guide/install/windows/index.html",
+  "guide/install/macos/index.html",
+  "guide/install/linux/index.html",
+  "guide/install/raspberry-pi/index.html",
+  "guide/install/vps/index.html",
   "drafts/handbook-hub.md",
   "drafts/handbook-vs-claude-code.md",
   "drafts/guide-memory.md",
   "drafts/guide-modes.md",
   "drafts/guide-desktop.md",
+  "drafts/guide-install-windows.md",
+  "drafts/guide-install-macos.md",
+  "drafts/guide-install-linux.md",
+  "drafts/guide-install-raspberry-pi.md",
+  "drafts/guide-install-vps.md",
 ];
 
 export const GENERATED_ARTIFACT_PATHS = [

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -333,11 +333,7 @@ By [Kevin Simback](https://x.com/ksimback) · Hermes Atlas maintainer · Updated
 
 ## 1. What Hermes Agent actually is
 
-<<<<<<< HEAD
-**Hermes Agent is an open-source AI agent by [Nous Research](https://nousresearch.com) that runs on your own machine or a cheap VPS, remembers what it learns across sessions, and writes its own reusable skills as it works. It talks to you through a CLI, Telegram, Discord, email, and many other messaging providers. It hit 238,978 GitHub stars (as of 2026-08-31), and it's the fastest-growing open-source agent of 2026.**
-=======
-**Hermes Agent is an open-source AI agent by [Nous Research](https://nousresearch.com) that runs on your own machine or a cheap VPS, remembers what it learns across sessions, and writes its own reusable skills as it works. It talks to you through a CLI, Telegram, Discord, email, and many other messaging providers. It hit 238,978 GitHub stars (as of 2026-08-31), and it's the fastest-growing open-source agent of 2026.**
->>>>>>> origin/main
+**Hermes Agent is an open-source AI agent by [Nous Research](https://nousresearch.com) that runs on your own machine or a cheap VPS, remembers what it learns across sessions, and writes its own reusable skills as it works. It talks to you through a CLI, Telegram, Discord, email, and many other messaging providers. It hit 238,983 GitHub stars (as of 2026-08-31), and it's the fastest-growing open-source agent of 2026.**
 
 ### The 30-second version
 
@@ -751,13 +747,8 @@ If something is wrong, unclear, or out of date, open an issue on [the Atlas repo
 **Last updated:** 2026-08-31 · Version and star figures re-stamp automatically with every site build.
 
 **Cited stats:**
-<<<<<<< HEAD
-- 238,978 GitHub stars (as of 2026-08-31) — source: `api.github.com/repos/NousResearch/hermes-agent`
+- 238,983 GitHub stars (as of 2026-08-31) — source: `api.github.com/repos/NousResearch/hermes-agent`
 - 247+ projects in the Hermes Atlas (as of 2026-08-31)
-=======
-- 238,978 GitHub stars (as of 2026-08-31) — source: `api.github.com/repos/NousResearch/hermes-agent`
-- 247+ projects in the Hermes Atlas (as of 2026-08-31)
->>>>>>> origin/main
 - 643 skills in the community Hub (as of 2026-04-19)
 
 **Corrections and feedback:** [open an issue](https://github.com/ksimback/hermes-ecosystem/issues/new) or message on X.
@@ -808,7 +799,7 @@ The frame people reach for is: **Claude Code is a specialist; Hermes is a genera
 | **Messaging channels** | Terminal only | Terminal, Telegram, Discord, email, webhooks |
 | **Multi-agent / delegation** | Subagents via the Task tool | Native delegation, multi-agent teams, profiles |
 | **Sandboxing** | Approval prompts, permission system | Approval policies, Docker backend, profile isolation |
-| **License & openness** | Proprietary (Anthropic) | Open-source (MIT), 238,978 stars as of 2026-08-31 |
+| **License & openness** | Proprietary (Anthropic) | Open-source (MIT), 238,983 stars as of 2026-08-31 |
 
 The two rows that matter most for the decision: **model support** (Anthropic-only vs multi-provider) and **where it runs** (inside a repo vs on a server).
 
@@ -835,7 +826,7 @@ Hermes is the right tool when your task crosses sessions, channels, or models.
 - **You want cross-channel access.** Message Hermes from Telegram during a commute. Check back on the CLI that evening. Same agent, same memory, same skills. Claude Code doesn't leave the terminal.
 - **You want the agent to get better over time.** The learning loop — five-tool-call retrospectives, auto-generated skills — compounds quietly. Day thirty doesn't feel like day one.
 - **You want model flexibility.** Swap from Claude to GPT to GLM-5 to local Ollama with one command. No code changes, no vendor lock-in. Cheap models for cheap jobs, frontier models for real work.
-- **You want it to be yours.** MIT-licensed, 238,978 stars (as of 2026-08-31), self-hostable on a $5 VPS. The code is open, the data lives on your disk, and nothing phones home.
+- **You want it to be yours.** MIT-licensed, 238,983 stars (as of 2026-08-31), self-hostable on a $5 VPS. The code is open, the data lives on your disk, and nothing phones home.
 
 Hermes falls short when you need deep in-editor coding support. It can read and write code, but it's not optimized for the minute-by-minute code-edit-test loop the way Claude Code is. Use Claude Code for that, and use Hermes around it.
 
@@ -884,7 +875,7 @@ For *simple* coding tasks — "refactor this file," "add a test" — yes. For su
 
 ### Is Hermes production-ready?
 
-As of 2026-08-31, yes, with caveats. 238,978 GitHub stars, an active Nous team shipping every two weeks, and a ~650-project community ecosystem. Real companies run Hermes in production. The honest caveats: the skill ecosystem is younger than Claude Code's, and some integrations still have rough edges. Read the **[State of Hermes report →](/reports/state-of-hermes-april-2026)** for the full picture.
+As of 2026-08-31, yes, with caveats. 238,983 GitHub stars, an active Nous team shipping every two weeks, and a ~650-project community ecosystem. Real companies run Hermes in production. The honest caveats: the skill ecosystem is younger than Claude Code's, and some integrations still have rough edges. Read the **[State of Hermes report →](/reports/state-of-hermes-april-2026)** for the full picture.
 
 ---
 
@@ -901,7 +892,7 @@ As of 2026-08-31, yes, with caveats. 238,978 GitHub stars, an active Nous team s
 **Last updated:** 2026-08-31 · Version and star figures re-stamp automatically with every site build.
 
 **Cited stats:**
-- 238,978 GitHub stars (as of 2026-08-31) — source: `api.github.com/repos/NousResearch/hermes-agent`
+- 238,983 GitHub stars (as of 2026-08-31) — source: `api.github.com/repos/NousResearch/hermes-agent`
 - 643 skills in the community Hub (research bank snapshot, as of 2026-04-19)
 
 **Corrections and feedback:** [open an issue](https://github.com/ksimback/hermes-ecosystem/issues/new) or message on X.
@@ -932,14 +923,14 @@ Skip to content
  reports
  source
 
- map / handbook / install
+ home / handbook / install
 
  handbook · satellite · install
  How to install Hermes Agent
- The complete 2026 setup guide for macOS, Linux, and Windows (WSL2). With the full troubleshooting tree for every common install error.
+ The complete 2026 setup guide for every platform — with dedicated pages for Windows , macOS , Linux , Raspberry Pi , and VPS , plus the full troubleshooting tree for every common install error.
  By Kevin Simback · Hermes Atlas maintainer · Updated 2026-08-31 · ~8 min read
 
- TL;DR — Hermes Agent installs with a single curl command on macOS, Linux, or Windows via WSL2. The installer takes two to three minutes end-to-end and is maintained in lockstep with the main repo. This guide covers Hermes Agent v0.21.0 ( current release as of August 2026; 238,978 GitHub stars as of 2026-08-31).
+ TL;DR — Hermes Agent installs with a single curl command on macOS, Linux, or Windows via WSL2. The installer takes two to three minutes end-to-end and is maintained in lockstep with the main repo. This guide covers Hermes Agent v0.21.0 ( current release as of August 2026; 238,983 GitHub stars as of 2026-08-31).
 
  TL;DR
 
@@ -951,14 +942,17 @@ hermes # start chatting
 
  If that worked, skip to first run and model provider . If it didn't, the troubleshooting tree covers the nine failure modes I've seen, in the order you should check them.
 
+ Want the full walkthrough for your exact setup? Each platform has a dedicated page with its own installer specifics, pitfalls, and FAQ: Windows 10/11 · macOS (Apple Silicon) · Linux & servers · Raspberry Pi · VPS .
+
  Before you start
 
  Supported OSes (as of v0.21.0):
 
- macOS 13 Ventura or newer. Apple Silicon (M1/M2/M3/M4) and Intel both supported. Apple Silicon is faster for local-model workloads.
- Linux — Ubuntu 22.04 or newer, Debian 12, Fedora 39+, Arch rolling. Any modern distro with glibc 2.35+ should work.
- Windows — two options. WSL2 with Ubuntu or Debian inside is the road-tested path. Native Windows works via an early-beta PowerShell installer (Nous's wording: "not road-tested as broadly"). See Install on Windows below.
- Termux (Android) — supported via a curated .[termux] extra. The same curl one-liner works inside Termux; voice dependencies are excluded.
+ macOS — Apple Silicon (M1/M2/M3/M4) only , Tier 1. Intel (x86) Macs are explicitly unsupported , as are brew and pip installs. Details: macOS install guide .
+ Windows 10/11 — native is Tier 1 (x86_64 and aarch64), via the PowerShell installer or the Hermes Desktop installer; WSL2 is equally Tier 1 for POSIX workflows. Details: Windows install guide .
+ Linux & WSL2 — Tier 1 (x86_64 and aarch64). Nous tests on the latest Ubuntu; any glibc + systemd + FHS distro is expected to work. Details: Linux install guide .
+ Docker — Tier 1 (x86_64 and aarch64); the always-on path for VPS boxes and Raspberry Pis . Updates by pulling a new image, not hermes update .
+ Termux (Android) and Nix — Tier 2, best-effort. The same curl one-liner works inside Termux (voice excluded); Nix is no longer an explicitly supported path.
 
  Prerequisites — Hermes's installer is aggressive about setting up its own stack, so you need almost nothing pre-installed:
 
@@ -971,83 +965,44 @@ hermes # start chatting
 
  Install on macOS
 
- Open Terminal (or iTerm, or Warp — any shell). Run:
+ Apple Silicon only (Tier 1) — Intel Macs, brew , and pip installs are officially unsupported. Two paths: the Hermes Desktop installer (recommended — app + CLI in one), or terminal-only:
 
- curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+ curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+source ~/.zshrc # macOS default since Catalina
+hermes version
 
- Reload your shell so hermes is on PATH:
-
- source ~/.zshrc # macOS default since Catalina
-# or: source ~/.bashrc if you switched to bash
-
- Test it:
-
- hermes version
-
- Apple Silicon (M1/M2/M3/M4) notes
-
- The installer auto-detects arm64 and pulls native binaries. No Rosetta required. If you already have Homebrew installed, the installer uses it to pull missing dependencies — otherwise it installs Homebrew for you (and prints what it's doing).
-
- Intel Mac notes
-
- Everything works identically. The only caveat: local-model inference via Ollama is meaningfully slower than Apple Silicon — budget a frontier API key (Anthropic, OpenAI, GLM) for real work.
+ Full macOS guide → — Desktop vs CLI install, the Intel-Mac situation, Mac-specific pitfalls, and the Mac mini always-on setup.
 
  Install on Linux
 
- The command is identical across distros:
+ Tier 1 on x86_64 and aarch64; the command is identical across distros (make sure git , curl , and xz-utils are present first):
 
- curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+ curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
 source ~/.bashrc
 
- Distro-specific notes
-
- Ubuntu 22.04 / 24.04, Debian 12 — works out of the box. If you're on a fresh minimal cloud image, apt-get install -y git curl first.
- Fedora 39+ — identical. Uses dnf under the hood for any missing system packages.
- Arch / Manjaro — works; installer uses pacman for missing deps. The AUR has a community hermes-agent package too, but the official curl installer is what the Nous team ships against.
- Alpine — works with caveats. glibc is required; the installer will fall back to a statically-linked path, but memory and skills with native deps (ffmpeg audio handling, image cache) can be flaky. A $5 Debian VPS is the path of least resistance.
+ Full Linux guide → — distro notes (Ubuntu, Debian, Fedora, Arch — and why the AUR is a trap), per-user vs FHS layouts, and the complete Ubuntu Server / headless / systemd service-user recipe.
 
  Install on Windows
 
- Two supported paths. WSL2 is the road-tested option that most users should pick. Native Windows via PowerShell is shipped as an early beta in the official installer — Nous's wording is "not road-tested as broadly" — and is the right call if you can't or won't enable WSL.
+ Native Windows 10/11 is Tier 1 — no WSL required, no admin rights. Open PowerShell and run:
 
- Option A — WSL2 (recommended)
+ iex (irm https://hermes-agent.nousresearch.com/install.ps1)
 
- WSL2 runs a real Linux kernel inside Windows 11 with near-native performance.
+ Or use the Hermes Desktop installer for a double-click install. WSL2 is equally supported and the right pick for POSIX-heavy workflows (it's the standard Linux install inside Ubuntu).
 
- 1. Install WSL2
+ Full Windows guide → — the official native-vs-WSL2 guidance, what the installer does, the feature matrix, gateway auto-start at login, and every Windows-specific pitfall.
 
- Open PowerShell as Administrator:
+ Install on a Raspberry Pi
 
- wsl --install
+ A Pi 4 or 5 with 4+ GB RAM and a 64-bit OS is a legitimate Tier-1 host (aarch64 Linux and aarch64 Docker are both Tier 1). Direct install uses the Linux one-liner above; Docker gives set-and-forget supervision.
 
- This installs WSL2 + Ubuntu by default. Reboot when prompted. On first boot of Ubuntu, create a username and password.
+ Full Raspberry Pi guide → — hardware requirements by board, both install paths, and the always-on gateway setup.
 
- 2. Install Hermes inside WSL
+ Install on a VPS
 
- Open the Ubuntu terminal (from Start Menu) and run the same Linux install command:
+ A $5 VPS (1 CPU, 1 GB RAM) runs Hermes as an always-on bot or remote backend when paired with a hosted model API. Docker is the recommended path — and do the install over SSH, not your provider's browser console.
 
- curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
-source ~/.bashrc
-hermes version
-
- 3. Use Windows Terminal
-
- The default WSL console is workable but Windows Terminal (free, Microsoft Store) is substantially better — tabs, font control, and proper Unicode. Set Ubuntu as your default profile and you're done.
-
- Option B — Native Windows via PowerShell (early beta)
-
- Open PowerShell (not WSL, not cmd) and run:
-
- irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 | iex
-
- The installer drops Hermes into %LOCALAPPDATA%\hermes and unpacks a portable Git Bash (~45 MB MinGit) into %LOCALAPPDATA%\hermes\git so shell-based tools work without a system-wide Git install. It also sets up uv , Python 3.11, Node.js, ripgrep , and ffmpeg in the same directory.
-
- After the script finishes, close and reopen PowerShell so hermes is on PATH, then:
-
- hermes version
-hermes doctor
-
- What "early beta" actually means. The Nous team's own framing in the README: "not road-tested as broadly" as the Linux/macOS path. Expect more rough edges in the messaging gateway and any tool that shells out to native binaries. If something breaks and you have the option, WSL2 is the safer fallback.
+ Full VPS guide → — sizing from the official docs, Docker and direct-install paths, the mandatory-auth security guidance, and connecting Hermes Desktop or your phone to the box.
 
  Verify the install
 
@@ -1299,15 +1254,15 @@ curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scri
 
  Does Hermes Agent work on bare Windows?
 
- Yes, in early beta. Since v0.10.0, Nous ships a native Windows installer you run from PowerShell: irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 | iex . It installs to %LOCALAPPDATA%\hermes and bundles a portable Git Bash. Nous explicitly flags this path as "not road-tested as broadly" — for production use, prefer WSL2: wsl --install in PowerShell, install Ubuntu, then run the standard curl installer from inside WSL.
+ Yes — native Windows 10/11 is a Tier 1 platform. Run iex (irm https://hermes-agent.nousresearch.com/install.ps1) in PowerShell (no admin rights), or use the Desktop installer. It installs to %LOCALAPPDATA%\hermes and bundles a portable Git Bash. Everything except the dashboard's embedded terminal runs natively; WSL2 is equally supported for POSIX workflows. Full details: the Windows install guide .
 
  Does Hermes work on Apple Silicon (M1, M2, M3, M4)?
 
- Yes, natively. Apple Silicon is a first-class target. The installer detects arm64 and pulls native binaries. No Rosetta required.
+ Yes, natively — Apple Silicon is Tier 1. The installer detects arm64 and pulls native binaries; no Rosetta required. Intel (x86) Macs are explicitly unsupported — see the macOS install guide .
 
  Can I run Hermes Agent on a Raspberry Pi or low-end VPS?
 
- Yes. Hermes itself runs comfortably on a $5 VPS (1 CPU, 1 GB RAM) or a Raspberry Pi 4/5 with 4+ GB RAM. The practical constraint is not Hermes but the model — pair it with a hosted API (Nous Portal, Anthropic) and the agent host stays lightweight.
+ Yes. Hermes itself runs comfortably on a $5 VPS (1 CPU, 1 GB RAM) or a Raspberry Pi 4/5 with 4+ GB RAM — we maintain dedicated Raspberry Pi and VPS setup guides. The practical constraint is not Hermes but the model — pair it with a hosted API (Nous Portal, Anthropic) and the agent host stays lightweight.
 
  How much disk space does Hermes Agent use?
 
@@ -1329,7 +1284,7 @@ curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scri
  Last updated: 2026-08-31 · Version and star figures re-stamp automatically with every site build.
  Cited stats:
 
- 238,978 GitHub stars (as of 2026-08-31) — source: api.github.com/repos/NousResearch/hermes-agent
+ 238,983 GitHub stars (as of 2026-08-31) — source: api.github.com/repos/NousResearch/hermes-agent
  Hermes Agent v0.21.0 — release notes
 
  Corrections and feedback: open an issue or message @ksimback on X.
@@ -1344,6 +1299,350 @@ curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scri
 
  hermes atlas · curated by ksimback · suggest a repo · privacy
  v2 · 2026.04
+
+---
+
+# Install Hermes Agent on Windows 10/11 (/guide/install/windows/)
+
+Canonical URL: https://hermesatlas.com/guide/install/windows/
+
+# How to Install Hermes Agent on Windows 10/11: PowerShell, Desktop Installer, or WSL2
+
+The Windows install guide. Live version: https://hermesatlas.com/guide/install/windows/ — facts sourced from the official docs. Current release is v0.21.0 (as of 2026-08-31).
+
+## TL;DR
+
+Native Windows is **Tier 1** — Hermes runs on Windows 10 and 11 (x86_64 and aarch64) with no WSL, no Cygwin, no Docker. Three install paths:
+
+1. **PowerShell one-liner** (fastest if you're in a terminal): `iex (irm https://hermes-agent.nousresearch.com/install.ps1)` — no admin rights required.
+2. **Hermes Desktop installer** (recommended by Nous for most people): download the `.exe` from the official site; on first launch it runs `install.ps1` under the hood, and the GUI and CLI share the same install.
+3. **WSL2** — only if you specifically want a POSIX environment (see below for the official when-to-pick guidance).
+
+This guide covers Hermes Agent **v0.21.0**.
+
+## What the PowerShell installer does
+
+- Installs everything to `%LOCALAPPDATA%\hermes\` and adds `hermes` to your **User PATH** — open a new terminal after it finishes. No admin rights, no UAC.
+- Bootstraps `uv`, Python 3.11, Node.js 26 (winget or a portable tarball), and — if `git` isn't already on PATH — a self-contained PortableGit (~45 MB) under `%LOCALAPPDATA%\hermes\git`.
+- Sets `HERMES_GIT_BASH_PATH` so Hermes can run shell commands through Git Bash (the same strategy Claude Code uses on Windows).
+- Runs the `hermes setup` wizard at the end (skip with `-SkipSetup`).
+
+Installer parameters (scriptblock form required): `-Branch`, `-Commit`, `-Tag` (pin a version), `-NoVenv`, `-SkipSetup`, `-HermesHome`, `-InstallDir`.
+
+## What works natively
+
+Per the official feature matrix, everything except one feature runs natively on Windows: CLI, interactive TUI (`hermes --tui`), the full messaging gateway (Telegram, Discord, Slack, WhatsApp, 15+ platforms), cron scheduler, browser tool, MCP servers, local Ollama/LM Studio, web dashboard, and auto-start at login (via Scheduled Tasks, no admin). The one exception: the dashboard's `/chat` embedded terminal pane needs a POSIX PTY and is WSL2-only.
+
+## Native or WSL2?
+
+Both are Tier 1. Official guidance: pick **WSL2** if you want the dashboard's embedded terminal, you do POSIX-heavy development and want Hermes on the same Linux filesystem as your tools, or you already maintain WSL2. **Native is fine — or better** — for everyone else: you skip crossing the WSL↔Windows boundary every time you touch a file or URL.
+
+WSL2 path: `wsl --install` in Admin PowerShell, reboot, then run the Linux installer inside Ubuntu: `curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash`. Native data lives under `%LOCALAPPDATA%\hermes`, WSL data under `~/.hermes` — the two coexist cleanly.
+
+## Gateway at Windows login
+
+`hermes gateway install` registers a Scheduled Task (`ONLOGON`, non-elevated — no UAC) with a Startup-folder fallback, and spawns the gateway detached via `pythonw.exe` so a stray Ctrl+C can't kill it. Manage with `hermes gateway status/start/stop/restart/uninstall`.
+
+## Common pitfalls
+
+- **`hermes: command not found` right after install** — open a NEW PowerShell window; existing shells don't see the updated User PATH.
+- **`[scriptblock]::Create(...)` fails** — your `install.ps1` download picked up a UTF-8 BOM; use the plain `irm | iex` form instead.
+- **`/edit` does nothing** — Hermes defaults `EDITOR=notepad`; to use VS Code set `$env:EDITOR = "code --wait"` (the `--wait` is critical).
+- **Non-Latin characters show as `?`** — the UTF-8 stdio shim didn't activate; check `HERMES_DISABLE_WINDOWS_UTF8` is unset, or switch to Windows Terminal.
+- **Weird Node version errors** — an older system Node is earlier on PATH than Hermes's bundled Node 26.
+
+## Uninstall
+
+`hermes uninstall` removes the scheduled task, launchers, and the `hermes-agent\` checkout but keeps your config/sessions/skills in `%LOCALAPPDATA%\hermes`. To remove everything: also `Remove-Item -Recurse -Force "$env:LOCALAPPDATA\hermes"`.
+
+## FAQ
+
+**Do I need admin rights to install Hermes on Windows?** No. The PowerShell installer writes only to `%LOCALAPPDATA%\hermes` and your User PATH; gateway auto-start uses a non-elevated Scheduled Task.
+
+**Is native Windows still "early beta"?** No — Windows 10/11 native is a Tier 1 platform in the official support matrix, alongside macOS and Linux. Only the dashboard's embedded terminal pane is WSL2-only.
+
+**Should I install natively or in WSL2?** Native for most people. WSL2 if you want the dashboard's embedded terminal or a real POSIX dev environment shared with your tools.
+
+**Where does Hermes install on Windows?** Code at `%LOCALAPPDATA%\hermes\hermes-agent\`, your data (config, keys, sessions, skills) directly under `%LOCALAPPDATA%\hermes\`. Reinstalls replace only the checkout; your data survives.
+
+**Does the messaging gateway (Telegram/Discord) work on native Windows?** Yes — the full gateway is in the native feature matrix, and `hermes gateway install` keeps it running at login via Scheduled Tasks.
+
+**Windows on ARM?** Yes — the official matrix lists Windows 10/11 on both x86_64 and aarch64 as Tier 1.
+
+
+---
+
+# Install Hermes Agent on macOS (/guide/install/macos/)
+
+Canonical URL: https://hermesatlas.com/guide/install/macos/
+
+# How to Install Hermes Agent on macOS (Apple Silicon)
+
+The macOS install guide. Live version: https://hermesatlas.com/guide/install/macos/ — facts sourced from the official docs. Current release is v0.21.0 (as of 2026-08-31).
+
+## TL;DR
+
+Two supported paths on a Mac, both Tier 1 on **Apple Silicon** (M1–M4):
+
+1. **Hermes Desktop installer** (recommended by Nous): download from the official site and run it — you get the desktop app and the CLI in one shot, sharing the same config and data.
+2. **CLI-only curl install**: `curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash`, then `source ~/.zshrc` and run `hermes`.
+
+Two paths that are explicitly **unsupported**: `brew install hermes-agent` and `pip`/`uv tool install` — the official platform-support page says they may be broken now, may break more, and compat code can be removed at any point.
+
+This guide covers Hermes Agent **v0.21.0**.
+
+## Intel Macs are unsupported
+
+The official support matrix lists **macOS on Intel (x86) processors as unsupported** — only Apple Silicon is Tier 1. If you're on an Intel Mac, the practical alternatives are running Hermes on a Linux box/VPS you SSH into, or the Docker image (Tier 1 on x86_64) on other hardware. Don't expect the installer to keep working on Intel.
+
+## Prerequisites
+
+Just **Git** (`git --version`). The installer handles the rest: `uv`, Python 3.11 (no sudo), Node.js 26 (existing Node 22.22+/24.11+/26+ is used as-is), ripgrep, and ffmpeg. For the desktop app it also needs a working compiler toolchain to build native modules.
+
+## Install and verify
+
+```
+curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+source ~/.zshrc     # macOS default shell since Catalina
+hermes version      # prints v0.21.0 (or newer)
+hermes doctor       # health check — every line should be green
+```
+
+Code lands in `~/.hermes/hermes-agent/`, the `hermes` command at `~/.local/bin/hermes`, and your data (config, keys, sessions, skills, memory) in `~/.hermes/`.
+
+First run: `hermes` starts the provider wizard. Fastest path is `hermes setup --portal` — one Nous Portal login covers 300+ models plus the Tool Gateway. Already running Hermes elsewhere? `hermes import` restores a full backup.
+
+If you installed CLI-only and want the app later: `hermes desktop` installs and launches Hermes Desktop against your existing config.
+
+## FAQ
+
+**Does Hermes work on Apple Silicon (M1, M2, M3, M4)?** Yes — macOS on Apple Silicon is Tier 1. The installer pulls native arm64 binaries; no Rosetta.
+
+**Does Hermes work on Intel Macs?** No — Intel Macs are explicitly listed as unsupported in the official platform matrix. Use a Linux machine, a VPS, or Docker on other hardware instead.
+
+**Can I install Hermes with Homebrew?** No — `brew install hermes-agent` is an unsupported path per the official docs. Use the Desktop installer or the curl one-liner.
+
+**Should I use the Desktop installer or the curl install?** Desktop installer if you want the app (Nous recommends it as the easy path); curl if you're terminal-only. They share the same agent core, config, and data — and `hermes desktop` upgrades a CLI install to the app any time.
+
+**Is a Mac mini a good always-on Hermes host?** An Apple Silicon Mac mini works well — it's a Tier 1 platform and popular for exactly this. For headless always-on setups, compare the Docker/VPS route in our modes guide.
+
+**How much disk space does it need?** Roughly 200 MB for a fresh install; budget another 100–500 MB for sessions, skills, and memory as you use it.
+
+
+---
+
+# Install Hermes Agent on Linux (/guide/install/linux/)
+
+Canonical URL: https://hermesatlas.com/guide/install/linux/
+
+# How to Install Hermes Agent on Linux (Ubuntu, Debian, Fedora, Arch)
+
+The Linux install guide. Live version: https://hermesatlas.com/guide/install/linux/ — facts sourced from the official docs. Current release is v0.21.0 (as of 2026-08-31).
+
+## TL;DR
+
+One command on any supported distro:
+
+```
+curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+source ~/.bashrc
+hermes
+```
+
+Linux (x86_64 and aarch64) is **Tier 1**. Nous tests on the latest Ubuntu and WSL2; per the official matrix, "if your distro has glibc, systemd, and follows the Filesystem Hierarchy Standard, it's likely to work pretty well."
+
+This guide covers Hermes Agent **v0.21.0**.
+
+## Prerequisites
+
+- **Git**, plus **curl** and **xz-utils** (the installer downloads Node.js as a `.tar.xz`): `sudo apt install git curl xz-utils` on Debian/Ubuntu.
+- For the desktop app only: `build-essential` (g++) to compile native modules.
+- The installer handles the rest with no sudo: `uv`, Python 3.11, Node.js 26, ripgrep, ffmpeg.
+
+## Install layout: per-user vs system-wide
+
+- **Per-user (default):** code at `~/.hermes/hermes-agent/`, launcher symlinked to `~/.local/bin/hermes`, data at `~/.hermes/`.
+- **Root mode** (`curl … | sudo bash`): FHS layout — code at `/usr/local/lib/hermes-agent/`, binary at `/usr/local/bin/hermes`. Useful for shared machines; per-user config still lives in each user's `~/.hermes/`.
+
+## Ubuntu Server / headless / service-user installs
+
+Running Hermes as a dedicated unprivileged user (e.g. a `hermes` systemd service account) is officially supported. The only step that genuinely needs root is Playwright's Chromium system libraries:
+
+1. Once, as an admin: `sudo npx playwright install-deps chromium`.
+2. As the service user, run the normal installer — it detects missing sudo and degrades gracefully. Headless and don't need browser automation? Add `--skip-browser` (and `--skip-computer-use`).
+3. Make sure `~/.local/bin` is on the service user's PATH.
+4. Verify with `hermes doctor`.
+5. Running the messaging gateway from this account? `sudo loginctl enable-linger <service-user>` so the user-level service survives logout and starts at boot.
+
+The same pattern works on Arch, Fedora/RHEL, and openSUSE — those distros don't support Playwright's `--with-deps`, so the installer prints the exact `dnf`/`zypper` commands an admin should run.
+
+## Distro notes
+
+- **Ubuntu / Debian** — the tested reference platform. Fresh minimal cloud image: `apt-get install -y git curl xz-utils` first.
+- **Fedora / RHEL / openSUSE** — supported via the same installer; admin installs Chromium system libraries separately (commands printed by the installer).
+- **Arch** — the installer works (same sudo-detection logic, via pacman). **The AUR package is explicitly unsupported** — use the official installer.
+- **Nix / NixOS** — no longer an explicitly supported install path (Tier 2, best-effort): the official matrix says it "breaks often due to node.js packaging woes." There's a dedicated Nix setup guide with a flake and NixOS module if you accept that tradeoff.
+
+## Updating
+
+`hermes update` auto-detects the git-installer layout and updates in place. (Docker installs update by pulling a new image instead.)
+
+## FAQ
+
+**How do I install Hermes Agent on Ubuntu?** `curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash`, then `source ~/.bashrc`. Ubuntu is the distro Nous tests against.
+
+**Does the installer need sudo?** No for the core install — it's per-user under `~/.hermes/`. Root is only needed once for Playwright's Chromium system libraries (or skip browser tools with `--skip-browser`).
+
+**Which distros are supported?** Latest Ubuntu and WSL2 are tested; anything with glibc, systemd, and FHS is expected to work. Alpine (musl) doesn't fit that description.
+
+**Can I install from the AUR on Arch?** No — AUR installs are explicitly unsupported. Run the official installer on Arch instead.
+
+**How do I keep the gateway running on a server?** Install as a service user, run `hermes gateway setup` (it offers a systemd user unit), and enable lingering: `sudo loginctl enable-linger <user>`.
+
+**What about NixOS?** Tier 2 / best-effort — there's an extensive official Nix guide, but releases may break it. Docker or an FHS distro is the supported path.
+
+
+---
+
+# Install Hermes Agent on a Raspberry Pi (/guide/install/raspberry-pi/)
+
+Canonical URL: https://hermesatlas.com/guide/install/raspberry-pi/
+
+# How to Install Hermes Agent on a Raspberry Pi (4 & 5)
+
+The Raspberry Pi install guide. Live version: https://hermesatlas.com/guide/install/raspberry-pi/ — facts sourced from the official docs. Current release is v0.21.0 (as of 2026-08-31).
+
+## TL;DR
+
+Yes, Hermes Agent runs on a Raspberry Pi — there's no Pi-specific build because none is needed: **Linux on aarch64 is Tier 1**, and so is the official Docker image on aarch64. A Pi 4 or Pi 5 with **4+ GB RAM** running a **64-bit OS** (Raspberry Pi OS 64-bit or Ubuntu Server) is the sweet spot. Two install paths:
+
+1. **Direct install** (simplest): the standard Linux one-liner on Raspberry Pi OS 64-bit — `curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash`.
+2. **Docker** (best for always-on): `docker run` the official `nousresearch/hermes-agent` image (published for aarch64), with s6-supervised gateway auto-restart.
+
+The practical constraint isn't Hermes — it's the model. Pair the Pi with a hosted API (Nous Portal, Anthropic, OpenAI) and the agent host stays lightweight; don't plan on running local LLM inference on the Pi itself.
+
+This guide covers Hermes Agent **v0.21.0**.
+
+## Hardware requirements
+
+- **64-bit (aarch64) OS is required** — official support is for aarch64 Linux; use Raspberry Pi OS **64-bit** or Ubuntu Server 64-bit, not a 32-bit (armv7) image.
+- **Pi 4 / Pi 5 with 4 GB+ RAM recommended.** Docker minimums from the official docs: 1 GB RAM / 1 core, 2–4 GB recommended — browser automation (Playwright/Chromium) is the most memory-hungry feature; skip it (`--skip-browser`) on smaller Pis.
+- A Pi 3 technically has an aarch64 CPU but only 1 GB RAM — enough for a gateway-only setup without browser tools, but tight. Pi Zero–class boards are not realistic hosts.
+- Disk: ~200 MB for the install, plus 500 MB–2 GB+ as sessions and skills grow. Use a quality SD card or, better, USB/NVMe boot.
+
+## Path 1 — direct install on Raspberry Pi OS
+
+Raspberry Pi OS 64-bit is Debian-based, so the Pi is just a Tier-1 Linux aarch64 box:
+
+```
+sudo apt install -y git curl xz-utils
+curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+source ~/.bashrc
+hermes version   # prints v0.21.0 (or newer)
+```
+
+For an always-on Telegram/Discord bot: `hermes gateway setup` (offers a systemd user unit) and `sudo loginctl enable-linger <user>` so the gateway survives logout and starts at boot. Headless Pi? Add `--skip-browser` to the installer to skip Chromium entirely.
+
+## Path 2 — Docker (recommended for set-and-forget)
+
+The official image is published for aarch64 and supervises the gateway with s6 (auto-restart on crash):
+
+```
+mkdir -p ~/.hermes
+docker run -it --rm -v ~/.hermes:/opt/data nousresearch/hermes-agent setup
+docker run -d --name hermes --restart unless-stopped \
+  -v ~/.hermes:/opt/data -p 8642:8642 \
+  nousresearch/hermes-agent gateway run
+```
+
+Updating is `docker pull` + recreate (Docker installs intentionally don't support `hermes update`). Never run two gateway containers against the same data directory.
+
+## What people actually run on Pis
+
+Community reports in our user-story corpus include a Raspberry Pi 5 running Hermes 24/7 as an always-on personal agent and Pi-hosted gateways on residential IPs. Treat these as community anecdotes rather than official benchmarks — but they match what the Tier-1 aarch64 support implies.
+
+## FAQ
+
+**Can Hermes Agent run on a Raspberry Pi 5?** Yes — aarch64 Linux and aarch64 Docker are both Tier 1. A Pi 5 (4 or 8 GB) handles the agent, gateway, and cron comfortably with a hosted model API.
+
+**Can it run on a Raspberry Pi 4?** Yes — same paths. Prefer the 4 GB or 8 GB model; on 2 GB, skip browser tools.
+
+**What about a Raspberry Pi 3?** Borderline: it's aarch64 but has 1 GB RAM — the documented Docker minimum with no headroom. Gateway-only without browser tools can work; expect swap pressure.
+
+**Do I need a 64-bit OS?** Yes. Official support targets aarch64; install Raspberry Pi OS 64-bit or Ubuntu Server 64-bit, not the 32-bit image.
+
+**Can the Pi run the model locally?** Not realistically — pair Hermes on the Pi with a hosted API (Nous Portal, Anthropic, OpenAI) or a model server on beefier hardware on your LAN.
+
+**Docker or direct install on the Pi?** Docker for set-and-forget uptime (supervised auto-restart, clean upgrades by pulling a new image); direct install for the lightest footprint and `hermes update`.
+
+
+---
+
+# Install Hermes Agent on a VPS (/guide/install/vps/)
+
+Canonical URL: https://hermesatlas.com/guide/install/vps/
+
+# How to Install Hermes Agent on a VPS (Always-On Server Setup)
+
+The VPS/server install guide. Live version: https://hermesatlas.com/guide/install/vps/ — facts sourced from the official docs. Current release is v0.21.0 (as of 2026-08-31).
+
+## TL;DR
+
+A **$5 VPS (1 CPU, 1 GB RAM)** is enough to run Hermes as an always-on agent — Telegram/Discord bot, cron jobs, remote backend for Hermes Desktop — as long as the model is a hosted API (Nous Portal, Anthropic, OpenAI), not local inference. Recommended path: **Docker** (`nousresearch/hermes-agent`, Tier 1 on x86_64 and aarch64) with `--restart unless-stopped`; the image's s6 supervisor auto-restarts a crashed gateway. Direct install works too via the standard Linux one-liner.
+
+**Connect over SSH, not your provider's browser console** — official docs warn that browser-based VPS consoles (Hetzner Cloud and others) mis-transmit characters like `:` and `@`, silently corrupting `docker run -v/-e` arguments and pasted API keys.
+
+This guide covers Hermes Agent **v0.21.0**.
+
+## Sizing
+
+From the official Docker resource table: minimum 1 GB RAM / 1 core / 500 MB disk; recommended 2–4 GB RAM / 2 cores / 2 GB+ disk. Browser automation (Playwright/Chromium) is the most memory-hungry feature — a 1 GB box is fine if you skip it. Any glibc/systemd/FHS distro is likely to work; Ubuntu is the tested reference.
+
+## Path A — Docker (recommended)
+
+```
+ssh root@<your-vps>
+mkdir -p ~/.hermes
+docker run -it --rm -v ~/.hermes:/opt/data nousresearch/hermes-agent setup
+docker run -d --name hermes --restart unless-stopped \
+  -v ~/.hermes:/opt/data -p 8642:8642 \
+  nousresearch/hermes-agent gateway run
+```
+
+All state lives in the mounted `~/.hermes` — the container is stateless, so upgrading is `docker pull` + recreate (no `hermes update` in Docker, by design). One container can host multiple profiles (the officially recommended pattern), each gateway s6-supervised with per-profile rotated logs. Never point two gateway containers at one data directory.
+
+## Path B — direct install (service user)
+
+The standard installer, run as a dedicated unprivileged user: `curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash` (add `--skip-browser` on headless boxes to skip Chromium). One-time admin step for browser tools: `sudo npx playwright install-deps chromium`. Then `hermes gateway setup` (installs a systemd user unit) and `sudo loginctl enable-linger <user>` so the gateway starts at boot and survives logout.
+
+## Security: the part people get wrong
+
+Exposing the dashboard or API server on a VPS means a non-loopback bind, and that **engages a mandatory auth gate** — unauthenticated public dashboards were the entry point for a real June 2026 attack campaign (internet scanners drove exposed agents into planting SSH-key backdoors), and the old `--insecure` escape hatch is now a deprecated no-op. Official guidance:
+
+- **OAuth via Nous Portal** for anything reachable from the public internet.
+- **Username/password** only on a trusted LAN or VPN (e.g. Tailscale).
+- Or bind to `127.0.0.1` and reach the dashboard over an SSH tunnel — no public exposure at all.
+- The gateway's OpenAI-compatible API server is off by default; enabling it beyond loopback requires `API_SERVER_KEY`.
+
+## Using the VPS from your desktop and phone
+
+- **Hermes Desktop** connects to the VPS as a remote gateway: keep `hermes serve` running on the VPS (systemd), then add it under Settings → Gateways in the app — OAuth (Nous Portal) is the preferred provider for a VPS backend. One connection serves every profile on the box.
+- **Phone**: configure the messaging gateway (`hermes gateway setup`) and talk to your agent over Telegram/Discord/WhatsApp — the reason most people put Hermes on a VPS in the first place.
+
+## FAQ
+
+**How small a VPS can run Hermes Agent?** 1 GB RAM / 1 core is the documented minimum (without browser tools); 2–4 GB recommended. The typical $5 tier works with a hosted model API.
+
+**Which provider should I use?** Any standard Ubuntu/Debian VPS works — Hermes has no provider-specific requirements. Whatever you pick, do the install over SSH: official docs warn that browser-based VPS consoles (e.g. Hetzner's) corrupt special characters in pasted commands.
+
+**Docker or direct install on a VPS?** Docker for supervised auto-restart and clean image-based upgrades; direct install if you want `hermes update` and the lightest footprint.
+
+**Is it safe to expose the Hermes dashboard on a VPS?** Only behind the mandatory auth gate — OAuth (Nous Portal) for public reachability; username/password strictly for LAN/VPN; or keep it loopback-only behind an SSH tunnel. `--insecure` no longer bypasses anything.
+
+**Can Hermes Desktop connect to my VPS?** Yes — run `hermes serve` on the VPS and add it as a remote gateway in Desktop's Settings → Gateways, protected by OAuth.
+
+**How do I update Hermes on the VPS?** Docker: `docker pull nousresearch/hermes-agent:latest`, then recreate the container (data persists in `~/.hermes`). Direct install: `hermes update`.
+
 
 ---
 
@@ -2365,7 +2664,7 @@ Skills that connect Hermes to personal infrastructure like self-hosted Nextcloud
 URL: https://hermesatlas.com/projects/obra/superpowers
 GitHub: https://github.com/obra/superpowers
 Category: Skills & Skill Registries
-Stars: 280,052
+Stars: 280,057
 An agentic skills framework & software development methodology that works.
 
 Superpowers is a software development methodology and agentic skills framework designed for coding agents. It implements a workflow where agents refine user requirements into specifications, generate implementation plans, and execute tasks through a subagent-driven development process.
@@ -2382,7 +2681,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/NousResearch/hermes-agent
 GitHub: https://github.com/NousResearch/hermes-agent
 Category: Core & Official
-Stars: 238,978
+Stars: 238,983
 Official: Yes (maintained by Nous Research)
 The self-improving AI agent that grows with you — persistent memory, auto-generated skills, 14 platforms, 6 execution backends
 
@@ -2400,7 +2699,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/farion1231/cc-switch
 GitHub: https://github.com/farion1231/cc-switch
 Category: Workspaces & GUIs
-Stars: 130,392
+Stars: 130,391
 Cross-platform all-in-one manager for Claude Code, Codex, OpenCode, OpenClaw, Gemini CLI, and Hermes Agent
 
 CC Switch is a cross-platform manager built with Tauri 2 for Windows, macOS, and Linux. It provides a centralized interface for configuring and switching between various agentic tools and command-line interfaces, including Claude Code, Codex, Gemini CLI, and Hermes Agent.
@@ -2417,7 +2716,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/TauricResearch/TradingAgents
 GitHub: https://github.com/TauricResearch/TradingAgents
 Category: Multi-Agent & Orchestration
-Stars: 102,011
+Stars: 102,014
 TradingAgents: Multi-Agents LLM Financial Trading Framework
 
 TradingAgents is a multi-agent framework that uses specialized LLM-powered agents to evaluate market conditions and inform trading decisions. The system mirrors real-world trading firms by deploying teams of analysts, researchers, and managers to collaboratively develop strategies through structured debates and reports.
@@ -2434,7 +2733,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/nexu-io/open-design
 GitHub: https://github.com/nexu-io/open-design
 Category: Skills & Skill Registries
-Stars: 93,060
+Stars: 93,065
 Local-first open-source design/prototyping system with coding-agent CLI support including Hermes Agent
 
 OpenDesign is a local-first desktop application for macOS and Windows designed for prototyping and design system management. It functions as an open-source alternative to Claude Design, allowing users to generate web, mobile, and deck artifacts using various AI agents and design systems.
@@ -2451,7 +2750,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/colbymchenry/codegraph
 GitHub: https://github.com/colbymchenry/codegraph
 Category: Developer Tools
-Stars: 68,845
+Stars: 68,844
 Local pre-indexed code knowledge graph for Hermes Agent and other coding agents to reduce token usage and tool calls
 
 CodeGraph is a local code intelligence tool that builds a semantic graph of a project to provide context for AI agents. It uses a Rust-powered kernel to index code and automatically updates the graph as files are modified.
@@ -2468,7 +2767,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/mem0ai/mem0
 GitHub: https://github.com/mem0ai/mem0
 Category: Memory & Context
-Stars: 64,446
+Stars: 64,445
 Universal memory layer for AI Agents — official Hermes Agent memory provider, available as managed cloud or Apache-2.0 self-hosted OSS
 
 Mem0 is an intelligent memory layer designed to provide AI assistants and agents with personalized, long-term context. It utilizes a multi-level memory architecture—covering User, Session, and Agent states—and employs a single-pass extraction algorithm with temporal reasoning and multi-signal retrieval. The project is available as an open-source SDK via pip and npm, a self-hosted Docker deployment, or a managed cloud platform.
@@ -2485,7 +2784,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/volcengine/OpenViking
 GitHub: https://github.com/volcengine/OpenViking
 Category: Memory & Context
-Stars: 34,688
+Stars: 34,695
 Open-source context database for AI agents — official Hermes Agent memory provider using viking:// URIs and tiered L0/L1/L2 loading; 91% token reduction and 43-49% task-completion gain over baseline on LoCoMo10. AGPL-3.0.
 
 OpenViking is an open-source context database that organizes AI agent memories, resources, and skills into a virtual filesystem using the viking:// protocol. It employs a tiered loading system (L0, L1, and L2) to process content into abstracts, overviews, and full details for on-demand retrieval.
@@ -2519,7 +2818,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/mukul975/Anthropic-Cybersecurity-Skills
 GitHub: https://github.com/mukul975/Anthropic-Cybersecurity-Skills
 Category: Skills & Skill Registries
-Stars: 31,835
+Stars: 31,836
 754 structured cybersecurity skills mapped to MITRE ATT&CK, NIST CSF 2.0, ATLAS, D3FEND & NIST AI RMF
 
 Anthropic-Cybersecurity-Skills is an open-source library containing 818 structured cybersecurity skills designed for AI agents. The repository maps these skills across six industry frameworks, including MITRE ATT&CK, NIST CSF 2.0, and MITRE ATLAS, following the agentskills.io open standard.
@@ -2536,7 +2835,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/topoteretes/cognee
 GitHub: https://github.com/topoteretes/cognee
 Category: Memory & Context
-Stars: 30,374
+Stars: 30,373
 Cognee is the open-source AI memory platform for agents. Give your AI agents persistent long-term memory across sessions with a self-hosted knowledge graph engine.
 
 Cognee is an open-source AI memory platform that provides agents with persistent long-term memory across sessions by building self-hosted knowledge graphs. The system combines vector embeddings, graph reasoning, and ontology generation to process data from various formats into searchable and connected relationships.
@@ -2553,7 +2852,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/garrytan/gbrain
 GitHub: https://github.com/garrytan/gbrain
 Category: Memory & Context
-Stars: 29,368
+Stars: 29,369
 Garry's Opinionated OpenClaw/Hermes Agent Brain
 
 GBrain is a synthesis and memory layer for AI agents that combines graph traversal with gap analysis to provide cited answers from ingested data. It functions as a background daemon for consolidating information across people, companies, and ideas while maintaining scoped access for team environments.
@@ -2570,7 +2869,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/supermemoryai/supermemory
 GitHub: https://github.com/supermemoryai/supermemory
 Category: Memory & Context
-Stars: 29,168
+Stars: 29,167
 Memory engine and API — official Hermes Agent memory provider with sub-300ms recall sustained at 100B+ tokens/month, custom vector graph engine, context fencing, and byte-level dedupe with 100% prompt-cache discount.
 
 Supermemory is a memory and context engine for AI that manages user profiles, knowledge updates, and conversation history. It provides a single API for memory, RAG, and file processing, and supports various clients through an MCP server and plugins.
@@ -2587,7 +2886,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/vectorize-io/hindsight
 GitHub: https://github.com/vectorize-io/hindsight
 Category: Memory & Context
-Stars: 22,018
+Stars: 22,017
 Official: Yes (maintained by Nous Research)
 Agent memory that learns — long-term retain/recall/reflect workflows
 
@@ -2605,7 +2904,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/nesquena/hermes-webui
 GitHub: https://github.com/nesquena/hermes-webui
 Category: Workspaces & GUIs
-Stars: 17,935
+Stars: 17,936
 Hermes WebUI: The best way to use Hermes Agent from the web or from your phone!
 
 Hermes WebUI is a lightweight, dark-themed web interface for the Hermes Agent. It provides a three-panel layout with a chat center, session navigation sidebar, and workspace file browser, offering parity with the Hermes CLI experience.
@@ -2656,7 +2955,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/Agents365-ai/drawio-skill
 GitHub: https://github.com/Agents365-ai/drawio-skill
 Category: Skills & Skill Registries
-Stars: 8,872
+Stars: 8,876
 Generate draw.io diagrams from natural language descriptions
 
 This skill converts natural-language descriptions into.drawio XML and exports them to PNG, SVG, PDF, or JPG using the draw.io desktop CLI. It can generate diagrams from codebases, infrastructure configurations, and SQL schemas.
@@ -2759,7 +3058,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/NousResearch/hermes-agent-self-evolution
 GitHub: https://github.com/NousResearch/hermes-agent-self-evolution
 Category: Core & Official
-Stars: 5,211
+Stars: 5,210
 Official: Yes (maintained by Nous Research)
 Evolutionary self-improvement using DSPy + GEPA — optimizes skills, prompts, and code
 
@@ -2828,7 +3127,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/conorbronsdon/avoid-ai-writing
 GitHub: https://github.com/conorbronsdon/avoid-ai-writing
 Category: Skills & Skill Registries
-Stars: 3,884
+Stars: 3,886
 Audits and rewrites content to eliminate detectable AI writing patterns
 
 avoid-ai-writing is a portable skill for AI agents that audits and rewrites content to eliminate detectable AI writing patterns. It utilizes a structured two-pass detection system with a 112-entry word replacement table and 69 pattern categories to identify and fix specific linguistic tells.
@@ -2862,7 +3161,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/liaohch3/claude-tap
 GitHub: https://github.com/liaohch3/claude-tap
 Category: Developer Tools
-Stars: 3,155
+Stars: 3,154
 Local trace viewer for inspecting coding-agent API traffic from Hermes Agent, Claude Code, Codex, Gemini, Cursor, OpenCode, and others
 
 claude-tap is a local proxy and trace viewer designed to inspect API traffic and agent context for AI coding agents. It allows users to view system prompts, conversation history, tool schemas, and token usage while keeping traces on the local machine.
@@ -3049,7 +3348,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/Eynzof/Hermes-CN-Desktop
 GitHub: https://github.com/Eynzof/Hermes-CN-Desktop
 Category: Workspaces & GUIs
-Stars: 1,645
+Stars: 1,644
 Windows-first Chinese desktop app for Hermes Agent built with Tauri, TypeScript, and Rust
 
 Hermes Agent CN Desktop is a cross-platform client for the Hermes Agent Chinese community, built with Tauri, Rust, React, and TypeScript. It provides a native shell for the Hermes-CN-Core kernel, featuring local process management, runtime diagnostics, and a production-grade REST and WebSocket proxy layer.
@@ -3153,7 +3452,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/greyhaven-ai/autocontext
 GitHub: https://github.com/greyhaven-ai/autocontext
 Category: Memory & Context
-Stars: 1,289
+Stars: 1,290
 Recursive self-improving context harness — helps agents succeed on complex tasks
 
 autocontext is a harness for agent improvement that executes tasks against evaluations to capture useful lessons while discarding ineffective approaches. It generates traces, reports, playbooks, and datasets that can be used for future agent iterations or local-model training.
@@ -3374,7 +3673,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/jwangkun/hermes-agent-guide
 GitHub: https://github.com/jwangkun/hermes-agent-guide
 Category: Guides & Docs
-Stars: 662
+Stars: 663
 A systematic Chinese-language guide to Hermes Agent — 16 books, 300K+ words, covering installation, advanced development, single- and multi-agent orchestration.
 
 This project is a comprehensive Chinese-language guide designed to provide a systematic learning path for the Hermes Agent framework. It organizes fragmented documentation into 16 volumes covering the system's five-layer architecture, memory systems, and skill ecosystems. The guide includes practical tutorials for installation, MCP protocol integration, and multi-agent orchestration. It also provides specific migration paths for OpenClaw users and strategies for commercial application.
@@ -4224,7 +4523,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/Sibyl-Labs/Sibyl-Memory
 GitHub: https://github.com/Sibyl-Labs/Sibyl-Memory
 Category: Memory & Context
-Stars: 109
+Stars: 110
 Durable, file-based long-term memory for AI agents. Five-package plugin family: SDK, CLI, MCP server, Hermes adapter, and a LangGraph BaseStore. No vector database, no embeddings.
 
 Sibyl-Memory is a file-based agentic memory infrastructure that uses a SQLite-backed, five-tier hierarchical schema. It provides a suite of five PyPI packages including an SDK, CLI, MCP server, Hermes adapter, and a LangGraph BaseStore adapter. The system operates without vector databases or embedding models.
@@ -4360,7 +4659,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/sheawinkler/hermes-agent-ultra
 GitHub: https://github.com/sheawinkler/hermes-agent-ultra
 Category: Forks & Derivatives
-Stars: 85
+Stars: 86
 Rust-based Hermes Agent Ultra derivative focused on performance and Hermes Agent feature parity
 
 Hermes Agent Ultra is a Rust-based autonomous agent runtime designed to provide feature parity with the original Hermes Agent while adding enhanced reliability and operator control. It achieves this through a fully Rust-native core that implements deterministic execution paths and a dedicated safety policy engine. The project offers advanced session management features like time-travel debugging and provides extensive support for local and self-hosted inference backends. It is optimized for production operations through deep diagnostics, observability tools, and automated parity synchronization.
@@ -4394,7 +4693,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/topoteretes/cognee-integrations
 GitHub: https://github.com/topoteretes/cognee-integrations
 Category: Developer Tools
-Stars: 84
+Stars: 83
 No description
 
 Cognee Integrations is a monorepo containing integration packages that provide a persistent memory layer for various agent frameworks. These integrations utilize a permanent knowledge graph and a session cache backed by cognee.
@@ -4411,7 +4710,7 @@ Highlights:
 URL: https://hermesatlas.com/projects/longsizhuo/openInvest
 GitHub: https://github.com/longsizhuo/openInvest
 Category: Domain Applications
-Stars: 83
+Stars: 82
 基于multiple LLM的风险投资助手
 
 openInvest is a self-hosted investment decision engine designed to power AI agents. It provides a verifiable investment committee with evidence-based reasoning and auditable decision records to reduce human cognitive biases.

--- a/llms.txt
+++ b/llms.txt
@@ -6,7 +6,12 @@ Hermes Atlas tracks every open-source project in the Hermes Agent ecosystem acro
 
 ## Guide
 - [Beginner's Guide to Hermes Agent](https://hermesatlas.com/guide/): Install, pick a model, ship your first workflow, with the best community tool for every step.
-- [Install Hermes Agent](https://hermesatlas.com/guide/install/): Step-by-step install for macOS, Linux, Windows, and WSL, with troubleshooting.
+- [Install Hermes Agent](https://hermesatlas.com/guide/install/): Step-by-step install for every platform, with troubleshooting.
+- [Install on Windows 10/11](https://hermesatlas.com/guide/install/windows/): Native PowerShell (Tier 1, no admin), the Desktop installer, or WSL2 — with the official guidance on which to pick.
+- [Install on macOS](https://hermesatlas.com/guide/install/macos/): Desktop installer or curl one-liner — Apple Silicon only; Intel Macs and brew installs are unsupported.
+- [Install on Linux](https://hermesatlas.com/guide/install/linux/): Ubuntu, Debian, Fedora, Arch — plus the headless server and systemd service-user recipe.
+- [Install on a Raspberry Pi](https://hermesatlas.com/guide/install/raspberry-pi/): Pi 4/5 with a 64-bit OS — direct install or the official aarch64 Docker image.
+- [Install on a VPS](https://hermesatlas.com/guide/install/vps/): The always-on server setup — sizing, Docker vs direct, and the mandatory-auth security guidance.
 - [The Hermes Agent Memory Guidebook](https://hermesatlas.com/guide/memory/): Kevin Simback's guide to native memory, MemoryProviders, and community memory plug-ins.
 - [How to Run Hermes Agent: Desktop vs CLI vs Docker/VPS vs Bot Gateway](https://hermesatlas.com/guide/modes/): Every way to run Hermes compared — front-ends share state; the real decision is where the agent lives.
 - [Hermes Desktop: The Complete Guide](https://hermesatlas.com/guide/desktop/): Install on macOS/Windows/Linux, desktop-only features, plugins, remote/VPS connections, and known rough edges.
@@ -33,21 +38,21 @@ A hands-on developer tutorial for building on the Hermes Agent codebase, written
 - [The full ecosystem catalog](https://hermesatlas.com/ecosystem/): All 247 tracked projects across 12 categories on one page, with live GitHub data.
 
 ## Top Projects
-- [obra/superpowers](https://hermesatlas.com/projects/obra/superpowers): An agentic skills framework & software development methodology that works. (280,052 stars)
-- [NousResearch/hermes-agent](https://hermesatlas.com/projects/NousResearch/hermes-agent): The self-improving AI agent that grows with you — persistent memory, auto-generated skills, 14 platforms, 6 execution backends (238,978 stars, official)
-- [farion1231/cc-switch](https://hermesatlas.com/projects/farion1231/cc-switch): Cross-platform all-in-one manager for Claude Code, Codex, OpenCode, OpenClaw, Gemini CLI, and Hermes Agent (130,392 stars)
-- [TauricResearch/TradingAgents](https://hermesatlas.com/projects/TauricResearch/TradingAgents): TradingAgents: Multi-Agents LLM Financial Trading Framework (102,011 stars)
-- [nexu-io/open-design](https://hermesatlas.com/projects/nexu-io/open-design): Local-first open-source design/prototyping system with coding-agent CLI support including Hermes Agent (93,060 stars)
-- [colbymchenry/codegraph](https://hermesatlas.com/projects/colbymchenry/codegraph): Local pre-indexed code knowledge graph for Hermes Agent and other coding agents to reduce token usage and tool calls (68,845 stars)
-- [mem0ai/mem0](https://hermesatlas.com/projects/mem0ai/mem0): Universal memory layer for AI Agents — official Hermes Agent memory provider, available as managed cloud or Apache-2.0 self-hosted OSS (64,446 stars)
-- [volcengine/OpenViking](https://hermesatlas.com/projects/volcengine/OpenViking): Open-source context database for AI agents — official Hermes Agent memory provider using viking:// URIs and tiered L0/L1/L2 loading; 91% token reduction and 43-49% task-completion gain over baseline on LoCoMo10. AGPL-3.0. (34,688 stars)
+- [obra/superpowers](https://hermesatlas.com/projects/obra/superpowers): An agentic skills framework & software development methodology that works. (280,057 stars)
+- [NousResearch/hermes-agent](https://hermesatlas.com/projects/NousResearch/hermes-agent): The self-improving AI agent that grows with you — persistent memory, auto-generated skills, 14 platforms, 6 execution backends (238,983 stars, official)
+- [farion1231/cc-switch](https://hermesatlas.com/projects/farion1231/cc-switch): Cross-platform all-in-one manager for Claude Code, Codex, OpenCode, OpenClaw, Gemini CLI, and Hermes Agent (130,391 stars)
+- [TauricResearch/TradingAgents](https://hermesatlas.com/projects/TauricResearch/TradingAgents): TradingAgents: Multi-Agents LLM Financial Trading Framework (102,014 stars)
+- [nexu-io/open-design](https://hermesatlas.com/projects/nexu-io/open-design): Local-first open-source design/prototyping system with coding-agent CLI support including Hermes Agent (93,065 stars)
+- [colbymchenry/codegraph](https://hermesatlas.com/projects/colbymchenry/codegraph): Local pre-indexed code knowledge graph for Hermes Agent and other coding agents to reduce token usage and tool calls (68,844 stars)
+- [mem0ai/mem0](https://hermesatlas.com/projects/mem0ai/mem0): Universal memory layer for AI Agents — official Hermes Agent memory provider, available as managed cloud or Apache-2.0 self-hosted OSS (64,445 stars)
+- [volcengine/OpenViking](https://hermesatlas.com/projects/volcengine/OpenViking): Open-source context database for AI agents — official Hermes Agent memory provider using viking:// URIs and tiered L0/L1/L2 loading; 91% token reduction and 43-49% task-completion gain over baseline on LoCoMo10. AGPL-3.0. (34,695 stars)
 - [iOfficeAI/AionUi](https://hermesatlas.com/projects/iOfficeAI/AionUi): Local open-source cowork app for OpenClaw, Hermes Agent, Claude Code, Codex, OpenCode, Gemini CLI, and other agent CLIs (32,463 stars)
-- [mukul975/Anthropic-Cybersecurity-Skills](https://hermesatlas.com/projects/mukul975/Anthropic-Cybersecurity-Skills): 754 structured cybersecurity skills mapped to MITRE ATT&CK, NIST CSF 2.0, ATLAS, D3FEND & NIST AI RMF (31,835 stars)
-- [topoteretes/cognee](https://hermesatlas.com/projects/topoteretes/cognee): Cognee is the open-source AI memory platform for agents. Give your AI agents persistent long-term memory across sessions with a self-hosted knowledge graph engine. (30,374 stars)
-- [garrytan/gbrain](https://hermesatlas.com/projects/garrytan/gbrain): Garry's Opinionated OpenClaw/Hermes Agent Brain (29,368 stars)
-- [supermemoryai/supermemory](https://hermesatlas.com/projects/supermemoryai/supermemory): Memory engine and API — official Hermes Agent memory provider with sub-300ms recall sustained at 100B+ tokens/month, custom vector graph engine, context fencing, and byte-level dedupe with 100% prompt-cache discount. (29,168 stars)
-- [vectorize-io/hindsight](https://hermesatlas.com/projects/vectorize-io/hindsight): Agent memory that learns — long-term retain/recall/reflect workflows (22,018 stars, official)
-- [nesquena/hermes-webui](https://hermesatlas.com/projects/nesquena/hermes-webui): Hermes WebUI: The best way to use Hermes Agent from the web or from your phone! (17,935 stars)
+- [mukul975/Anthropic-Cybersecurity-Skills](https://hermesatlas.com/projects/mukul975/Anthropic-Cybersecurity-Skills): 754 structured cybersecurity skills mapped to MITRE ATT&CK, NIST CSF 2.0, ATLAS, D3FEND & NIST AI RMF (31,836 stars)
+- [topoteretes/cognee](https://hermesatlas.com/projects/topoteretes/cognee): Cognee is the open-source AI memory platform for agents. Give your AI agents persistent long-term memory across sessions with a self-hosted knowledge graph engine. (30,373 stars)
+- [garrytan/gbrain](https://hermesatlas.com/projects/garrytan/gbrain): Garry's Opinionated OpenClaw/Hermes Agent Brain (29,369 stars)
+- [supermemoryai/supermemory](https://hermesatlas.com/projects/supermemoryai/supermemory): Memory engine and API — official Hermes Agent memory provider with sub-300ms recall sustained at 100B+ tokens/month, custom vector graph engine, context fencing, and byte-level dedupe with 100% prompt-cache discount. (29,167 stars)
+- [vectorize-io/hindsight](https://hermesatlas.com/projects/vectorize-io/hindsight): Agent memory that learns — long-term retain/recall/reflect workflows (22,017 stars, official)
+- [nesquena/hermes-webui](https://hermesatlas.com/projects/nesquena/hermes-webui): Hermes WebUI: The best way to use Hermes Agent from the web or from your phone! (17,936 stars)
 
 ## Curated Lists
 - [Best Memory Providers for Hermes Agent](https://hermesatlas.com/lists/best-memory-providers): The top community-built memory and context management tools for Hermes Agent, ranked by GitHub stars. Memory is what makes Hermes self-improving — these tools extend its built-in r

--- a/scripts/build-chunks.js
+++ b/scripts/build-chunks.js
@@ -73,6 +73,11 @@ async function main() {
     { file: "guide-memory.md", source: "guide/memory/" },
     { file: "guide-modes.md", source: "guide/modes/" },
     { file: "guide-desktop.md", source: "guide/desktop/" },
+    { file: "guide-install-windows.md", source: "guide/install/windows/" },
+    { file: "guide-install-macos.md", source: "guide/install/macos/" },
+    { file: "guide-install-linux.md", source: "guide/install/linux/" },
+    { file: "guide-install-raspberry-pi.md", source: "guide/install/raspberry-pi/" },
+    { file: "guide-install-vps.md", source: "guide/install/vps/" },
   ];
   for (const g of guideSources) {
     const filePath = path.join(ROOT, "drafts", g.file);

--- a/scripts/build-pages.js
+++ b/scripts/build-pages.js
@@ -659,7 +659,12 @@ Hermes Atlas tracks every open-source project in the Hermes Agent ecosystem acro
 
 ## Guide
 - [Beginner's Guide to Hermes Agent](${SITE_URL}/guide/): Install, pick a model, ship your first workflow, with the best community tool for every step.
-- [Install Hermes Agent](${SITE_URL}/guide/install/): Step-by-step install for macOS, Linux, Windows, and WSL, with troubleshooting.
+- [Install Hermes Agent](${SITE_URL}/guide/install/): Step-by-step install for every platform, with troubleshooting.
+- [Install on Windows 10/11](${SITE_URL}/guide/install/windows/): Native PowerShell (Tier 1, no admin), the Desktop installer, or WSL2 — with the official guidance on which to pick.
+- [Install on macOS](${SITE_URL}/guide/install/macos/): Desktop installer or curl one-liner — Apple Silicon only; Intel Macs and brew installs are unsupported.
+- [Install on Linux](${SITE_URL}/guide/install/linux/): Ubuntu, Debian, Fedora, Arch — plus the headless server and systemd service-user recipe.
+- [Install on a Raspberry Pi](${SITE_URL}/guide/install/raspberry-pi/): Pi 4/5 with a 64-bit OS — direct install or the official aarch64 Docker image.
+- [Install on a VPS](${SITE_URL}/guide/install/vps/): The always-on server setup — sizing, Docker vs direct, and the mandatory-auth security guidance.
 - [The Hermes Agent Memory Guidebook](${SITE_URL}/guide/memory/): Kevin Simback's guide to native memory, MemoryProviders, and community memory plug-ins.
 - [How to Run Hermes Agent: Desktop vs CLI vs Docker/VPS vs Bot Gateway](${SITE_URL}/guide/modes/): Every way to run Hermes compared — front-ends share state; the real decision is where the agent lives.
 - [Hermes Desktop: The Complete Guide](${SITE_URL}/guide/desktop/): Install on macOS/Windows/Linux, desktop-only features, plugins, remote/VPS connections, and known rough edges.
@@ -751,6 +756,19 @@ This file is the companion to ${SITE_URL}/llms.txt (the concise index).`);
     const stripped = stripHtmlToText(installHtml);
     if (stripped) sections.push(`# Install Hermes Agent (/guide/install/)\n\nCanonical URL: ${SITE_URL}/guide/install/\n\n${stripped}`);
   } catch {}
+
+  for (const [draftFile, title, urlPath] of [
+    ["guide-install-windows.md", "Install Hermes Agent on Windows 10/11", "guide/install/windows/"],
+    ["guide-install-macos.md", "Install Hermes Agent on macOS", "guide/install/macos/"],
+    ["guide-install-linux.md", "Install Hermes Agent on Linux", "guide/install/linux/"],
+    ["guide-install-raspberry-pi.md", "Install Hermes Agent on a Raspberry Pi", "guide/install/raspberry-pi/"],
+    ["guide-install-vps.md", "Install Hermes Agent on a VPS", "guide/install/vps/"],
+  ]) {
+    try {
+      const draft = fs.readFileSync(path.join(ROOT, "drafts", draftFile), "utf-8");
+      sections.push(`# ${title} (/${urlPath})\n\nCanonical URL: ${SITE_URL}/${urlPath}\n\n${draft}`);
+    } catch {}
+  }
 
   try {
     const memoryDraft = fs.readFileSync(path.join(ROOT, "drafts", "guide-memory.md"), "utf-8");
@@ -2412,10 +2430,17 @@ function generateSitemap(projectPages, listPages, reportPages = [], useCasePages
   let urls = entry("/", "index.html", "daily", "1.0");
 
   urls += entry("/guide/", "guide/index.html", "monthly", "0.9");
-  const guideSlugs = fs.readdirSync(path.join(ROOT, "guide"), { withFileTypes: true })
-    .filter((d) => d.isDirectory() && fs.existsSync(path.join(ROOT, "guide", d.name, "index.html")))
-    .map((d) => d.name)
-    .sort();
+  const guideSlugs = [];
+  const collectGuideSlugs = (relDir) => {
+    for (const d of fs.readdirSync(path.join(ROOT, "guide", relDir), { withFileTypes: true })) {
+      if (!d.isDirectory()) continue;
+      const slug = relDir ? `${relDir}/${d.name}` : d.name;
+      if (fs.existsSync(path.join(ROOT, "guide", slug, "index.html"))) guideSlugs.push(slug);
+      collectGuideSlugs(slug);
+    }
+  };
+  collectGuideSlugs("");
+  guideSlugs.sort();
   for (const slug of guideSlugs) {
     urls += entry(`/guide/${slug}/`, `guide/${slug}/index.html`, "monthly", "0.8");
   }

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -4,6 +4,11 @@
   <url><loc>https://hermesatlas.com/guide/</loc><changefreq>monthly</changefreq><priority>0.9</priority><lastmod>2026-08-31</lastmod></url>
   <url><loc>https://hermesatlas.com/guide/desktop/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>2026-08-31</lastmod></url>
   <url><loc>https://hermesatlas.com/guide/install/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>2026-08-31</lastmod></url>
+  <url><loc>https://hermesatlas.com/guide/install/linux/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>2026-08-31</lastmod></url>
+  <url><loc>https://hermesatlas.com/guide/install/macos/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>2026-08-31</lastmod></url>
+  <url><loc>https://hermesatlas.com/guide/install/raspberry-pi/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>2026-08-31</lastmod></url>
+  <url><loc>https://hermesatlas.com/guide/install/vps/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>2026-08-31</lastmod></url>
+  <url><loc>https://hermesatlas.com/guide/install/windows/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>2026-08-31</lastmod></url>
   <url><loc>https://hermesatlas.com/guide/memory/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>2026-08-31</lastmod></url>
   <url><loc>https://hermesatlas.com/guide/modes/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>2026-08-31</lastmod></url>
   <url><loc>https://hermesatlas.com/guide/vs-claude-code/</loc><changefreq>monthly</changefreq><priority>0.8</priority><lastmod>2026-08-31</lastmod></url>

--- a/tests/build-artifacts.test.js
+++ b/tests/build-artifacts.test.js
@@ -16,11 +16,21 @@ test("refreshed content manifest covers the hand-authored pages + drafts", () =>
     "guide/vs-claude-code/index.html",
     "guide/modes/index.html",
     "guide/desktop/index.html",
+    "guide/install/windows/index.html",
+    "guide/install/macos/index.html",
+    "guide/install/linux/index.html",
+    "guide/install/raspberry-pi/index.html",
+    "guide/install/vps/index.html",
     "drafts/handbook-hub.md",
     "drafts/handbook-vs-claude-code.md",
     "drafts/guide-memory.md",
     "drafts/guide-modes.md",
     "drafts/guide-desktop.md",
+    "drafts/guide-install-windows.md",
+    "drafts/guide-install-macos.md",
+    "drafts/guide-install-linux.md",
+    "drafts/guide-install-raspberry-pi.md",
+    "drafts/guide-install-vps.md",
   ]);
 });
 

--- a/tests/install-platform-pages.test.js
+++ b/tests/install-platform-pages.test.js
@@ -1,0 +1,156 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { JSDOM } from "jsdom";
+
+// The per-platform install split (/guide/install/<platform>/) targets the
+// highest-impression GSC page on the site (/guide/install/: 157K impressions
+// at 0.85% CTR) with one page per query shape — Windows, macOS, Linux,
+// Raspberry Pi, VPS. These tests pin the contract: each satellite has the
+// guide-page anatomy (Article + FAQPage + BreadcrumbList JSON-LD,
+// current-version masthead, a table, CSP-clean markup), internal links
+// resolve, the hub keeps its HowTo anchor IDs and routes to every satellite,
+// the sitemap reaches the nested pages, and the RAG drafts stay registered.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.join(__dirname, "..");
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel), "utf8");
+const version = JSON.parse(read("data/latest-release.json")).version;
+
+const PLATFORMS = ["windows", "macos", "linux", "raspberry-pi", "vps"];
+const PAGES = PLATFORMS.map((p) => `guide/install/${p}/index.html`);
+
+for (const rel of PAGES) {
+  test(`${rel} has the guide-page anatomy`, () => {
+    const html = read(rel);
+    const { document } = new JSDOM(html).window;
+
+    const canonical = document.querySelector('link[rel="canonical"]');
+    assert.ok(canonical, "canonical present");
+    assert.match(
+      canonical.getAttribute("href"),
+      /^https:\/\/hermesatlas\.com\/guide\/install\/(windows|macos|linux|raspberry-pi|vps)\/$/,
+    );
+
+    const ldTypes = Array.from(
+      document.querySelectorAll('script[type="application/ld+json"]'),
+    ).map((s) => JSON.parse(s.textContent)["@type"]);
+    for (const t of ["Article", "FAQPage", "BreadcrumbList"]) {
+      assert.ok(ldTypes.includes(t), `${t} JSON-LD present`);
+    }
+
+    assert.ok(document.querySelector("header.masthead"), "masthead present");
+    assert.ok(html.includes(`hermes·${version}`), "masthead version is current");
+    assert.ok(document.querySelector("main.article"), "article layout");
+    assert.ok(document.querySelector(".article-table-scroll table"), "table present");
+    assert.ok(document.querySelector("#theme-toggle"), "theme toggle present");
+
+    // CSP contract: no inline executable scripts, no style attrs.
+    for (const s of document.querySelectorAll("script")) {
+      assert.ok(
+        s.getAttribute("src") || s.getAttribute("type") === "application/ld+json",
+        "no inline executable scripts",
+      );
+    }
+    assert.equal(document.querySelectorAll("[style]").length, 0, "no style attributes");
+  });
+
+  test(`${rel} internal links resolve to files on disk`, () => {
+    const { document } = new JSDOM(read(rel)).window;
+    const hrefs = new Set();
+    for (const a of document.querySelectorAll("a[href]")) {
+      const href = a.getAttribute("href") || "";
+      if (href.startsWith("/") && !href.startsWith("//")) {
+        hrefs.add(href.split("#")[0].split("?")[0]);
+      }
+    }
+    for (const href of hrefs) {
+      if (!href || href === "/") continue;
+      const relPath = href.replace(/^\//, "").replace(/\/$/, "");
+      const candidates = [
+        path.join(ROOT, relPath, "index.html"),
+        path.join(ROOT, `${relPath}.html`),
+        path.join(ROOT, relPath),
+      ];
+      assert.ok(
+        candidates.some((p) => fs.existsSync(p)),
+        `${rel} links ${href} but no file exists for it`,
+      );
+    }
+  });
+
+  test(`${rel} FAQ JSON-LD questions appear on the page`, () => {
+    const html = read(rel);
+    const { document } = new JSDOM(html).window;
+    const faq = Array.from(
+      document.querySelectorAll('script[type="application/ld+json"]'),
+    )
+      .map((s) => JSON.parse(s.textContent))
+      .find((b) => b["@type"] === "FAQPage");
+    assert.ok(faq.mainEntity.length >= 5, "at least five FAQ entries");
+    for (const q of faq.mainEntity) {
+      assert.ok(
+        html.includes(q.name.replace(/&/g, "&amp;").slice(0, 30)) || html.includes(q.name.slice(0, 30)),
+        `FAQ question "${q.name}" appears in the page body`,
+      );
+    }
+  });
+
+  test(`${rel} links back to the install hub`, () => {
+    const { document } = new JSDOM(read(rel)).window;
+    const hubLink = Array.from(document.querySelectorAll('a[href^="/guide/install/"]')).find(
+      (a) => a.getAttribute("href").split("#")[0] === "/guide/install/",
+    );
+    assert.ok(hubLink, "page links to /guide/install/");
+  });
+}
+
+test("install hub routes to every platform page and keeps its HowTo anchors", () => {
+  const html = read("guide/install/index.html");
+  const { document } = new JSDOM(html).window;
+
+  for (const p of PLATFORMS) {
+    const link = document.querySelector(`a[href="/guide/install/${p}/"]`);
+    assert.ok(link, `hub links to /guide/install/${p}/`);
+  }
+
+  // The hub's HowTo JSON-LD steps anchor to these fragments; the platform
+  // pages deep-link #verify/#first-run/#troubleshooting. Keep them stable.
+  for (const id of ["install-macos", "install-linux", "install-windows", "verify", "first-run", "troubleshooting"]) {
+    assert.ok(document.getElementById(id), `hub keeps #${id}`);
+  }
+});
+
+test("sitemap reaches the nested install pages", () => {
+  const sitemap = read("sitemap.xml");
+  for (const p of PLATFORMS) {
+    assert.ok(
+      sitemap.includes(`https://hermesatlas.com/guide/install/${p}/`),
+      `sitemap.xml contains /guide/install/${p}/`,
+    );
+  }
+});
+
+test("install drafts are registered as RAG guide sources", () => {
+  const chunks = read("scripts/build-chunks.js");
+  for (const p of PLATFORMS) {
+    const file = `guide-install-${p}.md`;
+    const source = `guide/install/${p}/`;
+    assert.ok(chunks.includes(`"${file}"`), `${file} in guideSources`);
+    assert.ok(chunks.includes(`"${source}"`), `${source} label in guideSources`);
+    assert.ok(fs.existsSync(path.join(ROOT, "drafts", file)), `drafts/${file} exists`);
+  }
+});
+
+test("install drafts trigger the chunk rebuild workflow", () => {
+  const workflow = read(".github/workflows/rebuild-chunks.yml");
+  for (const p of PLATFORMS) {
+    assert.ok(
+      workflow.includes(`drafts/guide-install-${p}.md`),
+      `rebuild-chunks.yml triggers on drafts/guide-install-${p}.md`,
+    );
+  }
+});

--- a/tests/seo-pages.test.js
+++ b/tests/seo-pages.test.js
@@ -57,6 +57,11 @@ test("guide pages carry the current Hermes release, not a stale one", () => {
     "guide/vs-claude-code/index.html",
     "guide/modes/index.html",
     "guide/desktop/index.html",
+    "guide/install/windows/index.html",
+    "guide/install/macos/index.html",
+    "guide/install/linux/index.html",
+    "guide/install/raspberry-pi/index.html",
+    "guide/install/vps/index.html",
   ]) {
     assert.ok(
       read(rel).includes(`hermes·${version}`),


### PR DESCRIPTION
## Strategy move 3: per-platform install split

`/guide/install/` is the site's highest-impression page (**1,336 clicks / 156,947 impressions / 0.85% CTR / avg position 8.12** in the 08-20 GSC snapshot) — one generic page absorbing every platform-shaped query. This PR splits it per the addendum, following the #939 pattern.

### New pages (each targeting its GSC query cluster)

| Page | Cluster |
|---|---|
| `/guide/install/windows/` | "how to install hermes agent on windows 11", "install hermes powershell" (23.8% CTR) |
| `/guide/install/macos/` | "hermes install mac", "how to install hermes on mac mini" |
| `/guide/install/linux/` | "hermes agent install ubuntu/debian", "hermes install linux" |
| `/guide/install/raspberry-pi/` | the ~40-click RPi cluster (pos 5–9, previously one FAQ line) |
| `/guide/install/vps/` | VPS/server demand folded into the Linux cluster |

Every factual claim is sourced to `research/docs/` (installation.md, platform-support.md, windows-native.md, windows-wsl-quickstart.md, docker.md, desktop.md). Each page: Article + FAQPage + BreadcrumbList JSON-LD, freshness-pass-compatible phrasings, CSP-clean.

### Hub rework (`/guide/install/`)

- Platform sections compressed to quick-start + "full guide →" link; **all HowTo anchor IDs preserved**; shared sections (verify, first-run, 9-item troubleshooting, MCP, FAQ) intact.
- New Raspberry Pi and VPS router sections; BreadcrumbList added; breadcrumb `map`→`home`.
- **Stale claims reconciled to current official docs** (approved decision): native Windows is Tier 1, not "early beta"; Intel Macs / brew / pip explicitly unsupported; Desktop installer is the recommended path; Nix is Tier 2. Same fixes applied to the two stale spots in `/guide/`.

### Wiring (the full #939 checklist, no #940-style follow-up needed)

- 5 drafts registered in `guideSources` + `REFRESHED_CONTENT_PATHS` + `rebuild-chunks.yml` push triggers + llms.txt bullets + llms-full.txt sections — all in this PR.
- **Sitemap fix:** the generator only globbed direct children of `guide/`, so nested `guide/install/<platform>/` pages would have been silently absent. It now recurses (`scripts/build-pages.js`); committed `sitemap.xml` contains all 5 new URLs (308 total).

### Verification

- `npm test`: **361 pass / 0 fail** (new suite `tests/install-platform-pages.test.js`: page anatomy, internal-link disk resolution, FAQ JSON-LD mirroring, hub anchors + routing, sitemap reach, RAG + workflow registration; `build-artifacts` pinned array and `seo-pages` version loop updated).
- Built locally twice with an authenticated token (`gh auth token`); freshness pass stamped v0.20.6 + current stars into all pages; only scoped artifacts committed (22 files — bulk regeneration left to the nightly bot).
- Note: one earlier full-suite run hit a known-flaky Windows libuv crash in `smoke-test-prod.test.js` at child exit *after* all 36 inner checks passed; it passes cleanly on re-run with and without this change.

### Out of scope

i18n install pages (addendum move 5, gated on this landing); comparison pages. No redirects needed — no URLs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
