### PR TITLE
Add 3 Hermes projects from Sahil-SS9 (walkie-talkie, judge-jury-executioner, project-stewardship)

### DIFF
--- a/data/repos.json
+++ b/data/repos.json
@@ -2478,5 +2478,35 @@
     "url": "https://github.com/Bandwidth/smartnumbers-hermes",
     "official": false,
     "category": "Plugins & Extensions"
+  },
+  {
+    "owner": "Sahil-SS9",
+    "repo": "hermes-walkie-talkie",
+    "name": "hermes-walkie-talkie",
+    "description": "Secure same-machine peer messaging for independent Hermes Agent sessions. Live session discovery, direct messages with delivery receipts, named groups and bounded broadcasts, and structured requests with status updates and idempotency — over Unix sockets or Windows named pipes, with no central daemon and no network exposure.",
+    "stars": 8,
+    "url": "https://github.com/Sahil-SS9/hermes-walkie-talkie",
+    "official": false,
+    "category": "Integrations & Bridges"
+  },
+  {
+    "owner": "Sahil-SS9",
+    "repo": "llm-judge-jury-executioner",
+    "name": "llm-judge-jury-executioner",
+    "description": "Multi-LLM deliberation council — Judge, Jury, Executioner pattern. Dynamic agent composition, cross-examination, cascade-breaking and minority reports. Research-backed synthesis of 5 community approaches and academic findings.",
+    "stars": 4,
+    "url": "https://github.com/Sahil-SS9/llm-judge-jury-executioner",
+    "official": false,
+    "category": "Multi-Agent & Orchestration"
+  },
+  {
+    "owner": "Sahil-SS9",
+    "repo": "hermes-project-stewardship",
+    "name": "hermes-project-stewardship",
+    "description": "Durable project ownership for Hermes agent fleets. Verifies project reality before acting, turns backlog gaps into evidence-backed initiatives, executes through existing Kanban and measures outcomes. Supports stewardship workflows, views, cross-team project overview and bot-team reporting, with explicit autonomy policy — across CLI, RPC, dashboard and Desktop.",
+    "stars": 4,
+    "url": "https://github.com/Sahil-SS9/hermes-project-stewardship",
+    "official": false,
+    "category": "Developer Tools"
   }
 ]


### PR DESCRIPTION
Adding three Hermes Agent projects by @Sahil-SS9 to data/repos.json:

- **[hermes-walkie-talkie](https://github.com/Sahil-SS9/hermes-walkie-talkie)** — Secure same-machine peer messaging for independent Hermes sessions (Integrations & Bridges)
- **[llm-judge-jury-executioner](https://github.com/Sahil-SS9/llm-judge-jury-executioner)** — Multi-LLM deliberation council: Judge/Jury/Executioner pattern (Multi-Agent & Orchestration)
- **[hermes-project-stewardship](https://github.com/Sahil-SS9/hermes-project-stewardship)** — Durable project ownership for Hermes agent fleets: verified cycles, evidence-backed initiatives, Kanban execution, workflows, views, cross-team overview and autonomy policy (Developer Tools)

All three are built specifically for Hermes Agent, pass a basic security review (no network exposure / no credential escalation), and have real READMEs with docs and tests. Descriptions sourced from the upstream READMEs.