### PR TITLE
Add TheSmokeDev/hermes-talk (30 stars) to Plugins & Extensions

### DIFF
--- a/data/repos.json
+++ b/data/repos.json
@@ -2478,5 +2478,15 @@
     "url": "https://github.com/Bandwidth/smartnumbers-hermes",
     "official": false,
     "category": "Plugins & Extensions"
+  },
+  {
+    "owner": "TheSmokeDev",
+    "repo": "hermes-talk",
+    "name": "hermes-talk",
+    "description": "Realtime duplex voice for Hermes Agent: terminal, Discord, and dashboard on OpenAI Realtime, xAI Grok Voice, or Gemini Live. Calls Hermes's own tools, delegates background runs, resolves approvals by voice. PyPI: hermes-talk",
+    "stars": 30,
+    "url": "https://github.com/TheSmokeDev/hermes-talk",
+    "official": false,
+    "category": "Plugins & Extensions"
   }
 ]


### PR DESCRIPTION
Adds [TheSmokeDev/hermes-talk](https://github.com/TheSmokeDev/hermes-talk) (30 stars, created 2026-08-02, active) to Plugins & Extensions — a realtime duplex voice plugin for Hermes Agent with terminal, Discord, and dashboard surfaces on OpenAI Realtime, xAI Grok Voice, or Gemini Live; also published as [`hermes-talk` on PyPI](https://pypi.org/project/hermes-talk/).
Only `data/repos.json` changes, in the existing entry shape; `node scripts/validate-repos-json.js` passes locally (248 repos).
— SmokeDev
